### PR TITLE
#trivial Fixes image nodes being stuck not being able to download image

### DIFF
--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -699,6 +699,7 @@
           //No longer in preload range, no point in setting the results (they won't be cleared in exit preload range)
           if (ASInterfaceStateIncludesPreload(self->_interfaceState) == NO) {
             self->_downloadIdentifier = nil;
+            self->_cacheUUID = nil;
             return;
           }
           

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -698,6 +698,7 @@
           
           //No longer in preload range, no point in setting the results (they won't be cleared in exit preload range)
           if (ASInterfaceStateIncludesPreload(self->_interfaceState) == NO) {
+            self->_downloadIdentifier = nil;
             return;
           }
           


### PR DESCRIPTION
Without this, the image node will not attempt to refetch the image when it enters the preload range again later.