### PR TITLE
[CI] BuildKite to ignore all markdown files

### DIFF
--- a/CI/exclude-from-build.json
+++ b/CI/exclude-from-build.json
@@ -1,5 +1,6 @@
 [
   "^plans/",
   "^docs/",
-  "^CI/exclude-from-build.json$"
+  "^CI/exclude-from-build.json$",
+  "^**/*.md$"
 ]


### PR DESCRIPTION
Updating these files, CHANGELOG.md for example, shouldn't cause CI to run tests and build examples again.