### PR TITLE
[ASDisplayNode] Fix some gaps in the bridging of new contents* properties.

### DIFF
--- a/Source/Private/_ASPendingState.mm
+++ b/Source/Private/_ASPendingState.mm
@@ -43,7 +43,6 @@ typedef struct {
   int setBounds:1;
   int setBackgroundColor:1;
   int setTintColor:1;
-  int setContents:1;
   int setHidden:1;
   int setAlpha:1;
   int setCornerRadius:1;
@@ -52,13 +51,14 @@ typedef struct {
   int setAnchorPoint:1;
   int setPosition:1;
   int setZPosition:1;
+  int setTransform:1;
+  int setSublayerTransform:1;
+  int setContents:1;
   int setContentsGravity:1;
   int setContentsRect:1;
   int setContentsCenter:1;
   int setContentsScale:1;
   int setRasterizationScale:1;
-  int setTransform:1;
-  int setSublayerTransform:1;
   int setUserInteractionEnabled:1;
   int setExclusiveTouch:1;
   int setShadowColor:1;
@@ -98,20 +98,20 @@ typedef struct {
   CGRect frame;   // Frame is only to be used for synchronous views wrapped by nodes (see setFrame:)
   CGRect bounds;
   CGColorRef backgroundColor;
-  id contents;
   CGFloat alpha;
   CGFloat cornerRadius;
   UIViewContentMode contentMode;
   CGPoint anchorPoint;
   CGPoint position;
   CGFloat zPosition;
+  CATransform3D transform;
+  CATransform3D sublayerTransform;
+  id contents;
   NSString *contentsGravity;
   CGRect contentsRect;
   CGRect contentsCenter;
   CGFloat contentsScale;
   CGFloat rasterizationScale;
-  CATransform3D transform;
-  CATransform3D sublayerTransform;
   CGColorRef shadowColor;
   CGFloat shadowOpacity;
   CGSize shadowOffset;
@@ -169,7 +169,6 @@ ASDISPLAYNODE_INLINE void ASPendingStateApplyMetricsToLayer(_ASPendingState *sta
 @synthesize frame=frame;
 @synthesize bounds=bounds;
 @synthesize backgroundColor=backgroundColor;
-@synthesize contents=contents;
 @synthesize hidden=isHidden;
 @synthesize needsDisplayOnBoundsChange=needsDisplayOnBoundsChange;
 @synthesize allowsGroupOpacity=allowsGroupOpacity;
@@ -184,13 +183,14 @@ ASDISPLAYNODE_INLINE void ASPendingStateApplyMetricsToLayer(_ASPendingState *sta
 @synthesize anchorPoint=anchorPoint;
 @synthesize position=position;
 @synthesize zPosition=zPosition;
+@synthesize transform=transform;
+@synthesize sublayerTransform=sublayerTransform;
+@synthesize contents=contents;
 @synthesize contentsGravity=contentsGravity;
 @synthesize contentsRect=contentsRect;
 @synthesize contentsCenter=contentsCenter;
 @synthesize contentsScale=contentsScale;
 @synthesize rasterizationScale=rasterizationScale;
-@synthesize transform=transform;
-@synthesize sublayerTransform=sublayerTransform;
 @synthesize userInteractionEnabled=userInteractionEnabled;
 @synthesize exclusiveTouch=exclusiveTouch;
 @synthesize shadowColor=shadowColor;
@@ -242,7 +242,6 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   bounds = CGRectZero;
   backgroundColor = nil;
   tintColor = defaultTintColor;
-  contents = nil;
   isHidden = NO;
   needsDisplayOnBoundsChange = NO;
   allowsGroupOpacity = defaultAllowsGroupOpacity;
@@ -255,9 +254,14 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   anchorPoint = CGPointMake(0.5, 0.5);
   position = CGPointZero;
   zPosition = 0.0;
-  contentsScale = 1.0f;
   transform = CATransform3DIdentity;
   sublayerTransform = CATransform3DIdentity;
+  contents = nil;
+  contentsGravity = kCAGravityResize;
+  contentsRect = CGRectMake(0.0f, 0.0f, 1.0f, 1.0f);
+  contentsCenter = CGRectMake(0.0f, 0.0f, 1.0f, 1.0f);
+  contentsScale = 1.0f;
+  rasterizationScale = 1.0f;
   userInteractionEnabled = YES;
   shadowColor = blackColorRef;
   shadowOpacity = 0.0;
@@ -388,16 +392,6 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   _flags.setTintColor = YES;
 }
 
-- (void)setContents:(id)newContents
-{
-  if (contents == newContents) {
-    return;
-  }
-
-  contents = newContents;
-  _flags.setContents = YES;
-}
-
 - (void)setHidden:(BOOL)flag
 {
   isHidden = flag;
@@ -445,12 +439,6 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   _flags.setZPosition = YES;
 }
 
-- (void)setContentsScale:(CGFloat)newContentsScale
-{
-  contentsScale = newContentsScale;
-  _flags.setContentsScale = YES;
-}
-
 - (void)setTransform:(CATransform3D)newTransform
 {
   transform = newTransform;
@@ -461,6 +449,46 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
 {
   sublayerTransform = newSublayerTransform;
   _flags.setSublayerTransform = YES;
+}
+
+- (void)setContents:(id)newContents
+{
+  if (contents == newContents) {
+    return;
+  }
+
+  contents = newContents;
+  _flags.setContents = YES;
+}
+
+- (void)setContentsGravity:(NSString *)newContentsGravity
+{
+  contentsGravity = newContentsGravity;
+  _flags.setContentsGravity = YES;
+}
+
+- (void)setContentsRect:(CGRect)newContentsRect
+{
+  contentsRect = newContentsRect;
+  _flags.setContentsRect = YES;
+}
+
+- (void)setContentsCenter:(CGRect)newContentsCenter
+{
+  contentsCenter = newContentsCenter;
+  _flags.setContentsCenter = YES;
+}
+
+- (void)setContentsScale:(CGFloat)newContentsScale
+{
+  contentsScale = newContentsScale;
+  _flags.setContentsScale = YES;
+}
+
+- (void)setRasterizationScale:(CGFloat)newRasterizationScale
+{
+  rasterizationScale = newRasterizationScale;
+  _flags.setRasterizationScale = YES;
 }
 
 - (void)setUserInteractionEnabled:(BOOL)flag
@@ -732,9 +760,6 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   if (flags.setZPosition)
     layer.zPosition = zPosition;
 
-  if (flags.setContentsScale)
-    layer.contentsScale = contentsScale;
-
   if (flags.setTransform)
     layer.transform = transform;
 
@@ -743,6 +768,21 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
 
   if (flags.setContents)
     layer.contents = contents;
+
+  if (flags.setContentsGravity)
+    layer.contentsGravity = contentsGravity;
+
+  if (flags.setContentsRect)
+    layer.contentsRect = contentsRect;
+
+  if (flags.setContentsCenter)
+    layer.contentsCenter = contentsCenter;
+
+  if (flags.setContentsScale)
+    layer.contentsScale = contentsScale;
+
+  if (flags.setRasterizationScale)
+    layer.rasterizationScale = rasterizationScale;
 
   if (flags.setClipsToBounds)
     layer.masksToBounds = clipsToBounds;
@@ -880,7 +920,7 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
     view.tintColor = self.tintColor;
 
   if (flags.setOpaque)
-    view.layer.opaque = opaque;
+    layer.opaque = opaque;
 
   if (flags.setHidden)
     view.hidden = isHidden;
@@ -942,7 +982,7 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
     view.asyncdisplaykit_asyncTransactionContainer = asyncTransactionContainer;
 
   if (flags.setOpaque)
-    ASDisplayNodeAssert(view.layer.opaque == opaque, @"Didn't set opaque as desired");
+    ASDisplayNodeAssert(layer.opaque == opaque, @"Didn't set opaque as desired");
 
   if (flags.setSemanticContentAttribute) {
     view.semanticContentAttribute = semanticContentAttribute;
@@ -1024,10 +1064,14 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   pendingState.position = layer.position;
   pendingState.zPosition = layer.zPosition;
   pendingState.bounds = layer.bounds;
-  pendingState.contentsScale = layer.contentsScale;
   pendingState.transform = layer.transform;
   pendingState.sublayerTransform = layer.sublayerTransform;
   pendingState.contents = layer.contents;
+  pendingState.contentsGravity = layer.contentsGravity;
+  pendingState.contentsRect = layer.contentsRect;
+  pendingState.contentsCenter = layer.contentsCenter;
+  pendingState.contentsScale = layer.contentsScale;
+  pendingState.rasterizationScale = layer.rasterizationScale;
   pendingState.clipsToBounds = layer.masksToBounds;
   pendingState.backgroundColor = layer.backgroundColor;
   pendingState.opaque = layer.opaque;
@@ -1139,10 +1183,14 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   || flags.setFrame
   || flags.setBounds
   || flags.setPosition
-  || flags.setContentsScale
   || flags.setTransform
   || flags.setSublayerTransform
   || flags.setContents
+  || flags.setContentsGravity
+  || flags.setContentsRect
+  || flags.setContentsCenter
+  || flags.setContentsScale
+  || flags.setRasterizationScale
   || flags.setClipsToBounds
   || flags.setBackgroundColor
   || flags.setTintColor


### PR DESCRIPTION
I audited this more carefully and found some gaps in my PR from yesterday.

This also ensures the grouping and ordering of all the contents properties
is consistent across all of the places they appear.

In the future, it would be great to make the #define macros more sophisticated
so that we can add property bridging with fewer lines changed, and for
objects besides ASDisplayNode too!