### PR TITLE
Assert only once we know URL has changed

### DIFF
--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -165,13 +165,13 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   {
     ASDN::MutexLocker l(__instanceLock__);
     
-    ASDisplayNodeAssert(_imageWasSetExternally == NO, @"Setting a URL to an ASNetworkImageNode after setting an image changes its behavior from an ASImageNode to an ASNetworkImageNode. If this is what you want, set the image to nil first.");
-    
-    _imageWasSetExternally = NO;
-    
     if (ASObjectIsEqual(URL, _URL)) {
       return;
     }
+    
+    ASDisplayNodeAssert(_imageWasSetExternally == NO, @"Setting a URL to an ASNetworkImageNode after setting an image changes its behavior from an ASImageNode to an ASNetworkImageNode. If this is what you want, set the image to nil first.");
+    
+    _imageWasSetExternally = NO;
     
     [self _locked_cancelImageDownloadWithResumePossibility:NO];
 


### PR DESCRIPTION
We need this in case someone is setting the URL to nil before setting
the image directly. I.e. they have a node which has been used as a network
node or an image node but now they want it to be an image node.

They should then set the URL to nil and then set the image.
*if* it was used as a network node previously, this would work.
If it was previously used as an image node it would historically assert.
This addresses that.