### PR TITLE
Remove Unused Node Code #trivial

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -1968,16 +1968,6 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   [self setNeedsLayout];
 }
 
-- (void)nodeDidRelayout:(ASCellNode *)node sizeChanged:(BOOL)sizeChanged
-{
-  ASDisplayNodeAssertMainThread();
-  
-  if (!sizeChanged) {
-    return;
-  }
-  [self nodesDidRelayout:@[node]];
-}
-
 - (void)nodesDidRelayout:(NSArray<ASCellNode *> *)nodes
 {
   ASDisplayNodeAssertMainThread();

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -1829,21 +1829,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   [self setNeedsLayout];
 }
 
-- (void)nodeDidRelayout:(ASCellNode *)node sizeChanged:(BOOL)sizeChanged
-{
-  ASDisplayNodeAssertMainThread();
-
-  if (!sizeChanged || _queuedNodeHeightUpdate || _remeasuringCellNodes) {
-    return;
-  }
-
-  _queuedNodeHeightUpdate = YES;
-  [self performSelector:@selector(requeryNodeHeights)
-             withObject:nil
-             afterDelay:0
-                inModes:@[ NSRunLoopCommonModes ]];
-}
-
 // Cause UITableView to requery for the new height of this node
 - (void)requeryNodeHeights
 {

--- a/Source/Private/ASCellNode+Internal.h
+++ b/Source/Private/ASCellNode+Internal.h
@@ -24,19 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ASCellNodeInteractionDelegate <NSObject>
 
 /**
- * Notifies the delegate that the specified cell node has done a relayout.
- * The notification is done on main thread.
- *
- * This will not be called due to measurement passes before the node has loaded
- * its view, even if triggered by -setNeedsLayout, as it is assumed these are
- * not relevant to UIKit.  Indeed, these calls can cause consistency issues.
- *
- * @param node A node informing the delegate about the relayout.
- * @param sizeChanged `YES` if the node's `calculatedSize` changed during the relayout, `NO` otherwise.
- */
-- (void)nodeDidRelayout:(ASCellNode *)node sizeChanged:(BOOL)sizeChanged;
-
-/**
  * Notifies the delegate that a specified cell node invalidates it's size what could result into a size change.
  *
  * @param node A node informing the delegate about the relayout.


### PR DESCRIPTION
This method is never called and is a leftover from a previous implementation of our collection/table-node-resize-observing system. It's been replaced by `nodeDidInvalidateSize:`.