### PR TITLE
[ASPagerNode] Fixing currentPageIndex take in consideration the scroll direction of ASPagerFlowLayout.

### DIFF
--- a/Source/ASPagerFlowLayout.m
+++ b/Source/ASPagerFlowLayout.m
@@ -67,8 +67,16 @@
     return proposedContentOffset;
   }
 
-  CGFloat xOffset = (CGRectGetWidth(self.collectionView.bounds) - CGRectGetWidth(attributes.frame)) / 2.0;
-  return CGPointMake(attributes.frame.origin.x - xOffset, proposedContentOffset.y);
+  switch (self.scrollDirection) {
+    case UICollectionViewScrollDirectionHorizontal: {
+      CGFloat xOffset = (CGRectGetWidth(self.collectionView.bounds) - CGRectGetWidth(attributes.frame)) / 2.0;
+      return CGPointMake(attributes.frame.origin.x - xOffset, proposedContentOffset.y);
+    }
+    case UICollectionViewScrollDirectionVertical: {
+      CGFloat yOffset = (CGRectGetHeight(self.collectionView.bounds) - CGRectGetHeight(attributes.frame)) / 2.0;
+      return CGPointMake(proposedContentOffset.x, attributes.frame.origin.y - yOffset);
+    }
+  }
 }
 
 - (BOOL)_dataSourceIsEmpty

--- a/Source/ASPagerNode.m
+++ b/Source/ASPagerNode.m
@@ -103,7 +103,12 @@
 
 - (NSInteger)currentPageIndex
 {
-  return (self.view.contentOffset.x / CGRectGetWidth(self.view.bounds));
+  switch (_flowLayout.scrollDirection) {
+    case UICollectionViewScrollDirectionHorizontal:
+      return (self.view.contentOffset.x / CGRectGetWidth(self.view.bounds));
+    case UICollectionViewScrollDirectionVertical:
+      return (self.view.contentOffset.y / CGRectGetHeight(self.view.bounds));
+  }
 }
 
 #pragma mark - Helpers


### PR DESCRIPTION
Currently, the current page index method does not take into account the scroll direction of the pager node and hence it would always return the current index as 0 for the vertical direction.
This commit fixed the above scenario.