### PR TITLE
Fix non layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this with your name.
+- Fixed an issue where calls to setNeedsDisplay and setNeedsLayout would stop working on loaded nodes. [Garrett Moon](https://github.com/garrettmoon)
 - [ASTextKitFontSizeAdjuster] [Ricky Cancro] Replace use of NSAttributedString's boundingRectWithSize:options:context: with NSLayoutManager's boundingRectForGlyphRange:inTextContainer:
 - Add support for IGListKit post-removal-of-IGListSectionType, in preparation for IGListKit 3.0.0 release. [Adlai Holler](https://github.com/Adlai-Holler) [#49](https://github.com/TextureGroup/Texture/pull/49)
 - Fix `__has_include` check in ASLog.h [Philipp Smorygo](Philipp.Smorygo@jetbrains.com)


### PR DESCRIPTION
Lock released between add to pend controller and modifying pend state
    
The existing design is pretty fraught with error. We should probably
rethink this but in the meantime, this fixes a bug where calling

setNeedsLayout can start failing for nodes.
    
Essentially the method ASDisplayNodeShouldApplyBridgedWriteToView has
a side effect of registering a node to apply it's pending state *if*
it doesn't currently need the pending state applied. My guess is this
was to avoid continually registering the node and this behavior actually
helped expose this bug.
    
The bug: after the node is registered for flushing it's state, several
code paths released the lock before applying that state to the pending
state object. Before it could re-obtain the lock to apply it to the pending
state, the pending state controller flushed it on the main thread.
    
On subsequent calls to setNeedsLayout, the pending state had pending state
already (from previous calls which missed the flush) and thus wasn't
registered for future flushing.