### PR TITLE
fix bug for ASVideoPlayNode

### DIFF
--- a/Source/ASVideoPlayerNode.mm
+++ b/Source/ASVideoPlayerNode.mm
@@ -499,7 +499,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
     [_delegate videoPlayerNode:self willChangeVideoNodeState:state toVideoNodeState:toState];
   }
 
-  if (toState == ASVideoNodePlayerStateReadyToPlay) {
+  if (toState == ASVideoNodePlayerStateReadyToPlay || toState == ASVideoNodePlayerStatePlaying) {
     _duration = _videoNode.currentItem.duration;
     [self updateDurationTimeLabel];
   }


### PR DESCRIPTION
fix bug.ASVideoNodePlayerStateReadyToPlay always called before ASVideoNodePlayerStateReadyToPlay when autoplay。cause duration and timelable couldn't update.