### PR TITLE
[Yoga] Minimize number of nodes that have MeasureFunc set on them.

### DIFF
--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -25,6 +25,15 @@
 
 #pragma mark <ASLayoutElement>
 
+- (BOOL)implementsLayoutMethod
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  return (_methodOverrides & (ASDisplayNodeMethodOverrideLayoutSpecThatFits |
+                              ASDisplayNodeMethodOverrideCalcLayoutThatFits |
+                              ASDisplayNodeMethodOverrideCalcSizeThatFits)) != 0 || _layoutSpecBlock != nil;
+}
+
+
 - (ASLayoutElementStyle *)style
 {
   ASDN::MutexLocker l(__instanceLock__);
@@ -148,9 +157,9 @@ ASPrimitiveTraitCollectionDeprecatedImplementation
 
 - (void)setLayoutSpecBlock:(ASLayoutSpecBlock)layoutSpecBlock
 {
-  // For now there should never be an override of layoutSpecThatFits: / layoutElementThatFits: and a layoutSpecBlock
-  ASDisplayNodeAssert(!(_methodOverrides & ASDisplayNodeMethodOverrideLayoutSpecThatFits), @"Overwriting layoutSpecThatFits: and providing a layoutSpecBlock block is currently not supported");
-
+  // For now there should never be an override of layoutSpecThatFits: and a layoutSpecBlock together.
+  ASDisplayNodeAssert(!(_methodOverrides & ASDisplayNodeMethodOverrideLayoutSpecThatFits),
+                      @"Nodes with a .layoutSpecBlock must not also implement -layoutSpecThatFits:");
   ASDN::MutexLocker l(__instanceLock__);
   _layoutSpecBlock = layoutSpecBlock;
 }

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -177,6 +177,15 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   if (ASDisplayNodeSubclassOverridesSelector(c, @selector(layoutSpecThatFits:))) {
     overrides |= ASDisplayNodeMethodOverrideLayoutSpecThatFits;
   }
+  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(calculateLayoutThatFits:)) ||
+      ASDisplayNodeSubclassOverridesSelector(c, @selector(calculateLayoutThatFits:
+                                                                 restrictedToSize:
+                                                             relativeToParentSize:))) {
+    overrides |= ASDisplayNodeMethodOverrideCalcLayoutThatFits;
+  }
+  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(calculateSizeThatFits:))) {
+    overrides |= ASDisplayNodeMethodOverrideCalcSizeThatFits;
+  }
   if (ASDisplayNodeSubclassOverridesSelector(c, @selector(fetchData))) {
     overrides |= ASDisplayNodeMethodOverrideFetchData;
   }

--- a/Source/Layout/ASLayoutElement.h
+++ b/Source/Layout/ASLayoutElement.h
@@ -144,6 +144,7 @@ typedef NS_ENUM(NSUInteger, ASLayoutElementType) {
                      restrictedToSize:(ASLayoutElementSize)size
                  relativeToParentSize:(CGSize)parentSize;
 
+- (BOOL)implementsLayoutMethod;
 
 #pragma mark - Deprecated
 

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -71,6 +71,11 @@
   return YES;
 }
 
+- (BOOL)implementsLayoutMethod
+{
+  return YES;
+}
+
 #pragma mark - Style
 
 - (ASLayoutElementStyle *)style

--- a/Source/Layout/ASYogaUtilities.h
+++ b/Source/Layout/ASYogaUtilities.h
@@ -22,8 +22,9 @@
 @interface ASDisplayNode (YogaHelpers)
 
 + (ASDisplayNode *)yogaNode;
-+ (ASDisplayNode *)verticalYogaStack;
-+ (ASDisplayNode *)horizontalYogaStack;
++ (ASDisplayNode *)yogaSpacerNode;
++ (ASDisplayNode *)yogaVerticalStack;
++ (ASDisplayNode *)yogaHorizontalStack;
 
 @end
 

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -51,8 +51,10 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
   ASDisplayNodeMethodOverrideTouchesEnded       = 1 << 2,
   ASDisplayNodeMethodOverrideTouchesMoved       = 1 << 3,
   ASDisplayNodeMethodOverrideLayoutSpecThatFits = 1 << 4,
-  ASDisplayNodeMethodOverrideFetchData          = 1 << 5,
-  ASDisplayNodeMethodOverrideClearFetchedData   = 1 << 6
+  ASDisplayNodeMethodOverrideCalcLayoutThatFits = 1 << 5,
+  ASDisplayNodeMethodOverrideCalcSizeThatFits   = 1 << 6,
+  ASDisplayNodeMethodOverrideFetchData          = 1 << 7,
+  ASDisplayNodeMethodOverrideClearFetchedData   = 1 << 8
 };
 
 typedef NS_OPTIONS(uint_least32_t, ASDisplayNodeAtomicFlags)

--- a/examples/ASDKgram/Sample/PhotoCellNode.m
+++ b/examples/ASDKgram/Sample/PhotoCellNode.m
@@ -316,7 +316,7 @@
   [_photoLocationLabel.style yogaNodeCreateIfNeeded];
   [_photoTimeIntervalSincePostLabel.style yogaNodeCreateIfNeeded];
 
-  ASDisplayNode *headerStack = [ASDisplayNode horizontalYogaStack];
+  ASDisplayNode *headerStack = [ASDisplayNode yogaHorizontalStack];
   headerStack.style.margin = ASEdgeInsetsMake(InsetForHeader);
   headerStack.style.alignItems = ASStackLayoutAlignItemsCenter;
   headerStack.style.flexGrow = 1.0;
@@ -327,7 +327,7 @@
   [headerStack addYogaChild:_userAvatarImageNode];
 
   // User Name and Photo Location stack is next
-  ASDisplayNode *userPhotoLocationStack = [ASDisplayNode verticalYogaStack];
+  ASDisplayNode *userPhotoLocationStack = [ASDisplayNode yogaVerticalStack];
   userPhotoLocationStack.style.flexShrink = 1.0;
   [headerStack addYogaChild:userPhotoLocationStack];
 
@@ -340,20 +340,15 @@
     [userPhotoLocationStack addYogaChild:_photoLocationLabel];
   }
 
-/* TODO: These parameters aren't working as expected. For now the timestamp is next to the username.
   // Add a spacer to allow a flexible space between the User Name / Location stack, and the Timestamp.
-  ASDisplayNode *spacer = [ASDisplayNode new];
-  spacer.style.flexShrink = 1.0;
-  spacer.style.width = ASDimensionMakeWithFraction(1.0);
-  [headerStack addYogaChild:spacer];
-*/
+  [headerStack addYogaChild:[ASDisplayNode yogaSpacerNode]];
 
   // Photo Timestamp Label.
   _photoTimeIntervalSincePostLabel.style.spacingBefore = HORIZONTAL_BUFFER;
   [headerStack addYogaChild:_photoTimeIntervalSincePostLabel];
 
   // Create the last stack before assembling everything: the Footer Stack contains the description and comments.
-  ASDisplayNode *footerStack = [ASDisplayNode verticalYogaStack];
+  ASDisplayNode *footerStack = [ASDisplayNode yogaVerticalStack];
   footerStack.style.margin = ASEdgeInsetsMake(InsetForFooter);
   footerStack.style.padding = ASEdgeInsetsMake(UIEdgeInsetsMake(0.0, 0.0, VERTICAL_BUFFER, 0.0));
   footerStack.yogaChildren = @[_photoLikesLabel, _photoDescriptionLabel, _photoCommentsNode];


### PR DESCRIPTION
NOTE: Yoga support is still highly experimental and is not
planned to become a supported / documented mode of the framework.
We recommend that most apps use ASStackLayoutSpec and the other
specs: http://texturegroup.org/docs/layout2-layoutspec-types.html

This has one important benefit: fixing the stretching behavior of spacer nodes. In addition, it should help efficiency of Yoga and certainly minimize calls to layoutThatFits:.

In the Yoga layout mode of ASDKgram, note how the timestamp is now correctly at the right-hand side of the screen, as allowed by a flexible spacer node placed in the photo header's horizontal stack:

![image](https://user-images.githubusercontent.com/565251/27258493-b1d565d0-53b0-11e7-88c5-c89658f31e9d.png)
