### PR TITLE
Revert Adds support for specifying a quality indexed array of URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
+- [ASNetworkImageNode] Deprecates .URLs in favor of .URL [Garrett Moon](https://github.com/garrettmoon) [#699](https://github.com/TextureGroup/Texture/pull/699)
 - [iOS11] Update project settings and fix errors [Eke](https://github.com/Eke)  [#676](https://github.com/TextureGroup/Texture/pull/676)
 - [ASCollectionView] Improve performance and behavior of rotation / bounds changes. [Scott Goodson](https://github.com/appleguy) [#431](https://github.com/TextureGroup/Texture/pull/431)
 - [ASCollectionView] Improve index space translation of Flow Layout Delegate methods. [Scott Goodson](https://github.com/appleguy)

--- a/Source/ASNetworkImageNode.h
+++ b/Source/ASNetworkImageNode.h
@@ -83,13 +83,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, strong, readwrite) NSURL *URL;
 
 /**
- * An array of URLs of increasing cost to download.
- *
- * @discussion By setting an array of URLs, the image property of this node will be managed internally. This means previously
- * directly set images to the image property will be cleared out and replaced by the placeholder (<defaultImage>) image
- * while loading and the final image after the new image data was downloaded and processed.
- */
-@property (nullable, nonatomic, strong, readwrite) NSArray <NSURL *> *URLs;
+  * An array of URLs of increasing cost to download.
+  *
+  * @discussion By setting an array of URLs, the image property of this node will be managed internally. This means previously
+  * directly set images to the image property will be cleared out and replaced by the placeholder (<defaultImage>) image
+  * while loading and the final image after the new image data was downloaded and processed.
+  *
+  * @deprecated This API has been removed for now due to the increased complexity to the class that it brought.
+  * Please use .URL instead.
+  */
+@property (nullable, nonatomic, strong, readwrite) NSArray <NSURL *> *URLs ASDISPLAYNODE_DEPRECATED_MSG("Please use URL instead.");
 
 /**
  * Download and display a new image.

--- a/Source/Details/ASImageProtocols.h
+++ b/Source/Details/ASImageProtocols.h
@@ -37,7 +37,7 @@ typedef void(^ASImageCacherCompletion)(id <ASImageContainerProtocol> _Nullable i
  @param URL The URL of the image to retrieve from the cache.
  @param callbackQueue The queue to call `completion` on.
  @param completion The block to be called when the cache has either hit or missed.
- @discussion If `URL` is nil, `completion` should be invoked immediately with a nil image. This method should not block
+ @discussion If `URL` is nil, `completion` will be invoked immediately with a nil image. This method should not block
  the calling thread as it is likely to be called from the main thread.
  */
 - (void)cachedImageWithURL:(NSURL *)URL
@@ -65,19 +65,6 @@ typedef void(^ASImageCacherCompletion)(id <ASImageContainerProtocol> _Nullable i
  if you have a memory and disk cache in which case you'll likely want to clear out the memory cache.
  */
 - (void)clearFetchedImageFromCacheWithURL:(NSURL *)URL;
-
-/**
- @abstract Attempts to fetch an image with the given URLs from the cache in reverse order.
- @param URLs The URLs of the image to retrieve from the cache.
- @param callbackQueue The queue to call `completion` on.
- @param completion The block to be called when the cache has either hit or missed.
- @discussion If `URLs` is nil or empty, `completion` should be invoked immediately with a nil image. This method should not block
- the calling thread as it is likely to be called from the main thread.
- @see downloadImageWithURLs:callbackQueue:downloadProgress:completion:
- */
-- (void)cachedImageWithURLs:(NSArray <NSURL *> *)URLs
-              callbackQueue:(dispatch_queue_t)callbackQueue
-                 completion:(ASImageCacherCompletion)completion;
 
 @end
 
@@ -166,21 +153,6 @@ typedef NS_ENUM(NSUInteger, ASImageDownloaderPriority) {
  */
 - (void)setPriority:(ASImageDownloaderPriority)priority
 withDownloadIdentifier:(id)downloadIdentifier;
-
-/**
- @abstract Downloads an image from a list of URLs depending on previously observed network speed conditions.
- @param URLs An array of URLs ordered by the cost of downloading them, the URL at index 0 being the lowest cost.
- @param callbackQueue The queue to call `downloadProgressBlock` and `completion` on.
- @param downloadProgress The block to be invoked when the download of `URL` progresses.
- @param completion The block to be invoked when the download has completed, or has failed.
- @discussion This method is likely to be called on the main thread, so any custom implementations should make sure to background any expensive download operations.
- @result An opaque identifier to be used in canceling the download, via `cancelImageDownloadForIdentifier:`. You must
- retain the identifier if you wish to use it later.
- */
-- (nullable id)downloadImageWithURLs:(NSArray <NSURL *> *)URLs
-                       callbackQueue:(dispatch_queue_t)callbackQueue
-                    downloadProgress:(nullable ASImageDownloaderProgress)downloadProgress
-                          completion:(ASImageDownloaderCompletion)completion;
 
 @end
 

--- a/Source/Details/ASPINRemoteImageDownloader.m
+++ b/Source/Details/ASPINRemoteImageDownloader.m
@@ -209,23 +209,6 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
   }];
 }
 
-- (void)cachedImageWithURLs:(NSArray <NSURL *> *)URLs
-              callbackQueue:(dispatch_queue_t)callbackQueue
-                 completion:(ASImageCacherCompletion)completion
-{
-  [self cachedImageWithURL:[URLs lastObject]
-             callbackQueue:callbackQueue
-                completion:^(id<ASImageContainerProtocol>  _Nullable imageFromCache) {
-                  if (imageFromCache.asdk_image == nil && URLs.count > 1) {
-                    [self cachedImageWithURLs:[URLs subarrayWithRange:NSMakeRange(0, URLs.count - 1)]
-                                callbackQueue:callbackQueue
-                                   completion:completion];
-                  } else {
-                    completion(imageFromCache);
-                  }
-                }];
-}
-
 - (void)clearFetchedImageFromCacheWithURL:(NSURL *)URL
 {
   if ([self sharedImageManagerSupportsMemoryRemoval]) {
@@ -239,18 +222,6 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
                       callbackQueue:(dispatch_queue_t)callbackQueue
                    downloadProgress:(ASImageDownloaderProgress)downloadProgress
                          completion:(ASImageDownloaderCompletion)completion;
-{
-    NSArray <NSURL *>*URLs = nil;
-    if (URL) {
-        URLs = @[URL];
-    }
-    return [self downloadImageWithURLs:URLs callbackQueue:callbackQueue downloadProgress:downloadProgress completion:completion];
-}
-
-- (nullable id)downloadImageWithURLs:(NSArray <NSURL *> *)URLs
-                       callbackQueue:(dispatch_queue_t)callbackQueue
-                    downloadProgress:(nullable ASImageDownloaderProgress)downloadProgress
-                          completion:(ASImageDownloaderCompletion)completion
 {
   PINRemoteImageManagerProgressDownload progressDownload = ^(int64_t completedBytes, int64_t totalBytes) {
     if (downloadProgress == nil) { return; }
@@ -279,11 +250,11 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
   // extra downloads isn't worth the effort of rechecking caches every single time. In order to provide
   // feedback to the consumer about whether images are cached, we can't simply make the cache a no-op and
   // check the cache as part of this download.
-  return [[self sharedPINRemoteImageManager] downloadImageWithURLs:URLs
-                                                           options:PINRemoteImageManagerDownloadOptionsSkipDecode | PINRemoteImageManagerDownloadOptionsIgnoreCache
-                                                     progressImage:nil
-                                                  progressDownload:progressDownload
-                                                        completion:imageCompletion];
+  return [[self sharedPINRemoteImageManager] downloadImageWithURL:URL
+                                                          options:PINRemoteImageManagerDownloadOptionsSkipDecode | PINRemoteImageManagerDownloadOptionsIgnoreCache
+                                                    progressImage:nil
+                                                 progressDownload:progressDownload
+                                                       completion:imageCompletion];
 }
 
 - (void)cancelImageDownloadForIdentifier:(id)downloadIdentifier


### PR DESCRIPTION
#557 
This reverts commit 3c77d4a5da44c46c7b80b2a627c95389b7d6352d.

This removes support for specifying multiple URLs on an ASNetworkImageNode. We decided to remove this for now because of the added complexity and the confusion between this and ASMultiplexImageNode.

This functionality may return at some point in another form.