### PR TITLE
Fix Case where Network Image Node Stays Locked

### DIFF
--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -403,7 +403,7 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
 - (void)handleProgressImage:(UIImage *)progressImage progress:(CGFloat)progress downloadIdentifier:(nullable id)downloadIdentifier
 {
-  __instanceLock__.lock();
+  ASDN::MutexLocker l(__instanceLock__);
   
   // Getting a result back for a different download identifier, download must not have been successfully canceled
   if (ASObjectIsEqual(_downloadIdentifier, downloadIdentifier) == NO && downloadIdentifier != nil) {
@@ -412,8 +412,6 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   
   [self _locked_setCurrentImageQuality:progress];
   [self _locked__setImage:progressImage];
-
-  __instanceLock__.unlock();
 }
 
 - (void)_updateProgressImageBlockOnDownloaderIfNeeded


### PR DESCRIPTION
This can eventually cause the rendering queue to get stalled https://jira.pinadmin.com/browse/BUG-54113