### PR TITLE
[ASCollectionNode] Add -isProcessingUpdates and -onDidFinishProcessingUpdates: APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this with your name.
+- [ASCollectionNode] Add -isProcessingUpdates and -onDidFinishProcessingUpdates: APIs. [#522](https://github.com/TextureGroup/Texture/pull/522) [Scott Goodson](https://github.com/appleguy)
 - Fix an issue in layout transition that causes it to unexpectedly use the old layout [Huy Nguyen](https://github.com/nguyenhuy) [#464](https://github.com/TextureGroup/Texture/pull/464)
 - Add -[ASDisplayNode detailedLayoutDescription] property to aid debugging. [Adlai Holler](https://github.com/Adlai-Holler) [#476](https://github.com/TextureGroup/Texture/pull/476)
 - Fix an issue that causes calculatedLayoutDidChange being called needlessly. [Huy Nguyen](https://github.com/nguyenhuy) [#490](https://github.com/TextureGroup/Texture/pull/490)

--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -253,11 +253,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)performBatchUpdates:(nullable AS_NOESCAPE void (^)())updates completion:(nullable void (^)(BOOL finished))completion;
 
 /**
- *  Blocks execution of the main thread until all section and item updates are committed to the view. This method must be called from the main thread.
- */
-- (void)waitUntilAllUpdatesAreProcessed;
-
-/**
  *  Returns YES if the ASCollectionNode is still processing changes from performBatchUpdates:.
  *  This is typically the concurrent allocation (calling nodeBlocks) and layout of newly inserted
  *  ASCellNodes. If YES is returned, then calling -waitUntilAllUpdatesAreProcessed may take tens of
@@ -269,7 +264,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  This method will always return NO if called immediately after -waitUntilAllUpdatesAreProcessed.
  */
-- (BOOL)isProcessingUpdates;
+@property (nonatomic, readonly) BOOL isProcessingUpdates;
 
 /**
  *  Schedules a block to be performed (on the main thread) after processing of performBatchUpdates:
@@ -285,6 +280,11 @@ NS_ASSUME_NONNULL_BEGIN
  *  Calling -waitUntilAllUpdatesAreProcessed is one way to flush any pending update completion blocks.
  */
 - (void)onDidFinishProcessingUpdates:(nullable void (^)())didFinishProcessingUpdates;
+
+/**
+ *  Blocks execution of the main thread until all section and item updates are committed to the view. This method must be called from the main thread.
+ */
+- (void)waitUntilAllUpdatesAreProcessed;
 
 /**
  * Inserts one or more sections.

--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -534,9 +534,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)reloadDataImmediately ASDISPLAYNODE_DEPRECATED_MSG("Use -reloadData / -reloadDataWithCompletion: followed by -waitUntilAllUpdatesAreProcessed instead.");
 
-// TODO: Rename framework uses of this method and add deprecation message.
-// ASDISPLAYNODE_DEPRECATED_MSG("This method has been renamed to -waitUntilAllUpdatesAreProcessed.");
-- (void)waitUntilAllUpdatesAreCommitted;
+- (void)waitUntilAllUpdatesAreCommitted ASDISPLAYNODE_DEPRECATED_MSG("This method has been renamed to -waitUntilAllUpdatesAreProcessed.");
 
 @end
 

--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -255,7 +255,36 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Blocks execution of the main thread until all section and item updates are committed to the view. This method must be called from the main thread.
  */
-- (void)waitUntilAllUpdatesAreCommitted;
+- (void)waitUntilAllUpdatesAreProcessed;
+
+/**
+ *  Returns YES if the ASCollectionNode is still processing changes from performBatchUpdates:.
+ *  This is typically the concurrent allocation (calling nodeBlocks) and layout of newly inserted
+ *  ASCellNodes. If YES is returned, then calling -waitUntilAllUpdatesAreProcessed may take tens of
+ *  milliseconds to return as it blocks on these concurrent operations.
+ *
+ *  Returns NO if ASCollectionNode is fully synchronized with the underlying UICollectionView. This
+ *  means that until the next performBatchUpdates: is called, it is safe to compare UIKit values
+ *  (such as from UICollectionViewLayout) with your app's data source.
+ *
+ *  This method will always return NO if called immediately after -waitUntilAllUpdatesAreProcessed.
+ */
+- (BOOL)isProcessingUpdates;
+
+/**
+ *  Schedules a block to be performed (on the main thread) after processing of performBatchUpdates:
+ *  is finished (completely synchronized to UIKit). The blocks will be run at the moment that
+ *  -isProcessingUpdates changes from YES to NO;
+ *
+ *  When isProcessingUpdates == NO, the block is run block immediately (before the method returns).
+ *
+ *  Blocks scheduled by this mechanism are NOT guaranteed to run in the order they are scheduled.
+ *  They may also be delayed if performBatchUpdates continues to be called; the blocks will wait until
+ *  all running updates are finished.
+ *
+ *  Calling -waitUntilAllUpdatesAreProcessed is one way to flush any pending update completion blocks.
+ */
+- (void)onDidFinishProcessingUpdates:(nullable void (^)())didFinishProcessingUpdates;
 
 /**
  * Inserts one or more sections.
@@ -501,9 +530,13 @@ NS_ASSUME_NONNULL_BEGIN
  * @warning This method is substantially more expensive than UICollectionView's version.
  *
  * @deprecated This method is deprecated in 2.0. Use @c reloadDataWithCompletion: and
- *   then @c waitUntilAllUpdatesAreCommitted instead.
+ *   then @c waitUntilAllUpdatesAreProcessed instead.
  */
-- (void)reloadDataImmediately ASDISPLAYNODE_DEPRECATED_MSG("Use -reloadData / -reloadDataWithCompletion: followed by -waitUntilAllUpdatesAreCommitted instead.");
+- (void)reloadDataImmediately ASDISPLAYNODE_DEPRECATED_MSG("Use -reloadData / -reloadDataWithCompletion: followed by -waitUntilAllUpdatesAreProcessed instead.");
+
+// TODO: Rename framework uses of this method and add deprecation message.
+// ASDISPLAYNODE_DEPRECATED_MSG("This method has been renamed to -waitUntilAllUpdatesAreProcessed.");
+- (void)waitUntilAllUpdatesAreCommitted;
 
 @end
 

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -713,6 +713,25 @@
   }
 }
 
+- (void)waitUntilAllUpdatesAreProcessed
+{
+  [self waitUntilAllUpdatesAreCommitted];
+}
+
+- (BOOL)isProcessingUpdates
+{
+  return (self.nodeLoaded ? [self.view isProcessingUpdates] : NO);
+}
+
+- (void)onDidFinishProcessingUpdates:(nullable void (^)())completion
+{
+  if (!self.nodeLoaded) {
+    completion();
+  } else {
+    [self.view onDidFinishProcessingUpdates:completion];
+  }
+}
+
 - (void)reloadDataWithCompletion:(void (^)())completion
 {
   ASDisplayNodeAssertMainThread();

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -705,19 +705,6 @@
   [self performBatchAnimated:UIView.areAnimationsEnabled updates:updates completion:completion];
 }
 
-- (void)waitUntilAllUpdatesAreCommitted
-{
-  ASDisplayNodeAssertMainThread();
-  if (self.nodeLoaded) {
-    [self.view waitUntilAllUpdatesAreCommitted];
-  }
-}
-
-- (void)waitUntilAllUpdatesAreProcessed
-{
-  [self waitUntilAllUpdatesAreCommitted];
-}
-
 - (BOOL)isProcessingUpdates
 {
   return (self.nodeLoaded ? [self.view isProcessingUpdates] : NO);
@@ -730,6 +717,19 @@
   } else {
     [self.view onDidFinishProcessingUpdates:completion];
   }
+}
+
+- (void)waitUntilAllUpdatesAreProcessed
+{
+  ASDisplayNodeAssertMainThread();
+  if (self.nodeLoaded) {
+    [self.view waitUntilAllUpdatesAreCommitted];
+  }
+}
+
+- (void)waitUntilAllUpdatesAreCommitted
+{
+  [self waitUntilAllUpdatesAreProcessed];
 }
 
 - (void)reloadDataWithCompletion:(void (^)())completion
@@ -757,7 +757,7 @@
 {
   ASDisplayNodeAssertMainThread();
   [self reloadData];
-  [self waitUntilAllUpdatesAreCommitted];
+  [self waitUntilAllUpdatesAreProcessed];
 }
 
 - (void)relayoutItems

--- a/Source/ASCollectionView.h
+++ b/Source/ASCollectionView.h
@@ -296,9 +296,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)relayoutItems ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode method instead.");
 
 /**
- *  Blocks execution of the main thread until all section and row updates are committed. This method must be called from the main thread.
+ * See ASCollectionNode.h for full documentation of these methods.
  */
 - (void)waitUntilAllUpdatesAreCommitted ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode method instead.");
+- (BOOL)isProcessingUpdates;
+- (void)onDidFinishProcessingUpdates:(nullable void (^)())completion;
 
 /**
  * Registers the given kind of supplementary node for use in creating node-backed supplementary views.

--- a/Source/ASCollectionView.h
+++ b/Source/ASCollectionView.h
@@ -300,7 +300,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) BOOL isProcessingUpdates;
 - (void)onDidFinishProcessingUpdates:(nullable void (^)())completion;
-- (void)waitUntilAllUpdatesAreCommitted ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode method instead.");
+- (void)waitUntilAllUpdatesAreCommitted ASDISPLAYNODE_DEPRECATED_MSG("Use -[ASCollectionNode waitUntilAllUpdatesAreProcessed] instead.");
 
 /**
  * Registers the given kind of supplementary node for use in creating node-backed supplementary views.

--- a/Source/ASCollectionView.h
+++ b/Source/ASCollectionView.h
@@ -298,9 +298,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * See ASCollectionNode.h for full documentation of these methods.
  */
-- (void)waitUntilAllUpdatesAreCommitted ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode method instead.");
-- (BOOL)isProcessingUpdates;
+@property (nonatomic, readonly) BOOL isProcessingUpdates;
 - (void)onDidFinishProcessingUpdates:(nullable void (^)())completion;
+- (void)waitUntilAllUpdatesAreCommitted ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode method instead.");
 
 /**
  * Registers the given kind of supplementary node for use in creating node-backed supplementary views.

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -359,18 +359,6 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   [_dataController relayoutAllNodes];
 }
 
-- (void)waitUntilAllUpdatesAreCommitted
-{
-  ASDisplayNodeAssertMainThread();
-  if (_batchUpdateCount > 0) {
-    // This assertion will be enabled soon.
-    //    ASDisplayNodeFailAssert(@"Should not call %@ during batch update", NSStringFromSelector(_cmd));
-    return;
-  }
-  
-  [_dataController waitUntilAllUpdatesAreCommitted];
-}
-
 - (BOOL)isProcessingUpdates
 {
   return [_dataController isProcessingUpdates];
@@ -379,6 +367,18 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 - (void)onDidFinishProcessingUpdates:(nullable void (^)())completion
 {
   [_dataController onDidFinishProcessingUpdates:completion];
+}
+
+- (void)waitUntilAllUpdatesAreCommitted
+{
+  ASDisplayNodeAssertMainThread();
+  if (_batchUpdateCount > 0) {
+    // This assertion will be enabled soon.
+    //    ASDisplayNodeFailAssert(@"Should not call %@ during batch update", NSStringFromSelector(_cmd));
+    return;
+  }
+
+  [_dataController waitUntilAllUpdatesAreProcessed];
 }
 
 - (void)setDataSource:(id<UICollectionViewDataSource>)dataSource
@@ -2207,7 +2207,7 @@ minimumLineSpacingForSectionAtIndex:(NSInteger)section
 
   if (changedInNonScrollingDirection) {
     [_dataController relayoutAllNodes];
-    [_dataController waitUntilAllUpdatesAreCommitted];
+    [_dataController waitUntilAllUpdatesAreProcessed];
     // We need to ensure the size requery is done before we update our layout.
     [self.collectionViewLayout invalidateLayout];
   }

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -371,6 +371,16 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   [_dataController waitUntilAllUpdatesAreCommitted];
 }
 
+- (BOOL)isProcessingUpdates
+{
+  return [_dataController isProcessingUpdates];
+}
+
+- (void)onDidFinishProcessingUpdates:(nullable void (^)())completion
+{
+  [_dataController onDidFinishProcessingUpdates:completion];
+}
+
 - (void)setDataSource:(id<UICollectionViewDataSource>)dataSource
 {
   // UIKit can internally generate a call to this method upon changing the asyncDataSource; only assert for non-nil. We also allow this when we're doing interop.

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -207,9 +207,38 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)performBatchUpdates:(nullable AS_NOESCAPE void (^)())updates completion:(nullable void (^)(BOOL finished))completion;
 
 /**
- *  Blocks execution of the main thread until all section and row updates are committed. This method must be called from the main thread.
+ *  Returns YES if the ASCollectionNode is still processing changes from performBatchUpdates:.
+ *  This is typically the concurrent allocation (calling nodeBlocks) and layout of newly inserted
+ *  ASCellNodes. If YES is returned, then calling -waitUntilAllUpdatesAreProcessed may take tens of
+ *  milliseconds to return as it blocks on these concurrent operations.
+ *
+ *  Returns NO if ASCollectionNode is fully synchronized with the underlying UICollectionView. This
+ *  means that until the next performBatchUpdates: is called, it is safe to compare UIKit values
+ *  (such as from UICollectionViewLayout) with your app's data source.
+ *
+ *  This method will always return NO if called immediately after -waitUntilAllUpdatesAreProcessed.
  */
-- (void)waitUntilAllUpdatesAreCommitted;
+@property (nonatomic, readonly) BOOL isProcessingUpdates;
+
+/**
+ *  Schedules a block to be performed (on the main thread) after processing of performBatchUpdates:
+ *  is finished (completely synchronized to UIKit). The blocks will be run at the moment that
+ *  -isProcessingUpdates changes from YES to NO;
+ *
+ *  When isProcessingUpdates == NO, the block is run block immediately (before the method returns).
+ *
+ *  Blocks scheduled by this mechanism are NOT guaranteed to run in the order they are scheduled.
+ *  They may also be delayed if performBatchUpdates continues to be called; the blocks will wait until
+ *  all running updates are finished.
+ *
+ *  Calling -waitUntilAllUpdatesAreProcessed is one way to flush any pending update completion blocks.
+ */
+- (void)onDidFinishProcessingUpdates:(nullable void (^)())didFinishProcessingUpdates;
+
+/**
+ *  Blocks execution of the main thread until all section and item updates are committed to the view. This method must be called from the main thread.
+ */
+- (void)waitUntilAllUpdatesAreProcessed;
 
 /**
  * Inserts one or more sections, with an option to animate the insertion.
@@ -696,6 +725,12 @@ NS_ASSUME_NONNULL_BEGIN
  * This method is deprecated. Use @c tableView:willDisplayNode:forRowAtIndexPath: instead.
  */
 - (void)tableView:(ASTableView *)tableView willDisplayNodeForRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode's method instead.");
+
+@end
+
+@interface ASTableNode (Deprecated)
+
+- (void)waitUntilAllUpdatesAreCommitted ASDISPLAYNODE_DEPRECATED_MSG("This method has been renamed to -waitUntilAllUpdatesAreProcessed.");
 
 @end
 

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -733,12 +733,31 @@ ASLayoutElementCollectionTableSetTraitCollection(_environmentStateLock)
   }
 }
 
-- (void)waitUntilAllUpdatesAreCommitted
+- (BOOL)isProcessingUpdates
+{
+  return (self.nodeLoaded ? [self.view isProcessingUpdates] : NO);
+}
+
+- (void)onDidFinishProcessingUpdates:(nullable void (^)())completion
+{
+  if (!self.nodeLoaded) {
+    completion();
+  } else {
+    [self.view onDidFinishProcessingUpdates:completion];
+  }
+}
+
+- (void)waitUntilAllUpdatesAreProcessed
 {
   ASDisplayNodeAssertMainThread();
   if (self.nodeLoaded) {
     [self.view waitUntilAllUpdatesAreCommitted];
   }
+}
+
+- (void)waitUntilAllUpdatesAreCommitted
+{
+  [self waitUntilAllUpdatesAreProcessed];
 }
 
 #pragma mark - Debugging (Private)

--- a/Source/ASTableView.h
+++ b/Source/ASTableView.h
@@ -219,9 +219,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)endUpdatesAnimated:(BOOL)animated completion:(void (^ _Nullable)(BOOL completed))completion ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode's -performBatchUpdates:completion: instead.");
 
 /**
- *  Blocks execution of the main thread until all section and row updates are committed. This method must be called from the main thread.
+ * See ASTableNode.h for full documentation of these methods.
  */
-- (void)waitUntilAllUpdatesAreCommitted ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode method instead.");
+@property (nonatomic, readonly) BOOL isProcessingUpdates;
+- (void)onDidFinishProcessingUpdates:(nullable void (^)())completion;
+- (void)waitUntilAllUpdatesAreCommitted ASDISPLAYNODE_DEPRECATED_MSG("Use -[ASTableNode waitUntilAllUpdatesAreProcessed] instead.");
 
 - (void)insertSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode method instead.");
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -548,7 +548,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 {
   ASDisplayNodeAssertMainThread();
   [self reloadData];
-  [_dataController waitUntilAllUpdatesAreCommitted];
+  [_dataController waitUntilAllUpdatesAreProcessed];
 }
 
 - (void)scrollToRowAtIndexPath:(NSIndexPath *)indexPath atScrollPosition:(UITableViewScrollPosition)scrollPosition animated:(BOOL)animated
@@ -735,6 +735,16 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   } 
 }
 
+- (BOOL)isProcessingUpdates
+{
+  return [_dataController isProcessingUpdates];
+}
+
+- (void)onDidFinishProcessingUpdates:(nullable void (^)())completion
+{
+  [_dataController onDidFinishProcessingUpdates:completion];
+}
+
 - (void)waitUntilAllUpdatesAreCommitted
 {
   ASDisplayNodeAssertMainThread();
@@ -743,8 +753,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     //    ASDisplayNodeFailAssert(@"Should not call %@ during batch update", NSStringFromSelector(_cmd));
     return;
   }
-  
-  [_dataController waitUntilAllUpdatesAreCommitted];
+
+  [_dataController waitUntilAllUpdatesAreProcessed];
 }
 
 - (void)layoutSubviews

--- a/Source/Details/ASDataController.h
+++ b/Source/Details/ASDataController.h
@@ -254,7 +254,12 @@ extern NSString * const ASCollectionInvalidUpdateException;
  */
 - (void)relayoutNodes:(id<NSFastEnumeration>)nodes nodesSizeChanged:(NSMutableArray * _Nonnull)nodesSizesChanged;
 
+/**
+ * See ASCollectionNode.h for full documentation of these methods.
+ */
 - (void)waitUntilAllUpdatesAreCommitted;
+- (BOOL)isProcessingUpdates;
+- (void)onDidFinishProcessingUpdates:(nullable void (^)())completion;
 
 /**
  * Notifies the data controller object that its environment has changed. The object will request its environment delegate for new information

--- a/Source/Details/ASDataController.h
+++ b/Source/Details/ASDataController.h
@@ -259,7 +259,7 @@ extern NSString * const ASCollectionInvalidUpdateException;
  */
 @property (nonatomic, readonly) BOOL isProcessingUpdates;
 - (void)onDidFinishProcessingUpdates:(nullable void (^)())completion;
-- (void)waitUntilAllUpdatesAreCommitted;
+- (void)waitUntilAllUpdatesAreProcessed;
 
 /**
  * Notifies the data controller object that its environment has changed. The object will request its environment delegate for new information

--- a/Source/Details/ASDataController.h
+++ b/Source/Details/ASDataController.h
@@ -257,9 +257,9 @@ extern NSString * const ASCollectionInvalidUpdateException;
 /**
  * See ASCollectionNode.h for full documentation of these methods.
  */
-- (void)waitUntilAllUpdatesAreCommitted;
-- (BOOL)isProcessingUpdates;
+@property (nonatomic, readonly) BOOL isProcessingUpdates;
 - (void)onDidFinishProcessingUpdates:(nullable void (^)())completion;
+- (void)waitUntilAllUpdatesAreCommitted;
 
 /**
  * Notifies the data controller object that its environment has changed. The object will request its environment delegate for new information

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -430,7 +430,7 @@ typedef dispatch_block_t ASDataControllerCompletionBlock;
 
 #pragma mark - Batching (External API)
 
-- (void)waitUntilAllUpdatesAreCommitted
+- (void)waitUntilAllUpdatesAreProcessed
 {
   // Schedule block in main serial queue to wait until all operations are finished that are
   // where scheduled while waiting for the _editingTransactionQueue to finish
@@ -592,7 +592,7 @@ typedef dispatch_block_t ASDataControllerCompletionBlock;
   });
   
   if (_usesSynchronousDataLoading) {
-    [self waitUntilAllUpdatesAreCommitted];
+    [self waitUntilAllUpdatesAreProcessed];
   }
 }
 

--- a/Source/Details/ASMainSerialQueue.h
+++ b/Source/Details/ASMainSerialQueue.h
@@ -21,6 +21,7 @@
 AS_SUBCLASSING_RESTRICTED
 @interface ASMainSerialQueue : NSObject
 
+@property (nonatomic, readonly) NSUInteger numberOfScheduledBlocks;
 - (void)performBlockOnMainThread:(dispatch_block_t)block;
 
 @end

--- a/Source/Details/ASMainSerialQueue.mm
+++ b/Source/Details/ASMainSerialQueue.mm
@@ -42,6 +42,7 @@
 
 - (NSUInteger)numberOfScheduledBlocks
 {
+  ASDN::MutexLocker l(_serialQueueLock);
   return _blocks.count;
 }
 

--- a/Source/Details/ASMainSerialQueue.mm
+++ b/Source/Details/ASMainSerialQueue.mm
@@ -40,6 +40,11 @@
   return self;
 }
 
+- (NSUInteger)numberOfScheduledBlocks
+{
+  return _blocks.count;
+}
+
 - (void)performBlockOnMainThread:(dispatch_block_t)block
 {
   ASDN::MutexLocker l(_serialQueueLock);

--- a/Tests/ASCollectionModernDataSourceTests.m
+++ b/Tests/ASCollectionModernDataSourceTests.m
@@ -71,7 +71,7 @@
 
 - (void)tearDown
 {
-  [collectionNode waitUntilAllUpdatesAreCommitted];
+  [collectionNode waitUntilAllUpdatesAreProcessed];
   [super tearDown];
 }
 

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -260,7 +260,7 @@
   [window makeKeyAndVisible];
   
   [testController.collectionNode reloadData];
-  [testController.collectionNode waitUntilAllUpdatesAreCommitted];
+  [testController.collectionNode waitUntilAllUpdatesAreProcessed];
   [testController.collectionView layoutIfNeeded];
   
   NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
@@ -397,7 +397,7 @@
   window.rootViewController = testController;\
   \
   [cn reloadData];\
-  [cn waitUntilAllUpdatesAreCommitted]; \
+  [cn waitUntilAllUpdatesAreProcessed]; \
   [testController.collectionView layoutIfNeeded];
 
 - (void)testThatSubmittingAValidInsertDoesNotThrowAnException
@@ -620,7 +620,7 @@
   [window makeKeyAndVisible];
 
   for (NSInteger i = 0; i < 2; i++) {
-    // NOTE: waitUntilAllUpdatesAreCommitted or reloadDataImmediately is not sufficient here!!
+    // NOTE: waitUntilAllUpdatesAreProcessed or reloadDataImmediately is not sufficient here!!
     XCTestExpectation *done = [self expectationWithDescription:[NSString stringWithFormat:@"Reload #%td complete", i]];
     [cn reloadDataWithCompletion:^{
       [done fulfill];
@@ -755,7 +755,7 @@
   
   del.sectionGeneration++;
   [cn reloadData];
-  [cn waitUntilAllUpdatesAreCommitted];
+  [cn waitUntilAllUpdatesAreProcessed];
   
   NSInteger sectionCount = del->_itemCounts.size();
   for (NSInteger section = 0; section < sectionCount; section++) {
@@ -857,7 +857,7 @@
   [window layoutIfNeeded];
 
   ASCollectionNode *cn = testController.collectionNode;
-  [cn waitUntilAllUpdatesAreCommitted];
+  [cn waitUntilAllUpdatesAreProcessed];
   [cn.view layoutIfNeeded];
   ASCellNode *node = [cn nodeForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
   XCTAssertTrue(node.visible);
@@ -880,7 +880,7 @@
   [window layoutIfNeeded];
 
   ASCollectionNode *cn = testController.collectionNode;
-  [cn waitUntilAllUpdatesAreCommitted];
+  [cn waitUntilAllUpdatesAreProcessed];
   XCTAssertGreaterThan(cn.bounds.size.height, cn.view.contentSize.height, @"Expected initial data not to fill collection view area.");
 
   __block NSUInteger batchFetchCount = 0;
@@ -926,7 +926,7 @@
   [window layoutIfNeeded];
 
   ASCollectionNode *cn = testController.collectionNode;
-  [cn waitUntilAllUpdatesAreCommitted];
+  [cn waitUntilAllUpdatesAreProcessed];
 
   __block NSUInteger batchFetchCount = 0;
   XCTestExpectation *e = [self expectationWithDescription:@"Batch fetching completed"];
@@ -1020,7 +1020,7 @@
   [view layoutIfNeeded];
   
   // Wait for ASDK reload to finish
-  [cn waitUntilAllUpdatesAreCommitted];
+  [cn waitUntilAllUpdatesAreProcessed];
   // Force UIKit to read updated data & range controller to update and account for it
   [cn.view layoutIfNeeded];
   [self waitForExpectationsWithTimeout:60 handler:nil];
@@ -1057,7 +1057,7 @@
   }];
 
   // Wait for ASDK reload to finish
-  [cn waitUntilAllUpdatesAreCommitted];
+  [cn waitUntilAllUpdatesAreProcessed];
 
   XCTAssertTrue(!cn.isProcessingUpdates, @"ASCollectionNode should no longer be processing updates after -wait call");
 
@@ -1102,7 +1102,7 @@
   traitCollection.containerSize = screenBounds.size;
   cn.primitiveTraitCollection = traitCollection;
   
-  [cn waitUntilAllUpdatesAreCommitted];
+  [cn waitUntilAllUpdatesAreProcessed];
   [cn.view layoutIfNeeded];
   
   // Assert that the new trait collection is picked up by all cell nodes, including ones that were not allocated but are forced to allocate now
@@ -1133,7 +1133,7 @@
   [window makeKeyAndVisible];
   [window layoutIfNeeded];
 
-  [cn waitUntilAllUpdatesAreCommitted];
+  [cn waitUntilAllUpdatesAreProcessed];
   for (NSInteger i = 0; i < itemCount; i++) {
     ASTextCellNodeWithSetSelectedCounter *node = [cn nodeForItemAtIndexPath:[NSIndexPath indexPathForItem:i inSection:0]];
     XCTAssert(node.automaticallyManagesSubnodes, @"Expected test cell node to use automatic subnode management. Can modify the test with a different class if needed.");

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -1050,8 +1050,17 @@
   // Trigger the initial reload to start
   [window layoutIfNeeded];
 
+  // Test the APIs that monitor ASCollectionNode update handling
+  XCTAssertTrue(cn.isProcessingUpdates, @"ASCollectionNode should still be processing updates after initial layoutIfNeeded call (reloadData)");
+  [cn onDidFinishProcessingUpdates:^{
+    XCTAssertTrue(!cn.isProcessingUpdates, @"ASCollectionNode should no longer be processing updates inside -onDidFinishProcessingUpdates: block");
+  }];
+
   // Wait for ASDK reload to finish
   [cn waitUntilAllUpdatesAreCommitted];
+
+  XCTAssertTrue(!cn.isProcessingUpdates, @"ASCollectionNode should no longer be processing updates after -wait call");
+
   // Force UIKit to read updated data & range controller to update and account for it
   [cn.view layoutIfNeeded];
 

--- a/Tests/ASTableViewTests.mm
+++ b/Tests/ASTableViewTests.mm
@@ -610,7 +610,7 @@
 
   [UITableView as_recordEditingCallsIntoArray:selectors];
   XCTAssertGreaterThan(node.numberOfSections, 0);
-  [node waitUntilAllUpdatesAreCommitted];
+  [node waitUntilAllUpdatesAreProcessed];
   XCTAssertGreaterThan(node.view.numberOfSections, 0);
 
   // The first reloadData call helps prevent UITableView from calling it multiple times while ASDataController is working.
@@ -635,13 +635,13 @@
 
   // Load initial data.
   XCTAssertGreaterThan(node.numberOfSections, 0);
-  [node waitUntilAllUpdatesAreCommitted];
+  [node waitUntilAllUpdatesAreProcessed];
   XCTAssertGreaterThan(node.view.numberOfSections, 0);
 
   // Reload data.
   [UITableView as_recordEditingCallsIntoArray:selectors];
   [node reloadData];
-  [node waitUntilAllUpdatesAreCommitted];
+  [node waitUntilAllUpdatesAreProcessed];
 
   // Assert that the beginning of the call pattern is correct.
   // There is currently noise that comes after that we will allow for this test.
@@ -668,7 +668,7 @@
 
   // Trigger data load BEFORE first layout pass, to ensure constrained size is correct.
   XCTAssertGreaterThan(node.numberOfSections, 0);
-  [node waitUntilAllUpdatesAreCommitted];
+  [node waitUntilAllUpdatesAreProcessed];
 
   ASSizeRange expectedSizeRange = ASSizeRangeMake(CGSizeMake(cellWidth, 0));
   expectedSizeRange.max.height = CGFLOAT_MAX;
@@ -703,7 +703,7 @@
   // So we need to force a new layout pass so that the table will pick up a new constrained size and apply to its node.
   [node setNeedsLayout];
   [node.view layoutIfNeeded];
-  [node waitUntilAllUpdatesAreCommitted];
+  [node waitUntilAllUpdatesAreProcessed];
 
   UITableViewCell *cell = [node.view cellForRowAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
   XCTAssertNotNil(cell);
@@ -758,7 +758,7 @@
   [window makeKeyAndVisible];
 
   [window layoutIfNeeded];
-  [node waitUntilAllUpdatesAreCommitted];
+  [node waitUntilAllUpdatesAreProcessed];
   XCTAssertEqual(node.view.numberOfSections, NumberOfSections);
   ASXCTAssertEqualRects(CGRectMake(0, 32, 375, 44), [node rectForRowAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]], @"This text requires very specific geometry. The rect for the first row should match up.");
 
@@ -812,7 +812,7 @@
   node.dataSource = ds;
   
   [node.view layoutIfNeeded];
-  [node waitUntilAllUpdatesAreCommitted];
+  [node waitUntilAllUpdatesAreProcessed];
   CGFloat rowHeight = [node.view rectForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]].size.height;
   // Scroll to row (0,1) + 10pt
   node.contentOffset = CGPointMake(0, rowHeight + 10);
@@ -825,7 +825,7 @@
       [node deleteRowsAtIndexPaths:@[ [NSIndexPath indexPathForItem:0 inSection:i]] withRowAnimation:UITableViewRowAnimationAutomatic];
     }
   } completion:nil];
-  [node waitUntilAllUpdatesAreCommitted];
+  [node waitUntilAllUpdatesAreProcessed];
   
   // Now that row (0,0) is deleted, we should have slid up to be at just 10
   // i.e. we should have subtracted the deleted row height from our content offset.


### PR DESCRIPTION
Over time, there have actually been a lot of legitimate uses for an API like this.
In fact, I'm not quite sure what has held us back from adding one!

I believe that at least some portion of -wait calls (even if less than 50%) could be
replaced with -onDidFinishProcessingUpdates:, which could potentially improve the
performance of applications using -wait by a significant amount.

Please take a close look at implementation correctness. Although I'm in a bit of a
rush, I'm aiming to make this properly documented and added a basic test -- but it
could certainly use some more detailed testing as a followup.