### PR TITLE
[ASTwoDimensionalArrayUtils] Fix extern C function definition to fix compiler issue.

### DIFF
--- a/Source/Private/ASTwoDimensionalArrayUtils.m
+++ b/Source/Private/ASTwoDimensionalArrayUtils.m
@@ -69,7 +69,7 @@ void ASDeleteElementsInTwoDimensionalArrayAtIndexPaths(NSMutableArray *mutableAr
   }
 }
 
-NSArray *ASIndexPathsForTwoDimensionalArray(NSArray <NSArray *>* twoDimensionalArray)
+NSArray<NSIndexPath *> *ASIndexPathsForTwoDimensionalArray(NSArray <NSArray *>* twoDimensionalArray)
 {
   NSMutableArray *result = [NSMutableArray array];
   NSInteger section = 0;


### PR DESCRIPTION
In some build environments, this causes an error. It seems to be a change since 2.2.