### PR TITLE
[WIP] First step toward the new layout system #trivial

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -438,6 +438,8 @@
 		E5B077FF1E69F4EB00C24B5B /* ASElementMap.h in Headers */ = {isa = PBXBuildFile; fileRef = E5B077FD1E69F4EB00C24B5B /* ASElementMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5B078001E69F4EB00C24B5B /* ASElementMap.m in Sources */ = {isa = PBXBuildFile; fileRef = E5B077FE1E69F4EB00C24B5B /* ASElementMap.m */; };
 		E5B5B9D11E9BAD9800A6B726 /* ASCollectionLayoutContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E5B5B9D01E9BAD9800A6B726 /* ASCollectionLayoutContext+Private.h */; };
+		E5C2D7B21EF31392007B865E /* ASDisplayNode+LayoutBeta.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5C2D7B11EF31392007B865E /* ASDisplayNode+LayoutBeta.mm */; };
+		E5C2D7B41EF31A85007B865E /* ASDisplayNode+LayoutCommon.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5C2D7B31EF31A85007B865E /* ASDisplayNode+LayoutCommon.mm */; };
 		E5C347B11ECB3D9200EC4BE4 /* ASBatchFetchingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E5C347B01ECB3D9200EC4BE4 /* ASBatchFetchingDelegate.h */; };
 		E5C347B31ECB40AA00EC4BE4 /* ASTableNode+Beta.h in Headers */ = {isa = PBXBuildFile; fileRef = E5C347B21ECB40AA00EC4BE4 /* ASTableNode+Beta.h */; };
 		E5E281741E71C833006B67C2 /* ASCollectionLayoutState.h in Headers */ = {isa = PBXBuildFile; fileRef = E5E281731E71C833006B67C2 /* ASCollectionLayoutState.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -909,6 +911,8 @@
 		E5B077FD1E69F4EB00C24B5B /* ASElementMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASElementMap.h; sourceTree = "<group>"; };
 		E5B077FE1E69F4EB00C24B5B /* ASElementMap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASElementMap.m; sourceTree = "<group>"; };
 		E5B5B9D01E9BAD9800A6B726 /* ASCollectionLayoutContext+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASCollectionLayoutContext+Private.h"; sourceTree = "<group>"; };
+		E5C2D7B11EF31392007B865E /* ASDisplayNode+LayoutBeta.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "ASDisplayNode+LayoutBeta.mm"; sourceTree = "<group>"; };
+		E5C2D7B31EF31A85007B865E /* ASDisplayNode+LayoutCommon.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "ASDisplayNode+LayoutCommon.mm"; sourceTree = "<group>"; };
 		E5C347B01ECB3D9200EC4BE4 /* ASBatchFetchingDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBatchFetchingDelegate.h; sourceTree = "<group>"; };
 		E5C347B21ECB40AA00EC4BE4 /* ASTableNode+Beta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASTableNode+Beta.h"; sourceTree = "<group>"; };
 		E5E281731E71C833006B67C2 /* ASCollectionLayoutState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCollectionLayoutState.h; sourceTree = "<group>"; };
@@ -1048,6 +1052,8 @@
 				CC034A071E60BEB400626263 /* ASDisplayNode+Convenience.h */,
 				CC034A081E60BEB400626263 /* ASDisplayNode+Convenience.m */,
 				69BCE3D71EC6513B007DCCAD /* ASDisplayNode+Layout.mm */,
+				E5C2D7B11EF31392007B865E /* ASDisplayNode+LayoutBeta.mm */,
+				E5C2D7B31EF31A85007B865E /* ASDisplayNode+LayoutCommon.mm */,
 				058D09DB195D050800B7D73C /* ASDisplayNodeExtras.h */,
 				058D09DC195D050800B7D73C /* ASDisplayNodeExtras.mm */,
 				0587F9BB1A7309ED00AFF0BA /* ASEditableTextNode.h */,
@@ -2118,6 +2124,7 @@
 				CCA282D11E9EBF6C0037E8B7 /* ASTipsWindow.m in Sources */,
 				CCCCCCE41EC3EF060087FE10 /* NSParagraphStyle+ASText.m in Sources */,
 				8BBBAB8D1CEBAF1E00107FC6 /* ASDefaultPlaybackButton.m in Sources */,
+				E5C2D7B41EF31A85007B865E /* ASDisplayNode+LayoutCommon.mm in Sources */,
 				B30BF6541C59D889004FCD53 /* ASLayoutManager.m in Sources */,
 				690C35671E0567C600069B91 /* ASDimensionDeprecated.mm in Sources */,
 				92DD2FE71BF4D0850074C9DD /* ASMapNode.mm in Sources */,
@@ -2221,6 +2228,7 @@
 				B35062271B010EFD0018CF92 /* ASRangeController.mm in Sources */,
 				0442850A1BAA63FE00D16268 /* ASBatchFetching.m in Sources */,
 				68FC85E61CE29B9400EDD713 /* ASNavigationController.m in Sources */,
+				E5C2D7B21EF31392007B865E /* ASDisplayNode+LayoutBeta.mm in Sources */,
 				CC4C2A791D88E3BF0039ACAB /* ASTraceEvent.m in Sources */,
 				34EFC76F1B701CF700AD841F /* ASRatioLayoutSpec.mm in Sources */,
 				254C6B8B1BF94F8A003EC431 /* ASTextKitShadower.mm in Sources */,

--- a/Source/ASDisplayNode+Deprecated.h
+++ b/Source/ASDisplayNode+Deprecated.h
@@ -41,6 +41,7 @@
  */
 @property (nonatomic, assign, readwrite) CGSize preferredFrameSize ASDISPLAYNODE_DEPRECATED_MSG("Use .style.preferredSize instead OR set individual values with .style.height and .style.width.");
 
+#if !ASDISPLAYNODE_NEW_LAYOUT_SYSTEM
 /**
  * @abstract Asks the node to measure and return the size that best fits its subnodes.
  *
@@ -61,6 +62,8 @@
  * @deprecated Deprecated in version 2.0: Use layoutThatFits: with a constrained size of (CGSizeZero, constrainedSize) and call size on the returned ASLayout
  */
 - (CGSize)measure:(CGSize)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use layoutThatFits: with a constrained size of (CGSizeZero, constrainedSize) and call size on the returned ASLayout.");
+
+#endif
 
 ASLayoutElementStyleForwardingDeclaration
 

--- a/Source/ASDisplayNode+LayoutCommon.mm
+++ b/Source/ASDisplayNode+LayoutCommon.mm
@@ -1,0 +1,71 @@
+//
+//  ASDisplayNode+LayoutCommon.mm
+//  Texture
+//
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASDisplayNodeInternal.h>
+#import <AsyncDisplayKit/ASDisplayNode+FrameworkSubclasses.h>
+
+#import <AsyncDisplayKit/ASLayoutSpec.h>
+
+#pragma mark -
+#pragma mark - ASLayoutElementAsciiArtProtocol
+
+@implementation ASDisplayNode (ASLayoutElementAsciiArtProtocol)
+
+- (NSString *)asciiArtString
+{
+  return [ASLayoutSpec asciiArtStringForChildren:@[] parentName:[self asciiArtName]];
+}
+
+- (NSString *)asciiArtName
+{
+  NSString *string = NSStringFromClass([self class]);
+  if (_debugName) {
+    string = [string stringByAppendingString:[NSString stringWithFormat:@"\"%@\"",_debugName]];
+  }
+  return string;
+}
+
+@end
+
+#pragma mark -
+#pragma mark - ASDisplayNode (ASLayoutElementStylability)
+
+@implementation ASDisplayNode (ASLayoutElementStylability)
+
+- (instancetype)styledWithBlock:(AS_NOESCAPE void (^)(__kindof ASLayoutElementStyle *style))styleBlock
+{
+  styleBlock(self.style);
+  return self;
+}
+
+@end
+
+#pragma mark -
+#pragma mark - ASDisplayNode (ASAutomatic Subnode Management)
+
+@implementation ASDisplayNode (ASAutomaticSubnodeManagement)
+
+#pragma mark Automatically Manages Subnodes
+
+- (BOOL)automaticallyManagesSubnodes
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  return _automaticallyManagesSubnodes;
+}
+
+- (void)setAutomaticallyManagesSubnodes:(BOOL)automaticallyManagesSubnodes
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  _automaticallyManagesSubnodes = automaticallyManagesSubnodes;
+}
+
+@end

--- a/Source/ASDisplayNode+Subclasses.h
+++ b/Source/ASDisplayNode+Subclasses.h
@@ -109,12 +109,12 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion For node subclasses that implement manual layout (e.g., they have a custom -layout method), 
  * calculatedLayout may be accessed on subnodes to retrieved cached information about their size.  
  * This allows -layout to be very fast, saving time on the main thread.  
- * Note: .calculatedLayout will only be set for nodes that have had -measure: called on them.  
- * For manual layout, make sure you call -measure: in your implementation of -calculateSizeThatFits:.
+ * Note: .calculatedLayout will only be set for nodes that have had -layoutThatFits: called on them.
+ * For manual layout, make sure you call -layoutThatFits: in your implementation of -calculateLayoutThatFits:.
  *
  * For node subclasses that use automatic layout (e.g., they implement -layoutSpecThatFits:), 
  * it is typically not necessary to use .calculatedLayout at any point.  For these nodes, 
- * the ASLayoutSpec implementation will automatically call -measureWithSizeRange: on all of the subnodes,
+ * the ASLayoutSpec implementation will automatically call -layoutThatFits: on all of the subnodes,
  * and the ASDisplayNode base class implementation of -layout will automatically make use of .calculatedLayout on the subnodes.
  *
  * @return Layout that wraps calculated size returned by -calculateSizeThatFits: (in manual layout mode),
@@ -176,7 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
  * or -calculateSizeThatFits:, whichever method is overriden. Subclasses rarely need to override this method,
  * override -layoutSpecThatFits: or -calculateSizeThatFits: instead.
  *
- * @note This method should not be called directly outside of ASDisplayNode; use -measure: or -calculatedLayout instead.
+ * @note This method should not be called directly outside of ASDisplayNode; use -layoutThatFits: or -calculatedLayout instead.
  */
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize;
 

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -723,7 +723,11 @@ extern NSInteger const ASDefaultDrawingPriority;
 
 @end
 
+#if ASDISPLAYNODE_NEW_LAYOUT_SYSTEM
+@interface ASDisplayNode (ASLayoutElementBeta) <ASLayoutElement>
+#else
 @interface ASDisplayNode (ASLayoutElement) <ASLayoutElement>
+#endif
 
 /**
  * @abstract Asks the node to return a layout based on given size range.
@@ -751,7 +755,11 @@ extern NSInteger const ASDefaultDrawingPriority;
 @interface ASDisplayNode (ASLayoutElementAsciiArtProtocol) <ASLayoutElementAsciiArtProtocol>
 @end
 
+#if ASDISPLAYNODE_NEW_LAYOUT_SYSTEM
+@interface ASDisplayNode (ASLayoutBeta)
+#else
 @interface ASDisplayNode (ASLayout)
+#endif
 
 /** @name Managing dimensions */
 
@@ -775,7 +783,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @abstract Return the calculated size.
  *
  * @discussion Ideal for use by subclasses in -layout, having already prompted their subnodes to calculate their size by
- * calling -measure: on them in -calculateLayoutThatFits.
+ * calling -layoutThatFits: on them in -calculateLayoutThatFits.
  *
  * @return Size already calculated by -calculateLayoutThatFits:.
  *

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -197,8 +197,10 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     
     ASDisplayNodeAssert(!ASDisplayNodeSubclassOverridesSelector(self, @selector(calculatedSize)), @"Subclass %@ must not override calculatedSize method.", classString);
     ASDisplayNodeAssert(!ASDisplayNodeSubclassOverridesSelector(self, @selector(calculatedLayout)), @"Subclass %@ must not override calculatedLayout method.", classString);
+#if !ASDISPLAYNODE_NEW_LAYOUT_SYSTEM
     ASDisplayNodeAssert(!ASDisplayNodeSubclassOverridesSelector(self, @selector(measure:)), @"Subclass %@ must not override measure: method", classString);
     ASDisplayNodeAssert(!ASDisplayNodeSubclassOverridesSelector(self, @selector(measureWithSizeRange:)), @"Subclass %@ must not override measureWithSizeRange: method. Instead override calculateLayoutThatFits:", classString);
+#endif
     ASDisplayNodeAssert(!ASDisplayNodeSubclassOverridesSelector(self, @selector(layoutThatFits:)), @"Subclass %@ must not override layoutThatFits: method. Instead override calculateLayoutThatFits:.", classString);
     ASDisplayNodeAssert(!ASDisplayNodeSubclassOverridesSelector(self, @selector(layoutThatFits:parentSize:)), @"Subclass %@ must not override layoutThatFits:parentSize method. Instead override calculateLayoutThatFits:.", classString);
     ASDisplayNodeAssert(!ASDisplayNodeSubclassOverridesSelector(self, @selector(recursivelyClearContents)), @"Subclass %@ must not override recursivelyClearContents method.", classString);
@@ -904,7 +906,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     if (CGRectEqualToRect(bounds, CGRectZero)) {
       // Performing layout on a zero-bounds view often results in frame calculations
       // with negative sizes after applying margins, which will cause
-      // measureWithSizeRange: on subnodes to assert.
+      // layoutThatFits: on subnodes to assert.
       LOG(@"Warning: No size given for node before node was trying to layout itself: %@. Please provide a frame for the node.", self);
       return;
     }
@@ -1096,13 +1098,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   ASDisplayNodeAssertMainThread();
   ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
   ASDisplayNodeAssertTrue(self.isNodeLoaded);
-}
-
-#pragma mark Layout Transition
-
-- (void)_layoutTransitionMeasurementDidFinish
-{
-  // Hook for subclasses - No-Op in ASDisplayNode
 }
 
 #pragma mark <_ASTransitionContextCompletionDelegate>
@@ -3448,10 +3443,12 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
   self.automaticallyManagesSubnodes = enabled;
 }
 
+#if !ASDISPLAYNODE_NEW_LAYOUT_SYSTEM
 - (CGSize)measure:(CGSize)constrainedSize
 {
   return [self layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
 }
+#endif
 
 ASLayoutElementStyleForwarding
 

--- a/Source/Base/ASAvailability.h
+++ b/Source/Base/ASAvailability.h
@@ -30,6 +30,8 @@
 #define AS_AT_LEAST_IOS9   (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_9_0)
 #define AS_AT_LEAST_IOS10  (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_10_0)
 
+#define ASDISPLAYNODE_NEW_LAYOUT_SYSTEM 0
+
 // If Yoga is available, make it available anywhere we use ASAvailability.
 // This reduces Yoga-specific code in other files.
 // NOTE: Yoga integration is experimental and not fully tested. Use with caution and test layouts carefully.

--- a/Source/Layout/ASLayoutElement.h
+++ b/Source/Layout/ASLayoutElement.h
@@ -22,6 +22,8 @@
 #import <AsyncDisplayKit/ASAbsoluteLayoutElement.h>
 #import <AsyncDisplayKit/ASTraitCollection.h>
 
+#import <AsyncDisplayKit/ASAvailability.h>
+
 @class ASLayout;
 @class ASLayoutSpec;
 @protocol ASLayoutElementStylability;
@@ -149,6 +151,8 @@ typedef NS_ENUM(NSUInteger, ASLayoutElementType) {
 
 #define ASLayoutable ASLayoutElement
 
+#if !ASDISPLAYNODE_NEW_LAYOUT_SYSTEM
+
 /**
  * @abstract Calculate a layout based on given size range.
  *
@@ -160,6 +164,8 @@ typedef NS_ENUM(NSUInteger, ASLayoutElementType) {
  * ASLayoutSpec subclasses
  */
 - (nonnull ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use layoutThatFits: instead.");
+
+#endif
 
 @end
 

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -41,7 +41,10 @@
 {
   [super initialize];
   if (self != [ASLayoutSpec class]) {
+#if !ASDISPLAYNODE_NEW_LAYOUT_SYSTEM
     ASDisplayNodeAssert(!ASSubclassOverridesSelector([ASLayoutSpec class], self, @selector(measureWithSizeRange:)), @"Subclass %@ must not override measureWithSizeRange: method. Instead override calculateLayoutThatFits:", NSStringFromClass(self));
+#endif
+    ASDisplayNodeAssert(!ASSubclassOverridesSelector([ASLayoutSpec class], self, @selector(layoutThatFits:)), @"Subclass %@ must not override layoutThatFits: method. Instead override calculateLayoutThatFits:", NSStringFromClass(self));
   }
 }
 

--- a/Source/Private/ASDisplayNode+FrameworkPrivate.h
+++ b/Source/Private/ASDisplayNode+FrameworkPrivate.h
@@ -216,8 +216,11 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyState(ASHierarchyStat
 
 @end
 
-
+#if ASDISPLAYNODE_NEW_LAYOUT_SYSTEM
+@interface ASDisplayNode (ASLayoutInternalBeta)
+#else
 @interface ASDisplayNode (ASLayoutInternal)
+#endif
 
 /**
  * @abstract Informs the root node that the intrinsic size of the receiver is no longer valid.
@@ -246,7 +249,11 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyState(ASHierarchyStat
 
 @end
 
+#ifdef ASDISPLAYNODE_NEW_LAYOUT_SYSTEM
+@interface ASDisplayNode (ASLayoutTransitionInternalBeta)
+#else
 @interface ASDisplayNode (ASLayoutTransitionInternal)
+#endif
 
 /**
  * If one or multiple layout transitions are in flight this methods returns if the current layout transition that

--- a/Source/Private/Layout/ASStackUnpositionedLayout.mm
+++ b/Source/Private/Layout/ASStackUnpositionedLayout.mm
@@ -71,7 +71,7 @@ static ASLayout *crossChildLayout(const ASStackLayoutSpecChild &child,
                                  crossMax);
   const ASSizeRange childSizeRange = directionSizeRange(style.direction, stackMin, stackMax, childCrossMin, childCrossMax);
   ASLayout *layout = [child.element layoutThatFits:childSizeRange parentSize:parentSize];
-  ASDisplayNodeCAssertNotNil(layout, @"ASLayout returned from measureWithSizeRange: must not be nil: %@", child.element);
+  ASDisplayNodeCAssertNotNil(layout, @"ASLayout returned from layoutThatFits: must not be nil: %@", child.element);
   return layout ? : [ASLayout layoutWithLayoutElement:child.element size:{0, 0}];
 }
 

--- a/Tests/ASDisplayNodeLayoutTests.mm
+++ b/Tests/ASDisplayNodeLayoutTests.mm
@@ -1,5 +1,5 @@
 //
-//  ASDisplayNodeLayoutTests.m
+//  ASDisplayNodeLayoutTests.mm
 //  Texture
 //
 //  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.

--- a/Tests/ASDisplayNodeLayoutTests.mm
+++ b/Tests/ASDisplayNodeLayoutTests.mm
@@ -43,7 +43,7 @@
   ASXCTAssertEqualSizes(displayNode.calculatedSize, CGSizeZero, @"Calculated size before measurement and layout should be 0");
   ASXCTAssertEqualSizes(buttonNode.calculatedSize, CGSizeZero, @"Calculated size before measurement and layout should be 0");
   
-  // Trigger view creation and layout pass without a manual measure: call before so the automatic measurement
+  // Trigger view creation and layout pass without a manual layoutThatFits: call before so the automatic measurement
   // pass will trigger in the layout pass
   [displayNode.view layoutIfNeeded];
   


### PR DESCRIPTION
- Add a new `ASDISPLAYNODE_NEW_LAYOUT_SYSTEM` flag. All new layout code should be gated behind this flag.
- Fork `ASDisplayNode+Layout.mm` to a new beta implementation (`ASDisplayNode+LayoutBeta.mm`). All extensions in the new file have a "B
eta" prefix.
- Move common layout code into a new file: `ASDisplayNode+LayoutCommon.mm`
- The new system drops support for `measure:` and `measureWithSizeRange:`

More information regarding the new system can be found [here](https://paper.dropbox.com/doc/New-Texture-layout-system-1ZRd9V8yJIQFfBuZtn19J).