### PR TITLE
[ASTextNode] Move to class method of drawRect:withParameters:isCancelled:isRasterizing: for drawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - Add ASPageTable - A map table for fast retrieval of objects within a certain page [Huy Nguyen](https://github.com/nguyenhuy)
 - [ASDisplayNode] Pass drawParameter in rendering context callbacks [Michael Schneider](https://github.com/maicki)[#248](https://github.com/TextureGroup/Texture/pull/248)
 - [ASTextNode] Move to class method of drawRect:withParameters:isCancelled:isRasterizing: for drawing [Michael Schneider] (https://github.com/maicki)[#232](https://github.com/TextureGroup/Texture/pull/232)
+- [ASDisplayNode] Remove instance:-drawRect:withParameters:isCancelled:isRasterizing: (https://github.com/maicki)[#232](https://github.com/TextureGroup/Texture/pull/232)

--- a/Source/ASDisplayNode+Subclasses.h
+++ b/Source/ASDisplayNode+Subclasses.h
@@ -279,7 +279,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @note Called on the display queue and/or main queue (MUST BE THREAD SAFE)
  */
-+ (void)drawRect:(CGRect)bounds withParameters:(nullable id <NSObject>)parameters
++ (void)drawRect:(CGRect)bounds withParameters:(nullable id)parameters
                                    isCancelled:(AS_NOESCAPE asdisplaynode_iscancelled_block_t)isCancelledBlock
                                  isRasterizing:(BOOL)isRasterizing;
 
@@ -296,7 +296,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @note Called on the display queue and/or main queue (MUST BE THREAD SAFE)
  */
-+ (nullable UIImage *)displayWithParameters:(nullable id<NSObject>)parameters
++ (nullable UIImage *)displayWithParameters:(nullable id)parameters
                                 isCancelled:(AS_NOESCAPE asdisplaynode_iscancelled_block_t)isCancelledBlock;
 
 /**

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -142,11 +142,11 @@ static struct ASDisplayNodeFlags GetASDisplayNodeFlags(Class c, ASDisplayNode *i
   flags.implementsImageDisplay = ([c respondsToSelector:@selector(displayWithParameters:isCancelled:)] ? 1 : 0);
   if (instance) {
     flags.implementsDrawParameters = ([instance respondsToSelector:@selector(drawParametersForAsyncLayer:)] ? 1 : 0);
-    flags.implementsInstanceDrawRect = ([instance respondsToSelector:@selector(drawRect:withParameters:isCancelled:isRasterizing:)] ? 1 : 0);
   } else {
     flags.implementsDrawParameters = ([c instancesRespondToSelector:@selector(drawParametersForAsyncLayer:)] ? 1 : 0);
-    flags.implementsInstanceDrawRect = ([c instancesRespondToSelector:@selector(drawRect:withParameters:isCancelled:isRasterizing:)] ? 1 : 0);
   }
+  
+  
   return flags;
 }
 
@@ -2004,7 +2004,7 @@ NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp = @"AS
 {
   ASDN::MutexLocker l(__instanceLock__);
   
-  return _flags.implementsDrawRect || _flags.implementsImageDisplay || _flags.rasterizesSubtree || _flags.implementsInstanceDrawRect;
+  return _flags.implementsDrawRect || _flags.implementsImageDisplay || _flags.rasterizesSubtree;
 }
 
 // Track that a node will be displayed as part of the current node hierarchy.

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -52,11 +52,6 @@ static const CGFloat ASTextNodeHighlightLightOpacity = 0.11;
 static const CGFloat ASTextNodeHighlightDarkOpacity = 0.22;
 static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncationAttribute";
 
-struct ASTextNodeDrawParameter {
-  CGRect bounds;
-  UIColor *backgroundColor;
-};
-
 #pragma mark - ASTextKitRenderer
 
 @interface ASTextNodeRendererKey : NSObject
@@ -123,6 +118,42 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
   return renderer;
 }
 
+#pragma mark - ASTextNodeDrawParameter
+
+@interface ASTextNodeDrawParameter : NSObject {
+@package
+  ASTextKitAttributes _rendererAttributes;
+  UIColor *_backgroundColor;
+  UIEdgeInsets _textContainerInsets;
+}
+@end
+
+@implementation ASTextNodeDrawParameter
+
+- (instancetype)initWithRendererAttributes:(ASTextKitAttributes)rendererAttributes
+                           backgroundColor:(/*nullable*/ UIColor *)backgroundColor
+                       textContainerInsets:(UIEdgeInsets)textContainerInsets
+{
+  self = [super init];
+  if (self != nil) {
+    _rendererAttributes = rendererAttributes;
+    _backgroundColor = backgroundColor;
+    _textContainerInsets = textContainerInsets;
+  }
+  return self;
+}
+
+- (ASTextKitRenderer *)rendererForBounds:(CGRect)bounds
+{
+  CGRect rect = UIEdgeInsetsInsetRect(bounds, _textContainerInsets);
+  return rendererForAttributes(_rendererAttributes, rect.size);
+}
+
+@end
+
+
+#pragma mark - ASTextNode
+
 @interface ASTextNode () <UIGestureRecognizerDelegate>
 
 @end
@@ -147,23 +178,9 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
   NSRange _highlightRange;
   ASHighlightOverlayLayer *_activeHighlightLayer;
 
-  ASTextNodeDrawParameter _drawParameter;
-
   UILongPressGestureRecognizer *_longPressGestureRecognizer;
 }
 @dynamic placeholderEnabled;
-
-#pragma mark - NSObject
-
-+ (void)initialize
-{
-  [super initialize];
-  
-  if (self != [ASTextNode class]) {
-    // Prevent custom drawing in subclasses
-    ASDisplayNodeAssert(!ASSubclassOverridesClassSelector([ASTextNode class], self, @selector(drawRect:withParameters:isCancelled:isRasterizing:)), @"Subclass %@ must not override drawRect:withParameters:isCancelled:isRasterizing: method. Custom drawing in %@ subclass is not supported.", NSStringFromClass(self), NSStringFromClass([ASTextNode class]));
-  }
-}
 
 static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
@@ -294,23 +311,29 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
 - (ASTextKitRenderer *)_renderer
 {
-  CGSize constrainedSize = self.threadSafeBounds.size;
-  return [self _rendererWithBoundsSlow:{.size = constrainedSize}];
+  ASDN::MutexLocker l(__instanceLock__);
+  return [self _locked_renderer];
 }
 
-- (ASTextKitRenderer *)_rendererWithBoundsSlow:(CGRect)bounds
+- (ASTextKitRenderer *)_rendererWithBounds:(CGRect)bounds
 {
   ASDN::MutexLocker l(__instanceLock__);
-  bounds.size.width -= (_textContainerInset.left + _textContainerInset.right);
-  bounds.size.height -= (_textContainerInset.top + _textContainerInset.bottom);
-  return rendererForAttributes([self _rendererAttributes], bounds.size);
+  return [self _locked_rendererWithBounds:bounds];
 }
 
-
-- (ASTextKitAttributes)_rendererAttributes
+- (ASTextKitRenderer *)_locked_renderer
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  
+  return [self _locked_rendererWithBounds:[self _locked_threadSafeBounds]];
+}
+
+- (ASTextKitRenderer *)_locked_rendererWithBounds:(CGRect)bounds
+{
+  bounds = UIEdgeInsetsInsetRect(bounds, _textContainerInset);
+  return rendererForAttributes([self _locked_rendererAttributes], bounds.size);
+}
+
+- (ASTextKitAttributes)_locked_rendererAttributes
+{
   return {
     .attributedString = _attributedText,
     .truncationAttributedString = [self _locked_composedTruncationText],
@@ -360,7 +383,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
   [self setNeedsDisplay];
   
-  ASTextKitRenderer *renderer = [self _rendererWithBoundsSlow:{.size = constrainedSize}];
+  ASTextKitRenderer *renderer = [self _locked_rendererWithBounds:{.size = constrainedSize}];
   CGSize size = renderer.size;
   if (_attributedText.length > 0) {
     self.style.ascender = [[self class] ascenderWithAttributedString:_attributedText];
@@ -475,30 +498,23 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 {
   ASDN::MutexLocker l(__instanceLock__);
   
-  _drawParameter = {
-    .backgroundColor = self.backgroundColor,
-    .bounds = self.bounds
-  };
-  return nil;
+  return [[ASTextNodeDrawParameter alloc] initWithRendererAttributes:[self _locked_rendererAttributes]
+                                                     backgroundColor:self.backgroundColor
+                                                 textContainerInsets:_textContainerInset];
 }
 
-
-- (void)drawRect:(CGRect)bounds withParameters:(id <NSObject>)p isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
++ (void)drawRect:(CGRect)bounds withParameters:(id)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing
 {
-  ASDN::MutexLocker l(__instanceLock__);
-
-  ASTextNodeDrawParameter drawParameter = _drawParameter;
-  CGRect drawParameterBounds = drawParameter.bounds;
-  UIColor *backgroundColor = isRasterizing ? nil : drawParameter.backgroundColor;
+  ASTextNodeDrawParameter *drawParameter = (ASTextNodeDrawParameter *)parameters;
+  UIColor *backgroundColor = (isRasterizing || drawParameter == nil) ? nil : drawParameter->_backgroundColor;
+  UIEdgeInsets textContainerInsets = drawParameter ? drawParameter->_textContainerInsets : UIEdgeInsetsZero;
+  ASTextKitRenderer *renderer = [drawParameter rendererForBounds:bounds];
   
   CGContextRef context = UIGraphicsGetCurrentContext();
   ASDisplayNodeAssert(context, @"This is no good without a context.");
-  
+ 
   CGContextSaveGState(context);
-  
-  CGContextTranslateCTM(context, _textContainerInset.left, _textContainerInset.top);
-  
-  ASTextKitRenderer *renderer = [self _rendererWithBoundsSlow:drawParameterBounds];
+  CGContextTranslateCTM(context, textContainerInsets.left, textContainerInsets.top);
   
   // Fill background
   if (backgroundColor != nil) {
@@ -507,8 +523,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   }
   
   // Draw text
-  [renderer drawInContext:context bounds:drawParameterBounds];
-  
+  [renderer drawInContext:context bounds:bounds];
   CGContextRestoreGState(context);
 }
 
@@ -535,7 +550,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   
   ASDN::MutexLocker l(__instanceLock__);
   
-  ASTextKitRenderer *renderer = [self _renderer];
+  ASTextKitRenderer *renderer = [self _locked_renderer];
   NSRange visibleRange = renderer.firstVisibleRange;
   NSAttributedString *attributedString = _attributedText;
   NSRange clampedRange = NSIntersectionRange(visibleRange, NSMakeRange(0, attributedString.length));
@@ -841,7 +856,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
 {
   ASDN::MutexLocker l(__instanceLock__);
   
-  NSArray *rects = [[self _renderer] rectsForTextRange:textRange measureOption:measureOption];
+  NSArray *rects = [[self _locked_renderer] rectsForTextRange:textRange measureOption:measureOption];
   NSMutableArray *adjustedRects = [NSMutableArray array];
 
   for (NSValue *rectValue in rects) {
@@ -859,7 +874,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
 {
   ASDN::MutexLocker l(__instanceLock__);
   
-  CGRect rect = [[self _renderer] trailingRect];
+  CGRect rect = [[self _locked_renderer] trailingRect];
   return ASTextNodeAdjustRenderRectForShadowPadding(rect, self.shadowPadding);
 }
 
@@ -867,7 +882,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
 {
   ASDN::MutexLocker l(__instanceLock__);
   
-  CGRect frame = [[self _renderer] frameForTextRange:textRange];
+  CGRect frame = [[self _locked_renderer] frameForTextRange:textRange];
   return ASTextNodeAdjustRenderRectForShadowPadding(frame, self.shadowPadding);
 }
 
@@ -897,7 +912,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   UIGraphicsBeginImageContext(size);
   [self.placeholderColor setFill];
 
-  ASTextKitRenderer *renderer = [self _renderer];
+  ASTextKitRenderer *renderer = [self _locked_renderer];
   NSRange visibleRange = renderer.firstVisibleRange;
 
   // cap height is both faster and creates less subpixel blending
@@ -975,7 +990,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
     NSRange visibleRange = NSMakeRange(0, 0);
     {
       ASDN::MutexLocker l(__instanceLock__);
-      visibleRange = [self _renderer].firstVisibleRange;
+      visibleRange = [self _locked_renderer].firstVisibleRange;
     }
     NSRange truncationMessageRange = [self _additionalTruncationMessageRangeWithVisibleRange:visibleRange];
     [self _setHighlightRange:truncationMessageRange forAttributeName:ASTextNodeTruncationTokenAttributeName value:nil animated:YES];
@@ -1158,14 +1173,8 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
 
 - (UIEdgeInsets)shadowPadding
 {
-  return [self shadowPaddingWithRenderer:[self _renderer]];
-}
-
-- (UIEdgeInsets)shadowPaddingWithRenderer:(ASTextKitRenderer *)renderer
-{
   ASDN::MutexLocker l(__instanceLock__);
-  
-  return renderer.shadower.shadowPadding;
+  return [self _locked_renderer].shadower.shadowPadding;
 }
 
 #pragma mark - Truncation Message
@@ -1229,8 +1238,7 @@ static NSAttributedString *DefaultTruncationAttributedString()
 {
   ASDN::MutexLocker l(__instanceLock__);
   
-  ASTextKitRenderer *renderer = [self _renderer];
-  return renderer.isTruncated;
+  return [[self _locked_renderer] isTruncated];
 }
 
 - (void)setPointSizeScaleFactors:(NSArray *)pointSizeScaleFactors
@@ -1266,7 +1274,7 @@ static NSAttributedString *DefaultTruncationAttributedString()
 {
   ASDN::MutexLocker l(__instanceLock__);
   
-  return [[self _renderer] lineCount];
+  return [[self _locked_renderer] lineCount];
 }
 
 #pragma mark - Truncation Message

--- a/Source/Details/_ASDisplayLayer.h
+++ b/Source/Details/_ASDisplayLayer.h
@@ -109,7 +109,7 @@
  @param isCancelledBlock Execute this block to check whether the current drawing operation has been cancelled to avoid unnecessary work. A return value of YES means cancel drawing and return.
  @param isRasterizing YES if the layer is being rasterized into another layer, in which case drawRect: probably wants to avoid doing things like filling its bounds with a zero-alpha color to clear the backing store.
  */
-+ (void)drawRect:(CGRect)bounds withParameters:(id<NSObject>)parameters isCancelled:(AS_NOESCAPE asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
++ (void)drawRect:(CGRect)bounds withParameters:(id)parameters isCancelled:(AS_NOESCAPE asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
 
 /**
  @summary Delegate override to provide new layer contents as a UIImage.
@@ -118,12 +118,6 @@
  @return A UIImage with contents that are ready to display on the main thread. Make sure that the image is already decoded before returning it here.
  */
 + (UIImage *)displayWithParameters:(id<NSObject>)parameters isCancelled:(AS_NOESCAPE asdisplaynode_iscancelled_block_t)isCancelledBlock;
-
-/**
- * @abstract instance version of drawRect class method
- * @see drawRect:withParameters:isCancelled:isRasterizing class method
- */
-- (void)drawRect:(CGRect)bounds withParameters:(id <NSObject>)parameters isCancelled:(AS_NOESCAPE asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
 
 // Called on the main thread only
 

--- a/Source/Private/ASDefaultPlayButton.m
+++ b/Source/Private/ASDefaultPlayButton.m
@@ -31,7 +31,7 @@
   return self;
 }
 
-+ (void)drawRect:(CGRect)bounds withParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing
++ (void)drawRect:(CGRect)bounds withParameters:(id)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing
 {
   CGFloat originX = bounds.size.width/4;
   CGRect buttonBounds = CGRectMake(originX, bounds.size.height/4, bounds.size.width/2, bounds.size.height/2);

--- a/Source/Private/ASDefaultPlaybackButton.m
+++ b/Source/Private/ASDefaultPlaybackButton.m
@@ -54,7 +54,7 @@
   };
 }
 
-+ (void)drawRect:(CGRect)bounds withParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing
++ (void)drawRect:(CGRect)bounds withParameters:(id)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing
 {
   ASDefaultPlaybackButtonType buttonType = (ASDefaultPlaybackButtonType)[parameters[@"buttonType"] intValue];
   UIColor *color = parameters[@"color"];

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -170,9 +170,8 @@
   // We always create a graphics context, unless a -display method is used, OR if we are a subnode drawing into a rasterized parent.
   BOOL shouldCreateGraphicsContext = (flags.implementsImageDisplay == NO && rasterizing == NO);
   BOOL shouldBeginRasterizing = (rasterizing == NO && flags.rasterizesSubtree);
-  BOOL usesInstanceMethodDisplay = (flags.implementsInstanceDrawRect);
-  BOOL usesImageDisplay = (flags.implementsImageDisplay);
-  BOOL usesDrawRect = (flags.implementsDrawRect || flags.implementsInstanceDrawRect);
+  BOOL usesImageDisplay = flags.implementsImageDisplay;
+  BOOL usesDrawRect = flags.implementsDrawRect;
   
   if (usesImageDisplay == NO && usesDrawRect == NO && shouldBeginRasterizing == NO) {
     // Early exit before requesting more expensive properties like bounds and opaque from the layer.
@@ -195,8 +194,6 @@
   }
   
   ASDisplayNodeAssert(contentsScaleForDisplay != 0.0, @"Invalid contents scale");
-  ASDisplayNodeAssert(usesInstanceMethodDisplay == NO || (flags.implementsDrawRect == NO && flags.implementsImageDisplay == NO),
-                      @"Node %@ should not implement both class and instance method display or draw", self);
   ASDisplayNodeAssert(rasterizing || !(_hierarchyState & ASHierarchyStateRasterized),
                       @"Rasterized descendants should never display unless being drawn into the rasterized container.");
 
@@ -254,15 +251,10 @@
         willDisplayNodeContentWithRenderingContext(currentContext, drawParameters);
       }
       
-      // Decide if we use a class or instance method to draw or display.
-      id object = usesInstanceMethodDisplay ? self : [self class];
-      
       if (usesImageDisplay) {                                   // If we are using a display method, we'll get an image back directly.
-        image = [object displayWithParameters:drawParameters
-                                  isCancelled:isCancelledBlock];
+        image = [self.class displayWithParameters:drawParameters isCancelled:isCancelledBlock];
       } else if (usesDrawRect) {                                // If we're using a draw method, this will operate on the currentContext.
-        [object drawRect:bounds withParameters:drawParameters
-             isCancelled:isCancelledBlock isRasterizing:rasterizing];
+        [self.class drawRect:bounds withParameters:drawParameters isCancelled:isCancelledBlock isRasterizing:rasterizing];
       }
       
       if (didDisplayNodeContentWithRenderingContext != nil) {

--- a/Source/Private/ASDisplayNode+FrameworkPrivate.h
+++ b/Source/Private/ASDisplayNode+FrameworkPrivate.h
@@ -123,6 +123,8 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyState(ASHierarchyStat
 
 // Thread safe way to access the bounds of the node
 @property (nonatomic, assign) CGRect threadSafeBounds;
+
+// Returns the bounds of the node without reaching the view or layer
 - (CGRect)_locked_threadSafeBounds;
 
 // delegate to inform of ASInterfaceState changes (used by ASNodeController)

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -107,8 +107,6 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
     // methods at all instead it throws away the contents of the layer and nothing will show up.
     unsigned canCallSetNeedsDisplayOfLayer:1;
 
-    // whether custom drawing is enabled
-    unsigned implementsInstanceDrawRect:1;
     unsigned implementsDrawRect:1;
     unsigned implementsImageDisplay:1;
     unsigned implementsDrawParameters:1;


### PR DESCRIPTION
In our effort going forward to make the framework safer to work with and to enable future optimizations like lifting up caching into a generalized way out of `ASImageNode` and `ASTextNode` specific ways this PR will remove the instance version of `drawRect:withParameters:isCancelled:isRasterizing:` in favor of using the class method.