### PR TITLE
Improve Our Handling of Subnodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - [Yoga Beta] Improvements to the experimental support for Yoga layout [Scott Goodson](appleguy)
 - Update the rasterization API and un-deprecate it. [Adlai Holler](https://github.com/Adlai-Holler)[#82](https://github.com/TextureGroup/Texture/pull/49)
 - Simplified & optimized hashing code. [Adlai Holler](https://github.com/Adlai-Holler) [#86](https://github.com/TextureGroup/Texture/pull/86)
+- Improve the performance & safety of ASDisplayNode subnodes. [Adlai Holler](https://github.com/Adlai-Holler) [#223](https://github.com/TextureGroup/Texture/pull/223)

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -121,7 +121,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  */
 
-@interface ASDisplayNode : NSObject <ASLayoutElement, ASLayoutElementStylability, NSFastEnumeration>
+@interface ASDisplayNode : NSObject <ASLayoutElement, ASLayoutElementStylability>
 
 /** @name Initializing a node object */
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -2673,6 +2673,8 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   ASDN::MutexLocker l(__instanceLock__);
   if (_cachedSubnodes == nil) {
     _cachedSubnodes = [_subnodes copy];
+  } else {
+    ASDisplayNodeAssert(ASObjectIsEqual(_cachedSubnodes, _subnodes), @"Expected _subnodes and _cachedSubnodes to have the same contents.");
   }
   return _cachedSubnodes ?: @[];
 }

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -127,6 +127,9 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   ASDisplayNode * __weak _supernode;
   NSMutableArray<ASDisplayNode *> *_subnodes;
 
+  // Set this to nil whenever you modify _subnodes
+  NSArray<ASDisplayNode *> *_cachedSubnodes;
+
   ASLayoutElementStyle *_style;
   ASPrimitiveTraitCollection _primitiveTraitCollection;
 


### PR DESCRIPTION
- Remove ASDisplayNode's conformance to NSFastEnumeration
  - We were creating a new copy of subnodes for each chunk of enumeration.
  - The enumerated collection wasn't stable – technically nodes could be deallocated during enumeration under the right circumstances.
- Instead of making a new copy of subnodes each time, just store a cached copy.
- Remove silly `dealloc` line that explicitly nils the ivar.