### PR TITLE
Add support for toggling logs off and back on at runtime

### DIFF
--- a/Source/Base/ASLog.h
+++ b/Source/Base/ASLog.h
@@ -42,6 +42,16 @@ ASDISPLAYNODE_EXTERN_C_BEGIN
  */
 void ASDisableLogging(void);
 
+/**
+ * Restore logging that has been runtime-disabled via ASDisableLogging().
+ *
+ * Logging can be disabled at runtime using the ASDisableLogging() function.
+ * This command restores logging to the level provided in the build
+ * configuration. This can be used in conjunction with ASDisableLogging()
+ * to allow logging to be toggled off and back on at runtime.
+ */
+void ASEnableLogging(void);
+
 /// Log for general node events e.g. interfaceState, didLoad.
 #define ASNodeLogEnabled 1
 os_log_t ASNodeLog(void);

--- a/Source/Base/ASLog.m
+++ b/Source/Base/ASLog.m
@@ -16,10 +16,11 @@
 static atomic_bool __ASLogEnabled = ATOMIC_VAR_INIT(YES);
 
 void ASDisableLogging() {
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    atomic_store(&__ASLogEnabled, NO);
-  });
+  atomic_store(&__ASLogEnabled, NO);
+}
+
+void ASEnableLogging() {
+  atomic_store(&__ASLogEnabled, YES);
 }
 
 ASDISPLAYNODE_INLINE BOOL ASLoggingIsEnabled() {


### PR DESCRIPTION
PR #528 (and related issue #524) provided a mechanism to disable logs at runtime. In most of my apps, I like to expose a menu in debug builds which allows me to toggle logs of certain types on/off at runtime. 

This PR adds an `ASEnableLogging()` function which parallels the existing `ASDisableLogging()`, so that logs can be toggled, rather than only disabled.