### PR TITLE
[ASTraitCollection] Convert ASPrimitiveTraitCollection from lock to atomic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this with your name.
+- [ASTraitCollection] Convert ASPrimitiveTraitCollection from lock to atomic. [Scott Goodson](https://github.com/appleguy)
 - Add a synchronous mode to ASCollectionNode, for colletion view data source debugging. [Hannah Troisi](https://github.com/hannahmbanana)
 - [ASDisplayNode+Layout] Add check for orphaned nodes after layout transition to clean up. #336. [Scott Goodson](https://github.com/appleguy)
 - Fixed an issue where GIFs with placeholders never had their placeholders uncover the GIF. [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -104,7 +104,7 @@ ASLayoutElementStyleExtensibilityForwarding
 - (void)setPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traitCollection
 {
   if (ASPrimitiveTraitCollectionIsEqualToASPrimitiveTraitCollection(traitCollection, _primitiveTraitCollection.load()) == NO) {
-    _primitiveTraitCollection.store(traitCollection);
+    _primitiveTraitCollection = traitCollection;
     ASDisplayNodeLogEvent(self, @"asyncTraitCollectionDidChange: %@", NSStringFromASPrimitiveTraitCollection(traitCollection));
 
     [self asyncTraitCollectionDidChange];

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -98,28 +98,21 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (ASPrimitiveTraitCollection)primitiveTraitCollection
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  return _primitiveTraitCollection;
+  return _primitiveTraitCollection.load();
 }
 
 - (void)setPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traitCollection
 {
-  __instanceLock__.lock();
-  if (ASPrimitiveTraitCollectionIsEqualToASPrimitiveTraitCollection(traitCollection, _primitiveTraitCollection) == NO) {
-    _primitiveTraitCollection = traitCollection;
+  if (ASPrimitiveTraitCollectionIsEqualToASPrimitiveTraitCollection(traitCollection, _primitiveTraitCollection.load()) == NO) {
+    _primitiveTraitCollection.store(traitCollection);
     ASDisplayNodeLogEvent(self, @"asyncTraitCollectionDidChange: %@", NSStringFromASPrimitiveTraitCollection(traitCollection));
-    __instanceLock__.unlock();
-    
+
     [self asyncTraitCollectionDidChange];
-    return;
   }
-  
-  __instanceLock__.unlock();
 }
 
 - (ASTraitCollection *)asyncTraitCollection
 {
-  ASDN::MutexLocker l(__instanceLock__);
   return [ASTraitCollection traitCollectionWithASPrimitiveTraitCollection:self.primitiveTraitCollection];
 }
 

--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -104,11 +104,11 @@ ASDISPLAYNODE_EXTERN_C_END
 #define ASPrimitiveTraitCollectionDefaults \
 - (ASPrimitiveTraitCollection)primitiveTraitCollection\
 {\
-  return _primitiveTraitCollection;\
+return _primitiveTraitCollection.load();\
 }\
 - (void)setPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traitCollection\
 {\
-  _primitiveTraitCollection = traitCollection;\
+_primitiveTraitCollection.store(traitCollection);\
 }\
 
 #define ASPrimitiveTraitCollectionDeprecatedImplementation \

--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -104,11 +104,11 @@ ASDISPLAYNODE_EXTERN_C_END
 #define ASPrimitiveTraitCollectionDefaults \
 - (ASPrimitiveTraitCollection)primitiveTraitCollection\
 {\
-return _primitiveTraitCollection.load();\
+  return _primitiveTraitCollection.load();\
 }\
 - (void)setPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traitCollection\
 {\
-_primitiveTraitCollection.store(traitCollection);\
+  _primitiveTraitCollection = traitCollection;\
 }\
 
 #define ASPrimitiveTraitCollectionDeprecatedImplementation \

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -55,7 +55,7 @@
   }
   
   _isMutable = YES;
-  _primitiveTraitCollection = ASPrimitiveTraitCollectionMakeDefault();
+  _primitiveTraitCollection.store(ASPrimitiveTraitCollectionMakeDefault());
   _childrenArray = [[NSMutableArray alloc] init];
   
   return self;

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -55,7 +55,7 @@
   }
   
   _isMutable = YES;
-  _primitiveTraitCollection.store(ASPrimitiveTraitCollectionMakeDefault());
+  _primitiveTraitCollection = ASPrimitiveTraitCollectionMakeDefault();
   _childrenArray = [[NSMutableArray alloc] init];
   
   return self;

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -127,7 +127,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   NSArray<ASDisplayNode *> *_cachedSubnodes;
 
   ASLayoutElementStyle *_style;
-  ASPrimitiveTraitCollection _primitiveTraitCollection;
+  std::atomic<ASPrimitiveTraitCollection> _primitiveTraitCollection;
 
   std::atomic_uint _displaySentinel;
 

--- a/Source/Private/Layout/ASLayoutSpecPrivate.h
+++ b/Source/Private/Layout/ASLayoutSpecPrivate.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASLayoutSpec() {
   ASDN::RecursiveMutex __instanceLock__;
-  ASPrimitiveTraitCollection _primitiveTraitCollection;
+  std::atomic <ASPrimitiveTraitCollection> _primitiveTraitCollection;
   ASLayoutElementStyle *_style;
   NSMutableArray *_childrenArray;
 }


### PR DESCRIPTION
This resolves a deadlock case, which might be more common with Yoga (unsure): https://github.com/TextureGroup/Texture/issues/353 .  Fortunately it also simplifies the code.

We should think carefully if there are any transactional locking cases that could cause this to be unsafe. However, I think it has fairly limited usage and is probably appropriate for an atomic.