### PR TITLE
Workaround clang4.0 <stdatomic.h> initialization #trivial

### DIFF
--- a/Source/Private/ASDispatch.h
+++ b/Source/Private/ASDispatch.h
@@ -29,7 +29,12 @@ static void ASDispatchApply(size_t iterationCount, dispatch_queue_t queue, NSUIn
     threadCount = NSProcessInfo.processInfo.activeProcessorCount * 2;
   }
   dispatch_group_t group = dispatch_group_create();
-  __block atomic_size_t counter = ATOMIC_VAR_INIT(0);
+  // HACK: This is a workaround for mm files that include this in Clang4.0
+  // Omitting ATOMIC_VAR_INIT is okay in this case because the current
+  // expansion of that macro no-ops.
+  // TODO: Move this implementation into a m file so it's not compiled in C++
+  // See: https://github.com/TextureGroup/Texture/pull/426
+  __block atomic_size_t counter = 0;
   for (NSUInteger t = 0; t < threadCount; t++) {
     dispatch_group_async(group, queue, ^{
       size_t i;


### PR DESCRIPTION
Texture fails to build with this error on clang 4.0:

```
external/Texture/pod_support/Headers/Public/AsyncDisplayKit/ASDispatch.h:32:35: error: illegal initializer type 'atomic_size_t' (aka '_Atomic(size_t)')
  __block atomic_size_t counter = ATOMIC_VAR_INIT(0);
                                  ^
In module 'std' imported from external/Texture/pod_support/Headers/Public/AsyncDisplayKit/ASStackUnpositionedLayout.h:18:
/private/var/tmp/_bazel_bkase/a00d4cbe29902fb63d5778cc19944cd2/external/clang40/bin/../include/c++/v1/atomic:1839:30: note: expanded from macro 'ATOMIC_VAR_INIT'
                             ^
1 error generated.
```

See
http://techqa.info/programming/question/38233019/Initializing-an--atomic-int--with-a-braced-constant--Is-this-valid-C-code--If-so-why-does-it-not-compile-in-clang-

Replacing the intialization with just 0 (and not the macro fixes the
error). The forum post notes:

> C11's <stdatomic.h> header defines a macro ATOMIC_VAR_INIT that's intended to be used to initialize atomic objects, with an example:
> atomic_int guide = ATOMIC_VAR_INIT(42);
> It appears to be needed for atomic objects with automatic storage duration, which doesn't apply here.

Since we don't need the automatic storage duration either, this code
should still be correct.