### PR TITLE
FIXED Typo in Layout Transition Documentation

### DIFF
--- a/docs/_docs/layout-transition-api.md
+++ b/docs/_docs/layout-transition-api.md
@@ -215,7 +215,7 @@ override func animateLayoutTransition(_ context: ASContextTransitioning) {
   if context.isAnimated() {
       
   } else {
-      super.animateLayoutTransition(contet)
+      super.animateLayoutTransition(context)
   }
 }
 </pre>


### PR DESCRIPTION
Fixed typo Contet -> Context when calling `super.animateLayoutTransition`