### PR TITLE
[ASVideoNode] Time observer fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add your own contributions to the next release on the line below this with your name.
+- [ASVideoNode] Fix unreleased time observer. [Flo Vouin](https://github.com/flovouin)
 - [PINCache] Set a default .byteLimit to reduce disk usage and startup time. [#595](https://github.com/TextureGroup/Texture/pull/595) [Scott Goodson](https://github.com/appleguy)
 - [ASNetworkImageNode] Fix deadlock in GIF handling. [#582](https://github.com/TextureGroup/Texture/pull/582) [Garrett Moon](https://github.com/garrettmoon)
 - [ASDisplayNode] Add attributed versions of a11y label, hint and value. [#554](https://github.com/TextureGroup/Texture/pull/554) [Alexander Hüllmandel](https://github.com/fruitcoder)


### PR DESCRIPTION
Hi guys,

I was adding a custom seek bar to a video node, and noticed that when changing the played video, I was still getting `didPlayToTimeInterval` delegate calls for the old video.

You can easily see what I mean in [this sample project](https://github.com/flovouin/Texture-VideoNodeObserver).
The video is reloaded after 2 seconds, and after that, the progress bar goes crazy, switching back and forth between the time info of the two players.
Not releasing the time observer also means that the former video keeps playing in the background, and hence seems to increase CPU consumption (twice the load on my device).

The fix is simple: actually release the time observer when removing the player. Because the observer is linked to the player, I just moved allocation/deallocation of the observer to `addPlayerObservers`/`removePlayerObservers`.

Tell me what you think,
Cheers,

Flo