### PR TITLE
[Yoga] Delete YOGA_TREE_CONTIGOUS gating and permanently enable. #trivial

### DIFF
--- a/Source/ASDisplayNode+Beta.h
+++ b/Source/ASDisplayNode+Beta.h
@@ -178,13 +178,11 @@ extern void ASDisplayNodePerformBlockOnEveryYogaChild(ASDisplayNode * _Nullable 
 
 - (void)semanticContentAttributeDidChange:(UISemanticContentAttribute)attribute;
 
-#if YOGA_TREE_CONTIGUOUS
 @property (nonatomic, assign) BOOL yogaLayoutInProgress;
 @property (nonatomic, strong, nullable) ASLayout *yogaCalculatedLayout;
 // These methods should not normally be called directly.
 - (void)invalidateCalculatedYogaLayout;
 - (void)calculateLayoutFromYogaRoot:(ASSizeRange)rootConstrainedSize;
-#endif
 
 @end
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -885,7 +885,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   
   _unflattenedLayout = nil;
 
-#if YOGA_TREE_CONTIGUOUS
+#if YOGA
   [self invalidateCalculatedYogaLayout];
 #endif
 }
@@ -959,7 +959,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
   ASDN::MutexLocker l(__instanceLock__);
 
-#if YOGA_TREE_CONTIGUOUS /* YOGA */
+#if YOGA
   // There are several cases where Yoga could arrive here:
   // - This node is not in a Yoga tree: it has neither a yogaParent nor yogaChildren.
   // - This node is a Yoga tree root: it has no yogaParent, but has yogaChildren.

--- a/Source/Base/ASAvailability.h
+++ b/Source/Base/ASAvailability.h
@@ -41,13 +41,6 @@
   #define YOGA __has_include(YOGA_HEADER_PATH)
 #endif
 
-// Contiguous Yoga layout attempts to build a connected tree of YGNodeRef objects, across multiple levels
-// in the ASDisplayNode tree (based on .yogaChildren). When disabled, ASYogaLayoutSpec is used, with a
-// disjoint Yoga tree for each level in the hierarchy. Currently, both modes are experimental.
-#ifndef YOGA_TREE_CONTIGUOUS
-  #define YOGA_TREE_CONTIGUOUS YOGA  // To enable, set to YOGA, as the code depends on YOGA also being set.
-#endif
-
 #define AS_PIN_REMOTE_IMAGE __has_include(<PINRemoteImage/PINRemoteImage.h>)
 #define AS_IG_LIST_KIT __has_include(<IGListKit/IGListKit.h>)
 

--- a/Source/Layout/ASYogaLayoutSpec.h
+++ b/Source/Layout/ASYogaLayoutSpec.h
@@ -13,7 +13,6 @@
 #import <AsyncDisplayKit/ASAvailability.h>
 
 #if YOGA /* YOGA */
-#if !YOGA_TREE_CONTIGUOUS /* !YOGA_TREE_CONTIGUOUS */
 
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASLayoutSpec.h>
@@ -22,5 +21,4 @@
 @property (nonatomic, strong, nonnull) ASDisplayNode *rootNode;
 @end
 
-#endif /* !YOGA_TREE_CONTIGUOUS */
 #endif /* YOGA */

--- a/Source/Layout/ASYogaLayoutSpec.mm
+++ b/Source/Layout/ASYogaLayoutSpec.mm
@@ -13,7 +13,6 @@
 #import <AsyncDisplayKit/ASAvailability.h>
 
 #if YOGA /* YOGA */
-#if !YOGA_TREE_CONTIGUOUS /* !YOGA_TREE_CONTIGUOUS */
 
 #import <AsyncDisplayKit/ASYogaLayoutSpec.h>
 #import <AsyncDisplayKit/ASYogaUtilities.h>
@@ -176,5 +175,4 @@
 
 @end
 
-#endif /* !YOGA_TREE_CONTIGUOUS */
 #endif /* YOGA */

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -203,8 +203,6 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   // create ASDisplayNodes to make a stack layout when using Yoga.
   // However, the implementation is mostly ready for id <ASLayoutElement>, with a few areas requiring updates.
   NSMutableArray<ASDisplayNode *> *_yogaChildren;
-#endif
-#if YOGA_TREE_CONTIGUOUS
   __weak ASDisplayNode *_yogaParent;
   ASLayout *_yogaCalculatedLayout;
 #endif


### PR DESCRIPTION
NOTE: Yoga support is still highly experimental and is not
planned to become a supported / documented mode of the framework.
We recommend that most apps use ASStackLayoutSpec and the other
specs: http://texturegroup.org/docs/layout2-layoutspec-types.html

This reduces complexity of the Yoga integration points, and is
a first step towards further minimization and formalization of
the Yoga footprint in the framework.