### PR TITLE
Add section-object support to new tests, improve test confinement. #trivial

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -370,8 +370,8 @@
 		CCA282CD1E9EB73E0037E8B7 /* ASTipNode.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA282CB1E9EB73E0037E8B7 /* ASTipNode.m */; };
 		CCA282D01E9EBF6C0037E8B7 /* ASTipsWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA282CE1E9EBF6C0037E8B7 /* ASTipsWindow.h */; };
 		CCA282D11E9EBF6C0037E8B7 /* ASTipsWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA282CF1E9EBF6C0037E8B7 /* ASTipsWindow.m */; };
-		CCA5F62E1EECC2A80060C137 /* ASAssert.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA5F62D1EECC2A80060C137 /* ASAssert.m */; };
 		CCA5F62C1EEC9E9B0060C137 /* NSInvocation+ASTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA5F62B1EEC9E9B0060C137 /* NSInvocation+ASTestHelpers.m */; };
+		CCA5F62E1EECC2A80060C137 /* ASAssert.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA5F62D1EECC2A80060C137 /* ASAssert.m */; };
 		CCB2F34D1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */; };
 		CCB338E41EEE11160081F21A /* OCMockObject+ASAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CCB338E31EEE11160081F21A /* OCMockObject+ASAdditions.m */; };
 		CCB338E71EEE27760081F21A /* ASTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = CCB338E61EEE27760081F21A /* ASTestCase.m */; };
@@ -832,9 +832,9 @@
 		CCA282CB1E9EB73E0037E8B7 /* ASTipNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTipNode.m; sourceTree = "<group>"; };
 		CCA282CE1E9EBF6C0037E8B7 /* ASTipsWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTipsWindow.h; sourceTree = "<group>"; };
 		CCA282CF1E9EBF6C0037E8B7 /* ASTipsWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTipsWindow.m; sourceTree = "<group>"; };
-		CCA5F62D1EECC2A80060C137 /* ASAssert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASAssert.m; sourceTree = "<group>"; };
 		CCA5F62A1EEC9E9B0060C137 /* NSInvocation+ASTestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSInvocation+ASTestHelpers.h"; sourceTree = "<group>"; };
 		CCA5F62B1EEC9E9B0060C137 /* NSInvocation+ASTestHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSInvocation+ASTestHelpers.m"; sourceTree = "<group>"; };
+		CCA5F62D1EECC2A80060C137 /* ASAssert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASAssert.m; sourceTree = "<group>"; };
 		CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeSnapshotTests.m; sourceTree = "<group>"; };
 		CCB338E21EEE11160081F21A /* OCMockObject+ASAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OCMockObject+ASAdditions.h"; sourceTree = "<group>"; };
 		CCB338E31EEE11160081F21A /* OCMockObject+ASAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "OCMockObject+ASAdditions.m"; sourceTree = "<group>"; };

--- a/Source/ASRunLoopQueue.h
+++ b/Source/ASRunLoopQueue.h
@@ -51,6 +51,8 @@ AS_SUBCLASSING_RESTRICTED
 
 + (instancetype)sharedDeallocationQueue;
 
+- (void)test_drain;
+
 - (void)releaseObjectInBackground:(id)object;
 
 @end

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -143,6 +143,29 @@ static void runLoopSourceCallback(void *info) {
   _thread = nil;
 }
 
+- (void)test_drain
+{
+  [self performSelector:@selector(_test_drain) onThread:_thread withObject:nil waitUntilDone:YES];
+}
+
+- (void)_test_drain
+{
+  while (true) {
+    @autoreleasepool {
+      _queueLock.lock();
+      std::deque<id> currentQueue = _queue;
+      _queue = std::deque<id>();
+      _queueLock.unlock();
+
+      if (currentQueue.empty()) {
+        return;
+      } else {
+        currentQueue.clear();
+      }
+    }
+  }
+}
+
 - (void)_stop
 {
   CFRunLoopStop(CFRunLoopGetCurrent());

--- a/Source/Details/ASWeakSet.m
+++ b/Source/Details/ASWeakSet.m
@@ -27,7 +27,7 @@
 {
   self = [super init];
   if (self) {
-    _hashTable = [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality];
+    _hashTable = [NSHashTable hashTableWithOptions:NSHashTableWeakMemory | NSHashTableObjectPointerPersonality];
   }
   return self;
 }

--- a/Tests/ASTestCase.h
+++ b/Tests/ASTestCase.h
@@ -12,6 +12,12 @@
 
 #import <XCTest/XCTest.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ASTestCase : XCTestCase
 
+@property (class, nonatomic, nullable, readonly) ASTestCase *currentTestCase;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/ASTestCase.m
+++ b/Tests/ASTestCase.m
@@ -12,8 +12,22 @@
 
 #import "ASTestCase.h"
 #import <objc/runtime.h>
+#import <AsyncDisplayKit/AsyncDisplayKit.h>
+#import <OCMock/OCMock.h>
+#import "OCMockObject+ASAdditions.h"
 
-@implementation ASTestCase
+static __weak ASTestCase *currentTestCase;
+
+@implementation ASTestCase {
+  ASWeakSet *registeredMockObjects;
+}
+
+- (void)setUp
+{
+  [super setUp];
+  currentTestCase = self;
+  registeredMockObjects = [ASWeakSet new];
+}
 
 - (void)tearDown
 {
@@ -22,12 +36,15 @@
   for (UIWindow *window in [UIApplication sharedApplication].windows) {
     [window resignKeyWindow];
     window.hidden = YES;
+    window.rootViewController = nil;
     for (UIView *view in window.subviews) {
       [view removeFromSuperview];
     }
   }
   
   // Set nil for all our subclasses' ivars. Use setValue:forKey: so memory is managed correctly.
+  // This is important to do _inside_ the test-perform, so that we catch any issues caused by the
+  // deallocation, and so that we're inside the @autoreleasepool for the test invocation.
   Class c = [self class];
   while (c != [ASTestCase class]) {
     unsigned int ivarCount;
@@ -40,11 +57,52 @@
     if (ivars) {
       free(ivars);
     }
-    
+
     c = [c superclass];
   }
+
+  for (OCMockObject *mockObject in registeredMockObjects) {
+    OCMVerifyAll(mockObject);
+    [mockObject stopMocking];
+
+    // Invocations retain arguments, which may cause retain cycles.
+    // Manually clear them all out.
+    NSMutableArray *invocations = object_getIvar(mockObject, class_getInstanceVariable(OCMockObject.class, "invocations"));
+    [invocations removeAllObjects];
+  }
+
+  // Go ahead and spin the run loop before finishing, so the system
+  // unregisters/cleans up whatever possible.
+  [NSRunLoop.mainRunLoop runMode:NSDefaultRunLoopMode beforeDate:NSDate.distantFuture];
   
   [super tearDown];
+}
+
+- (void)invokeTest
+{
+  // This will call setup, run, then teardown.
+  @autoreleasepool {
+    [super invokeTest];
+  }
+
+  // Now that the autorelease pool is drained, drain the dealloc queue also.
+  [[ASDeallocQueue sharedDeallocationQueue] test_drain];
+}
+
++ (ASTestCase *)currentTestCase
+{
+  return currentTestCase;
+}
+
+@end
+
+@implementation ASTestCase (OCMockObjectRegistering)
+
+- (void)registerMockObject:(id)mockObject
+{
+  @synchronized (registeredMockObjects) {
+    [registeredMockObjects addObject:mockObject];
+  }
 }
 
 @end

--- a/Tests/OCMockObject+ASAdditions.h
+++ b/Tests/OCMockObject+ASAdditions.h
@@ -15,6 +15,10 @@
 @interface OCMockObject (ASAdditions)
 
 /**
+ * NOTE: All OCMockObjects created during an ASTestCase call OCMVerifyAll during -tearDown.
+ */
+
+/**
  * A method to manually specify which optional protocol methods should return YES
  * from -respondsToSelector:.
  *

--- a/Tests/OCMockObject+ASAdditions.m
+++ b/Tests/OCMockObject+ASAdditions.m
@@ -10,18 +10,32 @@
 //      http://www.apache.org/licenses/LICENSE-2.0
 //
 
-#import <OCMock/OCMockObject.h>
+#import "OCMockObject+ASAdditions.h"
+
+#import <OCMock/OCMock.h>
 #import "ASInternalHelpers.h"
 #import <objc/runtime.h>
+#import "ASTestCase.h"
+
+@interface ASTestCase (OCMockObjectRegistering)
+
+- (void)registerMockObject:(id)mockObject;
+
+@end
 
 @implementation OCMockObject (ASAdditions)
 
 + (void)load
 {
-  // Swap [OCProtocolMockObject respondsToSelector:] with [(self) swizzled_protocolMockRespondsToSelector:]
+  // [OCProtocolMockObject respondsToSelector:] <-> [(self) swizzled_protocolMockRespondsToSelector:]
   Method orig = class_getInstanceMethod(OCMockObject.protocolMockObjectClass, @selector(respondsToSelector:));
   Method new = class_getInstanceMethod(self, @selector(swizzled_protocolMockRespondsToSelector:));
   method_exchangeImplementations(orig, new);
+
+  // init <-> swizzled_init
+  Method origInit = class_getInstanceMethod([OCMockObject class], @selector(init));
+  Method newInit = class_getInstanceMethod(self, @selector(swizzled_init));
+  method_exchangeImplementations(origInit, newInit);
 }
 
 /// Since OCProtocolMockObject is private, use this method to get the class.
@@ -118,6 +132,15 @@
   
   // It's an optional instance or class method. Override the return value.
   return [self implementsOptionalProtocolMethod:aSelector];
+}
+
+// Whenever a mock object is initted, register it with the current test case
+// so that it gets verified and its invocations are cleared during -tearDown.
+- (instancetype)swizzled_init
+{
+  [self swizzled_init];
+  [ASTestCase.currentTestCase registerMockObject:self];
+  return self;
 }
 
 @end


### PR DESCRIPTION
- Fix unit testing memory leaks caused by mock objects retaining their invocations, which retain their arguments, which may retain the mocks.
- Automatically verify all mocks during `[ASTestCase tearDown]`.
- Add section-object testing to the new collection tests file.
- Better encapsulate unit tests:
  - Ensure the autorelease pool is drained, and the dealloc queue is drained, inside of `invokeTest:`.
  - Ensure that view controllers aren't retained by windows after test ends (system may retain windows).
  - Break retain cycles: `(mockObject -> invocations -> owner -> mockObject)` by automatically registering all mocks created during tests, verifying them, then removing their saved invocations.
  - Manually verify that, as of now, no transient objects survive between test cases. No easy way to automate this verification.
- Let Xcode move the `ASAssert.m` file reference that it seems to really want to move.
- ASWeakSet: Use `NSHashTable*` constant names, instead of `NSPointerFunctions*`. This is shorter and it shows that we are compliant with the data structure.