### PR TITLE
Migrate to Latest OCMock, Demonstrate Improved Unit Testing

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -369,6 +369,7 @@
 		CCA282CD1E9EB73E0037E8B7 /* ASTipNode.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA282CB1E9EB73E0037E8B7 /* ASTipNode.m */; };
 		CCA282D01E9EBF6C0037E8B7 /* ASTipsWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA282CE1E9EBF6C0037E8B7 /* ASTipsWindow.h */; };
 		CCA282D11E9EBF6C0037E8B7 /* ASTipsWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA282CF1E9EBF6C0037E8B7 /* ASTipsWindow.m */; };
+		CCA5F62C1EEC9E9B0060C137 /* NSInvocation+ASTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA5F62B1EEC9E9B0060C137 /* NSInvocation+ASTestHelpers.m */; };
 		CCB2F34D1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */; };
 		CCBBBF5D1EB161760069AA91 /* ASRangeManagingNode.h in Headers */ = {isa = PBXBuildFile; fileRef = CCBBBF5C1EB161760069AA91 /* ASRangeManagingNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CCCCCCD51EC3EF060087FE10 /* ASTextDebugOption.h in Headers */ = {isa = PBXBuildFile; fileRef = CCCCCCC31EC3EF060087FE10 /* ASTextDebugOption.h */; };
@@ -825,6 +826,8 @@
 		CCA282CB1E9EB73E0037E8B7 /* ASTipNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTipNode.m; sourceTree = "<group>"; };
 		CCA282CE1E9EBF6C0037E8B7 /* ASTipsWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTipsWindow.h; sourceTree = "<group>"; };
 		CCA282CF1E9EBF6C0037E8B7 /* ASTipsWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTipsWindow.m; sourceTree = "<group>"; };
+		CCA5F62A1EEC9E9B0060C137 /* NSInvocation+ASTestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSInvocation+ASTestHelpers.h"; sourceTree = "<group>"; };
+		CCA5F62B1EEC9E9B0060C137 /* NSInvocation+ASTestHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSInvocation+ASTestHelpers.m"; sourceTree = "<group>"; };
 		CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeSnapshotTests.m; sourceTree = "<group>"; };
 		CCBBBF5C1EB161760069AA91 /* ASRangeManagingNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASRangeManagingNode.h; sourceTree = "<group>"; };
 		CCBD05DE1E4147B000D18509 /* ASIGListAdapterBasedDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIGListAdapterBasedDataSource.m; sourceTree = "<group>"; };
@@ -1104,6 +1107,8 @@
 		058D09C5195D04C000B7D73C /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				CCA5F62A1EEC9E9B0060C137 /* NSInvocation+ASTestHelpers.h */,
+				CCA5F62B1EEC9E9B0060C137 /* NSInvocation+ASTestHelpers.m */,
 				CC034A0F1E60C9BF00626263 /* ASRectTableTests.m */,
 				CC11F9791DB181180024D77B /* ASNetworkImageNodeTests.m */,
 				CC051F1E1D7A286A006434CB /* ASCALayerTests.m */,
@@ -2027,6 +2032,7 @@
 				ACF6ED5C1B178DC700DA7C62 /* ASCenterLayoutSpecSnapshotTests.mm in Sources */,
 				9F06E5CD1B4CAF4200F015D8 /* ASCollectionViewTests.mm in Sources */,
 				2911485C1A77147A005D0878 /* ASControlNodeTests.m in Sources */,
+				CCA5F62C1EEC9E9B0060C137 /* NSInvocation+ASTestHelpers.m in Sources */,
 				CC3B208E1C3F7D0A00798563 /* ASWeakSetTests.m in Sources */,
 				CC034A101E60C9BF00626263 /* ASRectTableTests.m in Sources */,
 				F711994E1D20C21100568860 /* ASDisplayNodeExtrasTests.m in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed an issue where GIFs with placeholders never had their placeholders uncover the GIF. [Garrett Moon](https://github.com/garrettmoon)
 - [Yoga] Implement ASYogaLayoutSpec, a simplified integration strategy for Yoga-powered layout calculation. [Scott Goodson](https://github.com/appleguy)
 - Fixed an issue where calls to setNeedsDisplay and setNeedsLayout would stop working on loaded nodes. [Garrett Moon](https://github.com/garrettmoon)
+- Migrated unit tests to OCMock 3.4 (from 2.2) and improved the multiplex image node tests. [Adlai Holler](https://github.com/Adlai-Holler)
 
 ##2.3.3
 - [ASTextKitFontSizeAdjuster] Replace use of NSAttributedString's boundingRectWithSize:options:context: with NSLayoutManager's boundingRectForGlyphRange:inTextContainer: [Ricky Cancro](https://github.com/rcancro)

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
 target :'AsyncDisplayKitTests' do
-  pod 'OCMock', '~> 2.2'
+  pod 'OCMock', '~> 3.4'
   pod 'FBSnapshotTestCase/Core', '~> 2.1'
   pod 'JGMethodSwizzler', :git => 'https://github.com/JonasGessner/JGMethodSwizzler', :branch => 'master'
 

--- a/Tests/ASCALayerTests.m
+++ b/Tests/ASCALayerTests.m
@@ -1,9 +1,14 @@
 //
-//  NSInvocation+ASTestHelpers.h
+//  ASCALayerTests.m
 //  Texture
 //
-//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
-//  Licensed under the Apache License, Version 2.0 (the "License");
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
+//
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) 2017-present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
 //

--- a/Tests/ASCALayerTests.m
+++ b/Tests/ASCALayerTests.m
@@ -1,9 +1,13 @@
 //
-//  ASCALayerTests.m
+//  NSInvocation+ASTestHelpers.h
 //  Texture
 //
-//  Created by Adlai Holler on 9/2/16.
-//  Copyright © 2016 Facebook. All rights reserved.
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <XCTest/XCTest.h>

--- a/Tests/ASCALayerTests.m
+++ b/Tests/ASCALayerTests.m
@@ -9,7 +9,6 @@
 #import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
-#import <OCMock/NSInvocation+OCMAdditions.h>
 
 /**
  * Tests that confirm what we know about Core Animation behavior.

--- a/Tests/ASMultiplexImageNodeTests.m
+++ b/Tests/ASMultiplexImageNodeTests.m
@@ -61,7 +61,9 @@
   [super setUp];
 
   mockCache = OCMStrictProtocolMock(@protocol(ASImageCacheProtocol));
+  [mockCache setExpectationOrderMatters:YES];
   mockDownloader = OCMStrictProtocolMock(@protocol(ASImageDownloaderProtocol));
+  [mockDownloader setExpectationOrderMatters:YES];
   imageNode = [[ASMultiplexImageNode alloc] initWithCache:mockCache downloader:mockDownloader];
 
   mockDataSource = OCMStrictProtocolMock(@protocol(ASMultiplexImageNodeDataSource));

--- a/Tests/ASMultiplexImageNodeTests.m
+++ b/Tests/ASMultiplexImageNodeTests.m
@@ -16,29 +16,29 @@
 //
 
 #import <OCMock/OCMock.h>
+#import "NSInvocation+ASTestHelpers.h"
 
 #import <AsyncDisplayKit/ASImageProtocols.h>
 #import <AsyncDisplayKit/ASMultiplexImageNode.h>
 #import <AsyncDisplayKit/ASImageContainerProtocolCategories.h>
-
-#import <libkern/OSAtomic.h>
 
 #import <XCTest/XCTest.h>
 
 @interface ASMultiplexImageNodeTests : XCTestCase
 {
 @private
-  id _mockCache;
-  id _mockDownloader;
+  id mockCache;
+  id mockDownloader;
+  id mockDataSource;
+  id mockDelegate;
+  ASMultiplexImageNode *imageNode;
 }
 
 @end
 
-
 @implementation ASMultiplexImageNodeTests
 
-#pragma mark -
-#pragma mark Helpers.
+#pragma mark - Helpers.
 
 - (NSURL *)_testImageURL
 {
@@ -52,8 +52,7 @@
   return [UIImage imageWithContentsOfFile:[self _testImageURL].path];
 }
 
-#pragma mark -
-#pragma mark Unit tests.
+#pragma mark - Unit tests.
 
 // TODO:  add tests for delegate display notifications
 
@@ -61,85 +60,71 @@
 {
   [super setUp];
 
-  _mockCache = [OCMockObject mockForProtocol:@protocol(ASImageCacheProtocol)];
-  _mockDownloader = [OCMockObject mockForProtocol:@protocol(ASImageDownloaderProtocol)];
+  mockCache = OCMStrictProtocolMock(@protocol(ASImageCacheProtocol));
+  mockDownloader = OCMStrictProtocolMock(@protocol(ASImageDownloaderProtocol));
+  imageNode = [[ASMultiplexImageNode alloc] initWithCache:mockCache downloader:mockDownloader];
+
+  mockDataSource = OCMStrictProtocolMock(@protocol(ASMultiplexImageNodeDataSource));
+  [mockDataSource setExpectationOrderMatters:YES];
+  imageNode.dataSource = mockDataSource;
+
+  mockDelegate = OCMProtocolMock(@protocol(ASMultiplexImageNodeDelegate));
+  [mockDelegate setExpectationOrderMatters:YES];
+  imageNode.delegate = mockDelegate;
 }
 
 - (void)tearDown
 {
-  _mockCache = nil;
-  _mockDownloader = nil;
+  OCMVerifyAll(mockDelegate);
+  OCMVerifyAll(mockDataSource);
+  OCMVerifyAll(mockDownloader);
+  OCMVerifyAll(mockCache);
   [super tearDown];
 }
 
 - (void)testDataSourceImageMethod
 {
-  ASMultiplexImageNode *imageNode = [[ASMultiplexImageNode alloc] initWithCache:_mockCache downloader:_mockDownloader];
-
-  // Mock the data source.
-  // Note that we're not using a niceMock because we want to assert if the URL data-source method gets hit, as the image
-  // method should be hit first and exclusively if it successfully returns an image.
-  id mockDataSource = [OCMockObject mockForProtocol:@protocol(ASMultiplexImageNodeDataSource)];
-  imageNode.dataSource = mockDataSource;
-
   NSNumber *imageIdentifier = @1;
 
-  // Expect the image method to be hit, and have it return our test image.
-  UIImage *testImage = [self _testImage];
-  [[[mockDataSource expect] andReturn:testImage] multiplexImageNode:imageNode imageForImageIdentifier:imageIdentifier];
+  OCMExpect([mockDataSource multiplexImageNode:imageNode imageForImageIdentifier:imageIdentifier])
+  .andReturn([self _testImage]);
 
   imageNode.imageIdentifiers = @[imageIdentifier];
   [imageNode reloadImageIdentifierSources];
-
-  [mockDataSource verify];
 
   // Also expect it to be loaded immediately.
   XCTAssertEqualObjects(imageNode.loadedImageIdentifier, imageIdentifier, @"imageIdentifier was not loaded");
   // And for the image to be equivalent to the image we provided.
   XCTAssertEqualObjects(UIImagePNGRepresentation(imageNode.image),
-                        UIImagePNGRepresentation(testImage),
+                        UIImagePNGRepresentation([self _testImage]),
                         @"Loaded image isn't the one we provided");
-
-  imageNode.delegate = nil;
-  imageNode.dataSource = nil;
 }
 
 - (void)testDataSourceURLMethod
 {
-  ASMultiplexImageNode *imageNode = [[ASMultiplexImageNode alloc] initWithCache:_mockCache downloader:_mockDownloader];
-
   NSNumber *imageIdentifier = @1;
 
-  // Mock the data source such that we...
-  id mockDataSource = [OCMockObject niceMockForProtocol:@protocol(ASMultiplexImageNodeDataSource)];
-  imageNode.dataSource = mockDataSource;
-  // (a) first expect to be hit for the image directly, and fail to return it.
-  [mockDataSource setExpectationOrderMatters:YES];
-  [[[mockDataSource expect] andReturn:nil] multiplexImageNode:imageNode imageForImageIdentifier:imageIdentifier];
-  // (b) and then expect to be hit for the URL, which we'll return.
-  [[[mockDataSource expect] andReturn:[self _testImageURL]] multiplexImageNode:imageNode URLForImageIdentifier:imageIdentifier];
+  // First expect to be hit for the image directly, and fail to return it.
+  OCMExpect([mockDataSource multiplexImageNode:imageNode imageForImageIdentifier:imageIdentifier])
+  .andReturn(nil);
+  // BUG: -imageForImageIdentifier is called twice in this case (where we return nil).
+  OCMExpect([mockDataSource multiplexImageNode:imageNode imageForImageIdentifier:imageIdentifier])
+  .andReturn(nil);
+  // Then expect to be hit for the URL, which we'll return.
+  OCMExpect([mockDataSource multiplexImageNode:imageNode URLForImageIdentifier:imageIdentifier])
+  .andReturn([self _testImageURL]);
 
   // Mock the cache to do a cache-hit for the test image URL.
-  [[[_mockCache stub] andDo:^(NSInvocation *inv) {
-    // Params are URL, callbackQueue, completion
-    __unsafe_unretained NSArray *URL;
-    [inv getArgument:&URL atIndex:2];
-
-    __unsafe_unretained ASImageCacherCompletion completionBlock;
-    [inv getArgument:&completionBlock atIndex:4];
-
-    // Call the completion block with our test image and URL.
-    NSURL *testImageURL = [self _testImageURL];
-    XCTAssertEqualObjects(URL, testImageURL, @"Fetching URL other than test image");
+  OCMExpect([mockCache cachedImageWithURL:[self _testImageURL] callbackQueue:OCMOCK_ANY completion:[OCMArg isNotNil]])
+  .andDo(^(NSInvocation *inv) {
+    ASImageCacherCompletion completionBlock = [inv as_argumentAtIndexAsObject:4];
     completionBlock([self _testImage]);
-  }] cachedImageWithURL:[OCMArg any] callbackQueue:[OCMArg any] completion:[OCMArg any]];
+  });
 
   imageNode.imageIdentifiers = @[imageIdentifier];
   // Kick off loading.
   [imageNode reloadImageIdentifierSources];
 
-  // Verify the data source.
-  [mockDataSource verify];
   // Also expect it to be loaded immediately.
   XCTAssertEqualObjects(imageNode.loadedImageIdentifier, imageIdentifier, @"imageIdentifier was not loaded");
   // And for the image to be equivalent to the image we provided.
@@ -151,156 +136,123 @@
 - (void)testAddLowerQualityImageIdentifier
 {
   // Adding a lower quality image identifier should not cause any loading.
-  ASMultiplexImageNode *imageNode = [[ASMultiplexImageNode alloc] initWithCache:_mockCache downloader:_mockDownloader];
+  NSNumber *highResIdentifier = @2, *lowResIdentifier = @1;
 
-  NSNumber *highResIdentifier = @2;
-
-  // Mock the data source such that we: (a) return the test image, and log whether we get hit for the lower-quality image.
-  id mockDataSource = [OCMockObject mockForProtocol:@protocol(ASMultiplexImageNodeDataSource)];
-  imageNode.dataSource = mockDataSource;
-  __block int dataSourceHits = 0;
-  [[[mockDataSource stub] andDo:^(NSInvocation *inv) {
-    dataSourceHits++;
-
-    // Return the test image.
-    [inv setReturnValue:(void *)[self _testImage]];
-  }] multiplexImageNode:[OCMArg any] imageForImageIdentifier:[OCMArg any]];
-
+  OCMExpect([mockDataSource multiplexImageNode:imageNode imageForImageIdentifier:highResIdentifier])
+  .andReturn([self _testImage]);
   imageNode.imageIdentifiers = @[highResIdentifier];
   [imageNode reloadImageIdentifierSources];
 
   // At this point, we should have the high-res identifier loaded and the DS should have been hit once.
   XCTAssertEqualObjects(imageNode.loadedImageIdentifier, highResIdentifier, @"High res identifier should be loaded.");
-  XCTAssertTrue(dataSourceHits == 1, @"Unexpected DS hit count");
 
-  // Add the low res identifier.
-  NSNumber *lowResIdentifier = @1;
+  // BUG: We should not get another -imageForImageIdentifier:highResIdentifier.
+  OCMExpect([mockDataSource multiplexImageNode:imageNode imageForImageIdentifier:highResIdentifier])
+  .andReturn([self _testImage]);
+
   imageNode.imageIdentifiers = @[highResIdentifier, lowResIdentifier];
   [imageNode reloadImageIdentifierSources];
 
-  // At this point the high-res should still be loaded, and the data source should have been hit again
+  // At this point the high-res should still be loaded, and the data source should not have been hit again (see BUG above).
   XCTAssertEqualObjects(imageNode.loadedImageIdentifier, highResIdentifier, @"High res identifier should be loaded.");
-  XCTAssertTrue(dataSourceHits == 2, @"Unexpected DS hit count");
 }
 
 - (void)testAddHigherQualityImageIdentifier
 {
-  // Adding a higher quality image identifier should cause loading.
-  ASMultiplexImageNode *imageNode = [[ASMultiplexImageNode alloc] initWithCache:_mockCache downloader:_mockDownloader];
+  NSNumber *lowResIdentifier = @1, *highResIdentifier = @2;
 
-  NSNumber *lowResIdentifier = @1;
-
-  // Mock the data source such that we: (a) return the test image, and log how many times the DS gets hit.
-  id mockDataSource = [OCMockObject mockForProtocol:@protocol(ASMultiplexImageNodeDataSource)];
-  imageNode.dataSource = mockDataSource;
-  __block int dataSourceHits = 0;
-  [[[mockDataSource stub] andDo:^(NSInvocation *inv) {
-    dataSourceHits++;
-
-    // Return the test image.
-    [inv setReturnValue:(void *)[self _testImage]];
-  }] multiplexImageNode:[OCMArg any] imageForImageIdentifier:[OCMArg any]];
+  OCMExpect([mockDataSource multiplexImageNode:imageNode imageForImageIdentifier:lowResIdentifier])
+  .andReturn([self _testImage]);
 
   imageNode.imageIdentifiers = @[lowResIdentifier];
   [imageNode reloadImageIdentifierSources];
 
   // At this point, we should have the low-res identifier loaded and the DS should have been hit once.
   XCTAssertEqualObjects(imageNode.loadedImageIdentifier, lowResIdentifier, @"Low res identifier should be loaded.");
-  XCTAssertTrue(dataSourceHits == 1, @"Unexpected DS hit count");
 
-  // Add the low res identifier.
-  NSNumber *highResIdentifier = @2;
+  OCMExpect([mockDataSource multiplexImageNode:imageNode imageForImageIdentifier:highResIdentifier])
+  .andReturn([self _testImage]);
+
   imageNode.imageIdentifiers = @[highResIdentifier, lowResIdentifier];
   [imageNode reloadImageIdentifierSources];
 
   // At this point the high-res should be loaded, and the data source should been hit twice.
   XCTAssertEqualObjects(imageNode.loadedImageIdentifier, highResIdentifier, @"High res identifier should be loaded.");
-  XCTAssertTrue(dataSourceHits == 2, @"Unexpected DS hit count");
 }
 
-- (void)testProgressiveDownloading
+- (void)testIntermediateImageDownloading
 {
-  ASMultiplexImageNode *imageNode = [[ASMultiplexImageNode alloc] initWithCache:_mockCache downloader:_mockDownloader];
   imageNode.downloadsIntermediateImages = YES;
+
+  // Let them call URLForImageIdentifier all they want.
+  OCMStub([mockDataSource multiplexImageNode:imageNode URLForImageIdentifier:[OCMArg isNotNil]]);
 
   // Set up a few identifiers to load.
   NSInteger identifierCount = 5;
   NSMutableArray *imageIdentifiers = [NSMutableArray array];
-  for (NSInteger identifierIndex = 0; identifierIndex < identifierCount; identifierIndex++)
-    [imageIdentifiers insertObject:@(identifierIndex + 1) atIndex:0];
+  for (NSInteger identifier = identifierCount; identifier > 0; identifier--) {
+    [imageIdentifiers addObject:@(identifier)];
+  }
 
-  // Mock the data source to only make the images available progressively.
-  // This is necessary because ASMultiplexImageNode will try to grab the best image immediately, regardless of
-  // `downloadsIntermediateImages`.
-  id mockDataSource = [OCMockObject niceMockForProtocol:@protocol(ASMultiplexImageNodeDataSource)];
-  imageNode.dataSource = mockDataSource;
-  __block NSUInteger loadedImageCount = 0;
-  [[[mockDataSource stub] andDo:^(NSInvocation *inv) {
-    __unsafe_unretained id requestedIdentifier;
-    [inv getArgument:&requestedIdentifier atIndex:3];
+  // Create the array of IDs in the order we expect them to get -imageForImageIdentifier:
+  // BUG: The second to last ID (the last one that returns nil) will get -imageForImageIdentifier: called
+  // again after the last ID (the one that returns non-nil).
+  id secondToLastID = imageIdentifiers[identifierCount - 2];
+  NSArray *imageIdentifiersThatWillBeCalled = [imageIdentifiers arrayByAddingObject:secondToLastID];
 
-    NSInteger requestedIdentifierValue = [requestedIdentifier intValue];
-
-    // If no images are loaded, bail on trying to load anything but the worst image.
-    if (!imageNode.loadedImageIdentifier && requestedIdentifierValue != [[imageIdentifiers lastObject] integerValue])
-      return;
-
-    // Bail if it's trying to load an identifier that's more than one step than what's loaded.
-    NSInteger nextImageIdentifier = [(NSNumber *)imageNode.loadedImageIdentifier integerValue] + 1;
-    if (requestedIdentifierValue != nextImageIdentifier)
-      return;
-
-    // Return the test image.
-    loadedImageCount++;
-    [inv setReturnValue:(void *)[self _testImage]];
-  }] multiplexImageNode:[OCMArg any] imageForImageIdentifier:[OCMArg any]];
+  for (id imageID in imageIdentifiersThatWillBeCalled) {
+    // Return nil for everything except the worst ID.
+    OCMExpect([mockDataSource multiplexImageNode:imageNode imageForImageIdentifier:imageID])
+    .andDo(^(NSInvocation *inv){
+      id imageID = [inv as_argumentAtIndexAsObject:3];
+      if ([imageID isEqual:imageIdentifiers.lastObject]) {
+        [inv as_setReturnValueWithObject:[self _testImage]];
+      } else {
+        [inv as_setReturnValueWithObject:nil];
+      }
+    });
+  }
 
   imageNode.imageIdentifiers = imageIdentifiers;
   [imageNode reloadImageIdentifierSources];
-
-  XCTAssertTrue(loadedImageCount == identifierCount, @"Expected to load the same number of identifiers we supplied");
 }
 
 - (void)testUncachedDownload
 {
   // Mock a cache miss.
-  id mockCache = [OCMockObject mockForProtocol:@protocol(ASImageCacheProtocol)];
-  [[[mockCache stub] andDo:^(NSInvocation *inv) {
-    __unsafe_unretained ASImageCacherCompletion completion;
-    [inv getArgument:&completion atIndex:4];
+  OCMExpect([mockCache cachedImageWithURL:[self _testImageURL] callbackQueue:OCMOCK_ANY completion:[OCMArg isNotNil]])
+  .andDo(^(NSInvocation *inv){
+    ASImageCacherCompletion completion = [inv as_argumentAtIndexAsObject:4];
     completion(nil);
-  }] cachedImageWithURL:[OCMArg any] callbackQueue:[OCMArg any] completion:[OCMArg any]];
+  });
 
   // Mock a 50%-progress URL download.
-  id mockDownloader = [OCMockObject mockForProtocol:@protocol(ASImageDownloaderProtocol)];
   const CGFloat mockedProgress = 0.5;
-  [[[mockDownloader stub] andDo:^(NSInvocation *inv) {
+  OCMExpect([mockDownloader downloadImageWithURL:[self _testImageURL] callbackQueue:OCMOCK_ANY downloadProgress:[OCMArg isNotNil] completion:[OCMArg isNotNil]])
+  .andDo(^(NSInvocation *inv){
     // Simulate progress.
-    __unsafe_unretained ASImageDownloaderProgress progressBlock;
-    [inv getArgument:&progressBlock atIndex:4];
+    ASImageDownloaderProgress progressBlock = [inv as_argumentAtIndexAsObject:4];
     progressBlock(mockedProgress);
 
     // Simulate completion.
-    __unsafe_unretained ASImageDownloaderCompletion completionBlock;
-    [inv getArgument:&completionBlock atIndex:5];
+    ASImageDownloaderCompletion completionBlock = [inv as_argumentAtIndexAsObject:5];
     completionBlock([self _testImage], nil, nil);
-  }] downloadImageWithURL:[OCMArg any] callbackQueue:[OCMArg any] downloadProgress:[OCMArg any] completion:[OCMArg any]];
+  });
 
-  ASMultiplexImageNode *imageNode = [[ASMultiplexImageNode alloc] initWithCache:mockCache downloader:mockDownloader];
   NSNumber *imageIdentifier = @1;
 
-  // Mock the data source to return our test URL.
-  id mockDataSource = [OCMockObject niceMockForProtocol:@protocol(ASMultiplexImageNodeDataSource)];
-  [[[mockDataSource stub] andReturn:[self _testImageURL]] multiplexImageNode:imageNode URLForImageIdentifier:imageIdentifier];
-  imageNode.dataSource = mockDataSource;
+  // Mock the data source to return nil image, and our test URL.
+  OCMExpect([mockDataSource multiplexImageNode:imageNode imageForImageIdentifier:imageIdentifier]);
+  // BUG: Multiplex image node will call imageForImageIdentifier twice if we return nil.
+  OCMExpect([mockDataSource multiplexImageNode:imageNode imageForImageIdentifier:imageIdentifier]);
+  OCMExpect([mockDataSource multiplexImageNode:imageNode URLForImageIdentifier:imageIdentifier])
+  .andReturn([self _testImageURL]);
 
   // Mock the delegate to expect start, 50% progress, and completion invocations.
-  id mockDelegate = [OCMockObject mockForProtocol:@protocol(ASMultiplexImageNodeDelegate)];
-  [[mockDelegate expect] multiplexImageNode:imageNode didStartDownloadOfImageWithIdentifier:imageIdentifier];
-  [[mockDelegate expect] multiplexImageNode:imageNode didUpdateDownloadProgress:mockedProgress forImageWithIdentifier:imageIdentifier];
-  [[mockDelegate expect] multiplexImageNode:imageNode didFinishDownloadingImageWithIdentifier:imageIdentifier error:nil];
-  [[mockDelegate expect] multiplexImageNode:imageNode didUpdateImage:[OCMArg any] withIdentifier:imageIdentifier fromImage:nil withIdentifier:nil];
-  imageNode.delegate = mockDelegate;
+  OCMExpect([mockDelegate multiplexImageNode:imageNode didStartDownloadOfImageWithIdentifier:imageIdentifier]);
+  OCMExpect([mockDelegate multiplexImageNode:imageNode didUpdateDownloadProgress:mockedProgress forImageWithIdentifier:imageIdentifier]);
+  OCMExpect([mockDelegate multiplexImageNode:imageNode didUpdateImage:[OCMArg isNotNil] withIdentifier:imageIdentifier fromImage:[OCMArg isNil] withIdentifier:[OCMArg isNil]]);
+  OCMExpect([mockDelegate multiplexImageNode:imageNode didFinishDownloadingImageWithIdentifier:imageIdentifier error:[OCMArg isNil]]);
 
   imageNode.imageIdentifiers = @[imageIdentifier];
   // Kick off loading.
@@ -309,15 +261,11 @@
   // Wait until the image is loaded.
   [self expectationForPredicate:[NSPredicate predicateWithFormat:@"loadedImageIdentifier = %@", imageIdentifier] evaluatedWithObject:imageNode handler:nil];
   [self waitForExpectationsWithTimeout:30 handler:nil];
-
-  // Verify the delegation.
-  [mockDelegate verify];
 }
 
 - (void)testThatSettingAnImageExternallyWillThrow
 {
-  ASMultiplexImageNode *multiplexImageNode = [[ASMultiplexImageNode alloc] init];
-  XCTAssertThrows(multiplexImageNode.image = [UIImage imageNamed:@""]);
+  XCTAssertThrows(imageNode.image = [UIImage imageNamed:@""]);
 }
 
 @end

--- a/Tests/ASMultiplexImageNodeTests.m
+++ b/Tests/ASMultiplexImageNodeTests.m
@@ -16,7 +16,6 @@
 //
 
 #import <OCMock/OCMock.h>
-#import <OCMock/NSInvocation+OCMAdditions.h>
 
 #import <AsyncDisplayKit/ASImageProtocols.h>
 #import <AsyncDisplayKit/ASMultiplexImageNode.h>
@@ -123,9 +122,11 @@
   // Mock the cache to do a cache-hit for the test image URL.
   [[[_mockCache stub] andDo:^(NSInvocation *inv) {
     // Params are URL, callbackQueue, completion
-    NSArray *URL = [inv getArgumentAtIndexAsObject:2];
+    __unsafe_unretained NSArray *URL;
+    [inv getArgument:&URL atIndex:2];
 
-    ASImageCacherCompletion completionBlock = [inv getArgumentAtIndexAsObject:4];
+    __unsafe_unretained ASImageCacherCompletion completionBlock;
+    [inv getArgument:&completionBlock atIndex:4];
 
     // Call the completion block with our test image and URL.
     NSURL *testImageURL = [self _testImageURL];
@@ -235,7 +236,8 @@
   imageNode.dataSource = mockDataSource;
   __block NSUInteger loadedImageCount = 0;
   [[[mockDataSource stub] andDo:^(NSInvocation *inv) {
-    id requestedIdentifier = [inv getArgumentAtIndexAsObject:3];
+    __unsafe_unretained id requestedIdentifier;
+    [inv getArgument:&requestedIdentifier atIndex:3];
 
     NSInteger requestedIdentifierValue = [requestedIdentifier intValue];
 
@@ -264,7 +266,8 @@
   // Mock a cache miss.
   id mockCache = [OCMockObject mockForProtocol:@protocol(ASImageCacheProtocol)];
   [[[mockCache stub] andDo:^(NSInvocation *inv) {
-    ASImageCacherCompletion completion = [inv getArgumentAtIndexAsObject:4];
+    __unsafe_unretained ASImageCacherCompletion completion;
+    [inv getArgument:&completion atIndex:4];
     completion(nil);
   }] cachedImageWithURL:[OCMArg any] callbackQueue:[OCMArg any] completion:[OCMArg any]];
 
@@ -273,11 +276,13 @@
   const CGFloat mockedProgress = 0.5;
   [[[mockDownloader stub] andDo:^(NSInvocation *inv) {
     // Simulate progress.
-    ASImageDownloaderProgress progressBlock = [inv getArgumentAtIndexAsObject:4];
+    __unsafe_unretained ASImageDownloaderProgress progressBlock;
+    [inv getArgument:&progressBlock atIndex:4];
     progressBlock(mockedProgress);
 
     // Simulate completion.
-    ASImageDownloaderCompletion completionBlock = [inv getArgumentAtIndexAsObject:5];
+    __unsafe_unretained ASImageDownloaderCompletion completionBlock;
+    [inv getArgument:&completionBlock atIndex:5];
     completionBlock([self _testImage], nil, nil);
   }] downloadImageWithURL:[OCMArg any] callbackQueue:[OCMArg any] downloadProgress:[OCMArg any] completion:[OCMArg any]];
 

--- a/Tests/ASUICollectionViewTests.m
+++ b/Tests/ASUICollectionViewTests.m
@@ -95,13 +95,15 @@
   cv.dataSource = dataSource;
   if (shouldFail) {
     XCTAssertThrowsSpecificNamed([cv layoutIfNeeded], NSException, NSInternalInconsistencyException);
-  } else {
-    [cv layoutIfNeeded];
-    XCTAssertEqualObjects(attr, [cv layoutAttributesForSupplementaryElementOfKind:@"SuppKind" atIndexPath:indexPath]);
-    XCTAssertEqual(view, [cv supplementaryViewForElementKind:@"SuppKind" atIndexPath:indexPath]);
-    [dataSource verify];
-    [layoutMock verify];
+    // Early return because behavior after exception is thrown is undefined.
+    return;
   }
+
+  [cv layoutIfNeeded];
+  XCTAssertEqualObjects(attr, [cv layoutAttributesForSupplementaryElementOfKind:@"SuppKind" atIndexPath:indexPath]);
+  XCTAssertEqual(view, [cv supplementaryViewForElementKind:@"SuppKind" atIndexPath:indexPath]);
+  [dataSource verify];
+  [layoutMock verify];
 }
 
 - (void)testThatIssuingAnUpdateBeforeInitialReloadIsUnacceptable

--- a/Tests/ASUICollectionViewTests.m
+++ b/Tests/ASUICollectionViewTests.m
@@ -8,7 +8,6 @@
 
 #import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
-#import <OCMock/NSInvocation+OCMAdditions.h>
 
 @interface ASUICollectionViewTests : XCTestCase
 
@@ -86,7 +85,8 @@
   id dataSource = [OCMockObject niceMockForProtocol:@protocol(UICollectionViewDataSource)];
   __block id view = nil;
   [[[dataSource expect] andDo:^(NSInvocation *invocation) {
-    NSIndexPath *indexPath = [invocation getArgumentAtIndexAsObject:4];
+    __unsafe_unretained NSIndexPath *indexPath;
+    [invocation getArgument:&indexPath atIndex:4];
     view = [cv dequeueReusableSupplementaryViewOfKind:@"SuppKind" withReuseIdentifier:@"ReuseID" forIndexPath:indexPath];
     [invocation setReturnValue:&view];
   }] collectionView:cv viewForSupplementaryElementOfKind:@"SuppKind" atIndexPath:indexPath];
@@ -99,10 +99,9 @@
     [cv layoutIfNeeded];
     XCTAssertEqualObjects(attr, [cv layoutAttributesForSupplementaryElementOfKind:@"SuppKind" atIndexPath:indexPath]);
     XCTAssertEqual(view, [cv supplementaryViewForElementKind:@"SuppKind" atIndexPath:indexPath]);
+    [dataSource verify];
+    [layoutMock verify];
   }
-
-  [dataSource verify];
-  [layoutMock verify];
 }
 
 - (void)testThatIssuingAnUpdateBeforeInitialReloadIsUnacceptable
@@ -113,7 +112,8 @@
 
   // Setup empty data source – 0 sections, 0 items
   [[[dataSource stub] andDo:^(NSInvocation *invocation) {
-    NSIndexPath *indexPath = [invocation getArgumentAtIndexAsObject:3];
+    __unsafe_unretained NSIndexPath *indexPath;
+    [invocation getArgument:&indexPath atIndex:3];
     __autoreleasing UICollectionViewCell *view = [cv dequeueReusableCellWithReuseIdentifier:@"CellID" forIndexPath:indexPath];
     [invocation setReturnValue:&view];
   }] collectionView:cv cellForItemAtIndexPath:OCMOCK_ANY];

--- a/Tests/ASUICollectionViewTests.m
+++ b/Tests/ASUICollectionViewTests.m
@@ -2,8 +2,17 @@
 //  ASUICollectionViewTests.m
 //  Texture
 //
-//  Created by Adlai Holler on 8/18/16.
-//  Copyright © 2016 Facebook. All rights reserved.
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
+//
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) 2017-present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <XCTest/XCTest.h>

--- a/Tests/ASUICollectionViewTests.m
+++ b/Tests/ASUICollectionViewTests.m
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
+#import "NSInvocation+ASTestHelpers.h"
 
 @interface ASUICollectionViewTests : XCTestCase
 
@@ -85,8 +86,7 @@
   id dataSource = [OCMockObject niceMockForProtocol:@protocol(UICollectionViewDataSource)];
   __block id view = nil;
   [[[dataSource expect] andDo:^(NSInvocation *invocation) {
-    __unsafe_unretained NSIndexPath *indexPath;
-    [invocation getArgument:&indexPath atIndex:4];
+    NSIndexPath *indexPath = [invocation as_argumentAtIndexAsObject:4];
     view = [cv dequeueReusableSupplementaryViewOfKind:@"SuppKind" withReuseIdentifier:@"ReuseID" forIndexPath:indexPath];
     [invocation setReturnValue:&view];
   }] collectionView:cv viewForSupplementaryElementOfKind:@"SuppKind" atIndexPath:indexPath];
@@ -112,8 +112,7 @@
 
   // Setup empty data source – 0 sections, 0 items
   [[[dataSource stub] andDo:^(NSInvocation *invocation) {
-    __unsafe_unretained NSIndexPath *indexPath;
-    [invocation getArgument:&indexPath atIndex:3];
+    NSIndexPath *indexPath = [invocation as_argumentAtIndexAsObject:3];
     __autoreleasing UICollectionViewCell *view = [cv dequeueReusableCellWithReuseIdentifier:@"CellID" forIndexPath:indexPath];
     [invocation setReturnValue:&view];
   }] collectionView:cv cellForItemAtIndexPath:OCMOCK_ANY];

--- a/Tests/ASViewControllerTests.m
+++ b/Tests/ASViewControllerTests.m
@@ -51,8 +51,7 @@
   [[[animator expect] andReturnValue:@0.3] transitionDuration:[OCMArg any]];
   XCTestExpectation *e = [self expectationWithDescription:@"Transition completed"];
   [[[animator expect] andDo:^(NSInvocation *invocation) {
-    id<UIViewControllerContextTransitioning> ctx =
-    [invocation as_argumentAtIndexAsObject:2];
+    id<UIViewControllerContextTransitioning> ctx = [invocation as_argumentAtIndexAsObject:2];
     UIView *container = [ctx containerView];
     [container addSubview:vc.view];
     vc.view.alpha = 0;

--- a/Tests/ASViewControllerTests.m
+++ b/Tests/ASViewControllerTests.m
@@ -2,8 +2,17 @@
 //  ASViewControllerTests.m
 //  Texture
 //
-//  Created by Adlai Holler on 8/25/16.
-//  Copyright © 2016 Facebook. All rights reserved.
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
+//
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) 2017-present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <XCTest/XCTest.h>

--- a/Tests/ASViewControllerTests.m
+++ b/Tests/ASViewControllerTests.m
@@ -9,7 +9,6 @@
 #import <XCTest/XCTest.h>
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 #import <OCMock/OCMock.h>
-#import <OCMock/NSInvocation+OCMAdditions.h>
 
 @interface ASViewControllerTests : XCTestCase
 
@@ -51,7 +50,8 @@
   [[[animator expect] andReturnValue:@0.3] transitionDuration:[OCMArg any]];
   XCTestExpectation *e = [self expectationWithDescription:@"Transition completed"];
   [[[animator expect] andDo:^(NSInvocation *invocation) {
-    id<UIViewControllerContextTransitioning> ctx = [invocation getArgumentAtIndexAsObject:2];
+    __unsafe_unretained id<UIViewControllerContextTransitioning> ctx;
+    [invocation getArgument:&ctx atIndex:2];
     UIView *container = [ctx containerView];
     [container addSubview:vc.view];
     vc.view.alpha = 0;

--- a/Tests/ASViewControllerTests.m
+++ b/Tests/ASViewControllerTests.m
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 #import <OCMock/OCMock.h>
+#import "NSInvocation+ASTestHelpers.h"
 
 @interface ASViewControllerTests : XCTestCase
 
@@ -50,8 +51,8 @@
   [[[animator expect] andReturnValue:@0.3] transitionDuration:[OCMArg any]];
   XCTestExpectation *e = [self expectationWithDescription:@"Transition completed"];
   [[[animator expect] andDo:^(NSInvocation *invocation) {
-    __unsafe_unretained id<UIViewControllerContextTransitioning> ctx;
-    [invocation getArgument:&ctx atIndex:2];
+    id<UIViewControllerContextTransitioning> ctx =
+    [invocation as_argumentAtIndexAsObject:2];
     UIView *container = [ctx containerView];
     [container addSubview:vc.view];
     vc.view.alpha = 0;

--- a/Tests/NSInvocation+ASTestHelpers.h
+++ b/Tests/NSInvocation+ASTestHelpers.h
@@ -1,9 +1,13 @@
 //
 //  NSInvocation+ASTestHelpers.h
-//  AsyncDisplayKit
+//  Texture
 //
-//  Created by Adlai Holler on 6/10/17.
-//  Copyright © 2017 Facebook. All rights reserved.
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <Foundation/Foundation.h>

--- a/Tests/NSInvocation+ASTestHelpers.h
+++ b/Tests/NSInvocation+ASTestHelpers.h
@@ -1,0 +1,32 @@
+//
+//  NSInvocation+ASTestHelpers.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 6/10/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSInvocation (ASTestHelpers)
+
+/**
+ * Formats the argument at the given index as an object and returns it.
+ *
+ * Currently only supports arguments that are themselves objects, but handles
+ * getting the argument into ARC safely.
+ */
+- (nullable id)as_argumentAtIndexAsObject:(NSInteger)index;
+
+/**
+ * Sets the return value, simulating ARC behavior.
+ *
+ * Currently only supports invocations whose return values are already object types.
+ */
+- (void)as_setReturnValueWithObject:(nullable id)object;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/NSInvocation+ASTestHelpers.m
+++ b/Tests/NSInvocation+ASTestHelpers.m
@@ -1,9 +1,13 @@
 //
 //  NSInvocation+ASTestHelpers.m
-//  AsyncDisplayKit
+//  Texture
 //
-//  Created by Adlai Holler on 6/10/17.
-//  Copyright © 2017 Facebook. All rights reserved.
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import "NSInvocation+ASTestHelpers.h"

--- a/Tests/NSInvocation+ASTestHelpers.m
+++ b/Tests/NSInvocation+ASTestHelpers.m
@@ -1,0 +1,32 @@
+//
+//  NSInvocation+ASTestHelpers.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 6/10/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "NSInvocation+ASTestHelpers.h"
+
+@implementation NSInvocation (ASTestHelpers)
+
+- (id)as_argumentAtIndexAsObject:(NSInteger)index
+{
+  void *buf;
+  [self getArgument:&buf atIndex:index];
+  return (__bridge id)buf;
+}
+
+- (void)as_setReturnValueWithObject:(id)object
+{
+  if (object == nil) {
+    const void *fixedBuf = NULL;
+    [self setReturnValue:&fixedBuf];
+  } else {
+    // Retain, then autorelease.
+    const void *fixedBuf = CFAutorelease((__bridge_retained void *)object);
+    [self setReturnValue:&fixedBuf];
+  }
+}
+
+@end


### PR DESCRIPTION
Unit tests are great! tl;dr: This diff migrates us from OCMock 2.2 to 3.4, and migrates ASMultiplexImageNodeTests to the latest syntax as a demonstration.

- The new version of OCMock supports a great new syntax, and prints much better error messages.
- There's no urgency to migrate the rest of our existing test cases. I migrated the multiplex image node tests only to provide a better reference for future test development.
- Recommend you use split diff for the multiplex image node tests file since it's changed a lot. The spirit/intention of each test method is preserved.
- The migration of the multiplex image node tests revealed a minor bug.
  - Namely that we call `imageForImageIdentifier:` twice if the first time it returns nil. Now #346.
  - Bug itself isn't interesting, but the total failure of our previous unit tests to catch it, is.
- New syntax is much more readable:
  - Old: `[[[mockCache expect] andDo:^(NSInvocation *inv) { … }] imageForImageID:OCMOCK_ANY];`
  - New: `OCMExpect([mockCache imageForImageID:OCMOCK_ANY]).andDo(^(NSInvocation *inv) { … });`
- `NSInvocation+OCMAdditions` file is no longer public, so I created a mini version of those methods `NSInvocation+ASTestHelpers` that is actually safer under ARC.
- New pattern established in multiplex image node tests is much tighter and cleaner:
  - `-tearDown` includes `OCMVerifyAll` of all mocks created in `-setUp`.
    - Test methods just have to `OCMExpect` and run their code, validation is done for them.
  - `-setUp` sets `expectationOrderMatters` on all mocks. Test methods can clear this flag if they need to, but they shouldn't.
  - Stubbing is used very sparingly (one place), since it doesn't make any assertion about when the method is called. Use `OCMExpect` instead, unless you're really sure the method sequence is irrelevant.
  - Test case ivars do not have underscores: `_mockCache` -> `mockCache`. 
    - Breaks from tradition but is readable and reduces boilerplate inside test methods.

Note: The indentation style for chained macros may seem strange to you (I quite like it), but it's the Xcode default:

```objc
OCMExpect([mockDataSource multiplexImageNode:imageNode imageForImageIdentifier:highResIdentifier])
.andReturn([self _testImage]);
```