### PR TITLE
[ASImageNode] Move to class method of displayWithParameters:isCancelled: for drawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - Remove finalLayoutElement [Michael Schneider] (https://github.com/maicki)[#96](https://github.com/TextureGroup/Texture/pull/96)
 - Add ASPageTable - A map table for fast retrieval of objects within a certain page [Huy Nguyen](https://github.com/nguyenhuy)
 - [ASDisplayNode] Pass drawParameter in rendering context callbacks [Michael Schneider](https://github.com/maicki)[#248](https://github.com/TextureGroup/Texture/pull/248)
+- [ASTextNode] Move to class method of drawRect:withParameters:isCancelled:isRasterizing: for drawing [Michael Schneider] (https://github.com/maicki)[#232](https://github.com/TextureGroup/Texture/pull/232)

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -143,11 +143,9 @@ static struct ASDisplayNodeFlags GetASDisplayNodeFlags(Class c, ASDisplayNode *i
   if (instance) {
     flags.implementsDrawParameters = ([instance respondsToSelector:@selector(drawParametersForAsyncLayer:)] ? 1 : 0);
     flags.implementsInstanceDrawRect = ([instance respondsToSelector:@selector(drawRect:withParameters:isCancelled:isRasterizing:)] ? 1 : 0);
-    flags.implementsInstanceImageDisplay = ([instance respondsToSelector:@selector(displayWithParameters:isCancelled:)] ? 1 : 0);
   } else {
     flags.implementsDrawParameters = ([c instancesRespondToSelector:@selector(drawParametersForAsyncLayer:)] ? 1 : 0);
     flags.implementsInstanceDrawRect = ([c instancesRespondToSelector:@selector(drawRect:withParameters:isCancelled:isRasterizing:)] ? 1 : 0);
-    flags.implementsInstanceImageDisplay = ([c instancesRespondToSelector:@selector(displayWithParameters:isCancelled:)] ? 1 : 0);
   }
   return flags;
 }
@@ -832,6 +830,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 - (CGRect)threadSafeBounds
 {
   ASDN::MutexLocker l(__instanceLock__);
+  return _threadSafeBounds;
+}
+
+- (CGRect)_locked_threadSafeBounds
+{
   return _threadSafeBounds;
 }
 
@@ -2001,8 +2004,7 @@ NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp = @"AS
 {
   ASDN::MutexLocker l(__instanceLock__);
   
-  return _flags.implementsDrawRect || _flags.implementsImageDisplay || _flags.rasterizesSubtree ||
-  _flags.implementsInstanceDrawRect || _flags.implementsInstanceImageDisplay;
+  return _flags.implementsDrawRect || _flags.implementsImageDisplay || _flags.rasterizesSubtree || _flags.implementsInstanceDrawRect;
 }
 
 // Track that a node will be displayed as part of the current node hierarchy.

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -830,7 +830,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 - (CGRect)threadSafeBounds
 {
   ASDN::MutexLocker l(__instanceLock__);
-  return _threadSafeBounds;
+  return [self _locked_threadSafeBounds];
 }
 
 - (CGRect)_locked_threadSafeBounds

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -148,7 +148,6 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
   void (^_displayCompletionBlock)(BOOL canceled);
   
   // Drawing
-  //ASImageNodeDrawParameters _drawParameter;
   ASTextNode *_debugLabelNode;
   
   // Cropping.
@@ -439,8 +438,6 @@ static ASDN::Mutex cacheLock;
     }
     ASWeakMapEntry *entry = [cache entryForKey:key];
     if (entry != nil) {
-      // cache hit
-        NSLog(@"cache hit");
       return entry;
     }
   }

--- a/Source/Details/_ASDisplayLayer.h
+++ b/Source/Details/_ASDisplayLayer.h
@@ -125,12 +125,6 @@
  */
 - (void)drawRect:(CGRect)bounds withParameters:(id <NSObject>)parameters isCancelled:(AS_NOESCAPE asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
 
-/**
- * @abstract instance version of display class method
- * @see displayWithParameters:isCancelled class method
- */
-- (UIImage *)displayWithParameters:(id <NSObject>)parameters isCancelled:(AS_NOESCAPE asdisplaynode_iscancelled_block_t)isCancelled;
-
 // Called on the main thread only
 
 /**

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -168,10 +168,10 @@
   flags = _flags;
   
   // We always create a graphics context, unless a -display method is used, OR if we are a subnode drawing into a rasterized parent.
-  BOOL shouldCreateGraphicsContext = (flags.implementsInstanceImageDisplay == NO && flags.implementsImageDisplay == NO && rasterizing == NO);
+  BOOL shouldCreateGraphicsContext = (flags.implementsImageDisplay == NO && rasterizing == NO);
   BOOL shouldBeginRasterizing = (rasterizing == NO && flags.rasterizesSubtree);
-  BOOL usesInstanceMethodDisplay = (flags.implementsInstanceDrawRect || flags.implementsInstanceImageDisplay);
-  BOOL usesImageDisplay = (flags.implementsImageDisplay || flags.implementsInstanceImageDisplay);
+  BOOL usesInstanceMethodDisplay = (flags.implementsInstanceDrawRect);
+  BOOL usesImageDisplay = (flags.implementsImageDisplay);
   BOOL usesDrawRect = (flags.implementsDrawRect || flags.implementsInstanceDrawRect);
   
   if (usesImageDisplay == NO && usesDrawRect == NO && shouldBeginRasterizing == NO) {

--- a/Source/Private/ASDisplayNode+FrameworkPrivate.h
+++ b/Source/Private/ASDisplayNode+FrameworkPrivate.h
@@ -123,6 +123,7 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyState(ASHierarchyStat
 
 // Thread safe way to access the bounds of the node
 @property (nonatomic, assign) CGRect threadSafeBounds;
+- (CGRect)_locked_threadSafeBounds;
 
 // delegate to inform of ASInterfaceState changes (used by ASNodeController)
 @property (nonatomic, weak) id<ASInterfaceStateDelegate> interfaceStateDelegate;

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -110,7 +110,6 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
     // whether custom drawing is enabled
     unsigned implementsInstanceDrawRect:1;
     unsigned implementsDrawRect:1;
-    unsigned implementsInstanceImageDisplay:1;
     unsigned implementsImageDisplay:1;
     unsigned implementsDrawParameters:1;
 


### PR DESCRIPTION
In our effort going forward to make the framework safer to work with and to enable future optimizations like lifting up caching into a generalized way out of ASImageNode and ASTextNode specific ways this PR will remove the instance version of displayWithParameters:isCancelled: in favor of using the class method.