### PR TITLE
Fix inserting a sublayer in an index of NSNotFound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Fix `__has_include` check in ASLog.h [Philipp Smorygo](Philipp.Smorygo@jetbrains.com)
 - Fix potential deadlock in ASControlNode [Garrett Moon](https://github.com/garrettmoon)
 - [Yoga Beta] Improvements to the experimental support for Yoga layout [Scott Goodson](appleguy)
+- Fix inserting a sublayer in an index of NSNotFound (Michael Schneider)[https://github.com/maicki] (#80)(https://github.com/TextureGroup/Texture/pull/80)


### PR DESCRIPTION
It can happen that the view get's loaded while `_setSupernode` is called. In this it's still assumed that the `sublayerIndex` is `NSNotFound` although the view is loaded now and we should have a valid sublayer index. To prevent this let's grab the sublayer index again if we discover this situation.