### PR TITLE
Don't set download results if no longer in preload range.

### DIFF
--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -709,7 +709,12 @@
         
         //Getting a result back for a different download identifier, download must not have been successfully canceled
         if (ASObjectIsEqual(strongSelf->_downloadIdentifier, downloadIdentifier) == NO && downloadIdentifier != nil) {
-            return;
+          return;
+        }
+          
+        //No longer in preload range, no point in setting the results (they won't be cleared in exit preload range)
+        if (ASInterfaceStateIncludesPreload(self->_interfaceState) == NO) {
+          return;
         }
 
         if (imageContainer != nil) {


### PR DESCRIPTION
Good catch by @djblake, if you scroll fast enough, you leave images
set on the image node because didExitPreloadRange (which would have
cleared it) was already called.