### PR TITLE
Fix crashes caused by failing to unlock or destroy a static mutex while the app is being terminated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add support for URLs on ASNetworkImageNode. [Garrett Moon](https://github.com/garrettmoon)
 - [ASImageNode] Always dealloc images in a background queue [Huy Nguyen](https://github.com/nguyenhuy) [#561](https://github.com/TextureGroup/Texture/pull/561)
 - Mark ASRunLoopQueue as drained if it contains only NULLs [Cesar Estebanez](https://github.com/cesteban) [#558](https://github.com/TextureGroup/Texture/pull/558)
+- Fix crashes caused by failing to unlock or destroy a static mutex while the app is being terminated [Huy Nguyen](https://github.com/nguyenhuy)
 
 ##2.4
 - Fix an issue where inserting/deleting sections could lead to inconsistent supplementary element behavior. [Adlai Holler](https://github.com/Adlai-Holler)

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -442,48 +442,32 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 }
 
 static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
-static ASDN::StaticMutex cacheLock = ASDISPLAYNODE_MUTEX_INITIALIZER;
+// Allocate cacheLock on the heap to prevent destruction at app exit (https://github.com/TextureGroup/Texture/issues/136)
+static ASDN::StaticMutex& cacheLock = *new ASDN::StaticMutex;
 
 + (ASWeakMapEntry *)contentsForkey:(ASImageNodeContentsKey *)key drawParameters:(id)drawParameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelled
 {
-  cacheLock.lock();
+  {
+    ASDN::StaticMutexLocker l(cacheLock);
     if (!cache) {
       cache = [[ASWeakMap alloc] init];
     }
     ASWeakMapEntry *entry = [cache entryForKey:key];
-  int unlockCode = cacheLock.unlock();
+    if (entry != nil) {
+      return entry;
+    }
+  }
 
-  if (unlockCode != 0) {
-    // Failed to unlock cacheLock static mutex.
-    // Since the mutex was locked just a few lines above, this usually means there is a race condition going on.
-    // The race condition occurs when a static mutex is being destroyed as part of an app exit on main thread,
-    // and, at the same time, being used here on another thread.
-    // See https://github.com/TextureGroup/Texture/issues/136.
-    //
-    // Return nil here to signal that this operation should be cancelled.
-    return nil;
-  }
-  
-  if (entry != nil) {
-    return entry;
-  }
-  
   // cache miss
   UIImage *contents = [self createContentsForkey:key drawParameters:drawParameters isCancelled:isCancelled];
   if (contents == nil) { // If nil, we were cancelled
     return nil;
   }
 
-  cacheLock.lock();
-    entry = [cache setObject:contents forKey:key];
-  unlockCode = cacheLock.unlock();
-
-  if (unlockCode != 0) {
-    // Same as above, return nil if fail to unlock.
-    return nil;
+  {
+    ASDN::StaticMutexLocker l(cacheLock);
+    return [cache setObject:contents forKey:key];
   }
-
-  return entry;
 }
 
 + (UIImage *)createContentsForkey:(ASImageNodeContentsKey *)key drawParameters:(id)drawParameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelled

--- a/Source/Details/ASBasicImageDownloader.mm
+++ b/Source/Details/ASBasicImageDownloader.mm
@@ -46,28 +46,42 @@ NSString * const kASBasicImageDownloaderContextCompletionBlock = @"kASBasicImage
 @implementation ASBasicImageDownloaderContext
 
 static NSMutableDictionary *currentRequests = nil;
-static ASDN::RecursiveMutex currentRequestsLock;
+static ASDN::StaticMutex currentRequestsLock = ASDISPLAYNODE_MUTEX_INITIALIZER;
 
 + (ASBasicImageDownloaderContext *)contextForURL:(NSURL *)URL
 {
-  ASDN::MutexLocker l(currentRequestsLock);
-  if (!currentRequests) {
-    currentRequests = [[NSMutableDictionary alloc] init];
+  currentRequestsLock.lock();
+    if (!currentRequests) {
+      currentRequests = [[NSMutableDictionary alloc] init];
+    }
+    ASBasicImageDownloaderContext *context = currentRequests[URL];
+    if (!context) {
+      context = [[ASBasicImageDownloaderContext alloc] initWithURL:URL];
+      currentRequests[URL] = context;
+    }
+  int unlockCode = currentRequestsLock.unlock();
+
+  if (unlockCode != 0) {
+    // Failed to unlock currentRequestsLock static mutex.
+    // Since the mutex was locked just a few lines above, this usually means there is a race condition going on.
+    // The race condition occurs when a static mutex is being destroyed as part of an app exit on main thread,
+    // and, at the same time, being used here on another thread.
+    // See https://github.com/TextureGroup/Texture/issues/136.
+    //
+    // Return nil here to signal that the image should not be loaded.
+    return nil;
   }
-  ASBasicImageDownloaderContext *context = currentRequests[URL];
-  if (!context) {
-    context = [[ASBasicImageDownloaderContext alloc] initWithURL:URL];
-    currentRequests[URL] = context;
-  }
+
   return context;
 }
 
 + (void)cancelContextWithURL:(NSURL *)URL
 {
-  ASDN::MutexLocker l(currentRequestsLock);
-  if (currentRequests) {
-    [currentRequests removeObjectForKey:URL];
-  }
+  currentRequestsLock.lock();
+    if (currentRequests) {
+      [currentRequests removeObjectForKey:URL];
+    }
+  currentRequestsLock.unlock(); // Ignoring unlock failure
 }
 
 - (instancetype)initWithURL:(NSURL *)URL
@@ -234,11 +248,14 @@ static const char *kContextKey = NSStringFromClass(ASBasicImageDownloaderContext
 #pragma mark ASImageDownloaderProtocol.
 
 - (id)downloadImageWithURL:(NSURL *)URL
-                      callbackQueue:(dispatch_queue_t)callbackQueue
-                   downloadProgress:(nullable ASImageDownloaderProgress)downloadProgress
-                         completion:(ASImageDownloaderCompletion)completion
+             callbackQueue:(dispatch_queue_t)callbackQueue
+          downloadProgress:(nullable ASImageDownloaderProgress)downloadProgress
+                completion:(ASImageDownloaderCompletion)completion
 {
   ASBasicImageDownloaderContext *context = [ASBasicImageDownloaderContext contextForURL:URL];
+  if (context == nil) {
+    return nil;
+  }
 
   // NSURLSessionDownloadTask will do file I/O to create a temp directory. If called on the main thread this will
   // cause significant performance issues.

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -314,8 +314,19 @@ namespace ASDN {
       ASDISPLAYNODE_THREAD_ASSERT_ON_ERROR(pthread_mutex_lock (this->mutex()));
     }
 
-    void unlock () {
-      ASDISPLAYNODE_THREAD_ASSERT_ON_ERROR(pthread_mutex_unlock (this->mutex()));
+    /**
+     Unlocks this mutex.
+
+     This method calls pthread_mutex_unlock() internally and returns its result.
+     Clients are expected to handle errors themselves.
+
+     Because of this behavior, StaticMutexLocker and StaticMutexUnlocker are not (and should not be) provided.
+
+     For more information, see https://github.com/TextureGroup/Texture/issues/136 and
+     https://www.ibm.com/support/knowledgecenter/en/ssw_i5_54/apis/users_65.htm
+     */
+    int unlock () {
+      return pthread_mutex_unlock (this->mutex());
     }
 
     pthread_mutex_t *mutex () { return &_m; }
@@ -323,9 +334,6 @@ namespace ASDN {
     StaticMutex(const StaticMutex&) = delete;
     StaticMutex &operator=(const StaticMutex&) = delete;
   };
-
-  typedef Locker<StaticMutex> StaticMutexLocker;
-  typedef Unlocker<StaticMutex> StaticMutexUnlocker;
 
   struct Condition
   {

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -59,7 +59,7 @@ static inline BOOL ASDisplayNodeThreadIsMain()
   _Pragma("clang diagnostic push"); \
   _Pragma("clang diagnostic ignored \"-Wunused-variable\""); \
   volatile int res = (x_); \
-  assert(res == 0); \
+  ASDisplayNodeCAssert(res == 0, @"Expected %@ to return 0, got %d instead", @#x_, res); \
   _Pragma("clang diagnostic pop"); \
 } while (0)
 
@@ -136,7 +136,7 @@ namespace ASDN {
 #if !TIME_LOCKER
     
     SharedLocker (std::shared_ptr<T> const& l) ASDISPLAYNODE_NOTHROW : _l (l) {
-      assert(_l != nullptr);
+      ASDisplayNodeCAssertTrue(_l != nullptr);
       _l->lock ();
     }
     
@@ -211,12 +211,12 @@ namespace ASDN {
       mach_port_t thread_id = pthread_mach_thread_np(pthread_self());
       if (thread_id != _owner) {
         // New owner. Since this mutex can't be acquired by another thread if there is an existing owner, _owner and _count must be 0.
-        assert(0 == _owner);
-        assert(0 == _count);
+        ASDisplayNodeCAssertTrue(0 == _owner);
+        ASDisplayNodeCAssertTrue(0 == _count);
         _owner = thread_id;
       } else {
         // Existing owner tries to reacquire this (recursive) mutex. _count must already be positive.
-        assert(_count > 0);
+        ASDisplayNodeCAssertTrue(_count > 0);
       }
       ++_count;
 #endif
@@ -226,9 +226,9 @@ namespace ASDN {
 #if CHECK_LOCKING_SAFETY
       mach_port_t thread_id = pthread_mach_thread_np(pthread_self());
       // Unlocking a mutex on an unowning thread causes undefined behaviour. Assert and fail early.
-      assert(thread_id == _owner);
+      ASDisplayNodeCAssertTrue(thread_id == _owner);
       // Current thread owns this mutex. _count must be positive.
-      assert(_count > 0);
+      ASDisplayNodeCAssertTrue(_count > 0);
       --_count;
       if (0 == _count) {
         // Current thread is no longer the owner.

--- a/Source/Private/ASBasicImageDownloaderInternal.h
+++ b/Source/Private/ASBasicImageDownloaderInternal.h
@@ -15,11 +15,9 @@
 //      http://www.apache.org/licenses/LICENSE-2.0
 //
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface ASBasicImageDownloaderContext : NSObject
 
-+ (nullable ASBasicImageDownloaderContext *)contextForURL:(NSURL *)URL;
++ (ASBasicImageDownloaderContext *)contextForURL:(NSURL *)URL;
 
 @property (nonatomic, strong, readonly) NSURL *URL;
 @property (nonatomic, weak) NSURLSessionTask *sessionTask;
@@ -28,5 +26,3 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)cancel;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/Source/Private/ASBasicImageDownloaderInternal.h
+++ b/Source/Private/ASBasicImageDownloaderInternal.h
@@ -15,9 +15,11 @@
 //      http://www.apache.org/licenses/LICENSE-2.0
 //
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ASBasicImageDownloaderContext : NSObject
 
-+ (ASBasicImageDownloaderContext *)contextForURL:(NSURL *)URL;
++ (nullable ASBasicImageDownloaderContext *)contextForURL:(NSURL *)URL;
 
 @property (nonatomic, strong, readonly) NSURL *URL;
 @property (nonatomic, weak) NSURLSessionTask *sessionTask;
@@ -26,3 +28,5 @@
 - (void)cancel;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/TextKit/ASTextKitContext.mm
+++ b/Source/TextKit/ASTextKitContext.mm
@@ -40,8 +40,8 @@
 {
   if (self = [super init]) {
     // Concurrently initialising TextKit components crashes (rdar://18448377) so we use a global lock.
-    static ASDN::Mutex __staticMutex;
-    ASDN::MutexLocker l(__staticMutex);
+    static ASDN::StaticMutex __staticMutex = ASDISPLAYNODE_MUTEX_INITIALIZER;
+    __staticMutex.lock();
     
     __instanceLock__ = std::make_shared<ASDN::Mutex>();
     
@@ -65,6 +65,18 @@
     _textContainer.maximumNumberOfLines = maximumNumberOfLines;
     _textContainer.exclusionPaths = exclusionPaths;
     [_layoutManager addTextContainer:_textContainer];
+
+    if (__staticMutex.unlock() != 0) {
+      // Failed to unlock __staticMutex
+      // Since the mutex was locked at the beginninng of this method, the failure usually means there is a race condition going on.
+      // The race condition occurs when a static mutex is being destroyed as part of an app exit on main thread,
+      // and, at the same time, being used here on another thread.
+      // See https://github.com/TextureGroup/Texture/issues/136.
+      //
+      // Return nil here to signal that this initialization should not be done in the first place,
+      // and to ensure that `self` won't be used later.
+      return nil;
+    }
   }
   return self;
 }


### PR DESCRIPTION
This is an interesting crash. Here is an example report in Pinterest app, happening on the static `cacheLock` mutex of `ASImageNode`:

<img width="1087" alt="screen shot 2017-09-20 at 7 09 29 pm" src="https://user-images.githubusercontent.com/587874/30660032-7c35268c-9e37-11e7-849e-9149d90f1d97.png">
<img width="1089" alt="screen shot 2017-09-20 at 7 09 42 pm" src="https://user-images.githubusercontent.com/587874/30660033-7c38619e-9e37-11e7-80d3-140a9fcce418.png">

There are other similar crashes related to `__staticMutex` in `ASTextKitContext` reported in https://github.com/TextureGroup/Texture/issues/136. For instance, see thread #0 and #5 in [this report](http://crashes.to/s/7d0c464960f), or thread #0 and #14 [here](http://crashes.to/s/e43ab8f7d5c).

Basically, what's happening is that all static mutexes are destroyed when an app is terminated by the system. At the same time, a static mutex is being unlocked or destroyed on another thread. The unlock or destruction yields a non-zero error code, which triggers an assertion, even in production.

A similar issue was discussed and fixed in Realm-Core (https://github.com/realm/realm-core/pull/2243). For Texture, I went with a different approach that is arguably safer, IMHO. This should fix https://github.com/TextureGroup/Texture/issues/136.

> Mutex initialization using the PTHREAD_MUTEX_INITIALIZER does not immediately initialize the mutex. Instead, on first use, pthread_mutex_timedlock_np() or pthread_mutex_lock() or pthread_mutex_trylock() branches into a slow path and causes the initialization of the mutex. Because a mutex is not just a simple memory object and requires that some resources be allocated by the system, an attempt to call pthread_mutex_destroy() or pthread_mutex_unlock() on a mutex that was statically initialized using PTHREAD_MUTEX_INITIALIZER and was not yet locked causes an EINVAL error.

(https://www.ibm.com/support/knowledgecenter/en/ssw_i5_54/apis/users_65.htm)
