### PR TITLE
[Layout] Remove finalLayoutElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Update the rasterization API and un-deprecate it. [Adlai Holler](https://github.com/Adlai-Holler)[#82](https://github.com/TextureGroup/Texture/pull/49)
 - Simplified & optimized hashing code. [Adlai Holler](https://github.com/Adlai-Holler) [#86](https://github.com/TextureGroup/Texture/pull/86)
 - Improve the performance & safety of ASDisplayNode subnodes. [Adlai Holler](https://github.com/Adlai-Holler) [#223](https://github.com/TextureGroup/Texture/pull/223)
+- Remove finalLayoutElement [Michael Schneider] (https://github.com/maicki)[#96](https://github.com/TextureGroup/Texture/pull/96)

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -121,7 +121,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  */
 
-@interface ASDisplayNode : NSObject <ASLayoutElementFinalLayoutElement>
+@interface ASDisplayNode : NSObject
 
 /** @name Initializing a node object */
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -866,8 +866,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   return !self.isNodeLoaded;
 }
 
-ASLayoutElementFinalLayoutElementDefault
-
 #pragma mark <ASDebugNameProvider>
 
 - (NSString *)debugName

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -334,7 +334,6 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
  *
  * @param kind The kind of the elements, e.g ASDataControllerRowNodeKind
  * @param sections The sections that should be populated by new elements
- * @param owningNode The node that owns the new elements.
  * @param traitCollection The trait collection needed to initialize elements
  * @param shouldFetchSizeRanges Whether constrained sizes should be fetched from data source
  */
@@ -360,7 +359,6 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
  * @param map The map to insert the elements into.
  * @param kind The kind of the elements, e.g ASDataControllerRowNodeKind
  * @param indexPaths The index paths at which new elements should be populated
- * @param owningNode The node that owns the new elements.
  * @param traitCollection The trait collection needed to initialize elements
  * @param shouldFetchSizeRanges Whether constrained sizes should be fetched from data source
  */

--- a/Source/Layout/ASLayoutElementPrivate.h
+++ b/Source/Layout/ASLayoutElementPrivate.h
@@ -70,45 +70,6 @@ extern void ASLayoutElementClearCurrentContext();
   return [self calculateLayoutThatFits:resolvedRange];\
 }\
 
-#pragma mark - ASLayoutElementFinalLayoutElement
-/**
- *  The base protocol for ASLayoutElementFinalLayoutElement. Generally the methods/properties in this class do not need to be
- *  called by the end user and are only called internally. However, there may be a case where the methods are useful.
- */
-@protocol ASLayoutElementFinalLayoutElement <NSObject>
-
-/**
- *  @abstract This method can be used to give the user a chance to wrap an ASLayoutElement in an ASLayoutSpec 
- *  just before it is added to a parent ASLayoutSpec. For example, if you wanted an ASTextNode that was always 
- *  inside of an ASInsetLayoutSpec, you could subclass ASTextNode and implement finalLayoutElement so that it wraps
- *  itself in an inset spec.
- *
- *  Note that any ASLayoutElement other than self that is returned MUST set isFinalLayoutElement to YES. Make sure
- *  to do this BEFORE adding a child to the ASLayoutElement.
- *
- *  @return The layoutElement that will be added to the parent layout spec. Defaults to self.
- */
-- (id<ASLayoutElement>)finalLayoutElement;
-
-/**
- *  A flag to indicate that this ASLayoutElement was created in finalLayoutElement. This MUST be set to YES
- *  before adding a child to this layoutElement.
- */
-@property (nonatomic, assign) BOOL isFinalLayoutElement;
-
-@end
-
-// Default implementation for ASLayoutElementPrivate that can be used in classes that comply to ASLayoutElementPrivate
-
-#define ASLayoutElementFinalLayoutElementDefault \
-\
-@synthesize isFinalLayoutElement = _isFinalLayoutElement;\
-\
-- (id<ASLayoutElement>)finalLayoutElement\
-{\
-    return self;\
-}\
-
 
 #pragma mark - ASLayoutElementExtensibility
 

--- a/Source/Layout/ASLayoutSpec+Subclasses.h
+++ b/Source/Layout/ASLayoutSpec+Subclasses.h
@@ -26,27 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASLayoutSpec (Subclassing)
 
 /**
- * Helper method for finalLayoutElement support
- *
- * @warning If you are getting recursion crashes here after implementing finalLayoutElement, make sure
- * that you are setting isFinalLayoutElement flag to YES. This must be one BEFORE adding a child
- * to the new ASLayoutElement.
- *
- * For example:
- * - (id<ASLayoutElement>)finalLayoutElement
- * {
- *   ASInsetLayoutSpec *insetSpec = [[ASInsetLayoutSpec alloc] init];
- *   insetSpec.insets = UIEdgeInsetsMake(10,10,10,10);
- *   insetSpec.isFinalLayoutElement = YES;
- *   [insetSpec setChild:self];
- *   return insetSpec;
- * }
- *
- * @see finalLayoutElement
- */
-- (id<ASLayoutElement>)layoutElementToAddFromLayoutElement:(id<ASLayoutElement>)child;
-
-/**
  * Adds a child with the given identifier to this layout spec.
  *
  * @param child A child to be added.

--- a/Source/Layout/ASLayoutSpec+Subclasses.mm
+++ b/Source/Layout/ASLayoutSpec+Subclasses.mm
@@ -56,27 +56,13 @@
 
 @implementation ASLayoutSpec (Subclassing)
 
-#pragma mark - Final layoutElement
-
-- (id<ASLayoutElement>)layoutElementToAddFromLayoutElement:(id<ASLayoutElement, ASLayoutElementFinalLayoutElement>)child
-{
-  if (self.isFinalLayoutElement == NO) {
-    id<ASLayoutElement> finalLayoutElement = [child finalLayoutElement];
-    if (finalLayoutElement != child) {
-      finalLayoutElement.primitiveTraitCollection = child.primitiveTraitCollection;
-      return finalLayoutElement;
-    }
-  }
-  return child;
-}
-
 #pragma mark - Child with index
 
 - (void)setChild:(id<ASLayoutElement>)child atIndex:(NSUInteger)index
 {
   ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
   
-  id<ASLayoutElement> layoutElement = child ? [self layoutElementToAddFromLayoutElement:child] : [ASNullLayoutSpec null];
+  id<ASLayoutElement> layoutElement = child ?: [ASNullLayoutSpec null];
   
   if (child) {
     if (_childrenArray.count < index) {

--- a/Source/Layout/ASLayoutSpec.h
+++ b/Source/Layout/ASLayoutSpec.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A layout spec is an immutable object that describes a layout, loosely inspired by React.
  */
-@interface ASLayoutSpec : NSObject <ASLayoutElement, ASLayoutElementFinalLayoutElement, ASLayoutElementStylability, NSFastEnumeration>
+@interface ASLayoutSpec : NSObject <ASLayoutElement, ASLayoutElementStylability, NSFastEnumeration>
 
 /** 
  * Creation of a layout spec should only happen by a user in layoutSpecThatFits:. During that method, a

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -71,10 +71,6 @@
   return YES;
 }
 
-#pragma mark - Final LayoutElement
-
-ASLayoutElementFinalLayoutElementDefault
-
 #pragma mark - Style
 
 - (ASLayoutElementStyle *)style
@@ -109,10 +105,7 @@ ASLayoutElementLayoutCalculationDefaults
   ASDisplayNodeAssert(_childrenArray.count < 2, @"This layout spec does not support more than one child. Use the setChildren: or the setChild:AtIndex: API");
  
   if (child) {
-    id<ASLayoutElement> finalLayoutElement = [self layoutElementToAddFromLayoutElement:child];
-    if (finalLayoutElement) {
-      _childrenArray[0] = finalLayoutElement;
-    }
+    _childrenArray[0] = child;
   } else {
     if (_childrenArray.count) {
       [_childrenArray removeObjectAtIndex:0];
@@ -138,7 +131,7 @@ ASLayoutElementLayoutCalculationDefaults
   NSUInteger i = 0;
   for (id<ASLayoutElement> child in children) {
     ASDisplayNodeAssert([child conformsToProtocol:NSProtocolFromString(@"ASLayoutElement")], @"Child %@ of spec %@ is not an ASLayoutElement!", child, self);
-    _childrenArray[i] = [self layoutElementToAddFromLayoutElement:child];
+    _childrenArray[i] = child;
     i += 1;
   }
 }


### PR DESCRIPTION
`finalLayoutElement` is not used within the frameworks as well as in Pinterest. It was never documented probably either or made public. As we don't rely on it anymore and further refactoring will go on in this area I would propose to remove it.