### PR TITLE
added error reporting callback to ASVideoNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
 - [ASDisplayNode] Pass drawParameter in rendering context callbacks [Michael Schneider](https://github.com/maicki)[#248](https://github.com/TextureGroup/Texture/pull/248)
 - [ASTextNode] Move to class method of drawRect:withParameters:isCancelled:isRasterizing: for drawing [Michael Schneider] (https://github.com/maicki)[#232](https://github.com/TextureGroup/Texture/pull/232)
 - [ASDisplayNode] Remove instance:-drawRect:withParameters:isCancelled:isRasterizing: (https://github.com/maicki)[#232](https://github.com/TextureGroup/Texture/pull/232)
+- [ASVideoNode] Added error reporing to ASVideoNode and it's delegate [#260](https://github.com/TextureGroup/Texture/pull/260)

--- a/Source/ASVideoNode.h
+++ b/Source/ASVideoNode.h
@@ -21,14 +21,14 @@
 @protocol ASVideoNodeDelegate;
 
 typedef NS_ENUM(NSInteger, ASVideoNodePlayerState) {
-  ASVideoNodePlayerStateUnknown,
-  ASVideoNodePlayerStateInitialLoading,
-  ASVideoNodePlayerStateReadyToPlay,
-  ASVideoNodePlayerStatePlaybackLikelyToKeepUpButNotPlaying,
-  ASVideoNodePlayerStatePlaying,
-  ASVideoNodePlayerStateLoading,
-  ASVideoNodePlayerStatePaused,
-  ASVideoNodePlayerStateFinished
+    ASVideoNodePlayerStateUnknown,
+    ASVideoNodePlayerStateInitialLoading,
+    ASVideoNodePlayerStateReadyToPlay,
+    ASVideoNodePlayerStatePlaybackLikelyToKeepUpButNotPlaying,
+    ASVideoNodePlayerStatePlaying,
+    ASVideoNodePlayerStateLoading,
+    ASVideoNodePlayerStatePaused,
+    ASVideoNodePlayerStateFinished
 };
 
 NS_ASSUME_NONNULL_BEGIN
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param videoNode The video node.
  * @param state player state that is going to be set.
  * @discussion Delegate method invoked when player changes it's state to
- * ASVideoNodePlayerStatePlaying or ASVideoNodePlayerStatePaused 
+ * ASVideoNodePlayerStatePlaying or ASVideoNodePlayerStatePaused
  * and asks delegate if state change is valid
  */
 - (BOOL)videoNode:(ASVideoNode*)videoNode shouldChangePlayerStateTo:(ASVideoNodePlayerState)state;
@@ -147,6 +147,13 @@ NS_ASSUME_NONNULL_BEGIN
  * @param videoNode The videoNode
  */
 - (void)videoNodeDidRecoverFromStall:(ASVideoNode *)videoNode;
+/**
+ * @abstract Delegate method invoked when an error occurs while trying to play a video
+ * @param videoNode The videoNode.
+ * @param currentItem The error that occurs
+ */
+- (void)videoNodeDidFailToInitAssetFor:(ASVideoNode *)videoNode withError:(NSError *)error;
+
 
 @end
 
@@ -157,3 +164,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+

--- a/Source/ASVideoNode.h
+++ b/Source/ASVideoNode.h
@@ -21,14 +21,14 @@
 @protocol ASVideoNodeDelegate;
 
 typedef NS_ENUM(NSInteger, ASVideoNodePlayerState) {
-    ASVideoNodePlayerStateUnknown,
-    ASVideoNodePlayerStateInitialLoading,
-    ASVideoNodePlayerStateReadyToPlay,
-    ASVideoNodePlayerStatePlaybackLikelyToKeepUpButNotPlaying,
-    ASVideoNodePlayerStatePlaying,
-    ASVideoNodePlayerStateLoading,
-    ASVideoNodePlayerStatePaused,
-    ASVideoNodePlayerStateFinished
+  ASVideoNodePlayerStateUnknown,
+  ASVideoNodePlayerStateInitialLoading,
+  ASVideoNodePlayerStateReadyToPlay,
+  ASVideoNodePlayerStatePlaybackLikelyToKeepUpButNotPlaying,
+  ASVideoNodePlayerStatePlaying,
+  ASVideoNodePlayerStateLoading,
+  ASVideoNodePlayerStatePaused,
+  ASVideoNodePlayerStateFinished
 };
 
 NS_ASSUME_NONNULL_BEGIN
@@ -148,12 +148,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)videoNodeDidRecoverFromStall:(ASVideoNode *)videoNode;
 /**
- * @abstract Delegate method invoked when an error occurs while trying to play a video
+ * @abstract Delegate method invoked when an error occurs while trying trying to load an asset
  * @param videoNode The videoNode.
- * @param currentItem The error that occurs
+ * @param key The key of value that failed to load.
+ * @param asset The asset.
+ * @param error The error that occurs.
  */
-- (void)videoNodeDidFailToInitAssetFor:(ASVideoNode *)videoNode withError:(NSError *)error;
-
+- (void)videoNode:(ASVideoNode *)videoNode didFailToLoadValueForKey:(NSString *)key asset:(AVAsset *)asset error:(NSError *)error;
 
 @end
 
@@ -164,4 +165,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-

--- a/Source/ASVideoNode.mm
+++ b/Source/ASVideoNode.mm
@@ -152,8 +152,8 @@ static NSString * const kRate = @"rate";
     NSError *error = nil;
     AVKeyValueStatus keyStatus = [asset statusOfValueForKey:key error:&error];
     if (keyStatus == AVKeyValueStatusFailed) {
-        NSLog(@"Asset loading failed with error: %@", error);
-        [self.delegate videoNodeDidFailToInitAssetFor:self withError:error];
+      NSLog(@"Asset loading failed with error: %@", error);
+      [self.delegate videoNode:self didFailToLoadValueForKey:key asset:asset error:error];
     }
   }
   

--- a/Source/ASVideoNode.mm
+++ b/Source/ASVideoNode.mm
@@ -152,7 +152,8 @@ static NSString * const kRate = @"rate";
     NSError *error = nil;
     AVKeyValueStatus keyStatus = [asset statusOfValueForKey:key error:&error];
     if (keyStatus == AVKeyValueStatusFailed) {
-      NSLog(@"Asset loading failed with error: %@", error);
+        NSLog(@"Asset loading failed with error: %@", error);
+        [self.delegate videoNodeDidFailToInitAssetFor:self withError:error];
     }
   }
   


### PR DESCRIPTION
here is a simple implementation of error reporter to ASVideoNodeDelegate. Once asset is failed to load an item - it reports to it's delegate that the error has occured

(huy: Closes https://github.com/TextureGroup/Texture/issues/252)