### PR TITLE
Gate orphaned node detector behind YOGA flag #trivial

### DIFF
--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -864,7 +864,11 @@ ASPrimitiveTraitCollectionDeprecatedImplementation
 
 - (void)_pendingLayoutTransitionDidComplete
 {
+  // This assertion introduces a breaking behavior for nodes that has ASM enabled but also manually manage some subnodes.
+  // Let's gate it behind YOGA flag and remove it right after a branch cut.
+#if YOGA
   [self _assertSubnodeState];
+#endif
 
   // Subclass hook
   [self calculatedLayoutDidChange];

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -143,7 +143,7 @@ ASPrimitiveTraitCollectionDeprecatedImplementation
 {
   NSString *string = NSStringFromClass([self class]);
   if (_debugName) {
-    string = [string stringByAppendingString:[NSString stringWithFormat:@"\"%@\"",_debugName]];
+    string = [string stringByAppendingString:[NSString stringWithFormat:@"\"%@\"", _debugName]];
   }
   return string;
 }


### PR DESCRIPTION
This is causing breaking behaviors for non-Yoga users (aka. Pin). Let's gate it now and roll out later.