### PR TITLE
iOS 11 UITableView automatic height estimation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix an issue that causes infinite layout loop in ASDisplayNode after [#428](https://github.com/TextureGroup/Texture/pull/428) [Huy Nguyen](https://github.com/nguyenhuy) [#455](https://github.com/TextureGroup/Texture/pull/455) 
 - Fix an issue in layout transition that causes it to unexpectedly use the old layout [Huy Nguyen](https://github.com/nguyenhuy) [#464](https://github.com/TextureGroup/Texture/pull/464)
 - Add -[ASDisplayNode detailedLayoutDescription] property to aid debugging. [Adlai Holler](https://github.com/Adlai-Holler) [#476](https://github.com/TextureGroup/Texture/pull/476)
+- Negate iOS 11 automatic estimated table row heights. [Christian Selig](https://github.com/christianselig) [#485](https://github.com/TextureGroup/Texture/pull/485)
 
 ##2.3.5
 - Fix an issue where inserting/deleting sections could lead to inconsistent supplementary element behavior. [Adlai Holler](https://github.com/Adlai-Holler)

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -345,6 +345,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _retainedLayer = self.layer;
   }
   
+  // iOS 11 automatically uses estimated heights, so disable those (see PR #485)
   if (AS_AT_LEAST_IOS11) {
     super.estimatedRowHeight = 0.0;
     super.estimatedSectionHeaderHeight = 0.0;

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -345,6 +345,12 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _retainedLayer = self.layer;
   }
   
+  if (AS_AT_LEAST_IOS11) {
+    super.estimatedRowHeight = 0.0;
+    super.estimatedSectionHeaderHeight = 0.0;
+    super.estimatedSectionFooterHeight = 0.0;
+  }
+  
   return self;
 }
 

--- a/Source/Base/ASAvailability.h
+++ b/Source/Base/ASAvailability.h
@@ -27,8 +27,13 @@
   #define kCFCoreFoundationVersionNumber_iOS_10_0 1348.00
 #endif
 
+#ifndef kCFCoreFoundationVersionNumber_iOS_11_0
+  #define kCFCoreFoundationVersionNumber_iOS_11_0 1438.10
+#endif
+
 #define AS_AT_LEAST_IOS9   (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_9_0)
 #define AS_AT_LEAST_IOS10  (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_10_0)
+#define AS_AT_LEAST_IOS11  (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_11_0)
 
 // If Yoga is available, make it available anywhere we use ASAvailability.
 // This reduces Yoga-specific code in other files.


### PR DESCRIPTION
Starting in iOS 11 `UITableView` automatically uses estimated heights. ([Source](https://twitter.com/smileyborg/status/871858815053946880))

This causes some odd behaviour in Texture, specifically with batch fetching where a lot of jumping can happen when the load occurs. 

[User djug](https://asyncdisplaykit.slack.com/archives/C0V63R86T/p1500761127076778) in the Slack encountered this issue earlier and posted their solution which is the basis for this, and is as simple as re-disabling the new default behaviour so that automatic height estimation does **not** occur.

In order to let this occur only on iOS 11 (not sure if there's any pre-iOS-11 code running on the assumption of the old default, don't want to cause a regression) I made it only occur on iOS 11 and later. This required an addition to `ASAvailability.h`, and like iOS 10 it's unfortunately not explicitly set, so I set it to what iOS 11 beta 4 currently outputs as its `kCFCoreFoundationVersionNumber`: `1438.1`.

(Interestingly Xcode 9 now allows for Objective-C to use the Swift-esque `@availability` checks, which may be worth looking into, but it obviously would break compatibility with previous versions of Xcode.)

Overall simple change that helps scrolling on iOS 11 to behave as expected. 