### PR TITLE
Clean Up ASAsyncTransaction #trivial

### DIFF
--- a/Source/Details/Transactions/_ASAsyncTransaction.h
+++ b/Source/Details/Transactions/_ASAsyncTransaction.h
@@ -25,8 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void(^asyncdisplaykit_async_transaction_completion_block_t)(_ASAsyncTransaction *completedTransaction, BOOL canceled);
 typedef id<NSObject> _Nullable(^asyncdisplaykit_async_transaction_operation_block_t)(void);
-typedef void(^asyncdisplaykit_async_transaction_operation_completion_block_t)(id<NSObject> _Nullable value, BOOL canceled);
-typedef void(^asyncdisplaykit_async_transaction_complete_async_operation_block_t)(id<NSObject> _Nullable value);
+typedef void(^asyncdisplaykit_async_transaction_operation_completion_block_t)(id _Nullable value, BOOL canceled);
+typedef void(^asyncdisplaykit_async_transaction_complete_async_operation_block_t)(id _Nullable value);
 typedef void(^asyncdisplaykit_async_transaction_async_operation_block_t)(asyncdisplaykit_async_transaction_complete_async_operation_block_t completeOperationBlock);
 
 /**
@@ -62,12 +62,9 @@ extern NSInteger const ASDefaultTransactionPriority;
 /**
  @summary Initialize a transaction that can start collecting async operations.
 
- @see initWithCallbackQueue:commitBlock:completionBlock:executeConcurrently:
- @param callbackQueue The dispatch queue that the completion blocks will be called on. Default is the main queue.
  @param completionBlock A block that is called when the transaction is completed.
  */
-- (instancetype)initWithCallbackQueue:(nullable dispatch_queue_t)callbackQueue
-                      completionBlock:(nullable asyncdisplaykit_async_transaction_completion_block_t)completionBlock;
+- (instancetype)initWithCompletionBlock:(nullable asyncdisplaykit_async_transaction_completion_block_t)completionBlock;
 
 /**
  @summary Block the main thread until the transaction is complete, including callbacks.
@@ -75,11 +72,6 @@ extern NSInteger const ASDefaultTransactionPriority;
  @desc This must be called on the main thread.
  */
 - (void)waitUntilComplete;
-
-/**
- The dispatch queue that the completion blocks will be called on.
- */
-@property (nonatomic, readonly, strong) dispatch_queue_t callbackQueue;
 
 /**
  A block that is called when the transaction is completed.

--- a/Source/Details/Transactions/_ASAsyncTransaction.mm
+++ b/Source/Details/Transactions/_ASAsyncTransaction.mm
@@ -35,7 +35,7 @@ NSInteger const ASDefaultTransactionPriority = 0;
 @interface ASAsyncTransactionOperation : NSObject
 - (instancetype)initWithOperationCompletionBlock:(asyncdisplaykit_async_transaction_operation_completion_block_t)operationCompletionBlock;
 @property (nonatomic, copy) asyncdisplaykit_async_transaction_operation_completion_block_t operationCompletionBlock;
-@property (nonatomic, strong) id<NSObject> value; // set on bg queue by the operation block
+@property (atomic, strong) id value; // set on bg queue by the operation block
 @end
 
 @implementation ASAsyncTransactionOperation
@@ -55,16 +55,17 @@ NSInteger const ASDefaultTransactionPriority = 0;
 
 - (void)callAndReleaseCompletionBlock:(BOOL)canceled;
 {
+  ASDisplayNodeAssertMainThread();
   if (_operationCompletionBlock) {
     _operationCompletionBlock(self.value, canceled);
-    // Guarantee that _operationCompletionBlock is released on _callbackQueue:
-    self.operationCompletionBlock = nil;
+    // Guarantee that _operationCompletionBlock is released on main thread
+    _operationCompletionBlock = nil;
   }
 }
 
 - (NSString *)description
 {
-  return [NSString stringWithFormat:@"<ASAsyncTransactionOperation: %p - value = %@", self, self.value];
+  return [NSString stringWithFormat:@"<ASAsyncTransactionOperation: %p - value = %@>", self, self.value];
 }
 
 @end
@@ -328,27 +329,25 @@ ASAsyncTransactionQueue & ASAsyncTransactionQueue::instance()
   return *instance;
 }
 
+@interface _ASAsyncTransaction ()
+@property (atomic) ASAsyncTransactionState state;
+@end
+
+
 @implementation _ASAsyncTransaction
 {
   ASAsyncTransactionQueue::Group *_group;
   NSMutableArray<ASAsyncTransactionOperation *> *_operations;
-  _Atomic(ASAsyncTransactionState) _state;
 }
 
 #pragma mark -
 #pragma mark Lifecycle
 
-- (instancetype)initWithCallbackQueue:(dispatch_queue_t)callbackQueue
-                      completionBlock:(void(^)(_ASAsyncTransaction *, BOOL))completionBlock
+- (instancetype)initWithCompletionBlock:(void(^)(_ASAsyncTransaction *, BOOL))completionBlock
 {
   if ((self = [self init])) {
-    if (callbackQueue == NULL) {
-      callbackQueue = dispatch_get_main_queue();
-    }
-    _callbackQueue = callbackQueue;
     _completionBlock = completionBlock;
-
-    _state = ATOMIC_VAR_INIT(ASAsyncTransactionStateOpen);
+    self.state = ASAsyncTransactionStateOpen;
   }
   return self;
 }
@@ -360,18 +359,6 @@ ASAsyncTransactionQueue & ASAsyncTransactionQueue::instance()
   if (_group) {
     _group->release();
   }
-}
-
-#pragma mark - Properties
-
-- (ASAsyncTransactionState)state
-{
-  return atomic_load(&_state);
-}
-
-- (void)setState:(ASAsyncTransactionState)state
-{
-  atomic_store(&_state, state);
 }
 
 #pragma mark - Transaction Management
@@ -402,7 +389,7 @@ ASAsyncTransactionQueue & ASAsyncTransactionQueue::instance()
     @autoreleasepool {
       if (self.state != ASAsyncTransactionStateCanceled) {
         _group->enter();
-        block(^(id<NSObject> value){
+        block(^(id value){
           operation.value = value;
           _group->leave();
         });
@@ -445,7 +432,8 @@ ASAsyncTransactionQueue & ASAsyncTransactionQueue::instance()
 - (void)addCompletionBlock:(asyncdisplaykit_async_transaction_completion_block_t)completion
 {
   __weak __typeof__(self) weakSelf = self;
-  [self addOperationWithBlock:^(){return (id<NSObject>)nil;} queue:_callbackQueue completion:^(id<NSObject> value, BOOL canceled) {
+  dispatch_queue_t bsQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+  [self addOperationWithBlock:^(){return (id)nil;} queue:bsQueue completion:^(id value, BOOL canceled) {
     __typeof__(self) strongSelf = weakSelf;
     completion(strongSelf, canceled);
   }];
@@ -472,10 +460,7 @@ ASAsyncTransactionQueue & ASAsyncTransactionQueue::instance()
   } else {
     NSAssert(_group != NULL, @"If there are operations, dispatch group should have been created");
     
-    _group->notify(_callbackQueue, ^{
-      // _callbackQueue is the main queue in current practice (also asserted in -waitUntilComplete).
-      // This code should be reviewed before taking on significantly different use cases.
-      ASAsyncTransactionAssertMainThread();
+    _group->notify(dispatch_get_main_queue(), ^{
       [self completeTransaction];
     });
   }
@@ -483,6 +468,7 @@ ASAsyncTransactionQueue & ASAsyncTransactionQueue::instance()
 
 - (void)completeTransaction
 {
+  ASAsyncTransactionAssertMainThread();
   ASAsyncTransactionState state = self.state;
   if (state != ASAsyncTransactionStateComplete) {
     BOOL isCanceled = (state == ASAsyncTransactionStateCanceled);
@@ -506,7 +492,6 @@ ASAsyncTransactionQueue & ASAsyncTransactionQueue::instance()
   ASAsyncTransactionAssertMainThread();
   if (self.state != ASAsyncTransactionStateComplete) {
     if (_group) {
-      NSAssert(_callbackQueue == dispatch_get_main_queue(), nil);
       _group->wait();
       
       // At this point, the asynchronous operation may have completed, but the runloop

--- a/Source/Details/Transactions/_ASAsyncTransactionContainer.m
+++ b/Source/Details/Transactions/_ASAsyncTransactionContainer.m
@@ -93,11 +93,11 @@ static const char *ASAsyncTransactionIsContainerKey = "ASTransactionIsContainer"
   if (transaction == nil) {
     NSHashTable *transactions = self.asyncdisplaykit_asyncLayerTransactions;
     if (transactions == nil) {
-      transactions = [NSHashTable hashTableWithOptions:NSPointerFunctionsObjectPointerPersonality];
+      transactions = [NSHashTable hashTableWithOptions:NSHashTableObjectPointerPersonality];
       self.asyncdisplaykit_asyncLayerTransactions = transactions;
     }
     __weak CALayer *weakSelf = self;
-    transaction = [[_ASAsyncTransaction alloc] initWithCallbackQueue:dispatch_get_main_queue() completionBlock:^(_ASAsyncTransaction *completedTransaction, BOOL cancelled) {
+    transaction = [[_ASAsyncTransaction alloc] initWithCompletionBlock:^(_ASAsyncTransaction *completedTransaction, BOOL cancelled) {
       __strong CALayer *self = weakSelf;
       if (self == nil) {
         return;


### PR DESCRIPTION
- Make operation values simply `id` rather than `id<NSObject>`. `id<NSObject>` can be a pain to deal with since it can't be implicitly cast, plus it's ugly.
- Make transactions always call back on the main thread, rather than parameterized `callbackQueue`.
  - Previously, you couldn't pass any queue for callback other than the main queue anyway.
  - Code was inconsistent. Some places directly used main thread, other places used parameterized `callbackQueue`.
- Make operation value `atomic` since it's set from background thread, but read from main thread.
- Other misc cleanup.