### PR TITLE
[ASTextKitFontSizeAdjuster] Replace use of boundingRectWithSize:options:context: with boundingRectForGlyphRange: inTextContainer:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this with your name.
+- [ASTextKitFontSizeAdjuster] [Ricky Cancro] Replace use of NSAttributedString's boundingRectWithSize:options:context: with NSLayoutManager's boundingRectForGlyphRange:inTextContainer:
 - Add support for IGListKit post-removal-of-IGListSectionType, in preparation for IGListKit 3.0.0 release. [Adlai Holler](https://github.com/Adlai-Holler) [#49](https://github.com/TextureGroup/Texture/pull/49)
 - Fix `__has_include` check in ASLog.h [Philipp Smorygo](Philipp.Smorygo@jetbrains.com)
 - Fix potential deadlock in ASControlNode [Garrett Moon](https://github.com/garrettmoon)


### PR DESCRIPTION

`boundingRectWithSize:options:context:`  started returning different values for the same strings between iOS 10.2 and iOS 10.3. Switching to using `NSLayoutManager`’s `boundingRectForGlyphRange: inTextContainer:` fixed this. It also makes sure we are consistent with what `ASTextKitTailTruncater` uses.