### PR TITLE
ASLayoutSpec to use more default implementations #trivial

### DIFF
--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -101,6 +101,16 @@ ASDISPLAYNODE_EXTERN_C_END
 
 @end
 
+#define ASPrimitiveTraitCollectionDefaults \
+- (ASPrimitiveTraitCollection)primitiveTraitCollection\
+{\
+  return _primitiveTraitCollection;\
+}\
+- (void)setPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traitCollection\
+{\
+  _primitiveTraitCollection = traitCollection;\
+}\
+
 #define ASPrimitiveTraitCollectionDeprecatedImplementation \
 - (ASEnvironmentTraitCollection)environmentTraitCollection\
 {\

--- a/Source/Layout/ASLayoutElementPrivate.h
+++ b/Source/Layout/ASLayoutElementPrivate.h
@@ -49,16 +49,17 @@ extern void ASLayoutElementClearCurrentContext();
 #define ASLayoutElementLayoutCalculationDefaults \
 - (ASLayout *)layoutThatFits:(ASSizeRange)constrainedSize\
 {\
-  _Pragma("clang diagnostic push")\
-  _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")\
-  /* For now we just call the deprecated measureWithSizeRange: method to not break old API */ \
-  return [self measureWithSizeRange:constrainedSize]; \
-  _Pragma("clang diagnostic pop")\
-} \
+  return [self layoutThatFits:constrainedSize parentSize:constrainedSize.max];\
+}\
 \
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize\
 {\
   return [self layoutThatFits:constrainedSize parentSize:constrainedSize.max];\
+}\
+\
+- (ASLayout *)layoutThatFits:(ASSizeRange)constrainedSize parentSize:(CGSize)parentSize\
+{\
+  return [self calculateLayoutThatFits:constrainedSize restrictedToSize:self.style.size relativeToParentSize:parentSize];\
 }\
 \
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize\
@@ -68,7 +69,6 @@ extern void ASLayoutElementClearCurrentContext();
   const ASSizeRange resolvedRange = ASSizeRangeIntersect(constrainedSize, ASLayoutElementSizeResolve(self.style.size, parentSize));\
   return [self calculateLayoutThatFits:resolvedRange];\
 }\
-
 
 #pragma mark - ASLayoutElementFinalLayoutElement
 /**

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -94,23 +94,7 @@ ASLayoutElementFinalLayoutElementDefault
 
 #pragma mark - Layout
 
-- (ASLayout *)layoutThatFits:(ASSizeRange)constrainedSize
-{
-  return [self layoutThatFits:constrainedSize parentSize:constrainedSize.max];
-}
-
-- (ASLayout *)layoutThatFits:(ASSizeRange)constrainedSize parentSize:(CGSize)parentSize
-{
-  return [self calculateLayoutThatFits:constrainedSize restrictedToSize:self.style.size relativeToParentSize:parentSize];
-}
-
-- (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
-                     restrictedToSize:(ASLayoutElementSize)size
-                 relativeToParentSize:(CGSize)parentSize
-{
-  const ASSizeRange resolvedRange = ASSizeRangeIntersect(constrainedSize, ASLayoutElementSizeResolve(self.style.size, parentSize));
-  return [self calculateLayoutThatFits:resolvedRange];
-}
+ASLayoutElementLayoutCalculationDefaults
 
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
 {
@@ -178,22 +162,13 @@ ASLayoutElementFinalLayoutElementDefault
 
 #pragma mark - ASTraitEnvironment
 
-- (ASPrimitiveTraitCollection)primitiveTraitCollection
-{
-  return _primitiveTraitCollection;
-}
-
-- (void)setPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traitCollection
-{
-  _primitiveTraitCollection = traitCollection;
-}
-
 - (ASTraitCollection *)asyncTraitCollection
 {
   ASDN::MutexLocker l(__instanceLock__);
   return [ASTraitCollection traitCollectionWithASPrimitiveTraitCollection:self.primitiveTraitCollection];
 }
 
+ASPrimitiveTraitCollectionDefaults
 ASPrimitiveTraitCollectionDeprecatedImplementation
 
 #pragma mark - ASLayoutElementStyleExtensibility
@@ -259,13 +234,6 @@ ASLayoutElementStyleExtensibilityForwarding
   if (!ASObjectIsEqual(_debugName, debugName)) {
     _debugName = [debugName copy];
   }
-}
-
-#pragma mark - Deprecated
-
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
-{
-  return [self layoutThatFits:constrainedSize];
 }
 
 @end


### PR DESCRIPTION
So I was trying to implement a dummy object that conforms to `ASLayoutElement` protocol and found out that there are already a bunch of helpful default implementations, some of them can be used directly in  `ASLayoutSpec`.  So I updated `ASLayoutSpec` to do just that.