### PR TITLE
Updates ASDKGram to use IGListKit 3.0.0

### DIFF
--- a/ASDKListKit/Podfile
+++ b/ASDKListKit/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 target 'ASDKListKitTests' do
 	pod 'Texture/IGListKit', :path => '..'
-	pod 'IGListKit', :git => 'https://github.com/Instagram/IGListKit', :commit => 'e9e09d7'
+	pod 'IGListKit', :git => 'https://github.com/Instagram/IGListKit', :commit => '357a28e'
 	pod 'JGMethodSwizzler', :git => 'https://github.com/JonasGessner/JGMethodSwizzler', :branch => 'master'
 end
 

--- a/Texture.podspec
+++ b/Texture.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |spec|
   end
 
   spec.subspec 'IGListKit' do |igl|
-      igl.dependency 'IGListKit', '2.1.0'
+      igl.dependency 'IGListKit', '3.0.0'
       igl.dependency 'Texture/Core'
   end
 

--- a/examples/ASDKgram/Sample/ASCollectionSectionController.m
+++ b/examples/ASDKgram/Sample/ASCollectionSectionController.m
@@ -52,24 +52,18 @@
     return;
   }
 
-  BOOL wasEmpty = (self.items.count == 0);
-
   dispatch_async(self.diffingQueue, ^{
     IGListIndexSetResult *result = IGListDiff(self.pendingItems, newItems, IGListDiffPointerPersonality);
     self.pendingItems = newItems;
     dispatch_async(dispatch_get_main_queue(), ^{
       id<IGListCollectionContext> ctx = self.collectionContext;
-      [ctx performBatchAnimated:animated updates:^{
-        [ctx insertInSectionController:(id)self atIndexes:result.inserts];
-        [ctx deleteInSectionController:(id)self atIndexes:result.deletes];
+      [ctx performBatchAnimated:animated updates:^(id<IGListBatchContext>  _Nonnull batchContext) {
+        [batchContext insertInSectionController:(id)self atIndexes:result.inserts];
+        [batchContext deleteInSectionController:(id)self atIndexes:result.deletes];
         _items = newItems;
       } completion:^(BOOL finished) {
         if (completion) {
           completion();
-        }
-        // WORKAROUND for https://github.com/Instagram/IGListKit/issues/378
-        if (wasEmpty) {
-          [(IGListAdapter *)ctx performUpdatesAnimated:NO completion:nil];
         }
       }];
     });

--- a/examples/ASDKgram/Sample/PhotoFeedListKitViewController.m
+++ b/examples/ASDKgram/Sample/PhotoFeedListKitViewController.m
@@ -65,7 +65,7 @@
 {
   // Ask the first section controller to do the refreshing.
   id<RefreshingSectionControllerType> secCtrl = [self.listAdapter sectionControllerForObject:self.photoFeed];
-  if ([secCtrl conformsToProtocol:@protocol(RefreshingSectionControllerType)]) {
+  if ([(NSObject*)secCtrl conformsToProtocol:@protocol(RefreshingSectionControllerType)]) {
     [secCtrl refreshContentWithCompletion:^{
       [self.refreshCtrl endRefreshing];
     }];
@@ -93,7 +93,7 @@
   return self.spinner;
 }
 
-- (IGListSectionController <IGListSectionType> *)listAdapter:(IGListAdapter *)listAdapter sectionControllerForObject:(id)object
+- (IGListSectionController *)listAdapter:(IGListAdapter *)listAdapter sectionControllerForObject:(id)object
 {
   if ([object isKindOfClass:[PhotoFeedModel class]]) {
     return [[PhotoFeedSectionController alloc] init];

--- a/examples/ASDKgram/Sample/PhotoFeedSectionController.h
+++ b/examples/ASDKgram/Sample/PhotoFeedSectionController.h
@@ -15,7 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface PhotoFeedSectionController : ASCollectionSectionController <IGListSectionType, ASSectionController, RefreshingSectionControllerType>
+@interface PhotoFeedSectionController : ASCollectionSectionController <ASSectionController, RefreshingSectionControllerType>
 
 @property (nonatomic, strong, nullable) PhotoFeedModel *photoFeed;
 

--- a/examples/ASDKgram/Sample/RefreshingSectionControllerType.h
+++ b/examples/ASDKgram/Sample/RefreshingSectionControllerType.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol RefreshingSectionControllerType <IGListSectionType>
+@protocol RefreshingSectionControllerType
 
 - (void)refreshContentWithCompletion:(nullable void(^)())completion;
 


### PR DESCRIPTION
Spotted #364 asking for an update to support IGListKit 3.0.0. This simply gets ASDKGram updated to use IGListKit 3.0.0, it doesn't make any drastic changes to make use of any of the new stuff added in IGListKit.

We've been using 3.0.0 within Buffer alongside Texture for a couple of releases without any issues.

Worth noting I tweaked the podspec and podfile. Wasn't sure how best to handle that & can totally adjust if needed until a future release of Texture.