### PR TITLE
[ASDimension] Remove warning about float precision using CGFloat and … #trivial

### DIFF
--- a/Source/Layout/ASDimension.h
+++ b/Source/Layout/ASDimension.h
@@ -239,7 +239,7 @@ extern ASSizeRange const ASSizeRangeUnconstrained;
  */
 ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT BOOL ASSizeRangeHasSignificantArea(ASSizeRange sizeRange)
 {
-  static CGFloat const limit = 0.1;
+  static CGFloat const limit = 0.1f;
   return (sizeRange.max.width > limit && sizeRange.max.height > limit);
 }
 


### PR DESCRIPTION
Remove the warning which appears when we build framework.
We were trying to build a static CGFloat assigning a Double.
