### PR TITLE
update Pinterest CDN URL in example code

### DIFF
--- a/examples/AnimatedGIF/ASAnimatedImage/ViewController.m
+++ b/examples/AnimatedGIF/ASAnimatedImage/ViewController.m
@@ -30,7 +30,7 @@
   // Do any additional setup after loading the view, typically from a nib.
   
   ASNetworkImageNode *imageNode = [[ASNetworkImageNode alloc] init];
-  imageNode.URL = [NSURL URLWithString:@"https://s-media-cache-ak0.pinimg.com/originals/07/44/38/074438e7c75034df2dcf37ba1057803e.gif"];
+  imageNode.URL = [NSURL URLWithString:@"https://i.pinimg.com/originals/07/44/38/074438e7c75034df2dcf37ba1057803e.gif"];
   // Uncomment to see animated webp support
   //  imageNode.URL = [NSURL URLWithString:@"https://storage.googleapis.com/downloads.webmproject.org/webp/images/dancing_banana2.lossless.webp"];
   imageNode.frame = self.view.bounds;


### PR DESCRIPTION
Pinterest is deprecating \*media-cache-\* URLs. s-media-cache-ak0.pinimg.com 301's to i.pinimg.com.
```
➜  curl -svo /dev/null https://s-media-cache-ak0.pinimg.com/originals/07/44/38/074438e7c75034df2dcf37ba1057803e.gif 2>&1 | grep "< "
< HTTP/1.1 301 Moved Permanently
< Location: https://i.pinimg.com/originals/07/44/38/074438e7c75034df2dcf37ba1057803e.gif
...
```