### PR TITLE
Simplify Override Checking, Only Do It When Assertions Are Enabled #trivial

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -188,10 +188,9 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   return overrides;
 }
 
+#if ASDISPLAYNODE_ASSERTIONS_ENABLED
 + (void)initialize
 {
-  [super initialize];
-  
   if (self != [ASDisplayNode class]) {
     
     // Subclasses should never override these. Use unused to prevent warnings
@@ -228,8 +227,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
   class_replaceMethod(self, @selector(_staticInitialize), staticInitialize, "v:@");
   
-  
-#if DEBUG
+
   // Check if subnodes where modified during the creation of the layout
   if (self == [ASDisplayNode class]) {
     __block IMP originalLayoutSpecThatFitsIMP = ASReplaceMethodWithBlock(self, @selector(_locked_layoutElementThatFits:), ^(ASDisplayNode *_self, ASSizeRange sizeRange) {
@@ -243,9 +241,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
       return layoutElement;
     });
   }
-#endif
-
 }
+#endif
 
 + (void)load
 {

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -118,6 +118,8 @@ _ASPendingState *ASDisplayNodeGetPendingState(ASDisplayNode *node)
   return result;
 }
 
+#if ASDISPLAYNODE_ASSERTIONS_ENABLED
+
 /**
  *  Returns ASDisplayNodeFlags for the given class/instance. instance MAY BE NIL.
  *
@@ -188,7 +190,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   return overrides;
 }
 
-#if ASDISPLAYNODE_ASSERTIONS_ENABLED
 + (void)initialize
 {
   if (self != [ASDisplayNode class]) {

--- a/Source/Private/ASInternalHelpers.m
+++ b/Source/Private/ASInternalHelpers.m
@@ -30,9 +30,7 @@ BOOL ASSubclassOverridesSelector(Class superclass, Class subclass, SEL selector)
   if (superclass == subclass) return NO; // Even if the class implements the selector, it doesn't override itself.
   Method superclassMethod = class_getInstanceMethod(superclass, selector);
   Method subclassMethod = class_getInstanceMethod(subclass, selector);
-  IMP superclassIMP = superclassMethod ? method_getImplementation(superclassMethod) : NULL;
-  IMP subclassIMP = subclassMethod ? method_getImplementation(subclassMethod) : NULL;
-  return (superclassIMP != subclassIMP);
+  return (superclassMethod != subclassMethod);
 }
 
 BOOL ASSubclassOverridesClassSelector(Class superclass, Class subclass, SEL selector)
@@ -40,9 +38,7 @@ BOOL ASSubclassOverridesClassSelector(Class superclass, Class subclass, SEL sele
   if (superclass == subclass) return NO; // Even if the class implements the selector, it doesn't override itself.
   Method superclassMethod = class_getClassMethod(superclass, selector);
   Method subclassMethod = class_getClassMethod(subclass, selector);
-  IMP superclassIMP = superclassMethod ? method_getImplementation(superclassMethod) : NULL;
-  IMP subclassIMP = subclassMethod ? method_getImplementation(subclassMethod) : NULL;
-  return (superclassIMP != subclassIMP);
+  return (superclassMethod != subclassMethod);
 }
 
 IMP ASReplaceMethodWithBlock(Class c, SEL origSEL, id block)


### PR DESCRIPTION
A quickie.

- Remove call to `[super initialize]`. The runtime will traverse the class hierarchy for us.
- Only run the override checking code when assertions are enabled.
- Check `Method != Method` rather than `IMP != IMP` because it's faster and simpler.