### PR TITLE
Add API for main thread deallocation of classes

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -72,7 +72,7 @@
 		34EFC75B1B701BAF00AD841F /* ASDimension.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED071B17843500DA7C62 /* ASDimension.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		34EFC75C1B701BD200AD841F /* ASDimension.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED081B17843500DA7C62 /* ASDimension.mm */; };
 		34EFC75D1B701BE900AD841F /* ASInternalHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED431B17847A00DA7C62 /* ASInternalHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		34EFC75E1B701BF000AD841F /* ASInternalHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED441B17847A00DA7C62 /* ASInternalHelpers.m */; };
+		34EFC75E1B701BF000AD841F /* ASInternalHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED441B17847A00DA7C62 /* ASInternalHelpers.mm */; };
 		34EFC75F1B701C8600AD841F /* ASInsetLayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED091B17843500DA7C62 /* ASInsetLayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		34EFC7601B701C8B00AD841F /* ASInsetLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED0A1B17843500DA7C62 /* ASInsetLayoutSpec.mm */; };
 		34EFC7611B701C9C00AD841F /* ASBackgroundLayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED011B17843500DA7C62 /* ASBackgroundLayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -157,6 +157,7 @@
 		698DFF471E36B7E9002891F1 /* ASLayoutSpecUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 698DFF461E36B7E9002891F1 /* ASLayoutSpecUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		69B225671D72535E00B25B22 /* ASDisplayNodeLayoutTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69B225661D72535E00B25B22 /* ASDisplayNodeLayoutTests.mm */; };
 		69BCE3D91EC6513B007DCCAD /* ASDisplayNode+Layout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69BCE3D71EC6513B007DCCAD /* ASDisplayNode+Layout.mm */; };
+		69C230D41F7ECC9200B766D5 /* ASLRUCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 69C230D31F7ECC9200B766D5 /* ASLRUCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		69CB62AC1CB8165900024920 /* _ASDisplayViewAccessiblity.h in Headers */ = {isa = PBXBuildFile; fileRef = 69CB62A91CB8165900024920 /* _ASDisplayViewAccessiblity.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		69CB62AE1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69CB62AA1CB8165900024920 /* _ASDisplayViewAccessiblity.mm */; };
 		69E0E8A71D356C9400627613 /* ASEqualityHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 1950C4481A3BB5C1005C8279 /* ASEqualityHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -678,6 +679,7 @@
 		699B83501E3C1BA500433FA4 /* ASLayoutSpecTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASLayoutSpecTests.m; sourceTree = "<group>"; };
 		69B225661D72535E00B25B22 /* ASDisplayNodeLayoutTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASDisplayNodeLayoutTests.mm; sourceTree = "<group>"; };
 		69BCE3D71EC6513B007DCCAD /* ASDisplayNode+Layout.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "ASDisplayNode+Layout.mm"; sourceTree = "<group>"; };
+		69C230D31F7ECC9200B766D5 /* ASLRUCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASLRUCache.h; sourceTree = "<group>"; };
 		69CB62A91CB8165900024920 /* _ASDisplayViewAccessiblity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASDisplayViewAccessiblity.h; sourceTree = "<group>"; };
 		69CB62AA1CB8165900024920 /* _ASDisplayViewAccessiblity.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _ASDisplayViewAccessiblity.mm; sourceTree = "<group>"; };
 		69F10C851C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASRangeControllerUpdateRangeProtocol+Beta.h"; sourceTree = "<group>"; };
@@ -762,7 +764,7 @@
 		ACF6ED181B17843500DA7C62 /* ASAbsoluteLayoutSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASAbsoluteLayoutSpec.h; sourceTree = "<group>"; };
 		ACF6ED191B17843500DA7C62 /* ASAbsoluteLayoutSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASAbsoluteLayoutSpec.mm; sourceTree = "<group>"; };
 		ACF6ED431B17847A00DA7C62 /* ASInternalHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASInternalHelpers.h; sourceTree = "<group>"; };
-		ACF6ED441B17847A00DA7C62 /* ASInternalHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASInternalHelpers.m; sourceTree = "<group>"; };
+		ACF6ED441B17847A00DA7C62 /* ASInternalHelpers.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASInternalHelpers.mm; sourceTree = "<group>"; };
 		ACF6ED531B178DC700DA7C62 /* ASCenterLayoutSpecSnapshotTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASCenterLayoutSpecSnapshotTests.mm; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		ACF6ED541B178DC700DA7C62 /* ASDimensionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASDimensionTests.mm; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		ACF6ED551B178DC700DA7C62 /* ASInsetLayoutSpecSnapshotTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASInsetLayoutSpecSnapshotTests.mm; sourceTree = "<group>"; };
@@ -1276,6 +1278,7 @@
 				05F20AA31A15733C00DCA68A /* ASImageProtocols.h */,
 				4640521D1A3F83C40061C0BA /* ASLayoutController.h */,
 				292C59991A956527007E5DD6 /* ASLayoutRangeType.h */,
+				69C230D31F7ECC9200B766D5 /* ASLRUCache.h */,
 				68EE0DBB1C1B4ED300BA1B99 /* ASMainSerialQueue.h */,
 				68EE0DBC1C1B4ED300BA1B99 /* ASMainSerialQueue.mm */,
 				058D09E8195D050800B7D73C /* ASMutableAttributedStringBuilder.h */,
@@ -1398,7 +1401,7 @@
 				058D0A0D195D050800B7D73C /* ASImageNode+CGExtras.h */,
 				058D0A0E195D050800B7D73C /* ASImageNode+CGExtras.m */,
 				ACF6ED431B17847A00DA7C62 /* ASInternalHelpers.h */,
-				ACF6ED441B17847A00DA7C62 /* ASInternalHelpers.m */,
+				ACF6ED441B17847A00DA7C62 /* ASInternalHelpers.mm */,
 				E52405B41C8FEF16004DC8E7 /* ASLayoutTransition.h */,
 				E52405B21C8FEF03004DC8E7 /* ASLayoutTransition.mm */,
 				0442850B1BAA64EC00D16268 /* ASTwoDimensionalArrayUtils.h */,
@@ -1823,6 +1826,7 @@
 				E5775B021F16759300CAC9BC /* ASCollectionLayoutCache.h in Headers */,
 				E5775B001F13D25400CAC9BC /* ASCollectionLayoutState+Private.h in Headers */,
 				E5667E8C1F33871300FA6FC0 /* _ASCollectionGalleryLayoutInfo.h in Headers */,
+				69C230D41F7ECC9200B766D5 /* ASLRUCache.h in Headers */,
 				E5775AFC1F13CE9F00CAC9BC /* _ASCollectionGalleryLayoutItem.h in Headers */,
 				E5855DF01EBB4D83003639AE /* ASCollectionLayoutDefines.h in Headers */,
 				E5B5B9D11E9BAD9800A6B726 /* ASCollectionLayoutContext+Private.h in Headers */,
@@ -2280,7 +2284,7 @@
 				34EFC7601B701C8B00AD841F /* ASInsetLayoutSpec.mm in Sources */,
 				AC6145441D8AFD4F003D62A2 /* ASSection.m in Sources */,
 				E5775AFE1F13CF7400CAC9BC /* _ASCollectionGalleryLayoutItem.mm in Sources */,
-				34EFC75E1B701BF000AD841F /* ASInternalHelpers.m in Sources */,
+				34EFC75E1B701BF000AD841F /* ASInternalHelpers.mm in Sources */,
 				34EFC7681B701CDE00AD841F /* ASLayout.mm in Sources */,
 				DECBD6EA1BE56E1900CF4905 /* ASButtonNode.mm in Sources */,
 				CCCCCCE01EC3EF060087FE10 /* ASTextRunDelegate.m in Sources */,

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		698371DB1E4379CD00437585 /* ASNodeController+Beta.h in Headers */ = {isa = PBXBuildFile; fileRef = 698371D91E4379CD00437585 /* ASNodeController+Beta.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		698371DC1E4379CD00437585 /* ASNodeController+Beta.m in Sources */ = {isa = PBXBuildFile; fileRef = 698371DA1E4379CD00437585 /* ASNodeController+Beta.m */; };
 		698C8B621CAB49FC0052DC3F /* ASLayoutElementExtensibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 698C8B601CAB49FC0052DC3F /* ASLayoutElementExtensibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		698DCE071F813D5F0048AF49 /* ASRequiringMainThreadDeallocating.h in Headers */ = {isa = PBXBuildFile; fileRef = 698DCE061F813D5F0048AF49 /* ASRequiringMainThreadDeallocating.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		698DFF441E36B6C9002891F1 /* ASStackLayoutSpecUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 698DFF431E36B6C9002891F1 /* ASStackLayoutSpecUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		698DFF471E36B7E9002891F1 /* ASLayoutSpecUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 698DFF461E36B7E9002891F1 /* ASLayoutSpecUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		69B225671D72535E00B25B22 /* ASDisplayNodeLayoutTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69B225661D72535E00B25B22 /* ASDisplayNodeLayoutTests.mm */; };
@@ -674,6 +675,7 @@
 		698371D91E4379CD00437585 /* ASNodeController+Beta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASNodeController+Beta.h"; sourceTree = "<group>"; };
 		698371DA1E4379CD00437585 /* ASNodeController+Beta.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ASNodeController+Beta.m"; sourceTree = "<group>"; };
 		698C8B601CAB49FC0052DC3F /* ASLayoutElementExtensibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayoutElementExtensibility.h; sourceTree = "<group>"; };
+		698DCE061F813D5F0048AF49 /* ASRequiringMainThreadDeallocating.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASRequiringMainThreadDeallocating.h; sourceTree = "<group>"; };
 		698DFF431E36B6C9002891F1 /* ASStackLayoutSpecUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASStackLayoutSpecUtilities.h; sourceTree = "<group>"; };
 		698DFF461E36B7E9002891F1 /* ASLayoutSpecUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayoutSpecUtilities.h; sourceTree = "<group>"; };
 		699B83501E3C1BA500433FA4 /* ASLayoutSpecTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASLayoutSpecTests.m; sourceTree = "<group>"; };
@@ -1242,12 +1244,10 @@
 		058D09E1195D050800B7D73C /* Details */ = {
 			isa = PBXGroup;
 			children = (
-				CC5601391F06E9A700DC4FBE /* ASIntegerMap.h */,
-				CC56013A1F06E9A700DC4FBE /* ASIntegerMap.mm */,
-				CC0F885E1E4280B800576FED /* _ASCollectionViewCell.h */,
-				CC0F885D1E4280B800576FED /* _ASCollectionViewCell.m */,
 				3917EBD21E9C2FC400D04A01 /* _ASCollectionReusableView.h */,
 				3917EBD31E9C2FC400D04A01 /* _ASCollectionReusableView.m */,
+				CC0F885E1E4280B800576FED /* _ASCollectionViewCell.h */,
+				CC0F885D1E4280B800576FED /* _ASCollectionViewCell.m */,
 				058D09E2195D050800B7D73C /* _ASDisplayLayer.h */,
 				058D09E3195D050800B7D73C /* _ASDisplayLayer.mm */,
 				058D09E4195D050800B7D73C /* _ASDisplayView.h */,
@@ -1261,21 +1261,21 @@
 				299DA1A71A828D2900162D41 /* ASBatchContext.h */,
 				299DA1A81A828D2900162D41 /* ASBatchContext.mm */,
 				E5C347B01ECB3D9200EC4BE4 /* ASBatchFetchingDelegate.h */,
-				68C215561DE10D330019C4BC /* ASCollectionViewLayoutInspector.h */,
-				68C215571DE10D330019C4BC /* ASCollectionViewLayoutInspector.m */,
 				205F0E1B1B373A2C007741D0 /* ASCollectionViewLayoutController.h */,
 				205F0E1C1B373A2C007741D0 /* ASCollectionViewLayoutController.m */,
+				68C215561DE10D330019C4BC /* ASCollectionViewLayoutInspector.h */,
+				68C215571DE10D330019C4BC /* ASCollectionViewLayoutInspector.m */,
 				696F01EA1DD2AF450049FBD5 /* ASEventLog.h */,
 				696F01EB1DD2AF450049FBD5 /* ASEventLog.mm */,
 				E5B225271F1790B5001E1431 /* ASHashing.h */,
 				E5B225261F1790B5001E1431 /* ASHashing.m */,
-				4640521B1A3F83C40061C0BA /* ASTableLayoutController.h */,
-				4640521C1A3F83C40061C0BA /* ASTableLayoutController.m */,
 				058D09E6195D050800B7D73C /* ASHighlightOverlayLayer.h */,
 				058D09E7195D050800B7D73C /* ASHighlightOverlayLayer.mm */,
 				68355B371CB57A5A001D4E68 /* ASImageContainerProtocolCategories.h */,
 				68355B381CB57A5A001D4E68 /* ASImageContainerProtocolCategories.m */,
 				05F20AA31A15733C00DCA68A /* ASImageProtocols.h */,
+				CC5601391F06E9A700DC4FBE /* ASIntegerMap.h */,
+				CC56013A1F06E9A700DC4FBE /* ASIntegerMap.mm */,
 				4640521D1A3F83C40061C0BA /* ASLayoutController.h */,
 				292C59991A956527007E5DD6 /* ASLayoutRangeType.h */,
 				69C230D31F7ECC9200B766D5 /* ASLRUCache.h */,
@@ -1292,10 +1292,13 @@
 				055F1A3619ABD413004DAFF1 /* ASRangeController.h */,
 				055F1A3719ABD413004DAFF1 /* ASRangeController.mm */,
 				69F10C851C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h */,
+				698DCE061F813D5F0048AF49 /* ASRequiringMainThreadDeallocating.h */,
 				81EE384D1C8E94F000456208 /* ASRunLoopQueue.h */,
 				81EE384E1C8E94F000456208 /* ASRunLoopQueue.mm */,
 				296A0A311A951715005ACEAA /* ASScrollDirection.h */,
 				205F0E111B371BD7007741D0 /* ASScrollDirection.m */,
+				4640521B1A3F83C40061C0BA /* ASTableLayoutController.h */,
+				4640521C1A3F83C40061C0BA /* ASTableLayoutController.m */,
 				058D0A12195D050800B7D73C /* ASThread.h */,
 				CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */,
 				CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */,
@@ -1305,10 +1308,10 @@
 				68B8A4E01CBDB958007E4543 /* ASWeakProxy.m */,
 				CC3B20871C3F7A5400798563 /* ASWeakSet.h */,
 				CC3B20881C3F7A5400798563 /* ASWeakSet.m */,
+				E5B077EB1E6843AF00C24B5B /* Collection Layout */,
 				205F0E1F1B376416007741D0 /* CoreGraphics+ASConvenience.h */,
 				205F0E201B376416007741D0 /* CoreGraphics+ASConvenience.m */,
 				25B171EA1C12242700508A7A /* Data Controller */,
-				E5B077EB1E6843AF00C24B5B /* Collection Layout */,
 				DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */,
 				DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */,
 				CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */,
@@ -1826,7 +1829,7 @@
 				E5775B021F16759300CAC9BC /* ASCollectionLayoutCache.h in Headers */,
 				E5775B001F13D25400CAC9BC /* ASCollectionLayoutState+Private.h in Headers */,
 				E5667E8C1F33871300FA6FC0 /* _ASCollectionGalleryLayoutInfo.h in Headers */,
-				69C230D41F7ECC9200B766D5 /* ASLRUCache.h in Headers */,
+				698DCE071F813D5F0048AF49 /* ASRequiringMainThreadDeallocating.h in Headers */,
 				E5775AFC1F13CE9F00CAC9BC /* _ASCollectionGalleryLayoutItem.h in Headers */,
 				E5855DF01EBB4D83003639AE /* ASCollectionLayoutDefines.h in Headers */,
 				E5B5B9D11E9BAD9800A6B726 /* ASCollectionLayoutContext+Private.h in Headers */,
@@ -1897,6 +1900,7 @@
 				6900C5F41E8072DA00BCD75C /* ASImageNode+Private.h in Headers */,
 				68B0277B1C1A79D60041016B /* ASDisplayNode+Beta.h in Headers */,
 				B350622D1B010EFD0018CF92 /* ASScrollDirection.h in Headers */,
+				69C230D41F7ECC9200B766D5 /* ASLRUCache.h in Headers */,
 				254C6B751BF94DF4003EC431 /* ASTextKitComponents.h in Headers */,
 				B35062081B010EFD0018CF92 /* ASScrollNode.h in Headers */,
 				CCA282CC1E9EB73E0037E8B7 /* ASTipNode.h in Headers */,

--- a/Source/Details/ASLRUCache.h
+++ b/Source/Details/ASLRUCache.h
@@ -1,0 +1,194 @@
+//
+//  ASLRUCache.h
+//  Texture
+//
+//  Copyright (c) 2017-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <list>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <unordered_map>
+
+namespace ASDN {
+
+/**
+ * LRUCache implements a cache map with an LRU eviction policy.
+ *
+ * It's templated by:
+ *    KeyType - key type
+ *    ValueType - value type
+ *    LockType - a lock type that satisfies the Lockable concept
+ *    MapType - an associative container like std::unordered_map
+ *
+ * Sizing: The max size is the hard limit of keys and (maxSize + elasticity) is the soft limit the cache
+ * is allowed to grow till maxSize + elasticity and is trimmed back to maxSize keys.
+ *
+ * Threading: By default std::mutex is used as LockType what makes it thread safe. Every
+ * LockType that satisfies the Lockable concept is allowed.
+ *
+ */
+template <class KeyType, class ValueType, class LockType = std::mutex,
+          class MapType = std::unordered_map<
+              KeyType, typename std::list<std::pair<KeyType, ValueType>>::iterator>>
+class LRUCache final {
+ public:
+  typedef std::pair<KeyType, ValueType> node_type;
+  typedef std::list<node_type> list_type;
+  typedef MapType map_type;
+  typedef LockType lock_type;
+  using LockGuard = std::lock_guard<lock_type>;
+
+  explicit LRUCache(size_t maxSize = 64, size_t elasticity = 10)
+      : maxSize_(maxSize), elasticity_(elasticity) {}
+  
+  // No moving or copying
+  LRUCache(const LRUCache&) = delete;
+  LRUCache& operator=(const LRUCache&) = delete;
+  LRUCache(LRUCache&&) = delete;
+  LRUCache& operator=(LRUCache&&) = delete;
+  
+  /**
+   * Returns the current size of the Cache
+   */
+  size_t size() const {
+    LockGuard g(lock_);
+    return cache_.size();
+  }
+  
+  /**
+   * Returns if the Cache is empty
+   */
+  bool empty() const {
+    LockGuard g(lock_);
+    return cache_.empty();
+  }
+  
+  /**
+   * Removes all Values from the Cache.
+   */
+  void clear() {
+    LockGuard g(lock_);
+    cache_.clear();
+    keys_.clear();
+  }
+  
+  /**
+   * Insert the given Value for the Key.
+   */
+  void insert(const KeyType& k, const ValueType& v) {
+    LockGuard g(lock_);
+    const auto iter = cache_.find(k);
+    if (iter != cache_.end()) {
+      iter->second->second = v;
+      keys_.splice(keys_.begin(), keys_, iter->second);
+      return;
+    }
+
+    keys_.emplace_front(k, v);
+    cache_[k] = keys_.begin();
+    trim();
+  }
+  
+  /**
+   * Returns Value for the given Key. Throws std::out_of_range exception if the
+   * Value for the given Key was not found
+   */
+  const ValueType& get(const KeyType& k) {
+    LockGuard g(lock_);
+    const auto iter = cache_.find(k);
+    if (iter == cache_.end()) {
+      throw std::out_of_range("key_not_found");
+    }
+    keys_.splice(keys_.begin(), keys_, iter->second);
+    return iter->second->second;
+  }
+  
+  /**
+   * Try to get the Value for the given Key and assigns to vOut parameter. Returns false if Value was not found.
+   */
+  bool try_get(const KeyType& kIn, ValueType& vOut) {
+    LockGuard g(lock_);
+    const auto iter = cache_.find(kIn);
+    if (iter == cache_.end()) {
+      return false;
+    }
+    keys_.splice(keys_.begin(), keys_, iter->second);
+    vOut = iter->second->second;
+    return true;
+  }
+  
+  /**
+   * Remove the Value for the given Key. Returns if removal was succesfull.
+   */
+  bool remove(const KeyType& k) {
+    LockGuard g(lock_);
+    auto iter = cache_.find(k);
+    if (iter == cache_.end()) {
+      return false;
+    }
+    keys_.erase(iter->second);
+    cache_.erase(iter);
+    return true;
+  }
+  
+  /**
+   * Returns if the cache contains a Value for the given Key.
+   */
+  bool contains(const KeyType& k) {
+    LockGuard g(lock_);
+    return cache_.find(k) != cache_.end();
+  }
+
+  /**
+   * Returns the max size for the Cache.
+   */
+  size_t getMaxSize() const { return maxSize_; }
+  
+  /**
+   * Returns the elasticity for the Cache.
+   */
+  size_t getElasticity() const { return elasticity_; }
+
+  /**
+   * Returns the max allowed size based on the maxSize and the elasticity.
+   */
+  size_t getMaxAllowedSize() const { return maxSize_ + elasticity_; }
+
+ protected:
+  /**
+   * Trims the Cache's elements based on the maxSize and the elasticity.
+   */
+  size_t trim() {
+    size_t maxAllowed = maxSize_ + elasticity_;
+    if (maxSize_ == 0 || cache_.size() < maxAllowed) {
+      return 0;
+    }
+    size_t count = 0;
+    while (cache_.size() > maxSize_) {
+      cache_.erase(keys_.back().first);
+      keys_.pop_back();
+      ++count;
+    }
+    return count;
+  }
+
+ private:
+  mutable lock_type lock_;
+  map_type cache_;
+  list_type keys_;
+  size_t maxSize_;
+  size_t elasticity_;
+};
+
+}  // namespace ASDN

--- a/Source/Details/ASRequiringMainThreadDeallocating.h
+++ b/Source/Details/ASRequiringMainThreadDeallocating.h
@@ -1,0 +1,13 @@
+//
+//  ASRequiringMainThreadDeallocating.h
+//  AsyncDisplayKit
+//
+//  Created by Michael Schneider on 10/1/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol ASRequiringMainThreadDeallocating <NSObject>
++ (BOOL)requiresMainThreadDeallocation;
+@end

--- a/Source/Private/ASInternalHelpers.h
+++ b/Source/Private/ASInternalHelpers.h
@@ -54,6 +54,10 @@ CGFloat ASCeilPixelValue(CGFloat f);
 
 CGFloat ASRoundPixelValue(CGFloat f);
 
+@protocol ASRequiringMainThreadDeallocating
++ (BOOL)requiresMainThreadDeallocation;
+@end
+
 BOOL ASClassRequiresMainThreadDeallocation(Class _Nullable c);
 
 Class _Nullable ASGetClassFromType(const char * _Nullable type);

--- a/Source/Private/ASInternalHelpers.h
+++ b/Source/Private/ASInternalHelpers.h
@@ -54,10 +54,6 @@ CGFloat ASCeilPixelValue(CGFloat f);
 
 CGFloat ASRoundPixelValue(CGFloat f);
 
-@protocol ASRequiringMainThreadDeallocating
-+ (BOOL)requiresMainThreadDeallocation;
-@end
-
 BOOL ASClassRequiresMainThreadDeallocation(Class _Nullable c);
 
 Class _Nullable ASGetClassFromType(const char * _Nullable type);

--- a/Source/Private/ASInternalHelpers.mm
+++ b/Source/Private/ASInternalHelpers.mm
@@ -23,6 +23,7 @@
 #import <tgmath.h>
 
 #import <AsyncDisplayKit/ASLRUCache.h>
+#import <AsyncDisplayKit/ASRequiringMainThreadDeallocating.h>
 #import <AsyncDisplayKit/ASRunLoopQueue.h>
 #import <AsyncDisplayKit/ASThread.h>
 

--- a/Source/TextKit/ASTextKitComponents.h
+++ b/Source/TextKit/ASTextKitComponents.h
@@ -17,11 +17,12 @@
 
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 AS_SUBCLASSING_RESTRICTED
-@interface ASTextKitComponents : NSObject
+@interface ASTextKitComponents : NSObject <ASRequiringMainThreadDeallocating>
 
 /**
  @abstract Creates the stack of TextKit components.

--- a/Source/TextKit/ASTextKitComponents.h
+++ b/Source/TextKit/ASTextKitComponents.h
@@ -17,7 +17,7 @@
 
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
-#import <AsyncDisplayKit/ASInternalHelpers.h>
+#import <AsyncDisplayKit/ASRequiringMainThreadDeallocating.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/TextKit/ASTextKitComponents.mm
+++ b/Source/TextKit/ASTextKitComponents.mm
@@ -30,6 +30,11 @@
 
 @implementation ASTextKitComponents
 
++ (BOOL)requiresMainThreadDeallocation
+{
+  return YES;
+}
+
 + (instancetype)componentsWithAttributedSeedString:(NSAttributedString *)attributedSeedString
                                  textContainerSize:(CGSize)textContainerSize
 {


### PR DESCRIPTION
This PR add's a new API to let classes define if objects of that class need to be deallocated on main. Therefore we create the `ASRequiringMainThreadDeallocating` protocol that classes can conform to.

As we add some overhead for checking `conformsToProtocol` as well as `ASClassRequiresMainThreadDeallocation` is a hot path, I added a generic LRUCache to cache main thread deallocation of classes. The LRUCache in general could be handy in other places too as in comparison to NSURLCache it can also have support for primitive types so it could save us boxing / unboxing cost.

It is not ready for merge yet as it needs to be cleanup, but I would like to start a conversation if we would like to go forward with this approach.

TODOs:
- [ ] Move ASRequiringMainThreadDeallocating related code out of `ASInternalHelpers`
- [ ] Decide if we would like to add the LRUCache at all 

Follow up PR to #598
Addresses #586