### PR TITLE
[Yoga] Ensure that calculated layout is nil'd in invalidate*Layout

### DIFF
--- a/Source/ASDisplayNode+Beta.h
+++ b/Source/ASDisplayNode+Beta.h
@@ -167,8 +167,8 @@ extern void ASDisplayNodePerformBlockOnEveryYogaChild(ASDisplayNode * _Nullable 
 
 @interface ASDisplayNode (Yoga)
 
-@property (nonatomic, strong) NSArray *yogaChildren;
-@property (nonatomic, strong) ASLayout *yogaCalculatedLayout;
+@property (nonatomic, strong, nullable) NSArray *yogaChildren;
+@property (nonatomic, strong, nullable) ASLayout *yogaCalculatedLayout;
 
 - (void)addYogaChild:(ASDisplayNode *)child;
 - (void)removeYogaChild:(ASDisplayNode *)child;

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -335,6 +335,7 @@ YGSize ASLayoutElementYogaMeasureFunc(YGNodeRef yogaNode, float width, YGMeasure
   if (YGNodeGetMeasureFunc(yogaNode)) {
     YGNodeMarkDirty(yogaNode);
   }
+  self.yogaCalculatedLayout = nil;
 }
 
 - (void)semanticContentAttributeDidChange:(UISemanticContentAttribute)attribute
@@ -350,7 +351,7 @@ YGSize ASLayoutElementYogaMeasureFunc(YGNodeRef yogaNode, float width, YGMeasure
 - (void)calculateLayoutFromYogaRoot:(ASSizeRange)rootConstrainedSize
 {
   if (self.yogaParent) {
-    if (ASHierarchyStateIncludesYogaLayoutMeasuring(self.hierarchyState) == NO) {
+    if (self.yogaCalculatedLayout == nil) {
       [self _setNeedsLayoutFromAbove];
     }
     return;

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1166,17 +1166,19 @@ ASLayoutElementFinalLayoutElementDefault
   ASDN::MutexLocker l(__instanceLock__);
 
 #if YOGA /* YOGA */
-  if (ASHierarchyStateIncludesYogaLayoutEnabled(_hierarchyState) == YES &&
-      ASHierarchyStateIncludesYogaLayoutMeasuring(_hierarchyState) == NO) {
-    ASDN::MutexUnlocker ul(__instanceLock__);
-    [self calculateLayoutFromYogaRoot:constrainedSize];
-  }
+  if (ASHierarchyStateIncludesYogaLayoutEnabled(_hierarchyState) == YES) {
+    if (ASHierarchyStateIncludesYogaLayoutMeasuring(_hierarchyState) == NO && self.yogaCalculatedLayout == nil) {
+      ASDN::MutexUnlocker ul(__instanceLock__);
+      [self calculateLayoutFromYogaRoot:constrainedSize];
+    }
 
-  if (ASHierarchyStateIncludesYogaLayoutEnabled(_hierarchyState) == YES && self.yogaCalculatedLayout) {
-    return self.yogaCalculatedLayout;
+    // The call above may set yogaCalculatedLayout, even if it tested as nil to enter it.
+    if (self.yogaCalculatedLayout && self.yogaChildren.count > 0) {
+      return self.yogaCalculatedLayout;
+    }
   }
 #endif /* YOGA */
-
+  
   // Manual size calculation via calculateSizeThatFits:
   if (((_methodOverrides & ASDisplayNodeMethodOverrideLayoutSpecThatFits) ||
       (_layoutSpecBlock != NULL)) == NO) {


### PR DESCRIPTION
This is a simple additional fix to the last Yoga patch. I was going to
upload it into the same diff, but fell behind for a couple days and 
didn't realize it was of interest to converge this area.

I have no other immediate plans to submit more changes here. However
I am planning to re-work the yoga integration to reduce its footprint
and improve its reliability. 

It would be awesome if there's any way I can keep up on plans in this area,
so that my design to improve the integration and make it more clean are
as applicable as possible. Let me know if I can help!