### PR TITLE
[Docs] Fixed typo in carthage project name 

### DIFF
--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -82,7 +82,7 @@ Or, to get the **master** branch:
 <div class = "highlight-group">
 <div class = "code">
 <pre lang="objc" class="objcCode">
-github "facetexturegroup/textureaster"
+github "texturegroup/texture" "master"
 </pre>
 </div>
 </div>


### PR DESCRIPTION
Fixed typo in carthage project name that's supposed to point to the master branch