### PR TITLE
ASTextKitComponents needs to be deallocated on main

### DIFF
--- a/Source/Private/ASInternalHelpers.m
+++ b/Source/Private/ASInternalHelpers.m
@@ -91,6 +91,7 @@ void ASPerformBackgroundDeallocation(id object)
 
 BOOL ASClassRequiresMainThreadDeallocation(Class c)
 {
+  // Specific classes
   if (c == [UIImage class] || c == [UIColor class]) {
     return NO;
   }
@@ -101,8 +102,14 @@ BOOL ASClassRequiresMainThreadDeallocation(Class c)
     return YES;
   }
 
+  // Apple classes with prefix
   const char *name = class_getName(c);
   if (strncmp(name, "UI", 2) == 0 || strncmp(name, "AV", 2) == 0 || strncmp(name, "CA", 2) == 0) {
+    return YES;
+  }
+  
+  // Specific Texture classes
+  if (strncmp(name, "ASTextKitComponents", 19) == 0) {
     return YES;
   }
 


### PR DESCRIPTION
Certain objects need to be deallocated on main. We have an automatic mechanism were it goes through each ivar and checks if the object needs to be deallocated on main or not. We have to add `ASTextKitComponents` to this list of classes now.

There are multiple ways to tackle this issue, this PR just adds the class right into the method that checks for classes who should be deallocated on main. It will have the problem as we check it with a string comparison if we change the name of the ASTextKitComponents we could miss this change in here as well as if we would like to add new classes this can easily hard to maintain.

I will follow up with a PR that is more flexible approach, but it will add some overhead.

Adresses #586