### PR TITLE
[ASCollectionElement] Check for nil elements on ASTableView as well.

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -1174,7 +1174,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   ASCellNode *cellNode = element.node;
   cellNode.scrollView = collectionView;
 
-  // Update the selected background view in collectionView:willDisplayCell:forItemAtIndexPath: otherwise it could be to
+  // Update the selected background view in collectionView:willDisplayCell:forItemAtIndexPath: otherwise it could be too
   // early e.g. if the selectedBackgroundView was set in didLoad()
   cell.selectedBackgroundView = cellNode.selectedBackgroundView;
   


### PR DESCRIPTION
This protects `ASTableView`'s `willDisplayCell:forRowAtIndexPath:` and `didEndDisplayingCell:forRowAtIndexPath:` against nil elements, matching the behaviour added to `ASCollectionView` on #421. Should fix the crash reported in #709.

I also added `consumesCellNodeVisibilityEvents` to `_ASTableViewCell`, again to resemble the implementation of its counterpart `_ASCollectionViewCell`.

Any feedback is very much welcome.