### PR TITLE
Update layout2-layoutspec-types.md

### DIFF
--- a/docs/_docs/layout2-layoutspec-types.md
+++ b/docs/_docs/layout2-layoutspec-types.md
@@ -452,7 +452,7 @@ Another use of `ASLayoutSpec` is to be used as a spacer in a `ASStackLayoutSpec`
   ...
   // ASLayoutSpec as spacer
   ASLayoutSpec *spacer = [[ASLayoutSpec alloc] init];
-  spacer.flexGrow = true;
+  spacer.style.flexGrow = true;
 
   stack.children = @[imageNode, spacer, textNode];
   ...


### PR DESCRIPTION
Objective-C code sample was still showing old syntax:
`spacer.flexGrow = true;`
I have updated to new one:
`spacer.style.flexGrow = true;`