### PR TITLE
[ASDataController] Fix a crash in table view caused by executing an empty change set during layoutSubviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ##2.3.5
 - Fix an issue where inserting/deleting sections could lead to inconsistent supplementary element behavior. [Adlai Holler](https://github.com/Adlai-Holler)
 - Overhaul logging and add activity tracing support. [Adlai Holler](https://github.com/Adlai-Holler)
+- Fix a crash where scrolling a table view after entering editing mode could lead to bad internal states in the table. [Huy Nguyen](https://github.com/nguyenhuy) [#416](https://github.com/TextureGroup/Texture/pull/416/)
 
 ##2.3.4
 - [Yoga] Rewrite YOGA_TREE_CONTIGUOUS mode with improved behavior and cleaner integration [Scott Goodson](https://github.com/appleguy)

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -558,12 +558,12 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
     as_activity_scope(as_activity_create("Latch new data for collection update", changeSet.rootActivity, OS_ACTIVITY_FLAG_DEFAULT));
 
     // Step 1: Populate a new map that reflects the data source's state and use it as pendingMap
+    ASElementMap *previousMap = self.pendingMap;
     if (changeSet.isEmpty) {
       // If the change set is empty, nothing has changed so we can just reuse the previous map
-      newMap = self.pendingMap;
+      newMap = previousMap;
     } else {
       // Mutable copy of current data.
-      ASElementMap *previousMap = self.pendingMap;
       ASMutableElementMap *mutableMap = [previousMap mutableCopy];
 
       // Step 1.1: Update the mutable copies to match the data source's state


### PR DESCRIPTION
- Previously, when a change set is empty, `ASDataController` forwards the change set to its delegate right away, without dispatching to its editing queue and then back to main.
- This behaviour can potentially cause bad internal states in UITableView which trigger a crash reported in #83.
- Fix by still reusing the existing pending map, because the data source's state has not changed, but go through the editing queue and main queue tunnel.

Fixes #83.