### PR TITLE
Fix internal Linter warnings #trivial

### DIFF
--- a/Source/ASDisplayNode+Subclasses.h
+++ b/Source/ASDisplayNode+Subclasses.h
@@ -122,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @warning Subclasses must not override this; it returns the last cached layout and is never expensive.
  */
-@property (nullable, nonatomic, readonly, assign) ASLayout *calculatedLayout;
+@property (nullable, nonatomic, readonly, strong) ASLayout *calculatedLayout;
 
 #pragma mark - View Lifecycle
 /** @name View Lifecycle */

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -646,12 +646,12 @@ extern NSInteger const ASDefaultDrawingPriority;
 #if TARGET_OS_IOS
 @property (nonatomic, assign, getter=isExclusiveTouch) BOOL exclusiveTouch;    // default=NO
 #endif
-@property (nonatomic, assign, nullable) CGColorRef shadowColor;                // default=opaque rgb black
+@property (nonatomic, nullable)         CGColorRef shadowColor;                // default=opaque rgb black
 @property (nonatomic, assign)           CGFloat shadowOpacity;                 // default=0.0
 @property (nonatomic, assign)           CGSize shadowOffset;                   // default=(0, -3)
 @property (nonatomic, assign)           CGFloat shadowRadius;                  // default=3
 @property (nonatomic, assign)           CGFloat borderWidth;                   // default=0
-@property (nonatomic, assign, nullable) CGColorRef borderColor;                // default=opaque rgb black
+@property (nonatomic, nullable)         CGColorRef borderColor;                // default=opaque rgb black
 
 // UIResponder methods
 // By default these fall through to the underlying view, but can be overridden.

--- a/Source/Details/ASImageProtocols.h
+++ b/Source/Details/ASImageProtocols.h
@@ -163,7 +163,7 @@ withDownloadIdentifier:(id)downloadIdentifier;
 /**
  @abstract A block which receives the cover image. Should be called when the objects cover image is ready.
  */
-@property (nonatomic, strong, readwrite) void (^coverImageReadyCallback)(UIImage *coverImage);
+@property (nonatomic, copy, readwrite) void (^coverImageReadyCallback)(UIImage *coverImage);
 
 /**
  @abstract Returns whether the supplied data contains a supported animated image format.
@@ -209,7 +209,7 @@ withDownloadIdentifier:(id)downloadIdentifier;
 /**
  @abstract Should be called when playback is ready.
  */
-@property (nonatomic, strong, readwrite) dispatch_block_t playbackReadyCallback;
+@property (nonatomic, readwrite) dispatch_block_t playbackReadyCallback;
 
 /**
  @abstract Return the image at a given index.

--- a/Source/Details/ASImageProtocols.h
+++ b/Source/Details/ASImageProtocols.h
@@ -163,7 +163,7 @@ withDownloadIdentifier:(id)downloadIdentifier;
 /**
  @abstract A block which receives the cover image. Should be called when the objects cover image is ready.
  */
-@property (nonatomic, copy, readwrite) void (^coverImageReadyCallback)(UIImage *coverImage);
+@property (nonatomic, readwrite) void (^coverImageReadyCallback)(UIImage *coverImage);
 
 /**
  @abstract Returns whether the supplied data contains a supported animated image format.

--- a/Source/Layout/ASLayoutElement.h
+++ b/Source/Layout/ASLayoutElement.h
@@ -72,7 +72,7 @@ typedef NS_ENUM(NSUInteger, ASLayoutElementType) {
 /**
  * @abstract A size constraint that should apply to this ASLayoutElement.
  */
-@property (nonatomic, assign, readonly) ASLayoutElementStyle *style;
+@property (nonatomic, strong, readonly) ASLayoutElementStyle *style;
 
 /**
  * @abstract Returns all children of an object which class conforms to the ASLayoutElement protocol


### PR DESCRIPTION
Our internal Linter caught a couple of warnings that this PR will fix. Thanks for @jerrymarino for discovering it:

```
...
In file included from /Users/jerry/Projects/ios/Platform/include/AsyncDisplayKit/ASDisplayNode.h:27:
/Users/jerry/Projects/ios/Platform/include/AsyncDisplayKit/ASLayoutElement.h:75:1: warning: Using assign for an ObjC pointer type is not valid. Either use strong or weak for a zeroing reference in this case.
@property (nonatomic, assign, readonly) ASLayoutElementStyle *style;
^
...
In file included from /Users/jerry/Projects/ios/Platform/include/AsyncDisplayKit/AsyncDisplayKit.h:19:
/Users/jerry/Projects/ios/Platform/include/AsyncDisplayKit/ASDisplayNode.h:649:1: warning: Using a pointer for a scalar type is invalid.
@property (nonatomic, assign, nullable) CGColorRef shadowColor;                // default=opaque rgb black
^
/Users/jerry/Projects/ios/Platform/include/AsyncDisplayKit/ASDisplayNode.h:654:1: warning: Using a pointer for a scalar type is invalid.
@property (nonatomic, assign, nullable) CGColorRef borderColor;                // default=opaque rgb black
^
...
/Users/jerry/Projects/ios/Platform/include/AsyncDisplayKit/ASDisplayNode+Subclasses.h:125:1: warning: Using assign for an ObjC pointer type is not valid. Either use strong or weak for a zeroing reference in this case.
@property (nullable, nonatomic, readonly, assign) ASLayout *calculatedLayout;
^
...
/Users/jerry/Projects/ios/Platform/include/AsyncDisplayKit/ASImageProtocols.h:166:1: warning: block property does not copy the block - use copy attribute instead
@property (nonatomic, strong, readwrite) void (^coverImageReadyCallback)(UIImage *coverImage);
^
...
/Users/jerry/Projects/ios/Platform/include/AsyncDisplayKit/ASImageProtocols.h:212:1: warning: block property does not copy the block - use copy attribute instead
@property (nonatomic, strong, readwrite) dispatch_block_t playbackReadyCallback;
^
6 warnings generated.
```