### PR TITLE
Upgrade ASLayoutElementContext to an Object #trivial

### DIFF
--- a/Source/Layout/ASLayoutElement.mm
+++ b/Source/Layout/ASLayoutElement.mm
@@ -30,69 +30,63 @@
 
 #pragma mark - ASLayoutElementContext
 
+@implementation ASLayoutElementContext
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _transitionID = ASLayoutElementContextDefaultTransitionID;
+  }
+  return self;
+}
+
+@end
+
 CGFloat const ASLayoutElementParentDimensionUndefined = NAN;
 CGSize const ASLayoutElementParentSizeUndefined = {ASLayoutElementParentDimensionUndefined, ASLayoutElementParentDimensionUndefined};
 
 int32_t const ASLayoutElementContextInvalidTransitionID = 0;
 int32_t const ASLayoutElementContextDefaultTransitionID = ASLayoutElementContextInvalidTransitionID + 1;
 
-static inline ASLayoutElementContext _ASLayoutElementContextMake(int32_t transitionID)
-{
-  struct ASLayoutElementContext context;
-  context.transitionID = transitionID;
-  return context;
-}
-
-static inline BOOL _IsValidTransitionID(int32_t transitionID)
-{
-  return transitionID > ASLayoutElementContextInvalidTransitionID;
-}
-
-struct ASLayoutElementContext const ASLayoutElementContextNull = _ASLayoutElementContextMake(ASLayoutElementContextInvalidTransitionID);
-
-BOOL ASLayoutElementContextIsNull(struct ASLayoutElementContext context)
-{
-  return !_IsValidTransitionID(context.transitionID);
-}
-
-ASLayoutElementContext ASLayoutElementContextMake(int32_t transitionID)
-{
-  NSCAssert(_IsValidTransitionID(transitionID), @"Invalid transition ID");
-  return _ASLayoutElementContextMake(transitionID);
-}
-
 pthread_key_t ASLayoutElementContextKey;
+
+static void ASLayoutElementDestructor(void *p) {
+  if (p != NULL) {
+  	ASDisplayNodeCFailAssert(@"Thread exited without clearing layout element context!");
+    CFBridgingRelease(p);
+  }
+};
 
 // pthread_key_create must be called before the key can be used. This function does that.
 void ASLayoutElementContextEnsureKey()
 {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    pthread_key_create(&ASLayoutElementContextKey, free);
+    // NOTE: NULL destructorm means that if a thread
+    pthread_key_create(&ASLayoutElementContextKey, ASLayoutElementDestructor);
   });
 }
 
-void ASLayoutElementSetCurrentContext(struct ASLayoutElementContext context)
+void ASLayoutElementPushContext(ASLayoutElementContext *context)
 {
   ASLayoutElementContextEnsureKey();
-  ASDisplayNodeCAssert(pthread_getspecific(ASLayoutElementContextKey) == NULL, @"Nested ASLayoutElementContexts aren't supported.");
-  pthread_setspecific(ASLayoutElementContextKey, new ASLayoutElementContext(context));
+  // NOTE: It would be easy to support nested contexts – just use an NSMutableArray here.
+  ASDisplayNodeCAssertNil(ASLayoutElementGetCurrentContext(), @"Nested ASLayoutElementContexts aren't supported.");
+  pthread_setspecific(ASLayoutElementContextKey, CFBridgingRetain(context));
 }
 
-struct ASLayoutElementContext ASLayoutElementGetCurrentContext()
+ASLayoutElementContext *ASLayoutElementGetCurrentContext()
 {
   ASLayoutElementContextEnsureKey();
-  auto heapCtx = (ASLayoutElementContext *)pthread_getspecific(ASLayoutElementContextKey);
-  return (heapCtx ? *heapCtx : ASLayoutElementContextNull);
+  // Don't retain here. Caller will retain if it wants to!
+  return (__bridge __unsafe_unretained ASLayoutElementContext *)pthread_getspecific(ASLayoutElementContextKey);
 }
 
-void ASLayoutElementClearCurrentContext()
+void ASLayoutElementPopContext()
 {
   ASLayoutElementContextEnsureKey();
-  auto heapCtx = (ASLayoutElementContext *)pthread_getspecific(ASLayoutElementContextKey);
-  if (heapCtx != NULL) {
-    delete heapCtx;
-  }
+  ASDisplayNodeCAssertNotNil(ASLayoutElementGetCurrentContext(), @"Attempt to pop context when there wasn't a context!");
+  CFBridgingRelease(pthread_getspecific(ASLayoutElementContextKey));
   pthread_setspecific(ASLayoutElementContextKey, NULL);
 }
 

--- a/Source/Layout/ASLayoutElement.mm
+++ b/Source/Layout/ASLayoutElement.mm
@@ -52,7 +52,7 @@ pthread_key_t ASLayoutElementContextKey;
 
 static void ASLayoutElementDestructor(void *p) {
   if (p != NULL) {
-  	ASDisplayNodeCFailAssert(@"Thread exited without clearing layout element context!");
+    ASDisplayNodeCFailAssert(@"Thread exited without clearing layout element context!");
     CFBridgingRelease(p);
   }
 };
@@ -62,7 +62,6 @@ void ASLayoutElementContextEnsureKey()
 {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    // NOTE: NULL destructorm means that if a thread
     pthread_key_create(&ASLayoutElementContextKey, ASLayoutElementDestructor);
   });
 }

--- a/Source/Layout/ASLayoutElementPrivate.h
+++ b/Source/Layout/ASLayoutElementPrivate.h
@@ -23,26 +23,25 @@
 
 #pragma mark - ASLayoutElementContext
 
-struct ASLayoutElementContext {
-  int32_t transitionID;
-};
+NS_ASSUME_NONNULL_BEGIN
+
+AS_SUBCLASSING_RESTRICTED
+@interface ASLayoutElementContext : NSObject
+@property (nonatomic) int32_t transitionID;
+@end
 
 extern int32_t const ASLayoutElementContextInvalidTransitionID;
 
 extern int32_t const ASLayoutElementContextDefaultTransitionID;
 
-extern struct ASLayoutElementContext const ASLayoutElementContextNull;
+// Does not currently support nesting – there must be no current context.
+extern void ASLayoutElementPushContext(ASLayoutElementContext * context);
 
-extern BOOL ASLayoutElementContextIsNull(struct ASLayoutElementContext context);
+extern ASLayoutElementContext * _Nullable ASLayoutElementGetCurrentContext();
 
-extern struct ASLayoutElementContext ASLayoutElementContextMake(int32_t transitionID);
+extern void ASLayoutElementPopContext();
 
-extern void ASLayoutElementSetCurrentContext(struct ASLayoutElementContext context);
-
-extern struct ASLayoutElementContext ASLayoutElementGetCurrentContext();
-
-extern void ASLayoutElementClearCurrentContext();
-
+NS_ASSUME_NONNULL_END
 
 #pragma mark - ASLayoutElementLayoutDefaults
 


### PR DESCRIPTION
This gives us a ton more flexibility for the future.

I'm on vacation so this was a little bit thrown-together, but I'm excited about it! Please give it a thorough review.

The GitHub diff got a little confused, so some lines that didn't change at all appear to have changed, like:

```
CGFloat const ASLayoutElementParentDimensionUndefined = NAN;
CGSize const ASLayoutElementParentSizeUndefined = {ASLayoutElementParentDimensionUndefined, ASLayoutElementParentDimensionUndefined};
```