### PR TITLE
[ASCollectionView] Small improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Overhaul logging and add activity tracing support. [Adlai Holler](https://github.com/Adlai-Holler)
 - Fix a crash where scrolling a table view after entering editing mode could lead to bad internal states in the table. [Huy Nguyen](https://github.com/nguyenhuy) [#416](https://github.com/TextureGroup/Texture/pull/416/)
 - Fix a crash in collection view that occurs if batch updates are performed while scrolling [Huy Nguyen](https://github.com/nguyenhuy) [#378](https://github.com/TextureGroup/Texture/issues/378)
+- Some improvements in ASCollectionView [Huy Nguyen](https://github.com/nguyenhuy) [#407](https://github.com/TextureGroup/Texture/pull/407)
 
 ##2.3.4
 - [Yoga] Rewrite YOGA_TREE_CONTIGUOUS mode with improved behavior and cleaner integration [Scott Goodson](https://github.com/appleguy)

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -952,7 +952,13 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   ASDisplayNodeAssertMainThread();
-  ASCellNode *cell = [self nodeForItemAtIndexPath:indexPath];
+  ASCollectionElement *element = [_dataController.visibleMap elementForItemAtIndexPath:indexPath];
+  if (element == nil) {
+    ASDisplayNodeAssert(NO, @"Unexpected nil element for collectionView:layout:sizeForItemAtIndexPath: %@, %@, %ld", self, layout, section);
+    return CGSizeZero;
+  }
+
+  ASCellNode *cell = element.node;
   if (cell.shouldUseUIKitCell) {
     if ([_asyncDelegate respondsToSelector:@selector(collectionView:layout:sizeForItemAtIndexPath:)]) {
       CGSize size = [(id)_asyncDelegate collectionView:collectionView layout:collectionViewLayout sizeForItemAtIndexPath:indexPath];
@@ -960,8 +966,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
       return size;
     }
   }
-  ASCollectionElement *e = [_dataController.visibleMap elementForItemAtIndexPath:indexPath];
-  return [self sizeForElement:e];
+
+  return [self sizeForElement:element];
 }
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)layout referenceSizeForHeaderInSection:(NSInteger)section
@@ -971,6 +977,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   ASCollectionElement *element = [_dataController.visibleMap supplementaryElementOfKind:UICollectionElementKindSectionHeader
                                                                             atIndexPath:indexPath];
   if (element == nil) {
+    ASDisplayNodeAssert(NO, @"Unexpected nil element for collectionView:layout:referenceSizeForHeaderInSection: %@, %@, %ld", self, layout, section);
     return CGSizeZero;
   }
 
@@ -990,6 +997,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   ASCollectionElement *element = [_dataController.visibleMap supplementaryElementOfKind:UICollectionElementKindSectionFooter
                                                                             atIndexPath:indexPath];
   if (element == nil) {
+    ASDisplayNodeAssert(NO, @"Unexpected nil element for collectionView:layout:referenceSizeForFooterInSection: %@, %@, %ld", self, layout, section);
     return CGSizeZero;
   }
 

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -1021,7 +1021,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     view = [self dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:kReuseIdentifier forIndexPath:indexPath];
   }
   
-  if (_ASCollectionReusableView *reusableView = ASCollectionReusableViewCast(view)) {
+  if (_ASCollectionReusableView *reusableView = ASDynamicCastStrict(view, _ASCollectionReusableView)) {
     reusableView.element = element;
   }
   
@@ -1047,7 +1047,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
   ASDisplayNodeAssert(element != nil, @"Element should exist. indexPath = %@, collectionDataSource = %@", indexPath, self);
 
-  if (_ASCollectionViewCell *asCell = ASCollectionViewCellCast(cell)) {
+  if (_ASCollectionViewCell *asCell = ASDynamicCastStrict(cell, _ASCollectionViewCell)) {
     asCell.element = element;
     [_rangeController configureContentView:cell.contentView forCellNode:node];
   }
@@ -1061,7 +1061,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     [(id <ASCollectionDelegateInterop>)_asyncDelegate collectionView:collectionView willDisplayCell:rawCell forItemAtIndexPath:indexPath];
   }
 
-  _ASCollectionViewCell *cell = ASCollectionViewCellCast(rawCell);
+  _ASCollectionViewCell *cell = ASDynamicCastStrict(rawCell, _ASCollectionViewCell);
   if (cell == nil) {
     [_rangeController setNeedsUpdate];
     return;
@@ -1117,7 +1117,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     [(id <ASCollectionDelegateInterop>)_asyncDelegate collectionView:collectionView didEndDisplayingCell:rawCell forItemAtIndexPath:indexPath];
   }
 
-  _ASCollectionViewCell *cell = ASCollectionViewCellCast(rawCell);
+  _ASCollectionViewCell *cell = ASDynamicCastStrict(rawCell, _ASCollectionViewCell);
   if (cell == nil) {
     [_rangeController setNeedsUpdate];
     return;
@@ -1154,7 +1154,12 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (void)collectionView:(UICollectionView *)collectionView willDisplaySupplementaryView:(UICollectionReusableView *)rawView forElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath
 {
-  ASCollectionElement *element = [_dataController.visibleMap supplementaryElementOfKind:elementKind atIndexPath:indexPath]
+  _ASCollectionReusableView *view = ASDynamicCastStrict(rawView, _ASCollectionReusableView);
+  if (view == nil) {
+    return;
+  }
+
+  ASCollectionElement *element = [_dataController.visibleMap supplementaryElementOfKind:elementKind atIndexPath:indexPath];
   if (element) {
     [_visibleElements addObject:element];
   } else {
@@ -1167,7 +1172,6 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   // if the user is scrolling back and forth across a small set of items.
   // In this case, we have to fetch the layout attributes manually.
   // This may be possible under iOS < 10 but it has not been observed yet.
-  ASCollectionReusableViewCastOrReturn(rawView, view, (void)0);
   if (view.layoutAttributes == nil) {
     view.layoutAttributes = [collectionView layoutAttributesForSupplementaryElementOfKind:elementKind atIndexPath:indexPath];
   }

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -968,30 +968,38 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 {
   ASDisplayNodeAssertMainThread();
   NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:section];
-  ASCellNode *cell = [self supplementaryNodeForElementKind:UICollectionElementKindSectionHeader
-                                               atIndexPath:indexPath];
-  if (cell.shouldUseUIKitCell && _asyncDelegateFlags.interop) {
+  ASCollectionElement *element = [_dataController.visibleMap supplementaryElementOfKind:UICollectionElementKindSectionHeader
+                                                                            atIndexPath:indexPath];
+  if (element == nil) {
+    return CGSizeZero;
+  }
+
+  if (element.node.shouldUseUIKitCell && _asyncDelegateFlags.interop) {
     if ([_asyncDelegate respondsToSelector:@selector(collectionView:layout:referenceSizeForHeaderInSection:)]) {
       return [(id)_asyncDelegate collectionView:collectionView layout:layout referenceSizeForHeaderInSection:section];
     }
   }
-  ASCollectionElement *e = [_dataController.visibleMap supplementaryElementOfKind:UICollectionElementKindSectionHeader atIndexPath:indexPath];
-  return [self sizeForElement:e];
+
+  return [self sizeForElement:element];
 }
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)layout referenceSizeForFooterInSection:(NSInteger)section
 {
   ASDisplayNodeAssertMainThread();
   NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:section];
-  ASCellNode *cell = [self supplementaryNodeForElementKind:UICollectionElementKindSectionFooter
-                                               atIndexPath:indexPath];
-  if (cell.shouldUseUIKitCell && _asyncDelegateFlags.interop) {
+  ASCollectionElement *element = [_dataController.visibleMap supplementaryElementOfKind:UICollectionElementKindSectionFooter
+                                                                            atIndexPath:indexPath];
+  if (element == nil) {
+    return CGSizeZero;
+  }
+
+  if (element.node.shouldUseUIKitCell && _asyncDelegateFlags.interop) {
     if ([_asyncDelegate respondsToSelector:@selector(collectionView:layout:referenceSizeForFooterInSection:)]) {
       return [(id)_asyncDelegate collectionView:collectionView layout:layout referenceSizeForFooterInSection:section];
     }
   }
-  ASCollectionElement *e = [_dataController.visibleMap supplementaryElementOfKind:UICollectionElementKindSectionFooter atIndexPath:indexPath];
-  return [self sizeForElement:e];
+
+  return [self sizeForElement:element];
 }
 
 - (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
@@ -1013,7 +1021,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     view = [self dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:kReuseIdentifier forIndexPath:indexPath];
   }
   
-  if (_ASCollectionReusableView *reusableView = ASDynamicCast(view, _ASCollectionReusableView)) {
+  if (_ASCollectionReusableView *reusableView = ASCollectionReusableViewCast(view)) {
     reusableView.element = element;
   }
   
@@ -1039,7 +1047,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
   ASDisplayNodeAssert(element != nil, @"Element should exist. indexPath = %@, collectionDataSource = %@", indexPath, self);
 
-  if (_ASCollectionViewCell *asCell = ASDynamicCast(cell, _ASCollectionViewCell)) {
+  if (_ASCollectionViewCell *asCell = ASCollectionViewCellCast(cell)) {
     asCell.element = element;
     [_rangeController configureContentView:cell.contentView forCellNode:node];
   }
@@ -1053,15 +1061,13 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     [(id <ASCollectionDelegateInterop>)_asyncDelegate collectionView:collectionView willDisplayCell:rawCell forItemAtIndexPath:indexPath];
   }
 
-  // Since _ASCollectionViewCell is not available for subclassing, this is faster than isKindOfClass:
-  // We must exit early here, because only _ASCollectionViewCell implements the -node accessor method.
-  if ([rawCell class] != [_ASCollectionViewCell class]) {
+  _ASCollectionViewCell *cell = ASCollectionViewCellCast(rawCell);
+  if (cell == nil) {
     [_rangeController setNeedsUpdate];
     return;
   }
-  auto cell = (_ASCollectionViewCell *)rawCell;
-  
-  ASCollectionElement *element = cell.element;
+
+  ASCollectionElement *element = [_dataController.visibleMap elementForItemAtIndexPath:indexPath];
   if (element) {
     [_visibleElements addObject:element];
   } else {
@@ -1100,7 +1106,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   
   [_rangeController setNeedsUpdate];
   
-  if (ASSubclassOverridesSelector([ASCellNode class], [cellNode class], @selector(cellNodeVisibilityEvent:inScrollView:withCellFrame:))) {
+  if ([cell consumesCellNodeVisibilityEvents]) {
     [_cellsForVisibilityUpdates addObject:cell];
   }
 }
@@ -1111,15 +1117,13 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     [(id <ASCollectionDelegateInterop>)_asyncDelegate collectionView:collectionView didEndDisplayingCell:rawCell forItemAtIndexPath:indexPath];
   }
 
-  // Since _ASCollectionViewCell is not available for subclassing, this is faster than isKindOfClass:
-  // We must exit early here, because only _ASCollectionViewCell implements the -node accessor method.
-  if ([rawCell class] != [_ASCollectionViewCell class]) {
+  _ASCollectionViewCell *cell = ASCollectionViewCellCast(rawCell);
+  if (cell == nil) {
     [_rangeController setNeedsUpdate];
     return;
   }
-  auto cell = (_ASCollectionViewCell *)rawCell;
   
-  ASCollectionElement *element = cell.element;
+  ASCollectionElement *element = [_dataController.visibleMap elementForItemAtIndexPath:indexPath];
   if (element) {
     [_visibleElements removeObject:element];
   } else {
@@ -1150,27 +1154,27 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (void)collectionView:(UICollectionView *)collectionView willDisplaySupplementaryView:(UICollectionReusableView *)rawView forElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath
 {
-  if (rawView.class != [_ASCollectionReusableView class]) {
-    return;
-  }
-  auto view = (_ASCollectionReusableView *)rawView;
-
-  if (view.element) {
-    [_visibleElements addObject:view.element];
+  ASCollectionElement *element = [_dataController.visibleMap supplementaryElementOfKind:elementKind atIndexPath:indexPath]
+  if (element) {
+    [_visibleElements addObject:element];
   } else {
     ASDisplayNodeAssert(NO, @"Unexpected nil element for willDisplaySupplementaryView: %@, %@, %@", rawView, self, indexPath);
     return;
   }
 
-  // This is a safeguard similar to the behavior for cells in -[ASCollectionView collectionView:willDisplayCell:forItemAtIndexPath:]
-  // It ensures _ASCollectionReusableView receives layoutAttributes and calls applyLayoutAttributes.
+  // Under iOS 10+, cells may be removed/re-added to the collection view without
+  // receiving prepareForReuse/applyLayoutAttributes, as an optimization for e.g.
+  // if the user is scrolling back and forth across a small set of items.
+  // In this case, we have to fetch the layout attributes manually.
+  // This may be possible under iOS < 10 but it has not been observed yet.
+  ASCollectionReusableViewCastOrReturn(rawView, view, (void)0);
   if (view.layoutAttributes == nil) {
     view.layoutAttributes = [collectionView layoutAttributesForSupplementaryElementOfKind:elementKind atIndexPath:indexPath];
   }
 
   if (_asyncDelegateFlags.collectionNodeWillDisplaySupplementaryElement) {
     GET_COLLECTIONNODE_OR_RETURN(collectionNode, (void)0);
-    ASCellNode *node = [self supplementaryNodeForElementKind:elementKind atIndexPath:indexPath];
+    ASCellNode *node = element.node;
     ASDisplayNodeAssert([node.supplementaryElementKind isEqualToString:elementKind], @"Expected node for supplementary element to have kind '%@', got '%@'.", elementKind, node.supplementaryElementKind);
     [_asyncDelegate collectionNode:collectionNode willDisplaySupplementaryElementWithNode:node];
   }
@@ -1178,13 +1182,9 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (void)collectionView:(UICollectionView *)collectionView didEndDisplayingSupplementaryView:(UICollectionReusableView *)rawView forElementOfKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath
 {
-  if (rawView.class != [_ASCollectionReusableView class]) {
-    return;
-  }
-  auto view = (_ASCollectionReusableView *)rawView;
-
-  if (view.element) {
-    [_visibleElements removeObject:view.element];
+  ASCollectionElement *element = [_dataController.visibleMap supplementaryElementOfKind:elementKind atIndexPath:indexPath];
+  if (element) {
+    [_visibleElements removeObject:element];
   } else {
     ASDisplayNodeAssert(NO, @"Unexpected nil element for didEndDisplayingSupplementaryView: %@, %@, %@", rawView, self, indexPath);
     return;
@@ -1192,7 +1192,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
   if (_asyncDelegateFlags.collectionNodeDidEndDisplayingSupplementaryElement) {
     GET_COLLECTIONNODE_OR_RETURN(collectionNode, (void)0);
-    ASCellNode *node = [self supplementaryNodeForElementKind:elementKind atIndexPath:indexPath];
+    ASCellNode *node = element.node;
     ASDisplayNodeAssert([node.supplementaryElementKind isEqualToString:elementKind], @"Expected node for supplementary element to have kind '%@', got '%@'.", elementKind, node.supplementaryElementKind);
     [_asyncDelegate collectionNode:collectionNode didEndDisplayingSupplementaryElementWithNode:node];
   }
@@ -1374,11 +1374,9 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     [self _checkForBatchFetching];
   }
   
-  for (_ASCollectionViewCell *collectionCell in _cellsForVisibilityUpdates) {
+  for (_ASCollectionViewCell *cell in _cellsForVisibilityUpdates) {
     // Only nodes that respond to the selector are added to _cellsForVisibilityUpdates
-    [[collectionCell node] cellNodeVisibilityEvent:ASCellNodeVisibilityEventVisibleRectChanged
-                                      inScrollView:scrollView
-                                     withCellFrame:collectionCell.frame];
+    [cell cellNodeVisibilityEvent:ASCellNodeVisibilityEventVisibleRectChanged inScrollView:scrollView];
   }
   if (_asyncDelegateFlags.scrollViewDidScroll) {
     [_asyncDelegate scrollViewDidScroll:scrollView];
@@ -1414,10 +1412,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
 {
-  for (_ASCollectionViewCell *collectionCell in _cellsForVisibilityUpdates) {
-    [[collectionCell node] cellNodeVisibilityEvent:ASCellNodeVisibilityEventWillBeginDragging
-                                          inScrollView:scrollView
-                                         withCellFrame:collectionCell.frame];
+  for (_ASCollectionViewCell *cell in _cellsForVisibilityUpdates) {
+    [cell cellNodeVisibilityEvent:ASCellNodeVisibilityEventWillBeginDragging inScrollView:scrollView];
   }
   if (_asyncDelegateFlags.scrollViewWillBeginDragging) {
     [_asyncDelegate scrollViewWillBeginDragging:scrollView];
@@ -1426,14 +1422,12 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
 {
-    for (_ASCollectionViewCell *collectionCell in _cellsForVisibilityUpdates) {
-        [[collectionCell node] cellNodeVisibilityEvent:ASCellNodeVisibilityEventDidEndDragging
-                                          inScrollView:scrollView
-                                         withCellFrame:collectionCell.frame];
-    }
-    if (_asyncDelegateFlags.scrollViewDidEndDragging) {
-        [_asyncDelegate scrollViewDidEndDragging:scrollView willDecelerate:decelerate];
-    }
+  for (_ASCollectionViewCell *cell in _cellsForVisibilityUpdates) {
+    [cell cellNodeVisibilityEvent:ASCellNodeVisibilityEventDidEndDragging inScrollView:scrollView];
+  }
+  if (_asyncDelegateFlags.scrollViewDidEndDragging) {
+    [_asyncDelegate scrollViewDidEndDragging:scrollView willDecelerate:decelerate];
+  }
 }
 
 #pragma mark - Scroll Direction.

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -954,7 +954,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   ASDisplayNodeAssertMainThread();
   ASCollectionElement *element = [_dataController.visibleMap elementForItemAtIndexPath:indexPath];
   if (element == nil) {
-    ASDisplayNodeAssert(NO, @"Unexpected nil element for collectionView:layout:sizeForItemAtIndexPath: %@, %@, %ld", self, layout, section);
+    ASDisplayNodeAssert(NO, @"Unexpected nil element for collectionView:layout:sizeForItemAtIndexPath: %@, %@, %@", self, collectionViewLayout, indexPath);
     return CGSizeZero;
   }
 

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -235,6 +235,12 @@
   ((c *) ([__val isKindOfClass:[c class]] ? __val : nil));\
 })
 
+/// Ensure that class is of certain kind, assuming it is subclass restricted
+#define ASDynamicCastStrict(x, c) ({ \
+  id __val = x;\
+  ((c *) ([__val class] == [c class] ? __val : nil));\
+})
+
 /**
  * Create a new set by mapping `collection` over `work`, ignoring nil.
  */

--- a/Source/Details/_ASCollectionReusableView.h
+++ b/Source/Details/_ASCollectionReusableView.h
@@ -20,33 +20,9 @@
 
 @class ASCollectionElement;
 
-/**
- * Attempts to cast x to _ASCollectionReusableView, or nil if not possible.
- *
- * Since _ASCollectionReusableView is not available for subclassing (see below),
- * comparing x's and _ASCollectionReusableView's classes is faster than calling -isKindOfClass: on x.
- */
-#define ASCollectionReusableViewCast(x) ({ \
-  id __var = x; \
-  ((_ASCollectionReusableView *) (x.class == [_ASCollectionReusableView class] ? __var : nil)); \
-})
-
-/**
- * Attempts to cast x to _ASCollectionReusableView and assigns to __var. If not possible, returns the given __val.
- *
- * Since _ASCollectionReusableView is not available for subclassing (see below),
- * comparing x's and _ASCollectionReusableView's classes is faster than calling -isKindOfClass: on x.
- */
-#define ASCollectionReusableViewCastOrReturn(x, __var, __val) \
-  _ASCollectionReusableView *__var = ASCollectionReusableViewCast(x); \
-  if (__var == nil) { \
-    return __val; \
-  }
-
 NS_ASSUME_NONNULL_BEGIN
 
-AS_SUBCLASSING_RESTRICTED
-
+AS_SUBCLASSING_RESTRICTED // Note: ASDynamicCastStrict is used on instances of this class based on this restriction.
 @interface _ASCollectionReusableView : UICollectionReusableView
 
 @property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;

--- a/Source/Details/_ASCollectionReusableView.h
+++ b/Source/Details/_ASCollectionReusableView.h
@@ -18,16 +18,16 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
-@class ASCollectionElement;
+@class ASCellnode, ASCollectionElement;
 
 NS_ASSUME_NONNULL_BEGIN
 
 AS_SUBCLASSING_RESTRICTED // Note: ASDynamicCastStrict is used on instances of this class based on this restriction.
 @interface _ASCollectionReusableView : UICollectionReusableView
 
+@property (nonatomic, strong, readonly, nullable) ASCellNode *node;
+@property (nonatomic, strong, nullable) ASCollectionElement *element;
 @property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
-
-- (void)setElement:(ASCollectionElement *)element;
 
 @end
 

--- a/Source/Details/_ASCollectionReusableView.h
+++ b/Source/Details/_ASCollectionReusableView.h
@@ -18,15 +18,41 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
-@class ASCellNode, ASCollectionElement;
+@class ASCollectionElement;
+
+/**
+ * Attempts to cast x to _ASCollectionReusableView, or nil if not possible.
+ *
+ * Since _ASCollectionReusableView is not available for subclassing (see below),
+ * comparing x's and _ASCollectionReusableView's classes is faster than calling -isKindOfClass: on x.
+ */
+#define ASCollectionReusableViewCast(x) ({ \
+  id __var = x; \
+  ((_ASCollectionReusableView *) (x.class == [_ASCollectionReusableView class] ? __var : nil)); \
+})
+
+/**
+ * Attempts to cast x to _ASCollectionReusableView and assigns to __var. If not possible, returns the given __val.
+ *
+ * Since _ASCollectionReusableView is not available for subclassing (see below),
+ * comparing x's and _ASCollectionReusableView's classes is faster than calling -isKindOfClass: on x.
+ */
+#define ASCollectionReusableViewCastOrReturn(x, __var, __val) \
+  _ASCollectionReusableView *__var = ASCollectionReusableViewCast(x); \
+  if (__var == nil) { \
+    return __val; \
+  }
 
 NS_ASSUME_NONNULL_BEGIN
 
 AS_SUBCLASSING_RESTRICTED
+
 @interface _ASCollectionReusableView : UICollectionReusableView
-@property (nonatomic, strong, readonly, nullable) ASCellNode *node;
-@property (nonatomic, strong, nullable) ASCollectionElement *element;
+
 @property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
+
+- (void)setElement:(ASCollectionElement *)element;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Details/_ASCollectionReusableView.h
+++ b/Source/Details/_ASCollectionReusableView.h
@@ -18,7 +18,7 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
-@class ASCellnode, ASCollectionElement;
+@class ASCellNode, ASCollectionElement;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/Details/_ASCollectionReusableView.m
+++ b/Source/Details/_ASCollectionReusableView.m
@@ -21,7 +21,7 @@
 
 @implementation _ASCollectionReusableView
 
-- (nullable ASCellNode *)node
+- (ASCellNode *)node
 {
   return self.element.node;
 }

--- a/Source/Details/_ASCollectionReusableView.m
+++ b/Source/Details/_ASCollectionReusableView.m
@@ -19,13 +19,11 @@
 #import <AsyncDisplayKit/ASCellNode+Internal.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>
 
-@implementation _ASCollectionReusableView {
-  ASCollectionElement *_element;
-}
+@implementation _ASCollectionReusableView
 
 - (nullable ASCellNode *)node
 {
-  return _element.node;
+  return self.element.node;
 }
 
 - (void)setElement:(ASCollectionElement *)element
@@ -46,7 +44,7 @@
   self.layoutAttributes = nil;
   
   // Need to clear element before UIKit calls setSelected:NO / setHighlighted:NO on its cells
-  _element = nil;
+  self.element = nil;
   [super prepareForReuse];
 }
 

--- a/Source/Details/_ASCollectionReusableView.m
+++ b/Source/Details/_ASCollectionReusableView.m
@@ -16,15 +16,16 @@
 //
 
 #import "_ASCollectionReusableView.h"
-#import "ASCellNode+Internal.h"
+#import <AsyncDisplayKit/ASCellNode+Internal.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>
-#import <AsyncDisplayKit/AsyncDisplayKit.h>
 
-@implementation _ASCollectionReusableView
+@implementation _ASCollectionReusableView {
+  ASCollectionElement *_element;
+}
 
-- (ASCellNode *)node
+- (nullable ASCellNode *)node
 {
-  return self.element.node;
+  return _element.node;
 }
 
 - (void)setElement:(ASCollectionElement *)element
@@ -45,7 +46,7 @@
   self.layoutAttributes = nil;
   
   // Need to clear element before UIKit calls setSelected:NO / setHighlighted:NO on its cells
-  self.element = nil;
+  _element = nil;
   [super prepareForReuse];
 }
 

--- a/Source/Details/_ASCollectionViewCell.h
+++ b/Source/Details/_ASCollectionViewCell.h
@@ -26,14 +26,15 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED // Note: ASDynamicCastStrict is used on instances of this class based on this restriction.
 @interface _ASCollectionViewCell : UICollectionViewCell
 
+@property (nonatomic, strong, nullable) ASCollectionElement *element;
+@property (nonatomic, strong, readonly, nullable) ASCellNode *node;
+@property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
+
 /**
  * Whether or not this cell is interested in cell node visibility events.
  * -cellNodeVisibilityEvent:inScrollView: should be called only if this property is YES.
  */
 @property (nonatomic, readonly) BOOL consumesCellNodeVisibilityEvents;
-@property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
-
-- (void)setElement:(ASCollectionElement *)element;
 
 - (void)cellNodeVisibilityEvent:(ASCellNodeVisibilityEvent)event inScrollView:(UIScrollView *)scrollView;
 

--- a/Source/Details/_ASCollectionViewCell.h
+++ b/Source/Details/_ASCollectionViewCell.h
@@ -17,16 +17,49 @@
 
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
+#import <AsyncDisplayKit/ASCellNode.h>
 
-@class ASCellNode, ASCollectionElement;
+@class ASCollectionElement;
+
+/**
+ * Attempts to cast x to _ASCollectionViewCell, or nil if not possible.
+ *
+ * Since _ASCollectionViewCell is not available for subclassing (see below),
+ * comparing x's and _ASCollectionViewCell's classes is faster than calling -isKindOfClass: on x.
+ */
+#define ASCollectionViewCellCast(x) ({ \
+  id __var = x; \
+  ((_ASCollectionViewCell *) (x.class == [_ASCollectionViewCell class] ? __var : nil)); \
+})
+
+/**
+ * Attempts to cast x to _ASCollectionViewCell and assigns to __var. If not possible, returns the given __val.
+ *
+ * Since _ASCollectionViewCell is not available for subclassing (see below),
+ * comparing x's and _ASCollectionViewCell's classes is faster than calling -isKindOfClass: on x.
+ */
+#define ASCollectionViewCellCastOrReturn(x, __var, __val) \
+  _ASCollectionViewCell *__var = ASCollectionViewCellCast(x); \
+  if (__var == nil) { \
+    return __val; \
+  }
 
 NS_ASSUME_NONNULL_BEGIN
 
 AS_SUBCLASSING_RESTRICTED
 @interface _ASCollectionViewCell : UICollectionViewCell
-@property (nonatomic, strong, nullable) ASCollectionElement *element;
-@property (nonatomic, strong, readonly, nullable) ASCellNode *node;
+
+/**
+ * Whether or not this cell is interested in cell node visibility events.
+ * -cellNodeVisibilityEvent:inScrollView: should be called only if this property is YES.
+ */
+@property (nonatomic, readonly) BOOL consumesCellNodeVisibilityEvents;
 @property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
+
+- (void)setElement:(ASCollectionElement *)element;
+
+- (void)cellNodeVisibilityEvent:(ASCellNodeVisibilityEvent)event inScrollView:(UIScrollView *)scrollView;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Details/_ASCollectionViewCell.h
+++ b/Source/Details/_ASCollectionViewCell.h
@@ -21,32 +21,9 @@
 
 @class ASCollectionElement;
 
-/**
- * Attempts to cast x to _ASCollectionViewCell, or nil if not possible.
- *
- * Since _ASCollectionViewCell is not available for subclassing (see below),
- * comparing x's and _ASCollectionViewCell's classes is faster than calling -isKindOfClass: on x.
- */
-#define ASCollectionViewCellCast(x) ({ \
-  id __var = x; \
-  ((_ASCollectionViewCell *) (x.class == [_ASCollectionViewCell class] ? __var : nil)); \
-})
-
-/**
- * Attempts to cast x to _ASCollectionViewCell and assigns to __var. If not possible, returns the given __val.
- *
- * Since _ASCollectionViewCell is not available for subclassing (see below),
- * comparing x's and _ASCollectionViewCell's classes is faster than calling -isKindOfClass: on x.
- */
-#define ASCollectionViewCellCastOrReturn(x, __var, __val) \
-  _ASCollectionViewCell *__var = ASCollectionViewCellCast(x); \
-  if (__var == nil) { \
-    return __val; \
-  }
-
 NS_ASSUME_NONNULL_BEGIN
 
-AS_SUBCLASSING_RESTRICTED
+AS_SUBCLASSING_RESTRICTED // Note: ASDynamicCastStrict is used on instances of this class based on this restriction.
 @interface _ASCollectionViewCell : UICollectionViewCell
 
 /**

--- a/Source/Details/_ASCollectionViewCell.m
+++ b/Source/Details/_ASCollectionViewCell.m
@@ -16,15 +16,17 @@
 //
 
 #import "_ASCollectionViewCell.h"
-#import "ASCellNode+Internal.h"
-#import <AsyncDisplayKit/AsyncDisplayKit.h>
+#import <AsyncDisplayKit/ASCellNode+Internal.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 
-@implementation _ASCollectionViewCell
+@implementation _ASCollectionViewCell {
+  ASCollectionElement *_element;
+}
 
-- (ASCellNode *)node
+- (nullable ASCellNode *)node
 {
-  return self.element.node;
+  return _element.node;
 }
 
 - (void)setElement:(ASCollectionElement *)element
@@ -36,6 +38,20 @@
   
   [node __setSelectedFromUIKit:self.selected];
   [node __setHighlightedFromUIKit:self.highlighted];
+}
+
+- (BOOL)consumesCellNodeVisibilityEvents
+{
+  ASCellNode *node = self.node;
+  if (node == nil) {
+    return NO;
+  }
+  return ASSubclassOverridesSelector([ASCellNode class], [node class], @selector(cellNodeVisibilityEvent:inScrollView:withCellFrame:));
+}
+
+- (void)cellNodeVisibilityEvent:(ASCellNodeVisibilityEvent)event inScrollView:(UIScrollView *)scrollView
+{
+  [self.node cellNodeVisibilityEvent:event inScrollView:scrollView withCellFrame:self.frame];
 }
 
 - (void)setSelected:(BOOL)selected
@@ -61,7 +77,7 @@
   self.layoutAttributes = nil;
 
   // Need to clear element before UIKit calls setSelected:NO / setHighlighted:NO on its cells
-  self.element = nil;
+  _element = nil;
   [super prepareForReuse];
 }
 

--- a/Source/Details/_ASCollectionViewCell.m
+++ b/Source/Details/_ASCollectionViewCell.m
@@ -22,7 +22,7 @@
 
 @implementation _ASCollectionViewCell
 
-- (nullable ASCellNode *)node
+- (ASCellNode *)node
 {
   return self.element.node;
 }

--- a/Source/Details/_ASCollectionViewCell.m
+++ b/Source/Details/_ASCollectionViewCell.m
@@ -20,13 +20,11 @@
 #import <AsyncDisplayKit/ASCollectionElement.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 
-@implementation _ASCollectionViewCell {
-  ASCollectionElement *_element;
-}
+@implementation _ASCollectionViewCell
 
 - (nullable ASCellNode *)node
 {
-  return _element.node;
+  return self.element.node;
 }
 
 - (void)setElement:(ASCollectionElement *)element
@@ -77,7 +75,7 @@
   self.layoutAttributes = nil;
 
   // Need to clear element before UIKit calls setSelected:NO / setHighlighted:NO on its cells
-  _element = nil;
+  self.element = nil;
   [super prepareForReuse];
 }
 


### PR DESCRIPTION
- `_ASCollectionReusableView` and `_ASCollectionViewCell` no longer expose getters for their collection element and cell node properties. This is to make sure that clients can only obtain elements from the visible map which is always the source of truth.
- Since the map can return `nil` for an element request, it's much safer to check and avoid adding/removing a nil pointer to an `NSArray`.
- Since we use a special way to check whether an object of kind of `_ASCollectionViewCell` or `_ASCollectionReusableView`, based on the assumption that these classes are subclass restricted, I added cast-or-return  macros in the header files, closer to where the restrictions are declared.