### PR TITLE
[ASVideoPlayerNode] Check that the video player's delegate implements the didTapFullScreenButtonNode method before calling it #trivial

### DIFF
--- a/Source/ASVideoPlayerNode.mm
+++ b/Source/ASVideoPlayerNode.mm
@@ -681,7 +681,9 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
 
 - (void)didTapFullScreenButton:(ASButtonNode*)node
 {
-  [_delegate didTapFullScreenButtonNode:node];
+  if (_delegateFlags.delegateDidTapFullScreenButtonNode) {
+    [_delegate didTapFullScreenButtonNode:node];
+  }
 }
 
 - (void)beginSeek


### PR DESCRIPTION
The ASVideoPlayerNode delegate flag that indicated whether the delegate implemented the didTapFullScreenButtonNode method wasn't getting used, so I've added the check to the ASVideoPlayerNode's didTapFullScreenButton method.