### PR TITLE
Only call -layout and -layoutDidFinish if the node is already loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,4 +24,5 @@
 - [Layout] Extract layout implementation code into it's own subcategories [Michael Schneider] (https://github.com/maicki)[#272](https://github.com/TextureGroup/Texture/pull/272)
 - [Fix] Fix a potential crash when cell nodes that need layout are deleted during the same runloop.  [Adlai Holler](https://github.com/Adlai-Holler) [#279](https://github.com/TextureGroup/Texture/pull/279)
 - [Batch fetching] Add ASBatchFetchingDelegate that takes scroll velocity and remaining time into account [Huy Nguyen](https://github.com/nguyenhuy) [#281](https://github.com/TextureGroup/Texture/pull/281)
+- [Layout] Ensure -layout and -layoutDidFinish are called only if a node is loaded. [Huy Nguyen](https://github.com/nguyenhuy) [#285](https://github.com/TextureGroup/Texture/pull/285)
 

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -293,7 +293,6 @@ ASPrimitiveTraitCollectionDeprecatedImplementation
   }
 }
 
-/// Needs to be called with lock held
 - (void)_locked_measureNodeWithBoundsIfNecessary:(CGRect)bounds
 {
   // Check if we are a subnode in a layout transition.

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1088,9 +1088,10 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (void)layout
 {
+  // Hook for subclasses
   ASDisplayNodeAssertMainThread();
+  ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
   ASDisplayNodeAssertTrue(self.isNodeLoaded);
-  // Subclass hook
 }
 
 #pragma mark Layout Transition

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -902,8 +902,10 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   ASDisplayNodeAssertThreadAffinity(self);
   ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
   
+  BOOL loaded = NO;
   {
     ASDN::MutexLocker l(__instanceLock__);
+    loaded = [self _locked_isNodeLoaded];
     CGRect bounds = _threadSafeBounds;
     
     if (CGRectEqualToRect(bounds, CGRectZero)) {
@@ -930,10 +932,13 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   
   [self _layoutSublayouts];
   
-  ASPerformBlockOnMainThread(^{
-    [self layout];
-    [self layoutDidFinish];
-  });
+  // Per API contract, `-layout` and `-layoutDidFinish` are called only if the node is loaded. 
+  if (loaded) {
+    ASPerformBlockOnMainThread(^{
+      [self layout];
+      [self layoutDidFinish];
+    });
+  }
 }
 
 - (void)layoutDidFinish
@@ -941,6 +946,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   // Hook for subclasses
   ASDisplayNodeAssertMainThread();
   ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
+  ASDisplayNodeAssertTrue(self.isNodeLoaded);
 }
 
 #pragma mark Calculation
@@ -1083,6 +1089,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 - (void)layout
 {
   ASDisplayNodeAssertMainThread();
+  ASDisplayNodeAssertTrue(self.isNodeLoaded);
   // Subclass hook
 }
 

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -234,7 +234,9 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 - (void)__setNeedsDisplay;
 
 /**
- * Called from [CALayer layoutSublayers:]. Executes the layout pass for the node
+ * Called whenever the node needs to layout its subnodes and, if it's already loaded, its subviews. Executes the layout pass for the node
+ *
+ * This method is thread-safe but asserts thread affinity.
  */
 - (void)__layout;
 


### PR DESCRIPTION
After https://github.com/facebookarchive/AsyncDisplayKit/pull/3263, a layout pass can be triggered even before a node is loaded. This is to ensure the node has valid bounds to fetch its content as soon as it enters preload state, regardless of its backing store.

However, the API contracts of `-layout` and `-layoutDidFinish` state that those methods are triggered by the view's `layoutSubviews`. That means the node must be loaded by the time they are called.

This PR adds a node loaded check to `__layout` that ensures those 2 methods are called only if the condition meets.