### PR TITLE
Fix -[ASPagerNode view] triggering pendingState + nodeLoaded assert #trivial

### DIFF
--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -183,6 +183,7 @@
   
   if (_pendingState) {
     _ASCollectionPendingState *pendingState = _pendingState;
+    self.pendingState               = nil;
     view.asyncDelegate              = pendingState.delegate;
     view.asyncDataSource            = pendingState.dataSource;
     view.inverted                   = pendingState.inverted;
@@ -191,7 +192,6 @@
     view.usesSynchronousDataLoading = pendingState.usesSynchronousDataLoading;
     view.layoutInspector            = pendingState.layoutInspector;
     view.contentInset               = pendingState.contentInset;
-    self.pendingState               = nil;
     
     if (pendingState.rangeMode != ASLayoutRangeModeUnspecified) {
       [view.rangeController updateCurrentRangeWithMode:pendingState.rangeMode];


### PR DESCRIPTION
`-[ASCollectionNode didLoad]` transfers contentInset from the `pendingState` to the newly materialized `ASCollectionView`'s `contentInset` . However for `ASPagerNode`, this action triggers `-[ASCollectionNode contentInset]` which in turns calls `-[ASCollectionNode pendingState]` before the `pendingState `is cleared on the pager node, thereby prematurely triggering the assert:
```
  ASDisplayNodeAssert(![self isNodeLoaded] || !_pendingState, @"ASCollectionNode should not have a pendingState once it is loaded");
```

To fix this we clear out the pending state on the node before transferring the `pendingState` properties to the` ASCollectionView`

<img width="392" alt="screen shot 2017-09-12 at 8 35 22 pm" src="https://user-images.githubusercontent.com/194822/30358672-d8db2f3c-97fa-11e7-833a-06387c31474d.png">
<img width="1137" alt="screen shot 2017-09-12 at 8 23 27 pm" src="https://user-images.githubusercontent.com/194822/30358676-e0226c9c-97fa-11e7-990f-92df8fcf49d3.png">
<img width="1138" alt="screen shot 2017-09-12 at 8 23 49 pm" src="https://user-images.githubusercontent.com/194822/30358691-ff8fc37c-97fa-11e7-9aca-1a6a6af7dad3.png">



