### PR TITLE
[ASTextKitComponents] Make sure Main Thread Checker isn't triggered during background calculations #trivial

### DIFF
--- a/Source/ASEditableTextNode.mm
+++ b/Source/ASEditableTextNode.mm
@@ -215,13 +215,13 @@
   ASDN::MutexLocker l(_textKitLock);
 
   // Create and configure the placeholder text view.
-  _placeholderTextKitComponents.textView = [[UITextView alloc] initWithFrame:CGRectZero textContainer:_placeholderTextKitComponents.textContainer];
+  _placeholderTextKitComponents.textView = [[ASTextKitComponentsTextView alloc] initWithFrame:CGRectZero textContainer:_placeholderTextKitComponents.textContainer];
   _placeholderTextKitComponents.textView.userInteractionEnabled = NO;
   _placeholderTextKitComponents.textView.accessibilityElementsHidden = YES;
   configureTextView(_placeholderTextKitComponents.textView);
 
   // Create and configure our text view.
-  _textKitComponents.textView = [[ASPanningOverriddenUITextView alloc] initWithFrame:CGRectZero textContainer:_textKitComponents.textContainer];
+  _textKitComponents.textView = [[ASTextKitComponentsTextView alloc] initWithFrame:CGRectZero textContainer:_textKitComponents.textContainer];
   _textKitComponents.textView.scrollEnabled = _scrollEnabled;
   _textKitComponents.textView.delegate = self;
   #if TARGET_OS_IOS
@@ -474,8 +474,8 @@
   ASDN::MutexLocker l(_textKitLock);
 
   // Layout filling our bounds.
-  [_textKitComponents setTextViewFrame:self.bounds];
-  [_placeholderTextKitComponents setTextViewFrame:self.bounds];
+  _textKitComponents.textView.frame = self.bounds;
+  _placeholderTextKitComponents.textView.frame = self.bounds;
 
   // Note that both of these won't be necessary once we can disable scrolling, pending rdar://14729288
   // When we resize to fit (above) the prior layout becomes invalid. For whatever reason, UITextView doesn't invalidate its layout when its frame changes on its own, so we have to do so ourselves.

--- a/Source/ASEditableTextNode.mm
+++ b/Source/ASEditableTextNode.mm
@@ -474,8 +474,8 @@
   ASDN::MutexLocker l(_textKitLock);
 
   // Layout filling our bounds.
-  _textKitComponents.textView.frame = self.bounds;
-  _placeholderTextKitComponents.textView.frame = self.bounds;
+  [_textKitComponents setTextViewFrame:self.bounds];
+  [_placeholderTextKitComponents setTextViewFrame:self.bounds];
 
   // Note that both of these won't be necessary once we can disable scrolling, pending rdar://14729288
   // When we resize to fit (above) the prior layout becomes invalid. For whatever reason, UITextView doesn't invalidate its layout when its frame changes on its own, so we have to do so ourselves.

--- a/Source/ASEditableTextNode.mm
+++ b/Source/ASEditableTextNode.mm
@@ -75,7 +75,7 @@
 
  See issue: https://github.com/facebook/AsyncDisplayKit/issues/1063
  */
-@interface ASPanningOverriddenUITextView : UITextView
+@interface ASPanningOverriddenUITextView : ASTextKitComponentsTextView
 {
   BOOL _shouldBlockPanGesture;
 }
@@ -221,7 +221,7 @@
   configureTextView(_placeholderTextKitComponents.textView);
 
   // Create and configure our text view.
-  _textKitComponents.textView = [[ASTextKitComponentsTextView alloc] initWithFrame:CGRectZero textContainer:_textKitComponents.textContainer];
+  _textKitComponents.textView = [[ASPanningOverriddenUITextView alloc] initWithFrame:CGRectZero textContainer:_textKitComponents.textContainer];
   _textKitComponents.textView.scrollEnabled = _scrollEnabled;
   _textKitComponents.textView.delegate = self;
   #if TARGET_OS_IOS

--- a/Source/TextKit/ASTextKitComponents.h
+++ b/Source/TextKit/ASTextKitComponents.h
@@ -21,6 +21,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 AS_SUBCLASSING_RESTRICTED
+@interface ASTextKitComponentsTextView : UITextView
+@end
+
+AS_SUBCLASSING_RESTRICTED
 @interface ASTextKitComponents : NSObject
 
 /**
@@ -64,7 +68,7 @@ AS_SUBCLASSING_RESTRICTED
 @property (nonatomic, strong, readonly) NSTextStorage *textStorage;
 @property (nonatomic, strong, readonly) NSTextContainer *textContainer;
 @property (nonatomic, strong, readonly) NSLayoutManager *layoutManager;
-@property (nonatomic, strong, nullable) UITextView *textView;
+@property (nonatomic, strong, nullable) ASTextKitComponentsTextView *textView;
 
 @end
 

--- a/Source/TextKit/ASTextKitComponents.h
+++ b/Source/TextKit/ASTextKitComponents.h
@@ -59,12 +59,6 @@ AS_SUBCLASSING_RESTRICTED
 - (CGSize)sizeForConstrainedWidth:(CGFloat)constrainedWidth
               forMaxNumberOfLines:(NSInteger)numberOfLines;
 
-/**
- * Set a new frame to the backing text view. Users should use this method instead of setting the frame directly on the view.
- * This method must be called on the main thread.
- */
-- (void)setTextViewFrame:(CGRect)frame;
-
 @property (nonatomic, strong, readonly) NSTextStorage *textStorage;
 @property (nonatomic, strong, readonly) NSTextContainer *textContainer;
 @property (nonatomic, strong, readonly) NSLayoutManager *layoutManager;

--- a/Source/TextKit/ASTextKitComponents.h
+++ b/Source/TextKit/ASTextKitComponents.h
@@ -20,7 +20,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-AS_SUBCLASSING_RESTRICTED
 @interface ASTextKitComponentsTextView : UITextView
 @end
 

--- a/Source/TextKit/ASTextKitComponents.h
+++ b/Source/TextKit/ASTextKitComponents.h
@@ -21,6 +21,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ASTextKitComponentsTextView : UITextView
+- (instancetype)initWithFrame:(CGRect)frame textContainer:(nullable NSTextContainer *)textContainer NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder __unavailable;
+- (instancetype)init __unavailable;
 @end
 
 AS_SUBCLASSING_RESTRICTED

--- a/Source/TextKit/ASTextKitComponents.h
+++ b/Source/TextKit/ASTextKitComponents.h
@@ -52,9 +52,14 @@ AS_SUBCLASSING_RESTRICTED
  */
 - (CGSize)sizeForConstrainedWidth:(CGFloat)constrainedWidth;
 
-
 - (CGSize)sizeForConstrainedWidth:(CGFloat)constrainedWidth
               forMaxNumberOfLines:(NSInteger)numberOfLines;
+
+/**
+ * Set a new frame to the backing text view. Users should use this method instead of setting the frame directly on the view.
+ * This method must be called on the main thread.
+ */
+- (void)setTextViewFrame:(CGRect)frame;
 
 @property (nonatomic, strong, readonly) NSTextStorage *textStorage;
 @property (nonatomic, strong, readonly) NSTextContainer *textContainer;

--- a/Source/TextKit/ASTextKitComponents.mm
+++ b/Source/TextKit/ASTextKitComponents.mm
@@ -17,18 +17,14 @@
 
 #import <AsyncDisplayKit/ASTextKitComponents.h>
 #import <AsyncDisplayKit/ASAssert.h>
-#import <AsyncDisplayKit/ASThread.h>
 
 #import <tgmath.h>
 
 @interface ASTextKitComponentsTextView ()
-@property (nonatomic, assign) CGRect threadSafeBounds;
+@property (atomic, assign) CGRect threadSafeBounds;
 @end
 
 @implementation ASTextKitComponentsTextView
-{
-  ASDN::Mutex __instanceLock__;
-}
 
 @synthesize threadSafeBounds = _threadSafeBounds;
 
@@ -53,18 +49,6 @@
   ASDisplayNodeAssertMainThread();
   [super setBounds:bounds];
   self.threadSafeBounds = bounds;
-}
-
-- (void)setThreadSafeBounds:(CGRect)bounds
-{
-  ASDN::MutexLocker l(__instanceLock__);
-  _threadSafeBounds = bounds;
-}
-
-- (CGRect)threadSafeBounds
-{
-  ASDN::MutexLocker l(__instanceLock__);
-  return _threadSafeBounds;
 }
 
 @end

--- a/Source/TextKit/ASTextKitComponents.mm
+++ b/Source/TextKit/ASTextKitComponents.mm
@@ -26,8 +26,6 @@
 
 @implementation ASTextKitComponentsTextView
 
-@synthesize threadSafeBounds = _threadSafeBounds;
-
 - (instancetype)initWithFrame:(CGRect)frame textContainer:(NSTextContainer *)textContainer
 {
   self = [super initWithFrame:frame textContainer:textContainer];

--- a/Source/TextKit/ASTextKitComponents.mm
+++ b/Source/TextKit/ASTextKitComponents.mm
@@ -41,15 +41,6 @@
   return self;
 }
 
-- (instancetype)initWithCoder:(NSCoder *)aDecoder
-{
-  self = [super initWithCoder:aDecoder];
-  if (self) {
-    _threadSafeBounds = self.bounds;
-  }
-  return self;
-}
-
 - (void)setFrame:(CGRect)frame
 {
   ASDisplayNodeAssertMainThread();

--- a/Source/TextKit/ASTextKitComponents.mm
+++ b/Source/TextKit/ASTextKitComponents.mm
@@ -52,7 +52,7 @@
 {
   ASDisplayNodeAssertMainThread();
   [super setBounds:bounds];
-  self.threadSafeBounds = self.bounds;
+  self.threadSafeBounds = bounds;
 }
 
 - (void)setThreadSafeBounds:(CGRect)bounds

--- a/Tests/ASTextKitTests.mm
+++ b/Tests/ASTextKitTests.mm
@@ -20,10 +20,13 @@
 
 #import <FBSnapshotTestCase/FBSnapshotTestController.h>
 
-#import <AsyncDisplayKit/ASTextKitEntityAttribute.h>
 #import <AsyncDisplayKit/ASTextKitAttributes.h>
+#import <AsyncDisplayKit/ASTextKitComponents.h>
+#import <AsyncDisplayKit/ASTextKitEntityAttribute.h>
 #import <AsyncDisplayKit/ASTextKitRenderer.h>
 #import <AsyncDisplayKit/ASTextKitRenderer+Positioning.h>
+
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 
 @interface ASTextKitTests : XCTestCase
 
@@ -199,6 +202,29 @@ static BOOL checkAttributes(const ASTextKitAttributes &attributes, const CGSize 
    }
    constrainedSize:{ 100, 100 }];
   XCTAssert([renderer rectsForTextRange:NSMakeRange(0, attributedString.length) measureOption:ASTextKitRendererMeasureOptionBlock].count > 0);
+}
+
+- (void)testTextKitComponentsCanCalculateSizeInBackground
+{
+  NSAttributedString *attributedString =
+  [[NSAttributedString alloc]
+   initWithString:@"90's cray photo booth tote bag bespoke Carles. Plaid wayfarers Odd Future master cleanse tattooed four dollar toast small batch kale chips leggings meh photo booth occupy irony.  " attributes:@{ASTextKitEntityAttributeName : [[ASTextKitEntityAttribute alloc] initWithEntity:@"entity"]}];
+  ASTextKitComponents *components = [ASTextKitComponents componentsWithAttributedSeedString:attributedString textContainerSize:CGSizeZero];
+  components.textView = [[UITextView alloc] initWithFrame:CGRectMake(0, 0, 20, 100) textContainer:components.textContainer];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Components deallocated in background"];
+  
+  ASPerformBlockOnBackgroundThread(^{
+    // Use an autorelease pool here to ensure temporary components are (and can be) released in background
+    @autoreleasepool {
+      [components sizeForConstrainedWidth:100];
+      [components sizeForConstrainedWidth:50 forMaxNumberOfLines:5];
+    }
+
+    [expectation fulfill];
+  });
+
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 @end

--- a/Tests/ASTextKitTests.mm
+++ b/Tests/ASTextKitTests.mm
@@ -210,7 +210,8 @@ static BOOL checkAttributes(const ASTextKitAttributes &attributes, const CGSize 
   [[NSAttributedString alloc]
    initWithString:@"90's cray photo booth tote bag bespoke Carles. Plaid wayfarers Odd Future master cleanse tattooed four dollar toast small batch kale chips leggings meh photo booth occupy irony.  " attributes:@{ASTextKitEntityAttributeName : [[ASTextKitEntityAttribute alloc] initWithEntity:@"entity"]}];
   ASTextKitComponents *components = [ASTextKitComponents componentsWithAttributedSeedString:attributedString textContainerSize:CGSizeZero];
-  components.textView = [[UITextView alloc] initWithFrame:CGRectMake(0, 0, 20, 100) textContainer:components.textContainer];
+  components.textView = [[ASTextKitComponentsTextView alloc] initWithFrame:CGRectZero textContainer:components.textContainer];
+  components.textView.frame = CGRectMake(0, 0, 20, 1000);
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Components deallocated in background"];
   


### PR DESCRIPTION
Currently the checker is triggered either when the components need to get the backing text view's bounds, or when the text view's delegate is cleared out during deallocation.

In the first case, I add a new subclass of UITextView that has a thread-safe bounds property and is used exclusively by ASTextKitComponents.

The second case is handled in #598. However, a new main thread assertion added in #603 causes background deallocations of temporary components to fail. #610 attempts to fix that, but since temporary components don't have a reference to a text view, it's fine to avoid the assertion altogether. 