### PR TITLE
[PINCache] Set a default .byteLimit to reduce disk usage & startup time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this with your name.
+- [PINCache] Set a default .byteLimit to reduce disk usage and startup time. [#595](https://github.com/TextureGroup/Texture/pull/595) [Scott Goodson](https://github.com/appleguy)
 - [ASNetworkImageNode] Fix deadlock in GIF handling. [#582](https://github.com/TextureGroup/Texture/pull/582) [Garrett Moon](https://github.com/garrettmoon)
 - [ASDisplayNode] Add attributed versions of a11y label, hint and value. [#554](https://github.com/TextureGroup/Texture/pull/554) [Alexander Hüllmandel](https://github.com/fruitcoder)
 - [ASCornerRounding] Introduce .cornerRoundingType: CALayer, Precomposited, or Clip Corners. [Scott Goodson](https://github.com/appleguy) [#465](https://github.com/TextureGroup/Texture/pull/465)

--- a/Source/Details/ASPINRemoteImageDownloader.m
+++ b/Source/Details/ASPINRemoteImageDownloader.m
@@ -84,7 +84,18 @@
 //Share image cache with sharedImageManager image cache.
 - (id <PINRemoteImageCaching>)defaultImageCache
 {
-  return [[PINRemoteImageManager sharedImageManager] cache];
+  static dispatch_once_t onceToken;
+  static id <PINRemoteImageCaching> cache = nil;
+  dispatch_once(&onceToken, ^{
+    cache = [[PINRemoteImageManager sharedImageManager] cache];
+
+    // Set a default byteLimit. PINCache recently implemented a 50MB default (PR #201).
+    // Ensure that older versions of PINCache also have a byteLimit applied.
+    PINDiskCache *diskCache = [ASDynamicCast(cache, PINCache) diskCache];
+    // NOTE: Using 20MB limit while large cache initialization is being optimized (Issue #144).
+    diskCache.byteLimit = 20 * 1024 * 1024;
+  });
+  return cache;
 }
 
 @end


### PR DESCRIPTION
This default is fairly low - only 20MB - but for most apps with images
in the size range of 10-50KB, this is still 400-1000 images.

Once some optimizations land to PINCache, we'll match the PINCache
default of 50MB to ensure the default better serves users with larger
objects in the cache.

Apps should preferably set their own byteLimit to an optimal value.

@garrettmoon - one interesting question for us is the best place to
set .byteLimit as an app. Digging into the ASPINRemoteImageDownloader
and doing this type cast is a bit complicated, so a passthrough API
to get the PIN* objects directly might be worthwhile.