### PR TITLE
[ASDataController] Add event logging for transaction queue flush duration #trivial

### DIFF
--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -510,7 +510,8 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   NSString *changeSetDescription = ASObjectDescriptionMakeTiny(changeSet);
   [changeSet addCompletionHandler:^(BOOL finished) {
     ASDataControllerLogEvent(self, @"finishedUpdate in %fms: %@",
-                             (CACurrentMediaTime() - changeSetStartTime) * 1000.0f, changeSetDescription);  }];
+                             (CACurrentMediaTime() - changeSetStartTime) * 1000.0f, changeSetDescription);
+  }];
 #endif
   
   // Attempt to mark the update completed. This is when update validation will occur inside the changeset.

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -486,7 +486,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
     _initialReloadDataHasBeenCalled = YES;
   }
   
-  NSTimeInterval transactionQueueFlushDuration;
+  NSTimeInterval transactionQueueFlushDuration = 0.0f;
   {
     ASDN::ScopeTimer t(transactionQueueFlushDuration);
     dispatch_group_wait(_editingTransactionGroup, DISPATCH_TIME_FOREVER);
@@ -503,7 +503,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   [self invalidateDataSourceItemCounts];
   
   // Log events
-  ASDataControllerLogEvent(self, @"triggeredUpdate (waited on editing queue for %@ms): %@", transactionQueueFlushDuration * 1000, changeSet);
+  ASDataControllerLogEvent(self, @"triggeredUpdate (waited on editing queue for %fms): %@", transactionQueueFlushDuration * 1000, changeSet);
 #if ASEVENTLOG_ENABLE
   NSString *changeSetDescription = ASObjectDescriptionMakeTiny(changeSet);
   [changeSet addCompletionHandler:^(BOOL finished) {

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -503,12 +503,14 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   [self invalidateDataSourceItemCounts];
   
   // Log events
-  ASDataControllerLogEvent(self, @"triggeredUpdate (waited on editing queue for %fms): %@", transactionQueueFlushDuration * 1000, changeSet);
 #if ASEVENTLOG_ENABLE
+  ASDataControllerLogEvent(self, @"updateWithChangeSet waited on previous update for %fms. changeSet: %@",
+                           transactionQueueFlushDuration * 1000.0f, changeSet);
+  NSTimeInterval changeSetStartTime = CACurrentMediaTime();
   NSString *changeSetDescription = ASObjectDescriptionMakeTiny(changeSet);
   [changeSet addCompletionHandler:^(BOOL finished) {
-    ASDataControllerLogEvent(self, @"finishedUpdate: %@", changeSetDescription);
-  }];
+    ASDataControllerLogEvent(self, @"finishedUpdate in %fms: %@",
+                             (CACurrentMediaTime() - changeSetStartTime) * 1000.0f, changeSetDescription);  }];
 #endif
   
   // Attempt to mark the update completed. This is when update validation will occur inside the changeset.


### PR DESCRIPTION
One of the most common performance problems in a Texture app occurs when a developer makes multiple edit transactions to a collection / table right after each other, before the processing of the previous operation is finished. In this case, Texture blocks on the completion of the current edit operation, even though it would have been asynchronous if the second / subsequent operation had not been started.

The ASEventLog provides the ability to capture the information on this subtle perf issue. In the -ASDataController updateWithChangeSet: method, we can time the duration of the dispatch group wait of the editing transaction queue and log both the time as well as the stack trace so the developer can see which edit operations are triggering performance issues.