### PR TITLE
Fix Alignment of Hashed Structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,4 +24,4 @@
 - [Layout] Extract layout implementation code into it's own subcategories [Michael Schneider] (https://github.com/maicki)[#272](https://github.com/TextureGroup/Texture/pull/272)
 - [Fix] Fix a potential crash when cell nodes that need layout are deleted during the same runloop.  [Adlai Holler](https://github.com/Adlai-Holler) [#279](https://github.com/TextureGroup/Texture/pull/279)
 - [Batch fetching] Add ASBatchFetchingDelegate that takes scroll velocity and remaining time into account [Huy Nguyen](https://github.com/nguyenhuy) [#281](https://github.com/TextureGroup/Texture/pull/281)
-
+- [Fix] Fix a major regression in our image node contents caching. [Adlai Holler](https://github.com/Adlai-Holler) [#287](https://github.com/TextureGroup/Texture/pull/287)

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -129,7 +129,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
     _image.hash,
     _backingSize,
     _imageDrawRect,
-    _isOpaque,
+    (NSUInteger)_isOpaque,
     _backgroundColor.hash,
     (void *)_willDisplayNodeContentWithRenderingContext,
     (void *)_didDisplayNodeContentWithRenderingContext,

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -119,7 +119,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
     NSUInteger imageHash;
     CGSize backingSize;
     CGRect imageDrawRect;
-    NSUInteger isOpaque;
+    NSInteger isOpaque;
     NSUInteger backgroundColorHash;
     void *willDisplayNodeContentWithRenderingContext;
     void *didDisplayNodeContentWithRenderingContext;
@@ -129,7 +129,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
     _image.hash,
     _backingSize,
     _imageDrawRect,
-    (NSUInteger)_isOpaque,
+    _isOpaque,
     _backgroundColor.hash,
     (void *)_willDisplayNodeContentWithRenderingContext,
     (void *)_didDisplayNodeContentWithRenderingContext,

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -113,15 +113,18 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 
 - (NSUInteger)hash
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wpadded"
   struct {
     NSUInteger imageHash;
     CGSize backingSize;
     CGRect imageDrawRect;
-    BOOL isOpaque;
+    NSUInteger isOpaque;
     NSUInteger backgroundColorHash;
     void *willDisplayNodeContentWithRenderingContext;
     void *didDisplayNodeContentWithRenderingContext;
     void *imageModificationBlock;
+#pragma clang diagnostic pop
   } data = {
     _image.hash,
     _backingSize,

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -64,9 +64,12 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
 
 - (NSUInteger)hash
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wpadded"
   struct {
     size_t attributesHash;
     CGSize constrainedSize;
+#pragma clang diagnostic pop
   } data = {
     _attributes.hash(),
     _constrainedSize

--- a/Source/Private/ASHashing.h
+++ b/Source/Private/ASHashing.h
@@ -34,6 +34,11 @@ ASDISPLAYNODE_EXTERN_C_BEGIN
  *    _bounds.size
  *  };
  *  return ASHashBytes(&data, sizeof(data));
+ *
+ * @warning: If a struct has padding, any fields that are intiailized in {} 
+ *   will have garbage data for their padding, which will break this hash! Either
+ *   use `pragma clang diagnostic warning "-Wpadded"` around your struct definition
+ *   or manually initialize the fields of your struct (`myStruct.x = 7;` etc).
  */
 NSUInteger ASHashBytes(void *bytes, size_t length);
 

--- a/Source/TextKit/ASTextKitAttributes.mm
+++ b/Source/TextKit/ASTextKitAttributes.mm
@@ -24,6 +24,8 @@ NSString *const ASTextKitEntityAttributeName = @"ck_entity";
 
 size_t ASTextKitAttributes::hash() const
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wpadded"
   struct {
     NSUInteger attrStringHash;
     NSUInteger truncationStringHash;
@@ -35,6 +37,7 @@ size_t ASTextKitAttributes::hash() const
     NSUInteger shadowColorHash;
     CGFloat shadowOpacity;
     CGFloat shadowRadius;
+#pragma clang diagnostic pop
   } data = {
     [attributedString hash],
     [truncationAttributedString hash],


### PR DESCRIPTION
- We initialize our structs using `{ 7, 5, 3 }`. When you do this, if the struct has padding, the memory contained in the padding bytes contains garbage.
- Our ASImageNodeContentsKey hashes a struct that has padding bytes.
- So that hash wasn't reliable, and our cache hit rate plummeted.

The solution is:
- Enable the `-Wpadded` warning around structs that we use `{}` and subsequently hash.
- Update the ASImageNodeContentsKey struct to be aligned (change BOOL to NSInteger).
- Update the documentation on ASHashBytes to point out this warning.


We could enable `-Wpadded` globally but usually we don't care too much about padding so let's not do it for now.

This patch is extremely important and should be released in a hotfix. The image cache hit rate before this patch is extremely low, at least on my mac.