### PR TITLE
[ASDisplayNode] Assert when attempt to remove a subnode from a supernode that has ASM enabled #trivial

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -2281,6 +2281,15 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 {
   ASDisplayNodeLogEvent(self, @"removeFromSupernode with automaticallyManagesSubnodes: %@",
                         self.automaticallyManagesSubnodes ? @"YES" : @"NO");
+
+#if ASDISPLAYNODE_ASSERTIONS_ENABLED
+  __instanceLock__.lock();
+    __weak ASDisplayNode *supernode = _supernode;
+  __instanceLock__.unlock();
+
+  ASDisplayNodeAssert(! supernode.automaticallyManagesSubnodes, @"Should not manually remove node %@ from its supernode %@ which has automaticallyManagesSubnodes enabled. Please talk to Huy if you're hitting this in closeup!", self, supernode);
+#endif
+
   [self _removeFromSupernode];
 }
 
@@ -2304,7 +2313,6 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
   
   __instanceLock__.lock();
-
     // Only remove if supernode is still the expected supernode
     if (!ASObjectIsEqual(_supernode, supernode)) {
       __instanceLock__.unlock();


### PR DESCRIPTION
If the removal proceeds, `_subnodes` and `_calculatedDisplayNodeLayout` of the supernode will be out-of-sync. Subsequence layouts applied to that node may cause range exception.

<img width="1085" alt="screen shot 2017-09-12 at 6 04 03 pm" src="https://user-images.githubusercontent.com/587874/30338843-e48c281a-97e4-11e7-99d8-89fba7eb8655.png">


