### PR TITLE
[ASCollectionLayout] Manually set size to measured cells

### DIFF
--- a/Source/Private/ASCollectionLayout.mm
+++ b/Source/Private/ASCollectionLayout.mm
@@ -9,6 +9,7 @@
 #import <AsyncDisplayKit/ASCollectionLayout.h>
 
 #import <AsyncDisplayKit/ASAssert.h>
+#import <AsyncDisplayKit/ASCellNode.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>
 #import <AsyncDisplayKit/ASCollectionLayoutContext+Private.h>
 #import <AsyncDisplayKit/ASCollectionLayoutDelegate.h>
@@ -116,6 +117,7 @@
   for (ASCollectionElement *element in attrsMap) {
     UICollectionViewLayoutAttributes *attrs = [attrsMap objectForKey:element];
     if (CGRectIntersectsRect(rect, attrs.frame)) {
+      [ASCollectionLayout setSize:attrs.frame.size toElement:element];
       [attributesInRect addObject:attrs];
     }
   }
@@ -126,17 +128,31 @@
 {
   ASCollectionLayoutState *state = _state;
   ASCollectionElement *element = [state.elements elementForItemAtIndexPath:indexPath];
-  return [state.elementToLayoutArrtibutesMap objectForKey:element];
+  UICollectionViewLayoutAttributes *attrs = [state.elementToLayoutArrtibutesMap objectForKey:element];
+  [ASCollectionLayout setSize:attrs.frame.size toElement:element];
+  return attrs;
 }
 
 - (UICollectionViewLayoutAttributes *)layoutAttributesForSupplementaryViewOfKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath
 {
   ASCollectionLayoutState *state = _state;
   ASCollectionElement *element = [state.elements supplementaryElementOfKind:elementKind atIndexPath:indexPath];
-  return [state.elementToLayoutArrtibutesMap objectForKey:element];
+  UICollectionViewLayoutAttributes *attrs = [state.elementToLayoutArrtibutesMap objectForKey:element];
+  [ASCollectionLayout setSize:attrs.frame.size toElement:element];
+  return attrs;
 }
 
 #pragma mark - Private methods
+
++ (void)setSize:(CGSize)size toElement:(ASCollectionElement *)element
+{
+  ASCellNode *node = element.node;
+  if (! CGSizeEqualToSize(size, node.frame.size)) {
+    CGRect nodeFrame = CGRectZero;
+    nodeFrame.size = size;
+    node.frame = nodeFrame;
+  }
+}
 
 - (CGSize)viewportSize
 {


### PR DESCRIPTION
(Ported from https://github.com/facebook/AsyncDisplayKit/pull/3262)

Currently, ASDataController sets the calculated size of a cell node right after measuring it (here). This behavior dates all the way back to the first implementation of ASDataController. This is to ensure that by the time the cell needs to display, it has a valid size and the needsLayout flag of its layer is on. Failing to do so will cause it to skip its display pass entirely.

ASCollectionLayout currently doesn't do this which causes some cells to be missing. This PR updates ASCollectionLayout to set the frame whenever a node's layout attributes is asked.

There are 2 other places we can fix this:

When the cell node applies its layout attributes. This event is driven by UICollectionView and is often too late. We want all cell nodes that are not only in visible range but also display and preload ranges to have a correct size.
When the cell node enters preload range: Inside didEnterPreloadState, the node needs to grab its calculated size and assumes that the size is valid. However, I'd prefer ASCollectionLayout to be in charge of these kind of decisions.

https://github.com/facebook/AsyncDisplayKit/issues/3219