### PR TITLE
[RTL] Bridge the UISemanticContentAttribute property for more convenient RTL support.

### DIFF
--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -692,6 +692,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * contentMode for your content while it's being re-rendered.
  */
 @property (nonatomic, assign)           UIViewContentMode contentMode;         // default=UIViewContentModeScaleToFill
+@property (nonatomic, assign)           UISemanticContentAttribute semanticContentAttribute; // default=Unspecified
 
 @property (nonatomic, assign, getter=isUserInteractionEnabled) BOOL userInteractionEnabled; // default=YES (NO for layer-backed nodes)
 #if TARGET_OS_IOS

--- a/Source/Details/UIView+ASConvenience.h
+++ b/Source/Details/UIView+ASConvenience.h
@@ -51,15 +51,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol ASDisplayNodeViewProperties
 
-@property (nonatomic, assign)           		BOOL clipsToBounds;
-@property (nonatomic, getter=isHidden)  		BOOL hidden;
-@property (nonatomic, assign)           		BOOL autoresizesSubviews;
-@property (nonatomic, assign)           		UIViewAutoresizing autoresizingMask;
-@property (nonatomic, strong, null_resettable)  UIColor *tintColor;
-@property (nonatomic, assign)           		CGFloat alpha;
-@property (nonatomic, assign)           		CGRect bounds;
-@property (nonatomic, assign)           		CGRect frame;   // Only for use with nodes wrapping synchronous views
-@property (nonatomic, assign)           		UIViewContentMode contentMode;
+@property (nonatomic, assign)          BOOL clipsToBounds;
+@property (nonatomic, getter=isHidden) BOOL hidden;
+@property (nonatomic, assign)          BOOL autoresizesSubviews;
+@property (nonatomic, assign)          UIViewAutoresizing autoresizingMask;
+@property (nonatomic, strong, null_resettable) UIColor *tintColor;
+@property (nonatomic, assign)          CGFloat alpha;
+@property (nonatomic, assign)          CGRect bounds;
+@property (nonatomic, assign)          CGRect frame;   // Only for use with nodes wrapping synchronous views
+@property (nonatomic, assign)          UIViewContentMode contentMode;
+@property (nonatomic, assign)          UISemanticContentAttribute semanticContentAttribute;
 @property (nonatomic, assign, getter=isUserInteractionEnabled) BOOL userInteractionEnabled;
 @property (nonatomic, assign, getter=isExclusiveTouch) BOOL exclusiveTouch;
 @property (nonatomic, assign, getter=asyncdisplaykit_isAsyncTransactionContainer, setter = asyncdisplaykit_setAsyncTransactionContainer:) BOOL asyncdisplaykit_asyncTransactionContainer;

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -773,6 +773,23 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
   _setToLayer(edgeAntialiasingMask, edgeAntialiasingMask);
 }
 
+- (UISemanticContentAttribute)semanticContentAttribute
+{
+  _bridge_prologue_read;
+  if (AS_AT_LEAST_IOS9) {
+    return _getFromViewOnly(semanticContentAttribute);
+  }
+  return UISemanticContentAttributeUnspecified;
+}
+
+- (void)setSemanticContentAttribute:(UISemanticContentAttribute)semanticContentAttribute
+{
+  _bridge_prologue_write;
+  if (AS_AT_LEAST_IOS9) {
+    _setToViewOnly(semanticContentAttribute, semanticContentAttribute);
+  }
+}
+
 @end
 
 

--- a/Source/Private/_ASPendingState.mm
+++ b/Source/Private/_ASPendingState.mm
@@ -75,6 +75,7 @@ typedef struct {
   int setAccessibilityHeaderElements:1;
   int setAccessibilityActivationPoint:1;
   int setAccessibilityPath:1;
+  int setSemanticContentAttribute:1;
 } ASPendingStateFlags;
 
 @implementation _ASPendingState
@@ -118,6 +119,7 @@ typedef struct {
   NSArray *accessibilityHeaderElements;
   CGPoint accessibilityActivationPoint;
   UIBezierPath *accessibilityPath;
+  UISemanticContentAttribute semanticContentAttribute;
 
   ASPendingStateFlags _flags;
 }
@@ -179,6 +181,7 @@ ASDISPLAYNODE_INLINE void ASPendingStateApplyMetricsToLayer(_ASPendingState *sta
 @synthesize borderWidth=borderWidth;
 @synthesize borderColor=borderColor;
 @synthesize asyncdisplaykit_asyncTransactionContainer=asyncTransactionContainer;
+@synthesize semanticContentAttribute=semanticContentAttribute;
 
 
 static CGColorRef blackColorRef = NULL;
@@ -259,6 +262,7 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   accessibilityActivationPoint = CGPointZero;
   accessibilityPath = nil;
   edgeAntialiasingMask = (kCALayerLeftEdge | kCALayerRightEdge | kCALayerTopEdge | kCALayerBottomEdge);
+  semanticContentAttribute = UISemanticContentAttributeUnspecified;
 
   return self;
 }
@@ -510,6 +514,11 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
 {
   asyncTransactionContainer = flag;
   _flags.setAsyncTransactionContainer = YES;
+}
+
+- (void)setSemanticContentAttribute:(UISemanticContentAttribute)attribute {
+  semanticContentAttribute = attribute;
+  _flags.setSemanticContentAttribute = YES;
 }
 
 - (BOOL)isAccessibilityElement
@@ -904,6 +913,10 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   if (flags.setOpaque)
     ASDisplayNodeAssert(view.layer.opaque == opaque, @"Didn't set opaque as desired");
 
+  if (flags.setSemanticContentAttribute) {
+    view.semanticContentAttribute = semanticContentAttribute;
+  }
+
   if (flags.setIsAccessibilityElement)
     view.isAccessibilityElement = isAccessibilityElement;
 
@@ -1045,6 +1058,7 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   pendingState.allowsGroupOpacity = layer.allowsGroupOpacity;
   pendingState.allowsEdgeAntialiasing = layer.allowsEdgeAntialiasing;
   pendingState.edgeAntialiasingMask = layer.edgeAntialiasingMask;
+  pendingState.semanticContentAttribute = view.semanticContentAttribute;
   pendingState.isAccessibilityElement = view.isAccessibilityElement;
   pendingState.accessibilityLabel = view.accessibilityLabel;
   pendingState.accessibilityHint = view.accessibilityHint;
@@ -1119,6 +1133,7 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   || flags.needsLayout
   || flags.setAsyncTransactionContainer
   || flags.setOpaque
+  || flags.setSemanticContentAttribute
   || flags.setIsAccessibilityElement
   || flags.setAccessibilityLabel
   || flags.setAccessibilityHint


### PR DESCRIPTION
Although apps could handle this before by setting the view's property in didLoad, it's
useful to bridge this property for setting during off-main initialization.

This change is required in order to finalize and land https://github.com/TextureGroup/Texture/pull/59/files - or otherwise I can do a followup PR to merge the small amount of code in +UIViewBridge that gives an opportunity to update other state when this attribute changes.