### PR TITLE
Catch Invalid Layer Bounds in a Nonfatal Assertion #trivial

### DIFF
--- a/Source/Base/ASAssert.h
+++ b/Source/Base/ASAssert.h
@@ -69,9 +69,11 @@
 #define ASDisplayNodeErrorDomain @"ASDisplayNodeErrorDomain"
 #define ASDisplayNodeNonFatalErrorCode 1
 
-#define ASDisplayNodeAssertNonFatal(condition, desc, ...)                                                                         \
-  ASDisplayNodeAssert(condition, desc, ##__VA_ARGS__);                                                                            \
-  if (condition ==  NO) {                                                                                                         \
+/// Returns YES if assertion passed, NO otherwise.
+#define ASDisplayNodeAssertNonFatal(condition, desc, ...) ({                                                                      \
+  BOOL __evaluated = condition;                                                                                                   \
+  if (__evaluated == NO) {                                                                                                        \
+    ASDisplayNodeFailAssert(desc, ##__VA_ARGS__);                                                                                 \
     ASDisplayNodeNonFatalErrorBlock block = [ASDisplayNode nonFatalErrorBlock];                                                   \
     if (block != nil) {                                                                                                           \
       NSDictionary *userInfo = nil;                                                                                               \
@@ -81,4 +83,6 @@
       NSError *error = [NSError errorWithDomain:ASDisplayNodeErrorDomain code:ASDisplayNodeNonFatalErrorCode userInfo:userInfo];  \
       block(error);                                                                                                               \
     }                                                                                                                             \
-  }
+  }                                                                                                                               \
+  __evaluated;                                                                                                                    \
+})                                                                                                                                \

--- a/Source/Details/_ASDisplayLayer.mm
+++ b/Source/Details/_ASDisplayLayer.mm
@@ -100,7 +100,7 @@
 
 - (void)setBounds:(CGRect)bounds
 {
-  BOOL valid = ASDisplayNodeAssertNonFatal(ASIsCGRectValidForLayout(bounds), @"Attempt to set invalid bounds %@ on %@.", NSStringFromCGRect(bounds), self);
+  BOOL valid = ASDisplayNodeAssertNonFatal(ASIsCGRectValidForLayout(bounds), @"Caught attempt to set invalid bounds %@ on %@.", NSStringFromCGRect(bounds), self);
   if (!valid) {
     return;
   }

--- a/Source/Details/_ASDisplayLayer.mm
+++ b/Source/Details/_ASDisplayLayer.mm
@@ -100,6 +100,10 @@
 
 - (void)setBounds:(CGRect)bounds
 {
+  BOOL valid = ASDisplayNodeAssertNonFatal(ASIsCGRectValidForLayout(bounds), @"Attempt to set invalid bounds %@ on %@.", NSStringFromCGRect(bounds), self);
+  if (!valid) {
+    return;
+  }
   if (_delegateFlags.delegateDidChangeBounds) {
     CGRect oldBounds = self.bounds;
     [super setBounds:bounds];


### PR DESCRIPTION
- Modify `ASDisplayNodeAssertNonFatal` to return YES/NO based on whether assertion passed.
- Add a nonfatal in `_ASDisplayLayer setBounds:` to ensure the bounds are valid and ignore-with-nonfatal otherwise.

The motivation for this diff is, in Pinterest we're seeing cases where UIScrollView's own gesture-recognizer is causing `nan` positions to be set on scroll views' layers. It's extremely unlikely that framework code is responsible for it but we can help catch the problem.