### PR TITLE
[ASTextKitComponents] Temporary components can be deallocated off main #trivial

### DIFF
--- a/Source/TextKit/ASTextKitComponents.h
+++ b/Source/TextKit/ASTextKitComponents.h
@@ -59,7 +59,7 @@ AS_SUBCLASSING_RESTRICTED
 @property (nonatomic, strong, readonly) NSTextStorage *textStorage;
 @property (nonatomic, strong, readonly) NSTextContainer *textContainer;
 @property (nonatomic, strong, readonly) NSLayoutManager *layoutManager;
-@property (nullable, nonatomic, strong) UITextView *textView;
+@property (nonatomic, strong, nullable) UITextView *textView;
 
 @end
 

--- a/Source/TextKit/ASTextKitComponents.mm
+++ b/Source/TextKit/ASTextKitComponents.mm
@@ -27,6 +27,9 @@
 @property (nonatomic, strong, readwrite) NSTextContainer *textContainer;
 @property (nonatomic, strong, readwrite) NSLayoutManager *layoutManager;
 
+// Indicates whether or not this object must be deallocated on main thread. Defaults to YES.
+@property (nonatomic, assign) BOOL requiresMainThreadDeallocation;
+
 @end
 
 @implementation ASTextKitComponents
@@ -58,6 +61,8 @@
   components.textContainer.lineFragmentPadding = 0.0; // We want the text laid out up to the very edges of the text-view.
   [components.layoutManager addTextContainer:components.textContainer];
 
+  components.requiresMainThreadDeallocation = YES;
+
   return components;
 }
 
@@ -65,10 +70,13 @@
 
 - (void)dealloc
 {
-  ASDisplayNodeAssertMainThread();
-
-  // Nil out all delegate to prevent crash
-  _textView.delegate = nil;
+  if (_requiresMainThreadDeallocation) {
+    ASDisplayNodeAssertMainThread();
+  }
+  // Nil out all delegates to prevent crash
+  if (_textView) {
+    _textView.delegate = nil;
+  }
   _layoutManager.delegate = nil;
 }
 
@@ -82,6 +90,8 @@
   // Otherwise, we create a temporary stack to size for `constrainedWidth`.
   if (CGRectGetWidth(components.textView.bounds) != constrainedWidth) {
     components = [ASTextKitComponents componentsWithAttributedSeedString:components.textStorage textContainerSize:CGSizeMake(constrainedWidth, CGFLOAT_MAX)];
+    // The temporary stack can be deallocated off main
+    components.requiresMainThreadDeallocation = NO;
   }
 
   // Force glyph generation and layout, which may not have happened yet (and isn't triggered by -usedRectForTextContainer:).
@@ -102,6 +112,8 @@
   
   // Always use temporary stack in case of threading issues
   components = [ASTextKitComponents componentsWithAttributedSeedString:components.textStorage textContainerSize:CGSizeMake(constrainedWidth, CGFLOAT_MAX)];
+  // The temporary stack can be deallocated off main
+  components.requiresMainThreadDeallocation = NO;
   
   // Force glyph generation and layout, which may not have happened yet (and isn't triggered by - usedRectForTextContainer:).
   [components.layoutManager ensureLayoutForTextContainer:components.textContainer];


### PR DESCRIPTION
https://github.com/TextureGroup/Texture/pull/603 unnecessarily triggers assertions when temporary components that are created [here](https://github.com/TextureGroup/Texture/blob/master/Source/TextKit/ASTextKitComponents.mm#L84) and [here](https://github.com/TextureGroup/Texture/blob/master/Source/TextKit/ASTextKitComponents.mm#L104) are deallocated off the main thread. Fix (and close https://github.com/TextureGroup/Texture/issues/607) by not asserting on these objects.