### PR TITLE
Rename -[ASCellNode viewModel] to -[ASCellNode nodeViewModel] to avoid collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add -[ASDisplayNode detailedLayoutDescription] property to aid debugging. [Adlai Holler](https://github.com/Adlai-Holler) [#476](https://github.com/TextureGroup/Texture/pull/476)
 - Fix an issue that causes calculatedLayoutDidChange being called needlessly. [Huy Nguyen](https://github.com/nguyenhuy) [#490](https://github.com/TextureGroup/Texture/pull/490)
 - Negate iOS 11 automatic estimated table row heights. [Christian Selig](https://github.com/christianselig) [#485](https://github.com/TextureGroup/Texture/pull/485)
+- Rename ASCellNode.viewModel to ASCellNode.nodeViewModel to reduce collisions with subclass properties implemented by clients. [Adlai Holler](https://github.com/Adlai-Holler) [#499](https://github.com/TextureGroup/Texture/pull/499)
 
 ##2.3.5
 - Fix an issue where inserting/deleting sections could lead to inconsistent supplementary element behavior. [Adlai Holler](https://github.com/Adlai-Holler)

--- a/Source/ASCellNode.h
+++ b/Source/ASCellNode.h
@@ -123,7 +123,7 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  *
  * This property may be set off the main thread, but this method will never be invoked concurrently on the 
  */
-@property (atomic, nullable) id viewModel;
+@property (atomic, nullable) id nodeViewModel;
 
 /**
  * Asks the node whether it can be updated to the given view model.

--- a/Source/ASCellNode.mm
+++ b/Source/ASCellNode.mm
@@ -172,7 +172,7 @@
 
 - (BOOL)canUpdateToViewModel:(id)viewModel
 {
-  return [self.viewModel class] == [viewModel class];
+  return [self.nodeViewModel class] == [viewModel class];
 }
 
 - (NSIndexPath *)indexPath

--- a/Source/Details/ASCollectionElement.mm
+++ b/Source/Details/ASCollectionElement.mm
@@ -64,7 +64,7 @@
     node.owningNode = _owningNode;
     node.collectionElement = self;
     ASTraitCollectionPropagateDown(node, _traitCollection);
-    node.viewModel = _viewModel;
+    node.nodeViewModel = _viewModel;
     _node = node;
   }
   return _node;

--- a/Tests/ASCollectionModernDataSourceTests.m
+++ b/Tests/ASCollectionModernDataSourceTests.m
@@ -254,7 +254,7 @@
       id viewModel = viewModels[indexPath.item];
       XCTAssertEqualObjects(viewModel, [collectionNode viewModelForItemAtIndexPath:indexPath]);
       ASCellNode *node = [collectionNode nodeForItemAtIndexPath:indexPath];
-      XCTAssertEqualObjects(node.viewModel, viewModel);
+      XCTAssertEqualObjects(node.nodeViewModel, viewModel);
     }
   }
 }


### PR DESCRIPTION
Thanks to @Kaspik and slack users mlilek, jdeguzman, and emre for reporting the issues this collision has caused in their apps.

This is an implementation of a proposal from @Kaspik to rename the field to `nodeViewModel`. This will be a breaking change for users who have already modified their product code to account for the collision.

As the implementor of the `viewModel` field, I take responsibility for all the effort y'all went through to adapt to it. Sorry. Hopefully this patch isn't too late to save some of you a lot of effort.

Everyone let me know what you think about this.