### PR TITLE
[ASCollectionView] synchronous mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this with your name.
+- Add a synchronous mode to ASCollectionNode, for colletion view data source debugging. [Hannah Troisi](https://github.com/hannahmbanana)
 - Fixed an issue where GIFs with placeholders never had their placeholders uncover the GIF. [Garrett Moon](https://github.com/garrettmoon)
 - [Yoga] Implement ASYogaLayoutSpec, a simplified integration strategy for Yoga-powered layout calculation. [Scott Goodson](https://github.com/appleguy)
 - Fixed an issue where calls to setNeedsDisplay and setNeedsLayout would stop working on loaded nodes. [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/ASCollectionNode+Beta.h
+++ b/Source/ASCollectionNode+Beta.h
@@ -40,6 +40,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) id<ASBatchFetchingDelegate> batchFetchingDelegate;
 
+/**
+ * When this mode is enabled, ASCollectionView matches the timing of UICollectionView as closely as possible, 
+ * ensuring that all reload and edit operations are performed on the main thread as blocking calls. 
+ *
+ * This mode is useful for applications that are debugging issues with their collection view implementation. 
+ * In particular, some applications do not properly conform to the API requirement of UICollectionView, and these 
+ * applications may experience difficulties with ASCollectionView. Providing this mode allows for developers to 
+ * work towards resolving technical debt in their collection view data source, while ramping up asynchronous 
+ * collection layout.
+ *
+ * NOTE: Because this mode results in expensive operations like cell layout being performed on the main thread, 
+ * it should be used as a tool to resolve data source conformance issues with Apple collection view API.
+ *
+ * @default defaults to NO.
+ */
+@property (nonatomic, assign) BOOL usesSynchronousDataLoading;
+
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(nullable id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator;
 
 - (instancetype)initWithLayoutDelegate:(id<ASCollectionLayoutDelegate>)layoutDelegate layoutFacilitator:(nullable id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator;

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -45,6 +45,7 @@
 @property (nonatomic, assign) BOOL allowsSelection; // default is YES
 @property (nonatomic, assign) BOOL allowsMultipleSelection; // default is NO
 @property (nonatomic, assign) BOOL inverted; //default is NO
+@property (nonatomic, assign) BOOL usesSynchronousDataLoading;
 @property (nonatomic, assign) CGFloat leadingScreensForBatching;
 @property (weak, nonatomic) id <ASCollectionViewLayoutInspecting> layoutInspector;
 @end
@@ -175,13 +176,14 @@
   
   if (_pendingState) {
     _ASCollectionPendingState *pendingState = _pendingState;
-    self.pendingState            = nil;
-    view.asyncDelegate           = pendingState.delegate;
-    view.asyncDataSource         = pendingState.dataSource;
-    view.inverted                = pendingState.inverted;
-    view.allowsSelection         = pendingState.allowsSelection;
-    view.allowsMultipleSelection = pendingState.allowsMultipleSelection;
-    view.layoutInspector         = pendingState.layoutInspector;
+    view.asyncDelegate              = pendingState.delegate;
+    view.asyncDataSource            = pendingState.dataSource;
+    view.inverted                   = pendingState.inverted;
+    view.allowsSelection            = pendingState.allowsSelection;
+    view.allowsMultipleSelection    = pendingState.allowsMultipleSelection;
+    view.usesSynchronousDataLoading = pendingState.usesSynchronousDataLoading;
+    view.layoutInspector            = pendingState.layoutInspector;
+    self.pendingState               = nil;
     
     if (pendingState.rangeMode != ASLayoutRangeModeUnspecified) {
       [view.rangeController updateCurrentRangeWithMode:pendingState.rangeMode];
@@ -466,12 +468,20 @@
 
 - (BOOL)usesSynchronousDataLoading
 {
-  return self.view.usesSynchronousDataLoading;
+  if ([self pendingState]) {
+    return _pendingState.usesSynchronousDataLoading; 
+  } else {
+    return self.view.usesSynchronousDataLoading;
+  }
 }
 
 - (void)setUsesSynchronousDataLoading:(BOOL)usesSynchronousDataLoading
 {
-  self.view.usesSynchronousDataLoading = usesSynchronousDataLoading;
+  if ([self pendingState]) {
+    _pendingState.usesSynchronousDataLoading = usesSynchronousDataLoading; 
+  } else {
+    self.view.usesSynchronousDataLoading = usesSynchronousDataLoading;
+  }
 }
 
 #pragma mark - Range Tuning

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -464,6 +464,16 @@
   return _batchFetchingDelegate;
 }
 
+- (BOOL)usesSynchronousDataLoading
+{
+  return self.view.usesSynchronousDataLoading;
+}
+
+- (void)setUsesSynchronousDataLoading:(BOOL)usesSynchronousDataLoading
+{
+  self.view.usesSynchronousDataLoading = usesSynchronousDataLoading;
+}
+
 #pragma mark - Range Tuning
 
 - (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -767,6 +767,16 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   return visibleNodes;
 }
 
+- (BOOL)usesSynchronousDataLoading
+{
+  return self.dataController.usesSynchronousDataLoading;
+}
+
+- (void)setUsesSynchronousDataLoading:(BOOL)usesSynchronousDataLoading
+{
+  self.dataController.usesSynchronousDataLoading = usesSynchronousDataLoading;
+}
+
 #pragma mark Internal
 
 - (void)_configureCollectionViewLayout:(nonnull UICollectionViewLayout *)layout

--- a/Source/Details/ASCollectionInternal.h
+++ b/Source/Details/ASCollectionInternal.h
@@ -32,6 +32,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) ASRangeController *rangeController;
 
 /**
+ * @see ASCollectionNode+Beta.h for full documentation.
+ */
+@property (nonatomic, assign) BOOL usesSynchronousDataLoading;
+
+/**
  * Attempt to get the view-layer index path for the item with the given index path.
  *
  * @param indexPath The index path of the item.

--- a/Source/Details/ASDataController.h
+++ b/Source/Details/ASDataController.h
@@ -227,6 +227,11 @@ extern NSString * const ASCollectionInvalidUpdateException;
 @property (nonatomic, strong, readonly) ASEventLog *eventLog;
 #endif
 
+/**
+ * @see ASCollectionNode+Beta.h for full documentation.
+ */
+@property (nonatomic, assign) BOOL usesSynchronousDataLoading;
+
 /** @name Data Updating */
 
 - (void)updateWithChangeSet:(_ASHierarchyChangeSet *)changeSet;

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -582,6 +582,10 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
       }];
     }];
   });
+  
+  if (_usesSynchronousDataLoading) {
+    dispatch_group_wait(_editingTransactionGroup, DISPATCH_TIME_FOREVER);
+  }
 }
 
 /**

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -584,7 +584,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   });
   
   if (_usesSynchronousDataLoading) {
-    dispatch_group_wait(_editingTransactionGroup, DISPATCH_TIME_FOREVER);
+    [self waitUntilAllUpdatesAreCommitted];
   }
 }
 


### PR DESCRIPTION
Adds a `usesSynchronousDataLoading` mode to `ASCollectionView`. When this mode is enabled, `ASCollectionView` matches the timing of `UICollectionView` as closely as possible, ensuring that all reload and edit operations are performed on the main thread as blocking calls. 

This mode is useful for applications that are debugging issues with their collection view implementation. In particular, some applications do not correctly conform to the `UICollectionView` API, and these apps may experience difficulties with `ASCollectionView`. Providing this mode allows for developers to work on resolving their issues with the collection view data source, while ramping up on asynchronous collection layout. 