### PR TITLE
Rejigger Cell Visibility Tracking

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -105,6 +105,9 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   
   NSMutableSet *_registeredSupplementaryKinds;
   
+  // CountedSet because UIKit may display the same element in multiple cells e.g. during animations.
+  NSCountedSet<ASCollectionElement *> *_visibleElements;
+  
   CGPoint _deceleratingVelocity;
 
   BOOL _zeroContentInsets;
@@ -294,6 +297,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   super.dataSource = (id<UICollectionViewDataSource>)_proxyDataSource;
   
   _registeredSupplementaryKinds = [NSMutableSet set];
+  _visibleElements = [[NSCountedSet alloc] init];
   
   _cellsForVisibilityUpdates = [NSMutableSet set];
   _cellsForLayoutUpdates = [NSMutableSet set];
@@ -997,7 +1001,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   }
   
   UICollectionReusableView *view = nil;
-  ASCellNode *node = [_dataController.visibleMap supplementaryElementOfKind:kind atIndexPath:indexPath].node;
+  ASCollectionElement *element = [_dataController.visibleMap supplementaryElementOfKind:kind atIndexPath:indexPath];
+  ASCellNode *node = element.node;
 
   BOOL shouldDequeueExternally = _asyncDataSourceFlags.interopViewForSupplementaryElement && (_asyncDataSourceFlags.interopAlwaysDequeue || node.shouldUseUIKitCell);
   if (shouldDequeueExternally) {
@@ -1009,7 +1014,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   }
   
   if (_ASCollectionReusableView *reusableView = ASDynamicCast(view, _ASCollectionReusableView)) {
-    reusableView.node = node;
+    reusableView.element = element;
   }
   
   if (node) {
@@ -1022,7 +1027,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   UICollectionViewCell *cell = nil;
-  ASCellNode *node = [self nodeForItemAtIndexPath:indexPath];
+  ASCollectionElement *element = [_dataController.visibleMap elementForItemAtIndexPath:indexPath];
+  ASCellNode *node = element.node;
 
   BOOL shouldDequeueExternally = _asyncDataSourceFlags.interopAlwaysDequeue || (_asyncDataSourceFlags.interop && node.shouldUseUIKitCell);
   if (shouldDequeueExternally) {
@@ -1031,30 +1037,33 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     cell = [self dequeueReusableCellWithReuseIdentifier:kReuseIdentifier forIndexPath:indexPath];
   }
 
-  ASDisplayNodeAssert(node != nil, @"Cell node should exist. indexPath = %@, collectionDataSource = %@", indexPath, self);
+  ASDisplayNodeAssert(element != nil, @"Element should exist. indexPath = %@, collectionDataSource = %@", indexPath, self);
 
   if (_ASCollectionViewCell *asCell = ASDynamicCast(cell, _ASCollectionViewCell)) {
-    asCell.node = node;
+    asCell.element = element;
     [_rangeController configureContentView:cell.contentView forCellNode:node];
   }
   
   return cell;
 }
 
-- (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(_ASCollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath
+- (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)rawCell forItemAtIndexPath:(NSIndexPath *)indexPath
 {
   if (_asyncDelegateFlags.interopWillDisplayCell) {
-    [(id <ASCollectionDelegateInterop>)_asyncDelegate collectionView:collectionView willDisplayCell:cell forItemAtIndexPath:indexPath];
+    [(id <ASCollectionDelegateInterop>)_asyncDelegate collectionView:collectionView willDisplayCell:rawCell forItemAtIndexPath:indexPath];
   }
 
   // Since _ASCollectionViewCell is not available for subclassing, this is faster than isKindOfClass:
   // We must exit early here, because only _ASCollectionViewCell implements the -node accessor method.
-  if ([cell class] != [_ASCollectionViewCell class]) {
+  if ([rawCell class] != [_ASCollectionViewCell class]) {
     [_rangeController setNeedsUpdate];
     return;
   }
+  auto cell = (_ASCollectionViewCell *)rawCell;
   
-  ASCellNode *cellNode = [cell node];
+  ASCollectionElement *element = cell.element;
+  [_visibleElements addObject:element];
+  ASCellNode *cellNode = element.node;
   cellNode.scrollView = collectionView;
 
   // Update the selected background view in collectionView:willDisplayCell:forItemAtIndexPath: otherwise it could be to
@@ -1090,21 +1099,24 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   }
 }
 
-- (void)collectionView:(UICollectionView *)collectionView didEndDisplayingCell:(_ASCollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath
+- (void)collectionView:(UICollectionView *)collectionView didEndDisplayingCell:(UICollectionViewCell *)rawCell forItemAtIndexPath:(NSIndexPath *)indexPath
 {
   if (_asyncDelegateFlags.interopDidEndDisplayingCell) {
-    [(id <ASCollectionDelegateInterop>)_asyncDelegate collectionView:collectionView didEndDisplayingCell:cell forItemAtIndexPath:indexPath];
+    [(id <ASCollectionDelegateInterop>)_asyncDelegate collectionView:collectionView didEndDisplayingCell:rawCell forItemAtIndexPath:indexPath];
   }
 
   // Since _ASCollectionViewCell is not available for subclassing, this is faster than isKindOfClass:
   // We must exit early here, because only _ASCollectionViewCell implements the -node accessor method.
-  if ([cell class] != [_ASCollectionViewCell class]) {
+  if ([rawCell class] != [_ASCollectionViewCell class]) {
     [_rangeController setNeedsUpdate];
     return;
   }
+  auto cell = (_ASCollectionViewCell *)rawCell;
   
-  ASCellNode *cellNode = [cell node];
-  ASDisplayNodeAssertNotNil(cellNode, @"Expected node associated with removed cell not to be nil.");
+  ASCollectionElement *element = cell.element;
+  [_visibleElements removeObject:element];
+  ASDisplayNodeAssertNotNil(element, @"Expected element associated with removed cell not to be nil.");
+  ASCellNode *cellNode = element.node;
 
   if (_asyncDelegateFlags.collectionNodeDidEndDisplayingItem) {
     if (ASCollectionNode *collectionNode = self.collectionNode) {
@@ -1125,8 +1137,14 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   cell.layoutAttributes = nil;
 }
 
-- (void)collectionView:(UICollectionView *)collectionView willDisplaySupplementaryView:(_ASCollectionReusableView *)view forElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath
+- (void)collectionView:(UICollectionView *)collectionView willDisplaySupplementaryView:(UICollectionReusableView *)rawView forElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath
 {
+  if (rawView.class != [_ASCollectionReusableView class]) {
+    return;
+  }
+  auto view = (_ASCollectionReusableView *)rawView;
+  
+  [_visibleElements addObject:view.element];
   // This is a safeguard similar to the behavior for cells in -[ASCollectionView collectionView:willDisplayCell:forItemAtIndexPath:]
   // It ensures _ASCollectionReusableView receives layoutAttributes and calls applyLayoutAttributes.
   if (view.layoutAttributes == nil) {
@@ -1141,8 +1159,14 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   }
 }
 
-- (void)collectionView:(UICollectionView *)collectionView didEndDisplayingSupplementaryView:(UICollectionReusableView *)view forElementOfKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath
+- (void)collectionView:(UICollectionView *)collectionView didEndDisplayingSupplementaryView:(UICollectionReusableView *)rawView forElementOfKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath
 {
+  if (rawView.class != [_ASCollectionReusableView class]) {
+    return;
+  }
+  auto view = (_ASCollectionReusableView *)rawView;
+
+  [_visibleElements removeObject:view.element];
   if (_asyncDelegateFlags.collectionNodeDidEndDisplayingSupplementaryElement) {
     GET_COLLECTIONNODE_OR_RETURN(collectionNode, (void)0);
     ASCellNode *node = [self supplementaryNodeForElementKind:elementKind atIndexPath:indexPath];
@@ -1805,35 +1829,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (NSArray<ASCollectionElement *> *)visibleElementsForRangeController:(ASRangeController *)rangeController
 {
-  if (CGRectIsEmpty(self.bounds)) {
-    return @[];
-  }
-
-  ASElementMap *map = _dataController.visibleMap;
-  NSMutableArray<ASCollectionElement *> *result = [NSMutableArray array];
-
-  // Visible items
-  for (NSIndexPath *indexPath in self.indexPathsForVisibleItems) {
-    ASCollectionElement *element = [map elementForItemAtIndexPath:indexPath];
-    if (element != nil) {
-      [result addObject:element];
-    } else {
-      ASDisplayNodeFailAssert(@"Couldn't find 'visible' item at index path %@ in map %@", indexPath, map);
-    }
-  }
-
-  // Visible supplementary elements
-  for (NSString *kind in map.supplementaryElementKinds) {
-    for (NSIndexPath *indexPath in [self asdk_indexPathsForVisibleSupplementaryElementsOfKind:kind]) {
-      ASCollectionElement *element = [map supplementaryElementOfKind:kind atIndexPath:indexPath];
-      if (element != nil) {
-        [result addObject:element];
-      } else {
-        ASDisplayNodeFailAssert(@"Couldn't find 'visible' supplementary element of kind %@ at index path %@ in map %@", kind, indexPath, map);
-      }
-    }
-  }
-  return result;
+  return _visibleElements.allObjects;
 }
 
 - (ASElementMap *)elementMapForRangeController:(ASRangeController *)rangeController

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -404,14 +404,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   _flags.isDeallocating = YES;
 
   // Synchronous nodes may not be able to call the hierarchy notifications, so only enforce for regular nodes.
-  // TODO: This condition should be an assertion, but a workaround is in place until the root issue is fixed:
-  // https://github.com/TextureGroup/Texture/issues/145
-#if DEBUG
-  if (checkFlag(Synchronous) == NO && ASInterfaceStateIncludesVisible(_interfaceState) == YES) {
-    NSLog(@"Node should always be marked invisible before deallocating. Node: %@", self);
-  }
-#endif
-
+  ASDisplayNodeAssert(checkFlag(Synchronous) || !ASInterfaceStateIncludesVisible(_interfaceState), @"Node should always be marked invisible before deallocating. Node: %@", self);
+  
   self.asyncLayer.asyncDelegate = nil;
   _view.asyncdisplaykit_node = nil;
   _layer.asyncdisplaykit_node = nil;

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -42,7 +42,6 @@
   BOOL _rangeIsValid;
   BOOL _needsRangeUpdate;
   NSSet<NSIndexPath *> *_allPreviousIndexPaths;
-  ASWeakSet<ASCellNode *> *_visibleNodes;
   ASLayoutRangeMode _currentRangeMode;
   BOOL _preserveCurrentRangeMode;
   BOOL _didRegisterForNodeDisplayNotifications;
@@ -153,7 +152,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   if (_needsRangeUpdate) {
     _needsRangeUpdate = NO;
       
-    [self _updateVisibleNodeIndexPaths];
+    [self _updateInterfaceStates];
   }
 }
 
@@ -183,25 +182,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   }
 }
 
-// Clear the visible bit from any nodes that disappeared since last update.
-// Currently we guarantee that nodes will not be marked visible when deallocated,
-// but it's OK to be in e.g. the preload range. So for the visible bit specifically,
-// we add this extra mechanism to account for e.g. deleted items.
-//
-// NOTE: There is a minor risk here, if a node is transferred from one range controller
-// to another before the first rc updates and clears the node out of this set. It's a pretty
-// wild scenario that I doubt happens in practice.
-- (void)_setVisibleNodes:(ASWeakSet *)newVisibleNodes
-{
-  for (ASCellNode *node in _visibleNodes) {
-    if (![newVisibleNodes containsObject:node] && node.isVisible) {
-      [node exitInterfaceState:ASInterfaceStateVisible];
-    }
-  }
-  _visibleNodes = newVisibleNodes;
-}
-
-- (void)_updateVisibleNodeIndexPaths
+- (void)_updateInterfaceStates
 {
   ASDisplayNodeAssert(_layoutController, @"An ASLayoutController is required by ASRangeController");
   if (!_layoutController || !_dataSource) {
@@ -217,12 +198,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   // TODO: Consider if we need to use this codepath, or can rely on something more similar to the data & display ranges
   // Example: ... = [_layoutController indexPathsForScrolling:scrollDirection rangeType:ASLayoutRangeTypeVisible];
   NSSet<ASCollectionElement *> *visibleElements = [NSSet setWithArray:[_dataSource visibleElementsForRangeController:self]];
-  ASWeakSet *newVisibleNodes = [[ASWeakSet alloc] init];
-
-  if (visibleElements.count == 0) { // if we don't have any visibleNodes currently (scrolled before or after content)...
-    [self _setVisibleNodes:newVisibleNodes];
-    return; // don't do anything for this update, but leave _rangeIsValid == NO to make sure we update it later
-  }
+  
   ASProfilingSignpostStart(1, self);
 
   // Get the scroll direction. Default to using the previous one, if they're not scrolling.
@@ -355,9 +331,6 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
     ASCellNode *node = [map elementForItemAtIndexPath:indexPath].nodeIfAllocated;
     if (node != nil) {
       ASDisplayNodeAssert(node.hierarchyState & ASHierarchyStateRangeManaged, @"All nodes reaching this point should be range-managed, or interfaceState may be incorrectly reset.");
-      if (ASInterfaceStateIncludesVisible(interfaceState)) {
-        [newVisibleNodes addObject:node];
-      }
       // Skip the many method calls of the recursive operation if the top level cell node already has the right interfaceState.
       if (node.interfaceState != interfaceState) {
 #if ASRangeControllerLoggingEnabled
@@ -376,8 +349,6 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
       }
     }
   }
-
-  [self _setVisibleNodes:newVisibleNodes];
   
   // TODO: This code is for debugging only, but would be great to clean up with a delegate method implementation.
   if (ASDisplayNode.shouldShowRangeDebugOverlay) {
@@ -493,9 +464,6 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
 - (void)dataController:(ASDataController *)dataController willUpdateWithChangeSet:(_ASHierarchyChangeSet *)changeSet
 {
   ASDisplayNodeAssertMainThread();
-  if (changeSet.includesReloadData) {
-    [self _setVisibleNodes:nil];
-  }
   [_delegate rangeController:self willUpdateWithChangeSet:changeSet];
 }
 

--- a/Source/Details/_ASCollectionReusableView.h
+++ b/Source/Details/_ASCollectionReusableView.h
@@ -18,13 +18,14 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
-@class ASCellNode;
+@class ASCellNode, ASCollectionElement;
 
 NS_ASSUME_NONNULL_BEGIN
 
 AS_SUBCLASSING_RESTRICTED
 @interface _ASCollectionReusableView : UICollectionReusableView
-@property (nonatomic, weak) ASCellNode *node;
+@property (nonatomic, strong, readonly, nullable) ASCellNode *node;
+@property (nonatomic, strong, nullable) ASCollectionElement *element;
 @property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
 @end
 

--- a/Source/Details/_ASCollectionReusableView.m
+++ b/Source/Details/_ASCollectionReusableView.m
@@ -17,29 +17,35 @@
 
 #import "_ASCollectionReusableView.h"
 #import "ASCellNode+Internal.h"
+#import <AsyncDisplayKit/ASCollectionElement.h>
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 
 @implementation _ASCollectionReusableView
 
-- (void)setNode:(ASCellNode *)node
+- (ASCellNode *)node
+{
+  return self.element.node;
+}
+
+- (void)setElement:(ASCollectionElement *)element
 {
   ASDisplayNodeAssertMainThread();
-  node.layoutAttributes = _layoutAttributes;
-  _node = node;
+  element.node.layoutAttributes = _layoutAttributes;
+  _element = element;
 }
 
 - (void)setLayoutAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes
 {
   _layoutAttributes = layoutAttributes;
-  _node.layoutAttributes = layoutAttributes;
+  self.node.layoutAttributes = layoutAttributes;
 }
 
 - (void)prepareForReuse
 {
   self.layoutAttributes = nil;
   
-  // Need to clear node pointer before UIKit calls setSelected:NO / setHighlighted:NO on its cells
-  self.node = nil;
+  // Need to clear element before UIKit calls setSelected:NO / setHighlighted:NO on its cells
+  self.element = nil;
   [super prepareForReuse];
 }
 

--- a/Source/Details/_ASCollectionViewCell.h
+++ b/Source/Details/_ASCollectionViewCell.h
@@ -18,13 +18,14 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
-@class ASCellNode;
+@class ASCellNode, ASCollectionElement;
 
 NS_ASSUME_NONNULL_BEGIN
 
 AS_SUBCLASSING_RESTRICTED
 @interface _ASCollectionViewCell : UICollectionViewCell
-@property (nonatomic, weak) ASCellNode *node;
+@property (nonatomic, strong, nullable) ASCollectionElement *element;
+@property (nonatomic, strong, readonly, nullable) ASCellNode *node;
 @property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
 @end
 

--- a/Source/Details/_ASCollectionViewCell.m
+++ b/Source/Details/_ASCollectionViewCell.m
@@ -18,14 +18,21 @@
 #import "_ASCollectionViewCell.h"
 #import "ASCellNode+Internal.h"
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
+#import <AsyncDisplayKit/ASCollectionElement.h>
 
 @implementation _ASCollectionViewCell
 
-- (void)setNode:(ASCellNode *)node
+- (ASCellNode *)node
+{
+  return self.element.node;
+}
+
+- (void)setElement:(ASCollectionElement *)element
 {
   ASDisplayNodeAssertMainThread();
+  ASCellNode *node = element.node;
   node.layoutAttributes = _layoutAttributes;
-  _node = node;
+  _element = element;
   
   [node __setSelectedFromUIKit:self.selected];
   [node __setHighlightedFromUIKit:self.highlighted];
@@ -34,27 +41,27 @@
 - (void)setSelected:(BOOL)selected
 {
   [super setSelected:selected];
-  [_node __setSelectedFromUIKit:selected];
+  [self.node __setSelectedFromUIKit:selected];
 }
 
 - (void)setHighlighted:(BOOL)highlighted
 {
   [super setHighlighted:highlighted];
-  [_node __setHighlightedFromUIKit:highlighted];
+  [self.node __setHighlightedFromUIKit:highlighted];
 }
 
 - (void)setLayoutAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes
 {
   _layoutAttributes = layoutAttributes;
-  _node.layoutAttributes = layoutAttributes;
+  self.node.layoutAttributes = layoutAttributes;
 }
 
 - (void)prepareForReuse
 {
   self.layoutAttributes = nil;
 
-  // Need to clear node pointer before UIKit calls setSelected:NO / setHighlighted:NO on its cells
-  self.node = nil;
+  // Need to clear element before UIKit calls setSelected:NO / setHighlighted:NO on its cells
+  self.element = nil;
   [super prepareForReuse];
 }
 


### PR DESCRIPTION
cc #145  . I never had a reliable repro for it, so I'm counting on the community to test this patch.

`willDisplayCell` and `didEndDisplayingCell` are the authoritative sources for what elements are visible. Elements may be visible in multiple cells e.g. during animations, so we use a counted set.

- Replace `(weak)_ASCollectionViewCell.node` with `(strong)_ASCollectionViewCell.element`.
- Add an `NSCountedSet<ASCollectionElement *> *_visibleElements` to collection view.
- In `willDisplayCell:` and `didEndDisplayingCell:`, add/remove the cell's element from the visible set.
- Modify `visibleElementsForRangeController:` to just return a copy of this set.
- Put back the dealloc-while-visible assertion.