### PR TITLE
Clear ivar after scheduling for main thread deallocation #trivial

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -428,9 +428,18 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
   for (Ivar ivar : ivars) {
     id value = object_getIvar(self, ivar);
+    if (value == nil) {
+      continue;
+    }
+    
     if (ASClassRequiresMainThreadDeallocation(object_getClass(value))) {
       as_log_debug(ASMainThreadDeallocationLog(), "%@: Trampolining ivar '%s' value %@ for main deallocation.", self, ivar_getName(ivar), value);
       ASPerformMainThreadDeallocation(value);
+      
+      // After scheduling the ivar for main thread deallocation we have clear out the ivar, otherwise we can run
+      // into a race condition where the main queue is drained earlier than this node is deallocated and the ivar
+      // is still deallocated on a background thread
+      object_setIvar(self, ivar, nil);
     } else {
       as_log_debug(ASMainThreadDeallocationLog(), "%@: Not trampolining ivar '%s' value %@.", self, ivar_getName(ivar), value);
     }

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -434,12 +434,13 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     
     if (ASClassRequiresMainThreadDeallocation(object_getClass(value))) {
       as_log_debug(ASMainThreadDeallocationLog(), "%@: Trampolining ivar '%s' value %@ for main deallocation.", self, ivar_getName(ivar), value);
-      ASPerformMainThreadDeallocation(value);
       
-      // After scheduling the ivar for main thread deallocation we have clear out the ivar, otherwise we can run
+      // Before scheduling the ivar for main thread deallocation we have clear out the ivar, otherwise we can run
       // into a race condition where the main queue is drained earlier than this node is deallocated and the ivar
       // is still deallocated on a background thread
       object_setIvar(self, ivar, nil);
+      
+      ASPerformMainThreadDeallocation(value);
     } else {
       as_log_debug(ASMainThreadDeallocationLog(), "%@: Not trampolining ivar '%s' value %@.", self, ivar_getName(ivar), value);
     }


### PR DESCRIPTION
After scheduling the ivar for main thread deallocation we have clear out the ivar, otherwise we can run into a race condition where the main queue is drained earlier than this node is deallocated and the ivar is still deallocated on a background thread