### PR TITLE
ASCollectionLayout to return a zero content size if its state is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Negate iOS 11 automatic estimated table row heights. [Christian Selig](https://github.com/christianselig) [#485](https://github.com/TextureGroup/Texture/pull/485)
 - [Breaking] Add content offset bridging property to ASTableNode and ASCollectionNode. Deprecate related methods in ASTableView and ASCollectionView [Huy Nguyen](https://github.com/nguyenhuy) [#460](https://github.com/TextureGroup/Texture/pull/460)
 - Remove re-entrant access to self.view when applying initial pending state. [Adlai Holler](https://github.com/Adlai-Holler) [#510](https://github.com/TextureGroup/Texture/pull/510)
-
+- Small improvements in ASCollectionLayout [Huy Nguyen](https://github.com/nguyenhuy) [#509](https://github.com/TextureGroup/Texture/pull/509)
 
 ##2.4
 - Fix an issue where inserting/deleting sections could lead to inconsistent supplementary element behavior. [Adlai Holler](https://github.com/Adlai-Holler)

--- a/Source/Private/ASCollectionLayout.mm
+++ b/Source/Private/ASCollectionLayout.mm
@@ -140,6 +140,8 @@ static const ASScrollDirection kASStaticScrollDirection = (ASScrollDirectionRigh
 - (CGSize)collectionViewContentSize
 {
   ASDisplayNodeAssertMainThread();
+  // The content size can be queried right after a layout invalidation (https://github.com/TextureGroup/Texture/pull/509).
+  // In that case, return zero.
   return _layout ? _layout.contentSize : CGSizeZero;
 }
 

--- a/Source/Private/ASCollectionLayout.mm
+++ b/Source/Private/ASCollectionLayout.mm
@@ -140,8 +140,7 @@ static const ASScrollDirection kASStaticScrollDirection = (ASScrollDirectionRigh
 - (CGSize)collectionViewContentSize
 {
   ASDisplayNodeAssertMainThread();
-  ASDisplayNodeAssertNotNil(_layout, @"Collection layout state should not be nil at this point");
-  return _layout.contentSize;
+  return _layout ? _layout.contentSize : CGSizeZero;
 }
 
 - (NSArray<UICollectionViewLayoutAttributes *> *)layoutAttributesForElementsInRect:(CGRect)blockingRect


### PR DESCRIPTION
Reported by @wsdwsd0829 [here](https://github.com/TextureGroup/Texture/pull/450#discussion_r132855870). 

Reproducible in "examples/ASCollectionView" by enabling `ASYNC_COLLECTION_LAYOUT` and popping the view controller after just 2 seconds ([this line
](https://github.com/TextureGroup/Texture/blob/master/examples/ASCollectionView/Sample/ViewController.m#L96)). The crash occurs when a containing view controller is popped out right after its collection view finished a batch update, but before an update animation settles. As soon as the view controller is deallocated, its collection view's layout is invalidated. Then when the update animation stops, it asks for the layout's content size and triggers the assertion. Fix by returning a zero size instead.