### PR TITLE
update faq toc links to match the generated html id #trivial

### DIFF
--- a/docs/_docs/faq.md
+++ b/docs/_docs/faq.md
@@ -1,5 +1,5 @@
 ---
-title: FAQ 
+title: FAQ
 layout: docs
 permalink: /docs/faq.html
 prevPage: subclassing.html
@@ -9,7 +9,7 @@ nextPage: containers-asviewcontroller.html
 ### Common Developer Mistakes
 
 <ul>
-<li><a href = "faq.html#accessing-the-node-s-view-before-it-is-loaded">Do not access a node's view in <code>-init:</code>.</a></li>
+<li><a href = "faq.html#accessing-the-nodes-view-before-it-is-loaded">Do not access a node's view in <code>-init:</code>.</a></li>
 <li><a href = "faq.html#make-sure-you-access-your-data-source-outside-the-node-block">Make sure you access your data source outside of a <code>nodeBlock</code>.</a></li>
 <li><a href = "faq.html#take-steps-to-avoid-a-retain-cycle-in-viewblocks">Take steps to avoid a retain cycle in <code>viewBlocks</code>.</a></li>
 </ul>
@@ -25,8 +25,8 @@ nextPage: containers-asviewcontroller.html
 
 ### Common Questions
 <ul>
-<li><a href = "faq.html#calayer-s-cornerradius-property-kills-performance">If you care about performance, do not use <code>CALayer</code>'s <code>.cornerRadius</code> property (or shadowPath, border or mask).</a></li>
-<li><a href = "faq.html#asyncdisplaykit-does-not-support-uikit-auto-layout-or-interfacebuilder">Texture does not support UIKit Auto Layout.</a></li>
+<li><a href = "faq.html#calayers-cornerradius-property-kills-performance">If you care about performance, do not use <code>CALayer</code>'s <code>.cornerRadius</code> property (or shadowPath, border or mask).</a></li>
+<li><a href = "faq.html#texture-does-not-support-uikit-auto-layout-or-interfacebuilder">Texture does not support UIKit Auto Layout.</a></li>
 <li><a href = "faq.html#uicollectionviewcell-compatibility">Can I use my <code>UICollectionViewCells</code> with Texture?.</a></li>
 <li><a href = "faq.html#asdisplaynode-keep-alive-reference"><code>ASDisplayNode</code> keep alive reference.</a></li>
 </ul>
@@ -36,35 +36,35 @@ nextPage: containers-asviewcontroller.html
 <br>
 Node `-init` methods are often called off the main thread, therefore it is imperative that no UIKit objects are accessed.  Examples of common errors include accessing the node's view or creating a gesture recognizer. Instead, these operations are ideal to perform in `-didLoad`.  
 
-Interacting with UIKit in `-init` can cause crashes and performance problems. 
+Interacting with UIKit in `-init` can cause crashes and performance problems.
 <br>
 
 ### Make sure you access your data source outside the node block
 <br>
-The `indexPath` parameter is only valid _outside_ the node block returned in `nodeBlockForItemAtIndexPath:` or `nodeBlockForRowAtIndexPath:`. Because these blocks are executed on a background thread, the `indexPath` may be invalid by execution time, due to additional changes in the data source. 
+The `indexPath` parameter is only valid _outside_ the node block returned in `nodeBlockForItemAtIndexPath:` or `nodeBlockForRowAtIndexPath:`. Because these blocks are executed on a background thread, the `indexPath` may be invalid by execution time, due to additional changes in the data source.
 
-See an example of how to correctly code a node block in the <a href = "containers-astablenode.html#node-block-thread-safety-warning">ASTableNode</a> page.  Just as with UIKit, it will cause an exception if Nil is returned from the block for any `ASCellNode`. 
+See an example of how to correctly code a node block in the <a href = "containers-astablenode.html#node-block-thread-safety-warning">ASTableNode</a> page.  Just as with UIKit, it will cause an exception if Nil is returned from the block for any `ASCellNode`.
 <br>
 
-### Take steps to avoid a retain cycle in viewBlocks 
+### Take steps to avoid a retain cycle in viewBlocks
 <br>
-When using `initWithViewBlock:` it is important to prevent a retain cycle by capturing a strong reference to self. The two ways that a cycle can be created are by using any instance variable inside the block or directly referencing self without using a weak pointer. 
+When using `initWithViewBlock:` it is important to prevent a retain cycle by capturing a strong reference to self. The two ways that a cycle can be created are by using any instance variable inside the block or directly referencing self without using a weak pointer.
 
-You can use properties instead of instance variables as long as they are accessed on a weak pointer to self. 
+You can use properties instead of instance variables as long as they are accessed on a weak pointer to self.
 
-Because viewBlocks are always executed on the main thread, it is safe to preform UIKit operations (including gesture recognizer creation and addition). 
+Because viewBlocks are always executed on the main thread, it is safe to preform UIKit operations (including gesture recognizer creation and addition).
 
-Although the block is destroyed after the view is created, in the event that the block is never run and the view is never created, then a cycle can persist preventing memory from being released. 
+Although the block is destroyed after the view is created, in the event that the block is never run and the view is never created, then a cycle can persist preventing memory from being released.
 <br>
 
 ### ASCellNode Reusability
 <br>
-Texture does not use cell reuse, for a number of specific reasons, one side effect of this is that it eliminates the large class of bugs associated with cell reuse. 
+Texture does not use cell reuse, for a number of specific reasons, one side effect of this is that it eliminates the large class of bugs associated with cell reuse.
 <br>
 
 ### LayoutSpecs Are Regenerated
 <br>
-A node's layoutSpec gets regenerated every time its `layoutThatFits:` method is called. 
+A node's layoutSpec gets regenerated every time its `layoutThatFits:` method is called.
 <br>
 
 ### Layout API Sizing
@@ -74,11 +74,11 @@ If you're confused by `ASRelativeDimension`, `ASRelativeSize`, `ASRelativeSizeRa
 
 ### CALayer's .cornerRadius Property Kills Performance
 <br>
-CALayer's' .cornerRadius property is a disastrously expensive property that should only be used when there is no alternative. It is one of the least efficient, most render-intensive properties on CALayer (alongside shadowPath, masking, borders, etc). These properties trigger offscreen rendering to perform the clipping operation on every frame — 60FPS during scrolling! — even if the content in that area isn't changing. 
+CALayer's' .cornerRadius property is a disastrously expensive property that should only be used when there is no alternative. It is one of the least efficient, most render-intensive properties on CALayer (alongside shadowPath, masking, borders, etc). These properties trigger offscreen rendering to perform the clipping operation on every frame — 60FPS during scrolling! — even if the content in that area isn't changing.
 
 Using `.cornerRadius` will visually degraded performance on iPhone 4, 4S, and 5 / 5C (along with comparable iPads / iPods) and reduce head room and make frame drops more likely on 5S and newer devices.
 
-For a longer discussion and easy alternative corner rounding solutions, please read our comprehensive <a href = "corner-rounding.html">corner rounding guide</a>. 
+For a longer discussion and easy alternative corner rounding solutions, please read our comprehensive <a href = "corner-rounding.html">corner rounding guide</a>.
 <br>
 
 ### Texture does not support UIKit Auto Layout or InterfaceBuilder
@@ -118,8 +118,8 @@ Good application design should not rely on this behavior, because a strong refer
 
 ### UICollectionViewCell Compatibility
 
-Texture supports using <code>UICollectionViewCells</code> alongside native <code>ASCellNodes</code>. 
+Texture supports using <code>UICollectionViewCells</code> alongside native <code>ASCellNodes</code>.
 
-Note that these UIKit cells will **not** have the performance benefits of `ASCellNodes` (like preloading, async layout, and async drawing), even when mixed within the same `ASCollectionNode`. 
+Note that these UIKit cells will **not** have the performance benefits of `ASCellNodes` (like preloading, async layout, and async drawing), even when mixed within the same `ASCollectionNode`.
 
 However, this interoperability allows developers the flexibility to test out the framework without needing to convert all of their cells at once. Read more <a href="uicollectionviewinterop.html">here</a>.


### PR DESCRIPTION
Right now the faq- table of contents has links to the different headlines that are mentioned in the faqs, but some of the generated id s don't match the referencing
a tag.