### PR TITLE
Enable tvOS support

### DIFF
--- a/Texture.podspec
+++ b/Texture.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
 
   spec.ios.deployment_target = '8.0'
 
-  #spec.tvos.deployment_target = '9.0'
+  spec.tvos.deployment_target = '9.0'
 
   # Subspecs
   spec.subspec 'Core' do |core|

--- a/Texture.podspec
+++ b/Texture.podspec
@@ -16,8 +16,7 @@ Pod::Spec.new do |spec|
 
   spec.ios.deployment_target = '8.0'
 
-  # Uncomment when fixed: issues with tvOS build for release 2.0
-  # spec.tvos.deployment_target = '9.0'
+  #spec.tvos.deployment_target = '9.0'
 
   # Subspecs
   spec.subspec 'Core' do |core|


### PR DESCRIPTION
Hello!

I re-enabled tvOS support which was disabled [by this commit](https://github.com/facebookarchive/AsyncDisplayKit/commit/2032cffd907d1740ebfc320f4e784b91d9938b66#diff-e275548079d7a46e0233837c70dfb71e).

At this moment everything works fine locally, but if there are some more details i need to know, please let me know. We have the project which needs tvOS support, so i'm ready to take this part over and fix everything.