### PR TITLE
Small changes required by the coming layout debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@
 - [Fix] Fixed a bug where ASVideoNodeDelegate error reporting callback would crash an app because of not responding to selector. [Sergey Petrachkov](https://github.com/Petrachkov) [#291](https://github.com/TextureGroup/Texture/issues/291)
 - [IGListKit] Add IGListKit headers to public section of Xcode project [Michael Schneider](https://github.com/maicki)[#286](https://github.com/TextureGroup/Texture/pull/286)
 - [Layout] Ensure -layout and -layoutDidFinish are called only if a node is loaded. [Huy Nguyen](https://github.com/nguyenhuy) [#285](https://github.com/TextureGroup/Texture/pull/285)
+- [Layout Debugger] Small changes needed for the coming layout debugger [Huy Nguyen](https://github.com/nguyenhuy) [#337](https://github.com/TextureGroup/Texture/pull/337)

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -911,6 +911,12 @@ ASPrimitiveTraitCollectionDeprecatedImplementation
   ASDisplayNodeAssertTrue(displayNodeLayout->layout.size.width >= 0.0);
   ASDisplayNodeAssertTrue(displayNodeLayout->layout.size.height >= 0.0);
   
+  // Flatten the layout if it wasn't done before (@see -calculateLayoutThatFits:).
+  if (ASDisplayNode.shouldStoreUnflattenedLayouts) {
+    _unflattenedLayout = displayNodeLayout->layout;
+    displayNodeLayout->layout = [_unflattenedLayout filteredNodeLayoutTree];
+  }
+  
   _calculatedDisplayNodeLayout = displayNodeLayout;
 }
 

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -912,7 +912,7 @@ ASPrimitiveTraitCollectionDeprecatedImplementation
   ASDisplayNodeAssertTrue(displayNodeLayout->layout.size.height >= 0.0);
   
   // Flatten the layout if it wasn't done before (@see -calculateLayoutThatFits:).
-  if (ASDisplayNode.shouldStoreUnflattenedLayouts) {
+  if ([ASDisplayNode shouldStoreUnflattenedLayouts]) {
     _unflattenedLayout = displayNodeLayout->layout;
     displayNodeLayout->layout = [_unflattenedLayout filteredNodeLayoutTree];
   }

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -554,6 +554,19 @@ extern NSInteger const ASDefaultDrawingPriority;
 @interface ASDisplayNode (Debugging) <ASDebugNameProvider>
 
 /**
+ * Whether ASDisplayNode should store their unflattened layouts. The layout can be accessed via `-unflattenedCalculatedLayout`.
+ * Flattened layouts use less memory and are faster to lookup, while unflattened ones are useful for debugging
+ * because they reserve original information.
+ *
+ * Defaults to NO.
+ */
++ (void)setShouldStoreUnflattenedLayouts:(BOOL)shouldStore;
+
++ (BOOL)shouldStoreUnflattenedLayouts;
+
+@property (nonatomic, strong, readonly, nullable) ASLayout *unflattenedCalculatedLayout;
+
+/**
  * @abstract Return a description of the node hierarchy.
  *
  * @discussion For debugging: (lldb) po [node displayNodeRecursiveDescription]

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -554,14 +554,25 @@ extern NSInteger const ASDefaultDrawingPriority;
 @interface ASDisplayNode (Debugging) <ASDebugNameProvider>
 
 /**
- * Whether ASDisplayNode should store their unflattened layouts. The layout can be accessed via `-unflattenedCalculatedLayout`.
- * Flattened layouts use less memory and are faster to lookup, while unflattened ones are useful for debugging
- * because they reserve original information.
+ * Set to YES to tell all ASDisplayNode instances to store their unflattened layouts.
  *
- * Defaults to NO.
+ * The layout can be accessed via `-unflattenedCalculatedLayout`.
+ *
+ * Flattened layouts use less memory and are faster to lookup. On the other hand, unflattened layouts are useful for debugging
+ * because they preserve original information.
  */
 + (void)setShouldStoreUnflattenedLayouts:(BOOL)shouldStore;
 
+/**
+ * Whether or not ASDisplayNode instances should store their unflattened layouts. 
+ *
+ * The layout can be accessed via `-unflattenedCalculatedLayout`.
+ * 
+ * Flattened layouts use less memory and are faster to lookup. On the other hand, unflattened layouts are useful for debugging
+ * because they preserve original information.
+ *
+ * Defaults to NO.
+ */
 + (BOOL)shouldStoreUnflattenedLayouts;
 
 @property (nonatomic, strong, readonly, nullable) ASLayout *unflattenedCalculatedLayout;

--- a/Source/ASDisplayNodeExtras.h
+++ b/Source/ASDisplayNodeExtras.h
@@ -98,7 +98,7 @@ extern ASDisplayNode * _Nullable ASLayerToDisplayNode(CALayer * _Nullable layer)
 extern ASDisplayNode * _Nullable ASViewToDisplayNode(UIView * _Nullable view) AS_WARN_UNUSED_RESULT;
 
 /**
- Given a node, returns the root of the node heirarchy (where supernode == nil)
+ Given a node, returns the root of the node hierarchy (where supernode == nil)
  */
 extern ASDisplayNode *ASDisplayNodeUltimateParentOfNode(ASDisplayNode *node) AS_WARN_UNUSED_RESULT;
 

--- a/Source/Layout/ASLayout.h
+++ b/Source/Layout/ASLayout.h
@@ -177,10 +177,16 @@ ASDISPLAYNODE_EXTERN_C_END
 @interface ASLayout (Debugging)
 
 /**
- * Set to YES to tell all ASLayout instances to retain their sublayouts. Defaults to NO.
- * Can be overridden at instance level. 
+ * Set to YES to tell all ASLayout instances to retain their sublayout elements. Defaults to NO.
+ * Can be overridden at instance level.
  */
 + (void)setShouldRetainSublayoutLayoutElements:(BOOL)shouldRetain;
+
+/**
+ * Whether or not ASLayout instances should retain their sublayout elements.
+ * Can be overridden at instance level.
+ */
++ (BOOL)shouldRetainSublayoutLayoutElements;
 
 /**
  * Recrusively output the description of the layout tree.

--- a/Source/Layout/ASLayout.h
+++ b/Source/Layout/ASLayout.h
@@ -177,6 +177,12 @@ ASDISPLAYNODE_EXTERN_C_END
 @interface ASLayout (Debugging)
 
 /**
+ * Set to YES to tell all ASLayout instances to retain their sublayouts. Defaults to NO.
+ * Can be overridden at instance level. 
+ */
++ (void)setShouldRetainSublayoutLayoutElements:(BOOL)shouldRetain;
+
+/**
  * Recrusively output the description of the layout tree.
  */
 - (NSString *)recursiveDescription;

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -76,6 +76,13 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 
 @dynamic frame, type;
 
+static BOOL static_retainsSublayoutLayoutElements = NO;
+
++ (void)setShouldRetainSublayoutLayoutElements:(BOOL)shouldRetain
+{
+  static_retainsSublayoutLayoutElements = shouldRetain;
+}
+
 - (instancetype)initWithLayoutElement:(id<ASLayoutElement>)layoutElement
                                  size:(CGSize)size
                              position:(CGPoint)position
@@ -118,7 +125,7 @@ static inline NSString * descriptionIndents(NSUInteger indents)
     }
     
     _flattened = NO;
-    _retainSublayoutLayoutElements = NO;
+    self.retainSublayoutLayoutElements = static_retainsSublayoutLayoutElements;
   }
   
   return self;

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -76,11 +76,16 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 
 @dynamic frame, type;
 
-static BOOL static_retainsSublayoutLayoutElements = NO;
+static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(NO);
 
 + (void)setShouldRetainSublayoutLayoutElements:(BOOL)shouldRetain
 {
-  static_retainsSublayoutLayoutElements = shouldRetain;
+  static_retainsSublayoutLayoutElements.store(shouldRetain);
+}
+
++ (BOOL)shouldRetainSublayoutLayoutElements
+{
+  return static_retainsSublayoutLayoutElements.load();
 }
 
 - (instancetype)initWithLayoutElement:(id<ASLayoutElement>)layoutElement
@@ -125,7 +130,7 @@ static BOOL static_retainsSublayoutLayoutElements = NO;
     }
     
     _flattened = NO;
-    self.retainSublayoutLayoutElements = static_retainsSublayoutLayoutElements;
+    self.retainSublayoutLayoutElements = [ASLayout shouldRetainSublayoutLayoutElements];
   }
   
   return self;

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -211,6 +211,9 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   
   NSString *_debugName;
 
+#pragma mark - ASDisplayNode (Debugging)
+  ASLayout *_unflattenedLayout;
+
 #if TIME_DISPLAYNODE_OPS
 @public
   NSTimeInterval _debugTimeToCreateView;


### PR DESCRIPTION
- `ASDisplayNode` can be told to not flatten its layout immediately but later on. The unflattened layout is also stored in a separate property. It's needed for inspecting not only display nodes but also layout specs used to compute a layout tree.
- `ASLayout` can be told to always retain its sublayout elements. This is needed especially for layout specs since they are usually not retained after an `ASLayout` is computed.