### PR TITLE
Ensure ASWeakMapEntry's value is atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Table and collection views to consider content inset when calculating (default) element size range [Huy Nguyen](https://github.com/nguyenhuy) [#525](https://github.com/TextureGroup/Texture/pull/525)
 - [ASEditableTextNode] added -editableTextNodeShouldBeginEditing to ASEditableTextNodeDelegate to mirror the corresponding method from UITextViewDelegate. [Yan S.](https://github.com/yans) [#535](https://github.com/TextureGroup/Texture/pull/535)
 - [Breaking] Remove APIs that have been deprecated since 2.0 and/or for at least 6 months [Huy Nguyen](https://github.com/nguyenhuy) [#529](https://github.com/TextureGroup/Texture/pull/529)
+- [ASImageNode] Potentially fix a memory corruption in ASImageNode [Huy Nguyen](https://github.com/nguyenhuy) [#556](https://github.com/TextureGroup/Texture/pull/556)
 
 ##2.4
 - Fix an issue where inserting/deleting sections could lead to inconsistent supplementary element behavior. [Adlai Holler](https://github.com/Adlai-Holler)

--- a/Source/Private/ASWeakMap.h
+++ b/Source/Private/ASWeakMap.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED
 @interface ASWeakMapEntry<Value> : NSObject
 
-@property (nonatomic, retain, readonly) Value value;
+@property (atomic, strong, readonly) Value value;
 
 @end
 

--- a/Source/Private/ASWeakMap.m
+++ b/Source/Private/ASWeakMap.m
@@ -17,8 +17,9 @@
 
 #import <AsyncDisplayKit/ASWeakMap.h>
 
-@interface ASWeakMapEntry ()
-@property (nonatomic, strong) NSObject *key;
+@interface ASWeakMapEntry<Value> ()
+@property (nonatomic, strong, readonly) NSObject *key;
+@property (atomic, strong) Value value;
 @end
 
 @implementation ASWeakMapEntry
@@ -31,11 +32,6 @@
     _value = value;
   }
   return self;
-}
-
-- (void)setValue:(NSObject *)value
-{
-  _value = value;
 }
 
 @end


### PR DESCRIPTION
It can be read and written on multiple threads. That may cause a crash that we're seeing in the Pinterest app.

<img width="1094" alt="screen shot 2017-09-07 at 7 37 04 pm" src="https://user-images.githubusercontent.com/587874/30179349-faffe9ea-9403-11e7-8aae-e400833291fc.png">
