### PR TITLE
[ASElementMap] Fix indexPath's section or item is actually negative.

### DIFF
--- a/Source/Details/ASElementMap.m
+++ b/Source/Details/ASElementMap.m
@@ -218,7 +218,8 @@
 - (BOOL)sectionIndexIsValid:(NSInteger)section assert:(BOOL)assert
 {
   NSInteger sectionCount = _sectionsOfItems.count;
-  if (section >= sectionCount) {
+  if (section >= sectionCount ||
+      section < 0) {
     if (assert) {
       ASDisplayNodeFailAssert(@"Invalid section index %zd when there are only %zd sections!", section, sectionCount);
     }
@@ -246,7 +247,8 @@
 
   NSInteger itemCount = _sectionsOfItems[section].count;
   NSInteger item = indexPath.item;
-  if (item >= itemCount) {
+  if (item >= itemCount ||
+      item < 0) {
     if (assert) {
       ASDisplayNodeFailAssert(@"Invalid item index %zd in section %zd which only has %zd items!", item, section, itemCount);
     }


### PR DESCRIPTION
when indexPath's section or item is actually negative that is invalid。