### PR TITLE
[ASTableView] Use ASTableView tableNode property instead of calling ASViewToDisplayNode #trivial

### DIFF
--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -576,11 +576,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   return [_rangeController tuningParametersForRangeMode:rangeMode rangeType:rangeType];
 }
 
-- (ASTableNode *)tableNode
-{
-  return (ASTableNode *)ASViewToDisplayNode(self);
-}
-
 - (ASElementMap *)elementMapForRangeController:(ASRangeController *)rangeController
 {
   return _dataController.visibleMap;


### PR DESCRIPTION
We are accessing the `tableNode` property in `ASTableView` in the batch fetching mechanism on a background thread. The problem is that we overwrite the `tableNode` accessor and calling `ASViewToDisplayNode` what will access the `ASTableView` on a background thread.

With Xcode 9 Apple added the Main Thread Checker and it will catch this issue. You can try it out within the Kittens example.

Fixes the report from @WymzeeLabs in #345