### PR TITLE
ASDimensionMake to be more lenient #trivial

### DIFF
--- a/Source/Layout/ASDimension.mm
+++ b/Source/Layout/ASDimension.mm
@@ -47,7 +47,6 @@ ASOVERLOADABLE ASDimension ASDimensionMake(NSString *dimension)
     }
   }
   
-  ASDisplayNodeCAssert(NO, @"Parsing dimension failed for: %@", dimension);
   return ASDimensionAuto;
 }
 

--- a/Tests/ASDimensionTests.mm
+++ b/Tests/ASDimensionTests.mm
@@ -29,7 +29,7 @@
 {
   XCTAssertNoThrow(ASDimensionMake(ASDimensionUnitAuto, 0));
   XCTAssertThrows(ASDimensionMake(ASDimensionUnitAuto, 100));
-  XCTAssertThrows(ASDimensionMake(@""));
+  ASXCTAssertEqualDimensions(ASDimensionAuto, ASDimensionMake(@""));
   ASXCTAssertEqualDimensions(ASDimensionAuto, ASDimensionMake(@"auto"));
 }
 


### PR DESCRIPTION
Using the layout debugger, users can frequently input an invalid dimension string. Instead of throwing assertion, let's be more lenient and fall back to Auto.