### PR TITLE
1st prototype of Texture debugger

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -444,8 +444,6 @@
 		E5EEAABD1EE7527D00FC07DA /* TDDebugger.m in Sources */ = {isa = PBXBuildFile; fileRef = E5EEAAAF1EE7527D00FC07DA /* TDDebugger.m */; };
 		E5EEAAC01EE7527D00FC07DA /* TDElementDomainController.h in Headers */ = {isa = PBXBuildFile; fileRef = E5EEAAB21EE7527D00FC07DA /* TDElementDomainController.h */; };
 		E5EEAAC11EE7527D00FC07DA /* TDElementDomainController.m in Sources */ = {isa = PBXBuildFile; fileRef = E5EEAAB31EE7527D00FC07DA /* TDElementDomainController.m */; };
-		E5EEAAC21EE7527D00FC07DA /* TDElementPropsDomainController.h in Headers */ = {isa = PBXBuildFile; fileRef = E5EEAAB41EE7527D00FC07DA /* TDElementPropsDomainController.h */; };
-		E5EEAAC31EE7527D00FC07DA /* TDElementPropsDomainController.m in Sources */ = {isa = PBXBuildFile; fileRef = E5EEAAB51EE7527D00FC07DA /* TDElementPropsDomainController.m */; };
 		E5EEAAC41EE7527D00FC07DA /* TDDOMContext.h in Headers */ = {isa = PBXBuildFile; fileRef = E5EEAAB61EE7527D00FC07DA /* TDDOMContext.h */; };
 		E5EEAAC51EE7527D00FC07DA /* TDDOMContext.m in Sources */ = {isa = PBXBuildFile; fileRef = E5EEAAB71EE7527D00FC07DA /* TDDOMContext.m */; };
 		F711994E1D20C21100568860 /* ASDisplayNodeExtrasTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F711994D1D20C21100568860 /* ASDisplayNodeExtrasTests.m */; };
@@ -918,8 +916,6 @@
 		E5EEAAAF1EE7527D00FC07DA /* TDDebugger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TDDebugger.m; path = Debugger/TDDebugger.m; sourceTree = "<group>"; };
 		E5EEAAB21EE7527D00FC07DA /* TDElementDomainController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TDElementDomainController.h; path = Debugger/TDElementDomainController.h; sourceTree = "<group>"; };
 		E5EEAAB31EE7527D00FC07DA /* TDElementDomainController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TDElementDomainController.m; path = Debugger/TDElementDomainController.m; sourceTree = "<group>"; };
-		E5EEAAB41EE7527D00FC07DA /* TDElementPropsDomainController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TDElementPropsDomainController.h; path = Debugger/TDElementPropsDomainController.h; sourceTree = "<group>"; };
-		E5EEAAB51EE7527D00FC07DA /* TDElementPropsDomainController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TDElementPropsDomainController.m; path = Debugger/TDElementPropsDomainController.m; sourceTree = "<group>"; };
 		E5EEAAB61EE7527D00FC07DA /* TDDOMContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TDDOMContext.h; path = Debugger/TDDOMContext.h; sourceTree = "<group>"; };
 		E5EEAAB71EE7527D00FC07DA /* TDDOMContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TDDOMContext.m; path = Debugger/TDDOMContext.m; sourceTree = "<group>"; };
 		EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AsyncDisplayKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1623,8 +1619,6 @@
 				E5EEAAAF1EE7527D00FC07DA /* TDDebugger.m */,
 				E5EEAAB21EE7527D00FC07DA /* TDElementDomainController.h */,
 				E5EEAAB31EE7527D00FC07DA /* TDElementDomainController.m */,
-				E5EEAAB41EE7527D00FC07DA /* TDElementPropsDomainController.h */,
-				E5EEAAB51EE7527D00FC07DA /* TDElementPropsDomainController.m */,
 				E5EEAAB61EE7527D00FC07DA /* TDDOMContext.h */,
 				E5EEAAB71EE7527D00FC07DA /* TDDOMContext.m */,
 			);
@@ -1764,7 +1758,6 @@
 				254C6B771BF94DF4003EC431 /* ASTextKitAttributes.h in Headers */,
 				254C6B7D1BF94DF4003EC431 /* ASTextKitShadower.h in Headers */,
 				690ED58E1E36BCA6000627C0 /* ASLayoutElementStylePrivate.h in Headers */,
-				E5EEAAC21EE7527D00FC07DA /* TDElementPropsDomainController.h in Headers */,
 				CC55A70D1E529FA200594372 /* UIResponder+AsyncDisplayKit.h in Headers */,
 				254C6B731BF94DF4003EC431 /* ASTextKitCoreTextAdditions.h in Headers */,
 				254C6B7A1BF94DF4003EC431 /* ASTextKitRenderer.h in Headers */,
@@ -2261,7 +2254,6 @@
 				696F01EE1DD2AF450049FBD5 /* ASEventLog.mm in Sources */,
 				9C70F2051CDA4F06007D6C76 /* ASTraitCollection.m in Sources */,
 				83A7D95B1D44547700BF333E /* ASWeakMap.m in Sources */,
-				E5EEAAC31EE7527D00FC07DA /* TDElementPropsDomainController.m in Sources */,
 				CC034A0A1E60BEB400626263 /* ASDisplayNode+Convenience.m in Sources */,
 				E58E9E431E941D74004CFC59 /* ASCollectionFlowLayoutDelegate.m in Sources */,
 				DE84918E1C8FFF9F003D89E9 /* ASRunLoopQueue.mm in Sources */,

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -436,6 +436,18 @@
 		E5C347B31ECB40AA00EC4BE4 /* ASTableNode+Beta.h in Headers */ = {isa = PBXBuildFile; fileRef = E5C347B21ECB40AA00EC4BE4 /* ASTableNode+Beta.h */; };
 		E5E281741E71C833006B67C2 /* ASCollectionLayoutState.h in Headers */ = {isa = PBXBuildFile; fileRef = E5E281731E71C833006B67C2 /* ASCollectionLayoutState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5E281761E71C845006B67C2 /* ASCollectionLayoutState.m in Sources */ = {isa = PBXBuildFile; fileRef = E5E281751E71C845006B67C2 /* ASCollectionLayoutState.m */; };
+		E5EEAAB81EE7527D00FC07DA /* NSObject+TextureDebugger.h in Headers */ = {isa = PBXBuildFile; fileRef = E5EEAAAA1EE7527D00FC07DA /* NSObject+TextureDebugger.h */; };
+		E5EEAAB91EE7527D00FC07DA /* NSObject+TextureDebugger.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5EEAAAB1EE7527D00FC07DA /* NSObject+TextureDebugger.mm */; };
+		E5EEAABA1EE7527D00FC07DA /* PDDOMTypes+UIKit.h in Headers */ = {isa = PBXBuildFile; fileRef = E5EEAAAC1EE7527D00FC07DA /* PDDOMTypes+UIKit.h */; };
+		E5EEAABB1EE7527D00FC07DA /* PDDOMTypes+UIKit.m in Sources */ = {isa = PBXBuildFile; fileRef = E5EEAAAD1EE7527D00FC07DA /* PDDOMTypes+UIKit.m */; };
+		E5EEAABC1EE7527D00FC07DA /* TDDebugger.h in Headers */ = {isa = PBXBuildFile; fileRef = E5EEAAAE1EE7527D00FC07DA /* TDDebugger.h */; };
+		E5EEAABD1EE7527D00FC07DA /* TDDebugger.m in Sources */ = {isa = PBXBuildFile; fileRef = E5EEAAAF1EE7527D00FC07DA /* TDDebugger.m */; };
+		E5EEAAC01EE7527D00FC07DA /* TDElementDomainController.h in Headers */ = {isa = PBXBuildFile; fileRef = E5EEAAB21EE7527D00FC07DA /* TDElementDomainController.h */; };
+		E5EEAAC11EE7527D00FC07DA /* TDElementDomainController.m in Sources */ = {isa = PBXBuildFile; fileRef = E5EEAAB31EE7527D00FC07DA /* TDElementDomainController.m */; };
+		E5EEAAC21EE7527D00FC07DA /* TDElementPropsDomainController.h in Headers */ = {isa = PBXBuildFile; fileRef = E5EEAAB41EE7527D00FC07DA /* TDElementPropsDomainController.h */; };
+		E5EEAAC31EE7527D00FC07DA /* TDElementPropsDomainController.m in Sources */ = {isa = PBXBuildFile; fileRef = E5EEAAB51EE7527D00FC07DA /* TDElementPropsDomainController.m */; };
+		E5EEAAC41EE7527D00FC07DA /* TDDOMContext.h in Headers */ = {isa = PBXBuildFile; fileRef = E5EEAAB61EE7527D00FC07DA /* TDDOMContext.h */; };
+		E5EEAAC51EE7527D00FC07DA /* TDDOMContext.m in Sources */ = {isa = PBXBuildFile; fileRef = E5EEAAB71EE7527D00FC07DA /* TDDOMContext.m */; };
 		F711994E1D20C21100568860 /* ASDisplayNodeExtrasTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F711994D1D20C21100568860 /* ASDisplayNodeExtrasTests.m */; };
 /* End PBXBuildFile section */
 
@@ -898,6 +910,18 @@
 		E5C347B21ECB40AA00EC4BE4 /* ASTableNode+Beta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASTableNode+Beta.h"; sourceTree = "<group>"; };
 		E5E281731E71C833006B67C2 /* ASCollectionLayoutState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCollectionLayoutState.h; sourceTree = "<group>"; };
 		E5E281751E71C845006B67C2 /* ASCollectionLayoutState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASCollectionLayoutState.m; sourceTree = "<group>"; };
+		E5EEAAAA1EE7527D00FC07DA /* NSObject+TextureDebugger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSObject+TextureDebugger.h"; path = "Debugger/NSObject+TextureDebugger.h"; sourceTree = "<group>"; };
+		E5EEAAAB1EE7527D00FC07DA /* NSObject+TextureDebugger.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSObject+TextureDebugger.mm"; path = "Debugger/NSObject+TextureDebugger.mm"; sourceTree = "<group>"; };
+		E5EEAAAC1EE7527D00FC07DA /* PDDOMTypes+UIKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "PDDOMTypes+UIKit.h"; path = "Debugger/PDDOMTypes+UIKit.h"; sourceTree = "<group>"; };
+		E5EEAAAD1EE7527D00FC07DA /* PDDOMTypes+UIKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "PDDOMTypes+UIKit.m"; path = "Debugger/PDDOMTypes+UIKit.m"; sourceTree = "<group>"; };
+		E5EEAAAE1EE7527D00FC07DA /* TDDebugger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TDDebugger.h; path = Debugger/TDDebugger.h; sourceTree = "<group>"; };
+		E5EEAAAF1EE7527D00FC07DA /* TDDebugger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TDDebugger.m; path = Debugger/TDDebugger.m; sourceTree = "<group>"; };
+		E5EEAAB21EE7527D00FC07DA /* TDElementDomainController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TDElementDomainController.h; path = Debugger/TDElementDomainController.h; sourceTree = "<group>"; };
+		E5EEAAB31EE7527D00FC07DA /* TDElementDomainController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TDElementDomainController.m; path = Debugger/TDElementDomainController.m; sourceTree = "<group>"; };
+		E5EEAAB41EE7527D00FC07DA /* TDElementPropsDomainController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TDElementPropsDomainController.h; path = Debugger/TDElementPropsDomainController.h; sourceTree = "<group>"; };
+		E5EEAAB51EE7527D00FC07DA /* TDElementPropsDomainController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TDElementPropsDomainController.m; path = Debugger/TDElementPropsDomainController.m; sourceTree = "<group>"; };
+		E5EEAAB61EE7527D00FC07DA /* TDDOMContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TDDOMContext.h; path = Debugger/TDDOMContext.h; sourceTree = "<group>"; };
+		E5EEAAB71EE7527D00FC07DA /* TDDOMContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TDDOMContext.m; path = Debugger/TDDOMContext.m; sourceTree = "<group>"; };
 		EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AsyncDisplayKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F711994D1D20C21100568860 /* ASDisplayNodeExtrasTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeExtrasTests.m; sourceTree = "<group>"; };
 		FB07EABBCF28656C6297BC2D /* Pods-AsyncDisplayKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1086,6 +1110,7 @@
 				058D0A01195D050800B7D73C /* Private */,
 				AC6456051B0A333200CF11B8 /* Layout */,
 				257754661BED245B00737CA5 /* TextKit */,
+				E56FF9AD1EC9A75D008C34EC /* Debugger */,
 				690ED5911E36D118000627C0 /* tvOS */,
 				058D09B2195D04C000B7D73C /* Supporting Files */,
 			);
@@ -1587,6 +1612,25 @@
 			path = Debug;
 			sourceTree = "<group>";
 		};
+		E56FF9AD1EC9A75D008C34EC /* Debugger */ = {
+			isa = PBXGroup;
+			children = (
+				E5EEAAAA1EE7527D00FC07DA /* NSObject+TextureDebugger.h */,
+				E5EEAAAB1EE7527D00FC07DA /* NSObject+TextureDebugger.mm */,
+				E5EEAAAC1EE7527D00FC07DA /* PDDOMTypes+UIKit.h */,
+				E5EEAAAD1EE7527D00FC07DA /* PDDOMTypes+UIKit.m */,
+				E5EEAAAE1EE7527D00FC07DA /* TDDebugger.h */,
+				E5EEAAAF1EE7527D00FC07DA /* TDDebugger.m */,
+				E5EEAAB21EE7527D00FC07DA /* TDElementDomainController.h */,
+				E5EEAAB31EE7527D00FC07DA /* TDElementDomainController.m */,
+				E5EEAAB41EE7527D00FC07DA /* TDElementPropsDomainController.h */,
+				E5EEAAB51EE7527D00FC07DA /* TDElementPropsDomainController.m */,
+				E5EEAAB61EE7527D00FC07DA /* TDDOMContext.h */,
+				E5EEAAB71EE7527D00FC07DA /* TDDOMContext.m */,
+			);
+			name = Debugger;
+			sourceTree = "<group>";
+		};
 		E5B077EB1E6843AF00C24B5B /* Collection Layout */ = {
 			isa = PBXGroup;
 			children = (
@@ -1626,6 +1670,8 @@
 				E5E281741E71C833006B67C2 /* ASCollectionLayoutState.h in Headers */,
 				E5B077FF1E69F4EB00C24B5B /* ASElementMap.h in Headers */,
 				CCCCCCE31EC3EF060087FE10 /* NSParagraphStyle+ASText.h in Headers */,
+				E5EEAABC1EE7527D00FC07DA /* TDDebugger.h in Headers */,
+				E5EEAAC01EE7527D00FC07DA /* TDElementDomainController.h in Headers */,
 				E58E9E441E941D74004CFC59 /* ASCollectionLayoutContext.h in Headers */,
 				E58E9E421E941D74004CFC59 /* ASCollectionFlowLayoutDelegate.h in Headers */,
 				696F01EC1DD2AF450049FBD5 /* ASEventLog.h in Headers */,
@@ -1640,6 +1686,7 @@
 				69F10C871C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h in Headers */,
 				B350623C1B010EFD0018CF92 /* _ASAsyncTransaction.h in Headers */,
 				68355B411CB57A6C001D4E68 /* ASImageContainerProtocolCategories.h in Headers */,
+				E5EEAAB81EE7527D00FC07DA /* NSObject+TextureDebugger.h in Headers */,
 				7630FFA81C9E267E007A7C0E /* ASVideoNode.h in Headers */,
 				B350623F1B010EFD0018CF92 /* _ASAsyncTransactionContainer.h in Headers */,
 				B13CA1011C52004900E031AB /* ASCollectionNode+Beta.h in Headers */,
@@ -1661,6 +1708,7 @@
 				A2763D7A1CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.h in Headers */,
 				34EFC7611B701C9C00AD841F /* ASBackgroundLayoutSpec.h in Headers */,
 				B35062591B010F070018CF92 /* ASBaseDefines.h in Headers */,
+				E5EEAAC41EE7527D00FC07DA /* TDDOMContext.h in Headers */,
 				B35062131B010EFD0018CF92 /* ASBasicImageDownloader.h in Headers */,
 				B35062151B010EFD0018CF92 /* ASBatchContext.h in Headers */,
 				B35061F31B010EFD0018CF92 /* ASCellNode.h in Headers */,
@@ -1716,6 +1764,7 @@
 				254C6B771BF94DF4003EC431 /* ASTextKitAttributes.h in Headers */,
 				254C6B7D1BF94DF4003EC431 /* ASTextKitShadower.h in Headers */,
 				690ED58E1E36BCA6000627C0 /* ASLayoutElementStylePrivate.h in Headers */,
+				E5EEAAC21EE7527D00FC07DA /* TDElementPropsDomainController.h in Headers */,
 				CC55A70D1E529FA200594372 /* UIResponder+AsyncDisplayKit.h in Headers */,
 				254C6B731BF94DF4003EC431 /* ASTextKitCoreTextAdditions.h in Headers */,
 				254C6B7A1BF94DF4003EC431 /* ASTextKitRenderer.h in Headers */,
@@ -1781,6 +1830,7 @@
 				CC3B208A1C3F7A5400798563 /* ASWeakSet.h in Headers */,
 				B35062041B010EFD0018CF92 /* ASMultiplexImageNode.h in Headers */,
 				DECBD6E81BE56E1900CF4905 /* ASButtonNode.h in Headers */,
+				E5EEAABA1EE7527D00FC07DA /* PDDOMTypes+UIKit.h in Headers */,
 				B35062241B010EFD0018CF92 /* ASMutableAttributedStringBuilder.h in Headers */,
 				B13CA0F81C519EBA00E031AB /* ASCollectionViewLayoutFacilitatorProtocol.h in Headers */,
 				B35062061B010EFD0018CF92 /* ASNetworkImageNode.h in Headers */,
@@ -2091,6 +2141,7 @@
 				B30BF6541C59D889004FCD53 /* ASLayoutManager.m in Sources */,
 				690C35671E0567C600069B91 /* ASDimensionDeprecated.mm in Sources */,
 				92DD2FE71BF4D0850074C9DD /* ASMapNode.mm in Sources */,
+				E5EEAABD1EE7527D00FC07DA /* TDDebugger.m in Sources */,
 				CCA282B91E9EA8E40037E8B7 /* AsyncDisplayKit+Tips.m in Sources */,
 				636EA1A51C7FF4EF00EE152F /* ASDefaultPlayButton.m in Sources */,
 				B350623D1B010EFD0018CF92 /* _ASAsyncTransaction.mm in Sources */,
@@ -2185,6 +2236,7 @@
 				9019FBBE1ED8061D00C45F72 /* ASYogaLayoutSpec.mm in Sources */,
 				B35062071B010EFD0018CF92 /* ASNetworkImageNode.mm in Sources */,
 				34EFC76D1B701CF100AD841F /* ASOverlayLayoutSpec.mm in Sources */,
+				E5EEAABB1EE7527D00FC07DA /* PDDOMTypes+UIKit.m in Sources */,
 				044285101BAA64EC00D16268 /* ASTwoDimensionalArrayUtils.m in Sources */,
 				CCCCCCDE1EC3EF060087FE10 /* ASTextAttribute.m in Sources */,
 				CCA282B51E9EA7310037E8B7 /* ASTipsController.m in Sources */,
@@ -2193,6 +2245,7 @@
 				68FC85E61CE29B9400EDD713 /* ASNavigationController.m in Sources */,
 				CC4C2A791D88E3BF0039ACAB /* ASTraceEvent.m in Sources */,
 				34EFC76F1B701CF700AD841F /* ASRatioLayoutSpec.mm in Sources */,
+				E5EEAAC51EE7527D00FC07DA /* TDDOMContext.m in Sources */,
 				254C6B8B1BF94F8A003EC431 /* ASTextKitShadower.mm in Sources */,
 				254C6B851BF94F8A003EC431 /* ASTextKitAttributes.mm in Sources */,
 				90FC784F1E4BFE1B00383C5A /* ASDisplayNode+Yoga.mm in Sources */,
@@ -2208,6 +2261,7 @@
 				696F01EE1DD2AF450049FBD5 /* ASEventLog.mm in Sources */,
 				9C70F2051CDA4F06007D6C76 /* ASTraitCollection.m in Sources */,
 				83A7D95B1D44547700BF333E /* ASWeakMap.m in Sources */,
+				E5EEAAC31EE7527D00FC07DA /* TDElementPropsDomainController.m in Sources */,
 				CC034A0A1E60BEB400626263 /* ASDisplayNode+Convenience.m in Sources */,
 				E58E9E431E941D74004CFC59 /* ASCollectionFlowLayoutDelegate.m in Sources */,
 				DE84918E1C8FFF9F003D89E9 /* ASRunLoopQueue.mm in Sources */,
@@ -2226,6 +2280,7 @@
 				509E68661B3AEDD7009B9150 /* CoreGraphics+ASConvenience.m in Sources */,
 				254C6B871BF94F8A003EC431 /* ASTextKitEntityAttribute.m in Sources */,
 				34566CB31BC1213700715E6B /* ASPhotosFrameworkImageRequest.m in Sources */,
+				E5EEAAC11EE7527D00FC07DA /* TDElementDomainController.m in Sources */,
 				254C6B831BF94F8A003EC431 /* ASTextKitCoreTextAdditions.m in Sources */,
 				CCCCCCE21EC3EF060087FE10 /* ASTextUtilities.m in Sources */,
 				CC55A70E1E529FA200594372 /* UIResponder+AsyncDisplayKit.m in Sources */,
@@ -2235,6 +2290,7 @@
 				044284FD1BAA365100D16268 /* UICollectionViewLayout+ASConvenience.m in Sources */,
 				CC0F885B1E42807F00576FED /* ASCollectionViewFlowLayoutInspector.m in Sources */,
 				690ED5981E36D118000627C0 /* ASControlNode+tvOS.m in Sources */,
+				E5EEAAB91EE7527D00FC07DA /* NSObject+TextureDebugger.mm in Sources */,
 				254C6B8A1BF94F8A003EC431 /* ASTextKitRenderer+TextChecking.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,4 +35,7 @@
 - [Fix] Fixed a bug where ASVideoNodeDelegate error reporting callback would crash an app because of not responding to selector. [Sergey Petrachkov](https://github.com/Petrachkov) [#291](https://github.com/TextureGroup/Texture/issues/291)
 - [IGListKit] Add IGListKit headers to public section of Xcode project [Michael Schneider](https://github.com/maicki)[#286](https://github.com/TextureGroup/Texture/pull/286)
 - [Layout] Ensure -layout and -layoutDidFinish are called only if a node is loaded. [Huy Nguyen](https://github.com/nguyenhuy) [#285](https://github.com/TextureGroup/Texture/pull/285)
-- [Layout Debugger] Small changes needed for the coming layout debugger [Huy Nguyen](https://github.com/nguyenhuy) [#337](https://github.com/TextureGroup/Texture/pull/337)
+- [Texture Debugger] Introduce the 1st prototype! [Huy Nguyen](https://github.com/nguyenhuy) [#337](htt
+ps://github.com/TextureGroup/Texture/pull/337)
+ [#339](https://github.com/TextureGroup/Texture/pull/339)
+

--- a/Source/Base/ASAvailability.h
+++ b/Source/Base/ASAvailability.h
@@ -50,6 +50,7 @@
 
 #define AS_PIN_REMOTE_IMAGE __has_include(<PINRemoteImage/PINRemoteImage.h>)
 #define AS_IG_LIST_KIT __has_include(<IGListKit/IGListKit.h>)
+#define AS_TEXTURE_DEBUGGER __has_include(<PonyDebugger/PonyDebugger.h>)
 
 /**
  * For IGListKit versions < 3.0, you have to use IGListCollectionView.

--- a/Source/Debugger/NSObject+TextureDebugger.h
+++ b/Source/Debugger/NSObject+TextureDebugger.h
@@ -1,5 +1,5 @@
 //
-//  NSObject+PDDOMNode.h
+//  NSObject+TextureDebugger.h
 //  Texture
 //
 //  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.

--- a/Source/Debugger/NSObject+TextureDebugger.h
+++ b/Source/Debugger/NSObject+TextureDebugger.h
@@ -1,0 +1,33 @@
+//
+//  NSObject+PDDOMNode.h
+//  Texture
+//
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_TEXTURE_DEBUGGER
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class PDDOMNode, TDDOMContext;
+
+@interface NSObject (TextureDebugger)
+
+- (PDDOMNode *)td_generateDOMNodeWithContext:(TDDOMContext *)context;
+- (CGRect)td_frameInWindow;
+- (NSArray *)td_children;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Source/Debugger/NSObject+TextureDebugger.mm
+++ b/Source/Debugger/NSObject+TextureDebugger.mm
@@ -1,0 +1,293 @@
+//
+//  NSObject+TextureDebugger.m
+//  Texture
+//
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_TEXTURE_DEBUGGER
+
+#import <AsyncDisplayKit/AsyncDisplayKit.h>
+#import <AsyncDisplayKit/ASCollectionElement.h>
+#import <AsyncDisplaykit/ASRectTable.h>
+#import <AsyncDisplayKit/NSObject+TextureDebugger.h>
+#import <AsyncDisplayKit/TDDOMContext.h>
+
+#import <PonyDebugger/PDDOMTypes.h>
+
+#import <queue>
+
+// Constants defined in the DOM Level 2 Core: http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-1950641247
+static const int kPDDOMNodeTypeElement = 1;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSObject (TDDOMNodeGenerating)
+
++ (NSString *)td_nodeName;
+
+@end
+
+@implementation NSObject (TextureDebugger)
+
++ (NSString *)td_nodeName
+{
+  return @"object";
+}
+
+- (PDDOMNode *)td_generateDOMNodeWithContext:(TDDOMContext *)context
+{
+  NSNumber *nodeId = [context idForObject:self];
+  [context.idToFrameInWindow setRect:[self td_frameInWindow] forKey:nodeId];
+  
+  PDDOMNode *node = [[PDDOMNode alloc] init];
+  node.nodeType = @(kPDDOMNodeTypeElement);
+  node.nodeId = nodeId;
+  node.nodeName = [[self class] td_nodeName];
+  node.attributes = @[ @"description", self.debugDescription ];
+
+  NSMutableArray *nodeChildren = [NSMutableArray array];
+  for (id child in [self td_children]) {
+    [nodeChildren addObject:[child td_generateDOMNodeWithContext:context]];
+  }
+  node.children = nodeChildren;
+  node.childNodeCount = @(nodeChildren.count);
+  
+  return node;
+}
+
+- (CGRect)td_frameInWindow
+{
+  return CGRectNull;
+}
+
+- (NSArray *)td_children
+{
+  return @[];
+}
+
+@end
+
+@implementation UIApplication (TextureDebugger)
+
++ (NSString *)td_nodeName
+{
+  return @"application";
+}
+
+- (NSArray *)td_children
+{
+  return self.windows;
+}
+
+@end
+
+@implementation CALayer (TextureDebugger)
+
++ (NSString *)td_nodeName
+{
+  return @"layer";
+}
+
+- (PDDOMNode *)td_generateDOMNodeWithContext:(TDDOMContext *)context
+{
+  // For backing store of a display node (view/layer), let the node handle this job
+  ASDisplayNode *displayNode = ASLayerToDisplayNode(self);
+  if (displayNode) {
+    return [displayNode td_generateDOMNodeWithContext:context];
+  }
+  
+  return [super td_generateDOMNodeWithContext:context];
+}
+
+- (CGRect)td_frameInWindow
+{
+  return [self convertRect:self.bounds toLayer:nil];
+}
+
+- (NSArray *)td_children
+{
+  return self.sublayers;
+}
+
+@end
+
+@implementation UIView (TextureDebugger)
+
++ (NSString *)td_nodeName
+{
+  return @"view";
+}
+
+- (PDDOMNode *)td_generateDOMNodeWithContext:(TDDOMContext *)context
+{
+  // For backing store of a display node (view/layer), let the node handle this job
+  ASDisplayNode *displayNode = ASViewToDisplayNode(self);
+  if (displayNode) {
+    return [displayNode td_generateDOMNodeWithContext:context];
+  }
+  
+  return [super td_generateDOMNodeWithContext:context];
+}
+
+- (CGRect)td_frameInWindow
+{
+  return [self convertRect:self.bounds toView:nil];
+}
+
+- (NSArray *)td_children
+{
+  return self.subviews;
+}
+
+@end
+
+@implementation UIWindow (TextureDebugger)
+
++ (NSString *)td_nodeName
+{
+  return @"window";
+}
+
+@end
+
+@implementation ASLayoutSpec (TextureDebugger)
+
++ (NSString *)td_nodeName
+{
+  return @"layout-spec";
+}
+
+@end
+
+@implementation ASDisplayNode (TextureDebugger)
+
++ (NSString *)td_nodeName
+{
+  return @"display-node";
+}
+
+- (PDDOMNode *)td_generateDOMNodeWithContext:(TDDOMContext *)DOMCcontext
+{
+  PDDOMNode *rootNode = [super td_generateDOMNodeWithContext:DOMCcontext];
+  if (rootNode.childNodeCount.intValue > 0) {
+    // If rootNode.children was populated, return right away.
+    return rootNode;
+  }
+  
+  /*
+   * The rest of this method does 2 things:
+   * - Generate the rest of the DOM tree:
+   *      ASDisplayNode has a different way to generate DOM children.
+   *      That is, from an unflattened layout, a DOM child is generated from the layout element of each sublayout in the layout tree.
+   *      In addition, since non-display-node layout elements (e.g layout specs) don't (and shouldn't) store their calculated layout, 
+   *      they can't generate their own DOM children. So it's the responsibility of the root display node to fill out the gaps.
+   * - Calculate the frame in window of some layout elements in the layout tree:
+   *      Non-display-node layout elements can't determine their own frame because they don't have a backing store.
+   *      Thus, it's also the responsibility of the root display node to calculate and keep track of the frame of each child
+   *      and assign to it if need to.
+   */
+  struct Context {
+    PDDOMNode *node;
+    ASLayout *layout;
+    CGRect frameInWindow;
+  };
+  
+  // Queue used to keep track of sublayouts while traversing this layout in BFS frashion.
+  std::queue<Context> queue;
+  queue.push({rootNode, self.unflattenedCalculatedLayout, self.td_frameInWindow});
+  
+  while (!queue.empty()) {
+    Context context = queue.front();
+    queue.pop();
+    
+    ASLayout *layout = context.layout;
+    NSArray<ASLayout *> *sublayouts = layout.sublayouts;
+    PDDOMNode *node = context.node;
+    NSMutableArray<PDDOMNode *> *children = [NSMutableArray arrayWithCapacity:sublayouts.count];
+    CGRect frameInWindow = context.frameInWindow;
+    
+    for (ASLayout *sublayout in sublayouts) {
+      NSObject<ASLayoutElement> *sublayoutElement = sublayout.layoutElement;
+      PDDOMNode *subnode = [sublayoutElement td_generateDOMNodeWithContext:DOMCcontext];
+      [children addObject:subnode];
+      
+      // Non-display-node (sub)elements can't generate their own DOM children and frame in window
+      // We calculate the frame and assign to those now
+      // We add them to the queue to generate their DOM children later
+      if ([sublayout.layoutElement isKindOfClass:[ASDisplayNode class]] == NO) {
+        CGRect sublayoutElementFrameInWindow = CGRectNull;
+        if (! CGRectIsNull(frameInWindow)) {
+          sublayoutElementFrameInWindow = CGRectMake(frameInWindow.origin.x + sublayout.position.x,
+                                                     frameInWindow.origin.y + sublayout.position.y,
+                                                     sublayout.size.width,
+                                                     sublayout.size.height);
+        }
+        [DOMCcontext.idToFrameInWindow setRect:sublayoutElementFrameInWindow forKey:subnode.nodeId];
+        
+        queue.push({subnode, sublayout, sublayoutElementFrameInWindow});
+      }
+    }
+    
+    node.children = children;
+    node.childNodeCount = @(children.count);
+  }
+  
+  return rootNode;
+}
+
+- (CGRect)td_frameInWindow
+{
+  if (self.isNodeLoaded == NO || self.isInHierarchy == NO) {
+    return CGRectNull;
+  }
+  
+  if (self.layerBacked) {
+    return self.layer.td_frameInWindow;
+  } else {
+    return self.view.td_frameInWindow;
+  }
+}
+
+@end
+
+@implementation ASCollectionNode (TextureDebugger)
+
++ (NSString *)td_nodeName
+{
+  return @"collection-node";
+}
+
+- (NSArray *)td_children
+{
+  // Only show visible nodes for now. This requires user to refresh the browser to update the DOM.
+  return self.visibleNodes;
+}
+
+@end
+
+@implementation ASTableNode (TextureDebugger)
+
++ (NSString *)td_nodeName
+{
+  return @"table-node";
+}
+
+- (NSArray *)td_children
+{
+  // Only show visible nodes for now. This requires user to refresh the browser to update the DOM.
+  return self.visibleNodes;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Source/Debugger/NSObject+TextureDebugger.mm
+++ b/Source/Debugger/NSObject+TextureDebugger.mm
@@ -1,5 +1,5 @@
 //
-//  NSObject+TextureDebugger.m
+//  NSObject+TextureDebugger.mm
 //  Texture
 //
 //  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.

--- a/Source/Debugger/PDDOMTypes+UIKit.h
+++ b/Source/Debugger/PDDOMTypes+UIKit.h
@@ -1,0 +1,38 @@
+//
+//  PDDOMTypes+UIKit.h
+//  Texture
+//
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_TEXTURE_DEBUGGER
+
+#import <UIKit/UIKit.h>
+#import <PonyDebugger/PDDOMTypes.h>
+
+@interface NSDictionary (PDDOMRGBA)
+
+-(UIColor *)UIColor;
+
+@end
+
+@interface NSDictionary (PDDOMHighlightConfig)
+
+-(UIColor *)contentUIColor;
+
+-(UIColor *)paddingUIColor;
+
+-(UIColor *)borderUIColor;
+
+-(UIColor *)marginUIColor;
+
+@end
+
+#endif

--- a/Source/Debugger/PDDOMTypes+UIKit.m
+++ b/Source/Debugger/PDDOMTypes+UIKit.m
@@ -1,0 +1,55 @@
+//
+//  PDDOMTypes+UIKit.m
+//  Texture
+//
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_TEXTURE_DEBUGGER
+
+#import "PDDOMTypes+UIKit.h"
+
+@implementation NSDictionary (PDDOMRGBA)
+
+- (UIColor *)UIColor
+{
+  return [UIColor colorWithRed:[[self valueForKey:@"r"] floatValue] / 255.0
+                         green:[[self valueForKey:@"g"] floatValue] / 255.0
+                          blue:[[self valueForKey:@"b"] floatValue] / 255.0
+                         alpha:[[self valueForKey:@"a"] floatValue]];
+}
+
+@end
+
+@implementation NSDictionary (PDDOMHighlightConfig)
+
+- (UIColor *)contentUIColor
+{
+    return ((NSDictionary *)[self valueForKey:@"contentColor"]).UIColor;
+}
+
+- (UIColor *)paddingUIColor
+{
+    return ((NSDictionary *)[self valueForKey:@"paddingColor"]).UIColor;
+}
+
+- (UIColor *)borderUIColor
+{
+    return ((NSDictionary *)[self valueForKey:@"borderColor"]).UIColor;
+}
+
+- (UIColor *)marginUIColor
+{
+    return ((NSDictionary *)[self valueForKey:@"marginColor"]).UIColor;
+}
+
+@end
+
+#endif

--- a/Source/Debugger/TDDOMContext.h
+++ b/Source/Debugger/TDDOMContext.h
@@ -1,0 +1,32 @@
+//
+//  TDDOMContext.h
+//  Texture
+//
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TDDOMContext : NSObject
+
+/**
+ * Id to object map for fast lookup. Populated on-the-fly whenever an object id is requested.
+ */
+@property (nonatomic, strong) NSMapTable<NSNumber *, NSObject *> *idToObjectMap;
+/**
+ * Map of id to frame in window of the represented object, for fast lookup. Populated on-the-fly.
+ */
+@property (nonatomic, strong) NSMapTable<NSNumber *, id> *idToFrameInWindow;
+
+- (NSNumber *)idForObject:(NSObject *)object;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Debugger/TDDOMContext.m
+++ b/Source/Debugger/TDDOMContext.m
@@ -1,0 +1,38 @@
+//
+//  TDDOMContext.m
+//  Texture
+//
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplaykit/TDDOMContext.h>
+
+#import <AsyncDisplaykit/ASRectTable.h>
+
+@implementation TDDOMContext {
+  NSUInteger _counter;
+}
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _idToObjectMap = [NSMapTable strongToStrongObjectsMapTable];
+    _idToFrameInWindow = [ASRectTable rectTableForStrongObjectPointers];
+  }
+  return self;
+}
+
+- (NSNumber *)idForObject:(NSObject *)object
+{
+  NSNumber *result = @(_counter++);
+  [_idToObjectMap setObject:object forKey:result];
+  return result;
+}
+
+@end

--- a/Source/Debugger/TDDebugger.h
+++ b/Source/Debugger/TDDebugger.h
@@ -1,0 +1,27 @@
+//
+//  TDDebugger.h
+//  Texture
+//
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_TEXTURE_DEBUGGER
+
+#import <PonyDebugger/PDDebugger.h>
+
+@interface TDDebugger : PDDebugger
+
++ (TDDebugger *)defaultInstance;
+
+- (void)enableLayoutElementDebuggingWithApplication:(UIApplication *)application;
+
+@end
+
+#endif // AS_TEXTURE_DEBUGGER

--- a/Source/Debugger/TDDebugger.m
+++ b/Source/Debugger/TDDebugger.m
@@ -1,0 +1,42 @@
+//
+//  TDDebugger.m
+//  Texture
+//
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_TEXTURE_DEBUGGER
+
+#import <AsyncDisplayKit/TDDebugger.h>
+#import <AsyncDisplayKit/TDElementDomainController.h>
+
+@implementation TDDebugger
+
++ (TDDebugger *)defaultInstance
+{
+  static dispatch_once_t onceToken;
+  static TDDebugger *defaultInstance = nil;
+  dispatch_once(&onceToken, ^{
+    defaultInstance = [[[self class] alloc] init];
+  });
+  
+  return defaultInstance;
+}
+
+- (void)enableLayoutElementDebuggingWithApplication:(UIApplication *)application
+{
+  TDElementDomainController *elementController = [TDElementDomainController defaultInstance];
+  [self addController:elementController];
+  [elementController startMonitoringWithApplication:application];
+}
+
+@end
+
+#endif // AS_TEXTURE_DEBUGGER

--- a/Source/Debugger/TDElementDomainController.h
+++ b/Source/Debugger/TDElementDomainController.h
@@ -1,0 +1,34 @@
+//
+//  TDElementDomainController.h
+//  Texture
+//
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_TEXTURE_DEBUGGER
+
+#import <PonyDebugger/PDDOMDomain.h>
+#import <PonyDebugger/PDDomainController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TDElementDomainController : PDDomainController <PDDOMCommandDelegate>
+
+@property (nonatomic, strong) PDDOMDomain *domain;
+
++ (TDElementDomainController *)defaultInstance;
+
+- (void)startMonitoringWithApplication:(UIApplication *)application;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Source/Debugger/TDElementDomainController.m
+++ b/Source/Debugger/TDElementDomainController.m
@@ -1,0 +1,149 @@
+//
+//  TDElementDomainController.m
+//  Texture
+//
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_TEXTURE_DEBUGGER
+
+#import "TDElementDomainController.h"
+
+#import <PonyDebugger/PDDOMTypes.h>
+#import <PonyDebugger/PDRuntimeTypes.h>
+
+#import <AsyncDisplayKit/AsyncDisplayKit.h>
+#import <AsyncDisplayKit/PDDOMTypes+UIKit.h>
+#import <AsyncDisplayKit/TDDOMContext.h>
+#import <AsyncDisplayKit/NSObject+TextureDebugger.h>
+#import <AsyncDisplayKit/ASRectTable.h>
+
+#import <UIKit/UIKit.h>
+
+// Constants defined in the DOM Level 2 Core: http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-1950641247
+static const int kPDDOMNodeTypeDocument = 9;
+
+@interface TDElementDomainController ()
+
+@property (nonatomic, strong) TDDOMContext *context;
+
+@property (nonatomic, strong) UIView *highlightOverlay;
+
+@property (nonatomic, weak) UIApplication *application;
+
+@end
+
+#pragma mark - Implementation
+
+@implementation TDElementDomainController
+
+@dynamic domain;
+
++ (TDElementDomainController *)defaultInstance;
+{
+  static TDElementDomainController *defaultInstance = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    defaultInstance = [[TDElementDomainController alloc] init];
+  });
+  return defaultInstance;
+}
+
++ (Class)domainClass;
+{
+  return [PDDOMDomain class];
+}
+
+- (id)init;
+{
+  if (self = [super init]) {
+    self.highlightOverlay = [[UIView alloc] initWithFrame:CGRectZero];
+    self.highlightOverlay.layer.borderWidth = 1.0;
+  }
+  return self;
+}
+
+- (void)startMonitoringWithApplication:(UIApplication *)application
+{
+  self.application = application;
+  [ASDisplayNode setShouldStoreUnflattenedLayouts:YES];
+  [ASLayout setShouldRetainSublayoutLayoutElements:YES];
+}
+
+#pragma mark - PDDOMCommandDelegate
+
+- (void)domain:(PDDOMDomain *)domain getDocumentWithCallback:(void (^)(PDDOMNode *root, id error))callback;
+{
+  // Generate the DOM tree
+  _context = [[TDDOMContext alloc] init];
+  PDDOMNode *documentNode = [TDElementDomainController documentNodeWithApplication:self.application context:_context];
+  
+  callback(documentNode, nil);
+}
+
+- (void)domain:(PDDOMDomain *)domain highlightNodeWithNodeId:(NSNumber *)nodeId highlightConfig:(PDDOMHighlightConfig *)highlightConfig callback:(void (^)(id))callback;
+{
+  NSObject *object = [_context.idToObjectMap objectForKey:nodeId];
+  if (object != nil) {
+    [self configureHighlightOverlayWithConfig:highlightConfig];
+    
+    CGRect frameInWindow = [_context.idToFrameInWindow rectForKey:nodeId];
+    [self revealHighlightOverlayAtRect:CGRectIsNull(frameInWindow) ? CGRectZero : frameInWindow];
+  }
+  
+  callback(nil);
+}
+
+- (void)domain:(PDDOMDomain *)domain hideHighlightWithCallback:(void (^)(id))callback;
+{
+  [self.highlightOverlay removeFromSuperview];
+  callback(nil);
+}
+
+- (void)domain:(PDDOMDomain *)domain requestNodeWithObjectId:(NSString *)objectId callback:(void (^)(NSNumber *, id))callback;
+{
+  callback(@([objectId intValue]), nil);
+}
+
+#pragma mark - Highlight Overlay
+
+- (void)configureHighlightOverlayWithConfig:(PDDOMHighlightConfig *)highlightConfig;
+{
+  self.highlightOverlay.backgroundColor = ((NSDictionary *)highlightConfig).contentUIColor;
+  self.highlightOverlay.layer.borderColor = ((NSDictionary *)highlightConfig).borderUIColor.CGColor;
+}
+
+- (void)revealHighlightOverlayAtRect:(CGRect)rect
+{
+  UIApplication *application = self.application;
+  if (!application) {
+    return;
+  }
+  
+  self.highlightOverlay.frame = rect;
+  [application.keyWindow addSubview:self.highlightOverlay];
+}
+
+#pragma mark - Node Generation
+
++ (PDDOMNode *)documentNodeWithApplication:(UIApplication *)application context:(TDDOMContext *)context
+{
+  PDDOMNode *rootNode = [[PDDOMNode alloc] init];
+  rootNode.nodeId = [context idForObject:[NSObject new]];
+  rootNode.nodeType = @(kPDDOMNodeTypeDocument);
+  rootNode.nodeName = @"#document";
+  rootNode.children = application ? @[ [application td_generateDOMNodeWithContext:context] ] : nil;
+  rootNode.childNodeCount = @(rootNode.children.count);
+  return rootNode;
+}
+
+@end
+
+#endif // AS_TEXTURE_DEBUGGER

--- a/Texture.podspec
+++ b/Texture.podspec
@@ -55,6 +55,18 @@ Pod::Spec.new do |spec|
       igl.dependency 'Texture/Core'
   end
 
+  spec.subspec 'Debugger' do |db|
+      db.dependency 'PonyDebugger'
+      db.dependency 'Texture/Core'
+      db.public_header_files = [
+        'Source/Debugger/*.h',
+      ]
+    
+      db.source_files = [
+        'Source/Debugger/**/*.{h,m,mm}',
+      ]
+  end
+
   spec.subspec 'Yoga' do |yoga|
       yoga.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) YOGA=1' }
       yoga.dependency 'Yoga', '1.5.0'

--- a/examples/ASDKgram/Podfile
+++ b/examples/ASDKgram/Podfile
@@ -1,6 +1,8 @@
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 target 'Sample' do
-	pod 'Texture/IGListKit', :path => '../..'
-	pod 'Texture/PINRemoteImage', :path => '../..'
+  pod 'PonyDebugger', :git => 'git@github.com:nguyenhuy/PonyDebugger.git', :branch => 'master'
+  pod 'Texture/IGListKit', :path => '../..'
+  pod 'Texture/PINRemoteImage', :path => '../..'
+  pod 'Texture/Debugger', :path => '../..'
 end

--- a/examples/ASDKgram/Podfile
+++ b/examples/ASDKgram/Podfile
@@ -1,7 +1,7 @@
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 target 'Sample' do
-  pod 'PonyDebugger', :git => 'git@github.com:nguyenhuy/PonyDebugger.git', :branch => 'master'
+  pod 'PonyDebugger', :git => 'https://github.com/nguyenhuy/PonyDebugger.git', :branch => 'master'
   pod 'Texture/IGListKit', :path => '../..'
   pod 'Texture/PINRemoteImage', :path => '../..'
   pod 'Texture/Debugger', :path => '../..'

--- a/examples/ASDKgram/Sample/AppDelegate.m
+++ b/examples/ASDKgram/Sample/AppDelegate.m
@@ -23,6 +23,7 @@
 #import "PhotoFeedListKitViewController.h"
 #import "WindowWithStatusBarUnderlay.h"
 #import "Utilities.h"
+#import <AsyncDisplaykit/TDDebugger.h>
 
 @interface AppDelegate () <UITabBarControllerDelegate>
 @end
@@ -75,6 +76,10 @@
   // iOS8 hides the status bar in landscape orientation, this forces the status bar hidden status to NO
   [application setStatusBarHidden:YES withAnimation:UIStatusBarAnimationNone];
   [application setStatusBarHidden:NO withAnimation:UIStatusBarAnimationNone];
+  
+  TDDebugger *debugger = [TDDebugger defaultInstance];
+  [debugger enableLayoutElementDebuggingWithApplication:application];;
+  [debugger connectToURL:[NSURL URLWithString:@"ws://localhost:9000/device"]];
   
   return YES;
 }

--- a/examples/ASDKgram/Sample/AppDelegate.m
+++ b/examples/ASDKgram/Sample/AppDelegate.m
@@ -1,20 +1,18 @@
 //
 //  AppDelegate.m
-//  Sample
-//
-//  Created by Hannah Troisi on 2/16/16.
+//  Texture
 //
 //  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
 //  This source code is licensed under the BSD-style license found in the
-//  LICENSE file in the root directory of this source tree. An additional grant
-//  of patent rights can be found in the PATENTS file in the same directory.
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
 //
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-//  FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-//  ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) 2017-present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import "AppDelegate.h"


### PR DESCRIPTION
- Client apps connect to Chrome DevTools via ponyd server. Setup instructions coming.
- Users can highlight display nodes as well as layout specs. ASDKGram is updated to use the debugger. See video [here](https://www.dropbox.com/s/4u9chy73u2ygi3o/Element%20highlighting.mov?dl=0).
- Style and other useful properties will be exposed later on.

This PR depends on https://github.com/TextureGroup/Texture/pull/337. Please review #337 first.