### PR TITLE
[ASCollectionNode] Fix missing properties and layoutInspector #trivial

### DIFF
--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -428,6 +428,16 @@
   }
 }
 
+- (ASScrollDirection)scrollDirection
+{
+  return [self isNodeLoaded] ? self.view.scrollDirection : ASScrollDirectionNone;
+}
+
+- (ASScrollDirection)scrollableDirections
+{
+  return [self isNodeLoaded] ? self.view.scrollableDirections : ASScrollDirectionNone;
+}
+
 - (ASElementMap *)visibleElements
 {
   ASDisplayNodeAssertMainThread();

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -181,6 +181,7 @@
     view.inverted                = pendingState.inverted;
     view.allowsSelection         = pendingState.allowsSelection;
     view.allowsMultipleSelection = pendingState.allowsMultipleSelection;
+    view.layoutInspector         = pendingState.layoutInspector;
     
     if (pendingState.rangeMode != ASLayoutRangeModeUnspecified) {
       [view.rangeController updateCurrentRangeWithMode:pendingState.rangeMode];


### PR DESCRIPTION
Hi guys,

Some `ASCollectionView` properties have recently been deprecated in favour of their `ASCollectionNode` counterparts, but it turns out that they're not fully functional yet:

- The `layoutInspector` from the `_pendingState` is not forwarded to the view in `didLoad`, which means that setting it only works *after* the view has been loaded, which kinda defeats the purpose of having the property at the node level.
- The `scrollDirection` and `scrollableDirections` properties are not implemented, which means that we never get the actual value from the underlying view.

These two problems are demonstrated in this sample project (along with a waterfall layout that could be useful to some Texture users :-)): https://github.com/flovouin/Texture-CollectionNodeProperties

The `layoutInspector` fix is rather straightforward. However concerning the property forwarding, I'm not entirely sure what the guidelines are. I just made sure not to load the view needlessly, but you might have a better way to do that. Please tell me and I'll update the PR ASAP if needed.

Cheers,
Flo