### PR TITLE
Fix bug that breaks ASNodeController docs page

### DIFF
--- a/docs/_docs/containers-asnodecontroller.md
+++ b/docs/_docs/containers-asnodecontroller.md
@@ -60,7 +60,7 @@ All of this logic can be removed from where it previously existed in the "view" 
   </pre>
 
   <pre lang="swift" class = "swiftCode hidden">
-final class PhotoCellNodeController: ASNodeController<PhotoCellNode> {
+final class PhotoCellNodeController: ASNodeController&lt;PhotoCellNode&gt; {
     
   override func loadNode() {
     self.node = PhotoCellNode(photoObject: photoModel)


### PR DESCRIPTION
When Obj-C is selected on this page, the bottom half of the documentation is missing. When Swift is selected, malformed content appears where the documentation and subsequent code blocks are nested inside the first code block.

Repro'd here in Safari and Chrome: http://texturegroup.org/docs/containers-asnodecontroller.html

I think the bug is that &lt;PhotoCellNode&gt; is being parsed as an HTML tag, and this should fix it.