### PR TITLE
Fix a crash in -[ASCollectionViewLayoutController elementsWithinRangeBounds:map:]

### DIFF
--- a/Source/Details/ASCollectionViewLayoutController.m
+++ b/Source/Details/ASCollectionViewLayoutController.m
@@ -120,7 +120,10 @@ typedef struct ASRangeGeometry ASRangeGeometry;
     if (CATransform3DIsIdentity(la.transform3D) && CGRectIntersectsRect(la.frame, rangeBounds) == NO) {
       continue;
     }
-    [elementSet addObject:[map elementForLayoutAttributes:la]];
+    ASCollectionElement *e = [map elementForLayoutAttributes:la];
+    if (e != nil) {
+      [elementSet addObject:e];
+    }
   }
 
   return elementSet;


### PR DESCRIPTION
`-[ASElementMap elementForLayoutAttributes:]` returns nil for collection decoration views. The `allElementsForScrolling:rangeMode:displaySet:preloadSet:map:` method above nil checks this value. Do that here too.

The only other use of this method is in `-[ASCollectionLayout layoutAttributesForElementsInRect:]` and `ASCollectionLayoutSetSizeToElement` looks like it's OK with a nil value.

This was also reported as #495.

Not sure how to make a test for this - if there's an easy way to test this let me know and I'll add one.