### PR TITLE
[Examples] Tweak Kittens app with demo of an interesting layout case.

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3934,11 +3934,13 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
     [result addObject:@{ @"alpha" : @(_pendingViewState.alpha) }];
     [result addObject:@{ @"frame" : [NSValue valueWithCGRect:_pendingViewState.frame] }];
   }
-  
-  // Check supernode so that if we are cell node we don't find self.
-  ASCellNode *cellNode = ASDisplayNodeFindFirstSupernodeOfClass(self.supernode, [ASCellNode class]);
-  if (cellNode != nil) {
-    [result addObject:@{ @"cellNode" : ASObjectDescriptionMakeTiny(cellNode) }];
+
+  if (ASDisplayNodeThreadIsMain()) {
+    // Check supernode so that if we are cell node we don't find self.
+    ASCellNode *cellNode = ASDisplayNodeFindFirstSupernodeOfClass(self.supernode, [ASCellNode class]);
+    if (cellNode != nil) {
+      [result addObject:@{ @"cellNode" : ASObjectDescriptionMakeTiny(cellNode) }];
+    }
   }
   
   [result addObject:@{ @"interfaceState" : NSStringFromASInterfaceState(self.interfaceState)} ];

--- a/examples/Kittens/Sample/KittenNode.mm
+++ b/examples/Kittens/Sample/KittenNode.mm
@@ -35,6 +35,7 @@ static const CGFloat kInnerPadding = 10.0f;
   
   ASNetworkImageNode *_imageNode;
   ASTextNode *_textNode;
+  ASDisplayNode *_separator;
   ASDisplayNode *_divider;
   BOOL _isImageEnlarged;
   BOOL _swappedTextAndImage;
@@ -101,7 +102,12 @@ static const CGFloat kInnerPadding = 10.0f;
   _textNode = [[ASTextNode alloc] init];
   _textNode.attributedText = [[NSAttributedString alloc] initWithString:[self kittyIpsum] attributes:[self textStyle]];
   [self addSubnode:_textNode];
-  
+
+  // hairline vertical divider
+  _separator = [[ASDisplayNode alloc] init];
+  _separator.backgroundColor = [UIColor grayColor];
+  [self addSubnode:_separator];
+
   // hairline cell separator
   _divider = [[ASDisplayNode alloc] init];
   _divider.backgroundColor = [UIColor lightGrayColor];
@@ -151,6 +157,10 @@ static const CGFloat kInnerPadding = 10.0f;
   // Shrink the text node in case the image + text gonna be too wide
   _textNode.style.flexShrink = 1.0;
 
+  // Vertical separator between image and text - match height of the tallest item in the stack.
+  _separator.style.flexBasis = ASDimensionMake(1.0);
+  _separator.style.alignSelf = ASStackLayoutAlignSelfStretch;
+
   // Configure stack
   ASStackLayoutSpec *stackLayoutSpec =
   [ASStackLayoutSpec
@@ -158,7 +168,7 @@ static const CGFloat kInnerPadding = 10.0f;
    spacing:kInnerPadding
    justifyContent:ASStackLayoutJustifyContentStart
    alignItems:ASStackLayoutAlignItemsStart
-   children:_swappedTextAndImage ? @[_textNode, _imageNode] : @[_imageNode, _textNode]];
+   children:_swappedTextAndImage ? @[_textNode, _separator, _imageNode] : @[_imageNode, _separator, _textNode]];
   
   // Add inset
   return [ASInsetLayoutSpec


### PR DESCRIPTION
(Ignore the change to ASDisplayNode - it's included here because it addresses an assertion triggered when running this code).

This layout behaves correctly / works as desired in production. However, during specifically the unconstrained / unpositioned initial pass of the stack, it encounters an infinite "parentSize" and triggers a warning.

I've thought about this quite a bit and tried a bunch of things, but haven't found a correct way to provide more specification on the layout to avoid this warning. Looking for advice on how to easily implement this. I think we might need to adjust the warning to not occur in the case of an item with alignSelf = stretch inside a stack.

Here's what the UI looks like, displaying correctly below. But the warning message here is always shown. Normally this warning is shown only when things will truly end up being zero sized, and makes sense to show for those cases. However in cases where the layout ends up being correct, it is misleading.

`2017-05-04 22:36:56.335 Sample[90753:3568319] Cannot calculate size of node: constrainedSize is infinite and node does not override -calculateSizeThatFits: or specify a preferredSize. Try setting style.preferredSize. Node: <ASDisplayNode: 0x7ff879c51620; alpha = 1; frame = (0 0; 0 0); interfaceState = { No state }; viewClass = _ASDisplayView>
`

![kittennode alignselfstretch separator line](https://cloud.githubusercontent.com/assets/565251/25734630/dd242816-3119-11e7-9074-21e2979278e4.png)
