### PR TITLE
[ASCellNode] Remove unnecessary frame setting #trivial

### DIFF
--- a/Source/ASCellNode.mm
+++ b/Source/ASCellNode.mm
@@ -114,13 +114,6 @@
   _viewControllerNode.frame = self.bounds;
 }
 
-- (void)layoutDidFinish
-{
-  [super layoutDidFinish];
-
-  _viewControllerNode.frame = self.bounds;
-}
-
 - (void)_rootNodeDidInvalidateSize
 {
   if (_interactionDelegate != nil) {


### PR DESCRIPTION
The same thing is (and should be) done in [`-layout`](https://github.com/TextureGroup/Texture/pull/387/files#diff-bf3128e7e068b8e2a4e939d402792365R110).