### PR TITLE
GLKit workaround #trivial

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -590,7 +590,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     }
       
     // CAEAGLLayer
-    if([view.layer class] isSubclassOfClass:[CAEAGLLayer class]]){
+    if([[view.layer class] isSubclassOfClass:[CAEAGLLayer class]]){
       _flags.canClearContentsOfLayer = NO;
     }
   }

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -590,8 +590,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     }
       
     // CAEAGLLayer
-    if([view.layer.class isSubclassOfClass:[CAEAGLLayer class]]){
-        _flags.canClearContentsOfLayer = NO;
+    if([view.layer class] isSubclassOfClass:[CAEAGLLayer class]]){
+      _flags.canClearContentsOfLayer = NO;
     }
   }
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -588,6 +588,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
         || [_viewClass isSubclassOfClass:[UIVisualEffectView class]]) {
       self.opaque = NO;
     }
+      
+    // CAEAGLLayer
+    if([view.layer.class isSubclassOfClass:[CAEAGLLayer class]]){
+        _flags.canClearContentsOfLayer = NO;
+    }
   }
 
   return view;

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1,11 +1,23 @@
 //
 //  ASDisplayNode.mm
-//  AsyncDisplayKit
+//  Texture
 //
 //  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
 //  This source code is licensed under the BSD-style license found in the
 //  LICENSE file in the root directory of this source tree. An additional grant
 //  of patent rights can be found in the PATENTS file in the same directory.
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) 2017-present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h>


### PR DESCRIPTION
canClearContentsOfLayer now turned off for views with CAEAGLLayer

more:
https://github.com/TextureGroup/Texture/issues/53