### PR TITLE
IGListKit related headers need to be in the module all time now #trivial

### DIFF
--- a/Source/AsyncDisplayKit.h
+++ b/Source/AsyncDisplayKit.h
@@ -55,11 +55,6 @@
 #import <AsyncDisplayKit/ASSectionController.h>
 #import <AsyncDisplayKit/ASSupplementaryNodeSource.h>
 
-#if AS_IG_LIST_KIT
-#import <AsyncDisplayKit/IGListAdapter+AsyncDisplayKit.h>
-#import <AsyncDisplayKit/AsyncDisplayKit+IGListKitMethods.h>
-#endif
-
 #import <AsyncDisplayKit/ASScrollNode.h>
 
 #import <AsyncDisplayKit/ASPagerFlowLayout.h>
@@ -128,3 +123,6 @@
 #import <AsyncDisplayKit/ASDisplayNode+Deprecated.h>
 
 #import <AsyncDisplayKit/ASCollectionNode+Beta.h>
+
+#import <AsyncDisplayKit/IGListAdapter+AsyncDisplayKit.h>
+#import <AsyncDisplayKit/AsyncDisplayKit+IGListKitMethods.h>


### PR DESCRIPTION
Apparently due to the change in #286 we broke some more stuff building the framework. For some reason the tests as well as the build script finished and was fine in this PR, now it's failing though. So let's fix it.

I tested it with our test suite, building all the examples as well as building the ASDKListKit project.

Resolves #298