### PR TITLE
[ASDataController] Clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix a crash where scrolling a table view after entering editing mode could lead to bad internal states in the table. [Huy Nguyen](https://github.com/nguyenhuy) [#416](https://github.com/TextureGroup/Texture/pull/416/)
 - Fix a crash in collection view that occurs if batch updates are performed while scrolling [Huy Nguyen](https://github.com/nguyenhuy) [#378](https://github.com/TextureGroup/Texture/issues/378)
 - Some improvements in ASCollectionView [Huy Nguyen](https://github.com/nguyenhuy) [#407](https://github.com/TextureGroup/Texture/pull/407)
+- Small refactors in ASDataController [Huy Nguyen](https://github.com/TextureGroup/Texture/pull/443) [#443](https://github.com/TextureGroup/Texture/pull/443)
 
 ##2.3.4
 - [Yoga] Rewrite YOGA_TREE_CONTIGUOUS mode with improved behavior and cleaner integration [Scott Goodson](https://github.com/appleguy)

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -121,18 +121,6 @@ typedef dispatch_block_t ASDataControllerCompletionBlock;
   return self;
 }
 
-+ (NSUInteger)parallelProcessorCount
-{
-  static NSUInteger parallelProcessorCount;
-
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    parallelProcessorCount = [[NSProcessInfo processInfo] activeProcessorCount];
-  });
-
-  return parallelProcessorCount;
-}
-
 - (id<ASDataControllerLayoutDelegate>)layoutDelegate
 {
   ASDisplayNodeAssertMainThread();
@@ -164,8 +152,8 @@ typedef dispatch_block_t ASDataControllerCompletionBlock;
 
   {
     as_activity_create_for_scope("Data controller batch");
-    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 
+    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
     ASDispatchApply(nodeCount, queue, 0, ^(size_t i) {
       __strong id<ASDataControllerSource> strongDataSource = weakDataSource;
       if (strongDataSource == nil) {


### PR DESCRIPTION
- Elements are not allocated and measured in batches anymore. Remove the code that does batch allocation.
- The value returned by `-_allocateNodesFromElements:andLayout:completion` is not used. Remove it.
- Remove `+parallelProcessorCount`.
- Remove `RETURN_IF_NO_DATASOURCE` macro. It's used only once and is not worth it.