### PR TITLE
[ASDisplayNode] Pass drawParameter in rendering context callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Move more properties from ASTableView, ASCollectionView to their respective node classes. [Adlai Holler](https://github.com/Adlai-Holler)
 - Remove finalLayoutElement [Michael Schneider] (https://github.com/maicki)[#96](https://github.com/TextureGroup/Texture/pull/96)
 - Add ASPageTable - A map table for fast retrieval of objects within a certain page [Huy Nguyen](https://github.com/nguyenhuy)
+- [ASDisplayNode] Pass drawParameter in rendering context callbacks [Michael Schneider](https://github.com/maicki)[#248](https://github.com/TextureGroup/Texture/pull/248)

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -56,7 +56,7 @@ typedef void (^ASDisplayNodeDidLoadBlock)(__kindof ASDisplayNode * node);
 /**
  * ASDisplayNode will / did render node content in context.
  */
-typedef void (^ASDisplayNodeContextModifier)(CGContextRef context);
+typedef void (^ASDisplayNodeContextModifier)(CGContextRef context, id _Nullable drawParameters);
 
 /**
  * ASDisplayNode layout spec block. This block can be used instead of implementing layoutSpecThatFits: in subclass

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -251,7 +251,7 @@
       // For -display methods, we don't have a context, and thus will not call the _willDisplayNodeContentWithRenderingContext or
       // _didDisplayNodeContentWithRenderingContext blocks. It's up to the implementation of -display... to do what it needs.
       if (willDisplayNodeContentWithRenderingContext != nil) {
-        willDisplayNodeContentWithRenderingContext(currentContext);
+        willDisplayNodeContentWithRenderingContext(currentContext, drawParameters);
       }
       
       // Decide if we use a class or instance method to draw or display.
@@ -266,7 +266,7 @@
       }
       
       if (didDisplayNodeContentWithRenderingContext != nil) {
-        didDisplayNodeContentWithRenderingContext(currentContext);
+        didDisplayNodeContentWithRenderingContext(currentContext, drawParameters);
       }
       
       if (shouldCreateGraphicsContext) {

--- a/examples/LayoutSpecExamples-Swift/Sample/LayoutExampleNode.swift
+++ b/examples/LayoutSpecExamples-Swift/Sample/LayoutExampleNode.swift
@@ -74,7 +74,7 @@ class PhotoWithInsetTextOverlay : LayoutExampleNode {
     backgroundColor = .clear
 
     photoNode.url = URL(string: "http://asyncdisplaykit.org/static/images/layout-examples-photo-with-inset-text-overlay-photo.png")
-    photoNode.willDisplayNodeContentWithRenderingContext = { context in
+    photoNode.willDisplayNodeContentWithRenderingContext = { context, drawParameters in
       let bounds = context.boundingBoxOfClipPath
       UIBezierPath(roundedRect: bounds, cornerRadius: 10).addClip()
     }

--- a/examples/LayoutSpecExamples/Sample/LayoutExampleNodes.m
+++ b/examples/LayoutSpecExamples/Sample/LayoutExampleNodes.m
@@ -125,7 +125,7 @@
     
     _photoNode = [[ASNetworkImageNode alloc] init];
     _photoNode.URL = [NSURL URLWithString:@"http://asyncdisplaykit.org/static/images/layout-examples-photo-with-inset-text-overlay-photo.png"];
-    _photoNode.willDisplayNodeContentWithRenderingContext = ^(CGContextRef context) {
+    _photoNode.willDisplayNodeContentWithRenderingContext = ^(CGContextRef context, id drawParameters) {
       CGRect bounds = CGContextGetClipBoundingBox(context);
       [[UIBezierPath bezierPathWithRoundedRect:bounds cornerRadius:10] addClip];
     };


### PR DESCRIPTION
The reasoning for this change is that developers came up with all kinds of interesting ideas how to use properties in the `ASDisplayNodeContextModifier` blocks as it's running on non main properties like `backgroundColor` is not accessible. It is possible to access this properties on the main thread though and as we know `drawParametersForAsyncLayer` is called on main, developers can store this kind of properties within the draw parameters and use this in the `ASDisplayNodeContextModifier` blocks. To be able to do that we actually have to pass them in what this PR is planning to do.

This is basically an API breakage change and I'm happy to change if we would like to deprecate the old API and move over to this one, but as `willDisplayNodeContentWithRenderingContext` and `didDisplayNodeContentWithRenderingContext` is in the beta header I don't think we have to worry too much, furthermore it's not too hard to change to the new `ASDisplayNodeContextModifier` block as it's just adding a parameter. 