### PR TITLE
[Waiting for 3.0] Remove deprecated APIs in table node protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [ASScrollNode] Invalidate the node's calculated layout if its scrollable directions changed. Also add unit tests for the class. [#637](https://github.com/TextureGroup/Texture/pull/637) [Huy Nguyen](https://github.com/nguyenhuy)
 - Add new unit testing to the layout engine. [Adlai Holler](https://github.com/Adlai-Holler) [#424](https://github.com/TextureGroup/Texture/pull/424)
 - [Automatic Subnode Management] Nodes with ASM enabled now insert/delete their subnodes as soon as they enter preload state, so the subnodes can preload too. [Huy Nguyen](https://github.com/nguyenhuy) [#706](https://github.com/TextureGroup/Texture/pull/706)
+- [API CHANGES] Remove deprecated APIs in table node protocols [Huy Nguyen](https://github.com/nguyenhuy) [#724](https://github.com/TextureGroup/Texture/pull/724)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -489,6 +489,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol ASTableDataSource <ASCommonTableDataSource, NSObject>
 
+/**
+ * Asks the data source for the number of rows in the given section of the table node.
+ *
+ * @see @c numberOfSectionsInTableView:
+ */
+- (NSInteger)tableNode:(ASTableNode *)tableNode numberOfRowsInSection:(NSInteger)section;
+
 @optional
 
 /**
@@ -497,13 +504,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @see @c numberOfSectionsInTableView:
  */
 - (NSInteger)numberOfSectionsInTableNode:(ASTableNode *)tableNode;
-
-/**
- * Asks the data source for the number of rows in the given section of the table node.
- *
- * @see @c numberOfSectionsInTableView:
- */
-- (NSInteger)tableNode:(ASTableNode *)tableNode numberOfRowsInSection:(NSInteger)section;
 
 /**
  * Asks the data source for a block to create a node to represent the row at the given index path.

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -533,18 +533,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (ASCellNode *)tableNode:(ASTableNode *)tableNode nodeForRowAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
- * Similar to -tableView:cellForRowAtIndexPath:.
- *
- * @param tableView The sender.
- *
- * @param indexPath The index path of the requested node.
- *
- * @return a node for display at this indexpath. This will be called on the main thread and should not implement reuse (it will be called once per row). Unlike UITableView's version, this method
- * is not called when the row is about to display.
- */
-- (ASCellNode *)tableView:(ASTableView *)tableView nodeForRowAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode's method instead.");
-
-/**
  * Similar to -tableView:nodeForRowAtIndexPath:
  * This method takes precedence over tableView:nodeForRowAtIndexPath: if implemented.
  * @param tableView The sender.

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -533,19 +533,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (ASCellNode *)tableNode:(ASTableNode *)tableNode nodeForRowAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
- * Similar to -tableView:nodeForRowAtIndexPath:
- * This method takes precedence over tableView:nodeForRowAtIndexPath: if implemented.
- * @param tableView The sender.
- *
- * @param indexPath The index path of the requested node.
- *
- * @return a block that creates the node for display at this indexpath.
- *   Must be thread-safe (can be called on the main thread or a background
- *   queue) and should not implement reuse (it will be called once per row).
- */
-- (ASCellNodeBlock)tableView:(ASTableView *)tableView nodeBlockForRowAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode's method instead.");
-
-/**
  * Indicator to lock the data source for data fetching in async mode.
  * We should not update the data source until the data source has been unlocked. Otherwise, it will incur data inconsistency or exception
  * due to the data access in async mode.

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -604,20 +604,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)shouldBatchFetchForTableNode:(ASTableNode *)tableNode;
 
 /**
- * Informs the delegate that the table view will add the given node
- * at the given index path to the view hierarchy.
- *
- * @param tableView The sender.
- * @param node The node that will be displayed.
- * @param indexPath The index path of the row that will be displayed.
- *
- * @warning AsyncDisplayKit processes table view edits asynchronously. The index path
- *   passed into this method may not correspond to the same item in your data source
- *   if your data source has been updated since the last edit was processed.
- */
-- (void)tableView:(ASTableView *)tableView willDisplayNode:(ASCellNode *)node forRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode's method instead.");
-
-/**
  * Informs the delegate that the table view did remove the provided node from the view hierarchy.
  * This may be caused by the node scrolling out of view, or by deleting the row
  * or its containing section with @c deleteRowsAtIndexPaths:withRowAnimation: or @c deleteSections:withRowAnimation: .

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -604,21 +604,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)shouldBatchFetchForTableNode:(ASTableNode *)tableNode;
 
 /**
- * Informs the delegate that the table view did remove the provided node from the view hierarchy.
- * This may be caused by the node scrolling out of view, or by deleting the row
- * or its containing section with @c deleteRowsAtIndexPaths:withRowAnimation: or @c deleteSections:withRowAnimation: .
- *
- * @param tableView The sender.
- * @param node The node which was removed from the view hierarchy.
- * @param indexPath The index path at which the node was located before the removal.
- *
- * @warning AsyncDisplayKit processes table view edits asynchronously. The index path
- *   passed into this method may not correspond to the same item in your data source
- *   if your data source has been updated since the last edit was processed.
- */
-- (void)tableView:(ASTableView *)tableView didEndDisplayingNode:(ASCellNode *)node forRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode's method instead.");
-
-/**
  * Receive a message that the tableView is near the end of its data set and more data should be fetched if necessary.
  *
  * @param tableView The sender.

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -604,33 +604,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)shouldBatchFetchForTableNode:(ASTableNode *)tableNode;
 
 /**
- * Receive a message that the tableView is near the end of its data set and more data should be fetched if necessary.
- *
- * @param tableView The sender.
- * @param context A context object that must be notified when the batch fetch is completed.
- *
- * @discussion You must eventually call -completeBatchFetching: with an argument of YES in order to receive future
- * notifications to do batch fetches. This method is called on a background queue.
- *
- * ASTableView currently only supports batch events for tail loads. If you require a head load, consider implementing a
- * UIRefreshControl.
- */
-- (void)tableView:(ASTableView *)tableView willBeginBatchFetchWithContext:(ASBatchContext *)context ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode's method instead.");
-
-/**
- * Tell the tableView if batch fetching should begin.
- *
- * @param tableView The sender.
- *
- * @discussion Use this method to conditionally fetch batches. Example use cases are: limiting the total number of
- * objects that can be fetched or no network connection.
- *
- * If not implemented, the tableView assumes that it should notify its asyncDelegate when batch fetching
- * should occur.
- */
-- (BOOL)shouldBatchFetchForTableView:(ASTableView *)tableView AS_WARN_UNUSED_RESULT ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode's method instead.");
-
-/**
  * Provides the constrained size range for measuring the row at the index path.
  * Note: the widths in the returned size range are ignored!
  *

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -532,16 +532,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (ASCellNode *)tableNode:(ASTableNode *)tableNode nodeForRowAtIndexPath:(NSIndexPath *)indexPath;
 
-/**
- * Indicator to unlock the data source for data fetching in asyn mode.
- * We should not update the data source until the data source has been unlocked. Otherwise, it will incur data inconsistency or exception
- * due to the data access in async mode.
- *
- * @param tableView The sender.
- * @deprecated The data source is always accessed on the main thread, and this method will not be called.
- */
-- (void)tableViewUnlockDataSource:(ASTableView *)tableView ASDISPLAYNODE_DEPRECATED_MSG("Data source accesses are on the main thread. Method will not be called.");
-
 @end
 
 /**

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -533,16 +533,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (ASCellNode *)tableNode:(ASTableNode *)tableNode nodeForRowAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
- * Indicator to lock the data source for data fetching in async mode.
- * We should not update the data source until the data source has been unlocked. Otherwise, it will incur data inconsistency or exception
- * due to the data access in async mode.
- *
- * @param tableView The sender.
- * @deprecated The data source is always accessed on the main thread, and this method will not be called.
- */
-- (void)tableViewLockDataSource:(ASTableView *)tableView ASDISPLAYNODE_DEPRECATED_MSG("Data source accesses are on the main thread. Method will not be called.");
-
-/**
  * Indicator to unlock the data source for data fetching in asyn mode.
  * We should not update the data source until the data source has been unlocked. Otherwise, it will incur data inconsistency or exception
  * due to the data access in async mode.

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -604,18 +604,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)shouldBatchFetchForTableNode:(ASTableNode *)tableNode;
 
 /**
- * Provides the constrained size range for measuring the row at the index path.
- * Note: the widths in the returned size range are ignored!
- *
- * @param tableView The sender.
- *
- * @param indexPath The index path of the node.
- *
- * @return A constrained size range for layout the node at this index path.
- */
-- (ASSizeRange)tableView:(ASTableView *)tableView constrainedSizeForRowAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode's method instead.");
-
-/**
  * Informs the delegate that the table view will add the node
  * at the given index path to the view hierarchy.
  *

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -603,21 +603,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)shouldBatchFetchForTableNode:(ASTableNode *)tableNode;
 
-/**
- * Informs the delegate that the table view will add the node
- * at the given index path to the view hierarchy.
- *
- * @param tableView The sender.
- * @param indexPath The index path of the row that will be displayed.
- *
- * @warning AsyncDisplayKit processes table view edits asynchronously. The index path
- *   passed into this method may not correspond to the same item in your data source
- *   if your data source has been updated since the last edit was processed.
- *
- * This method is deprecated. Use @c tableView:willDisplayNode:forRowAtIndexPath: instead.
- */
-- (void)tableView:(ASTableView *)tableView willDisplayNodeForRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode's method instead.");
-
 @end
 
 @interface ASTableNode (Deprecated)

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -501,7 +501,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Asks the data source for the number of sections in the table node.
  *
- * @see @c numberOfSectionsInTableView:
+ * @param tableNode The table node requesting this information
+ *
+ * @return the number of sections in the table node.
+ *
+ * @discussion If this method is not implemented, the table node uses a default value of 1.
  */
 - (NSInteger)numberOfSectionsInTableNode:(ASTableNode *)tableNode;
 

--- a/Source/ASTableView.h
+++ b/Source/ASTableView.h
@@ -242,12 +242,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-ASDISPLAYNODE_DEPRECATED_MSG("Renamed to ASTableDataSource.")
-@protocol ASTableViewDataSource <ASTableDataSource>
-@end
-
-ASDISPLAYNODE_DEPRECATED_MSG("Renamed to ASTableDelegate.")
-@protocol ASTableViewDelegate <ASTableDelegate>
-@end
-
 NS_ASSUME_NONNULL_END

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -232,7 +232,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int scrollViewWillEndDragging:1;
     unsigned int scrollViewDidEndDecelerating:1;
     unsigned int tableNodeWillDisplayNodeForRow:1;
-    unsigned int tableViewWillDisplayNodeForRowDeprecated:1;
     unsigned int tableNodeDidEndDisplayingNodeForRow:1;
     unsigned int tableNodeWillBeginBatchFetch:1;
     unsigned int shouldBatchFetchForTableNode:1;
@@ -466,7 +465,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.scrollViewDidScroll = [_asyncDelegate respondsToSelector:@selector(scrollViewDidScroll:)];
 
     _asyncDelegateFlags.tableNodeWillDisplayNodeForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willDisplayRowWithNode:)];
-    _asyncDelegateFlags.tableViewWillDisplayNodeForRowDeprecated = [_asyncDelegate respondsToSelector:@selector(tableView:willDisplayNodeForRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidEndDisplayingNodeForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didEndDisplayingRowWithNode:)];
     _asyncDelegateFlags.scrollViewWillEndDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:)];
     _asyncDelegateFlags.scrollViewDidEndDecelerating = [_asyncDelegate respondsToSelector:@selector(scrollViewDidEndDecelerating:)];
@@ -474,7 +472,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.shouldBatchFetchForTableNode = [_asyncDelegate respondsToSelector:@selector(shouldBatchFetchForTableNode:)];
     _asyncDelegateFlags.scrollViewWillBeginDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewWillBeginDragging:)];
     _asyncDelegateFlags.scrollViewDidEndDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewDidEndDragging:willDecelerate:)];
-    
+
     _asyncDelegateFlags.tableViewWillSelectRow = [_asyncDelegate respondsToSelector:@selector(tableView:willSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeWillSelectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableViewDidSelectRow = [_asyncDelegate respondsToSelector:@selector(tableView:didSelectRowAtIndexPath:)];
@@ -978,13 +976,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   if (_asyncDelegateFlags.tableNodeWillDisplayNodeForRow) {
     GET_TABLENODE_OR_RETURN(tableNode, (void)0);
     [_asyncDelegate tableNode:tableNode willDisplayRowWithNode:cellNode];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  } else if (_asyncDelegateFlags.tableViewWillDisplayNodeForRowDeprecated) {
-    [_asyncDelegate tableView:self willDisplayNodeForRowAtIndexPath:indexPath];
   }
-#pragma clang diagnostic pop
-  
+
   [_rangeController setNeedsUpdate];
   
   if ([cell consumesCellNodeVisibilityEvents]) {

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -234,7 +234,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableNodeWillDisplayNodeForRow:1;
     unsigned int tableViewWillDisplayNodeForRowDeprecated:1;
     unsigned int tableNodeDidEndDisplayingNodeForRow:1;
-    unsigned int tableViewDidEndDisplayingNodeForRow:1;
     unsigned int tableNodeWillBeginBatchFetch:1;
     unsigned int tableViewWillBeginBatchFetch:1;
     unsigned int shouldBatchFetchForTableView:1;
@@ -471,7 +470,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
     _asyncDelegateFlags.tableNodeWillDisplayNodeForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willDisplayRowWithNode:)];
     _asyncDelegateFlags.tableViewWillDisplayNodeForRowDeprecated = [_asyncDelegate respondsToSelector:@selector(tableView:willDisplayNodeForRowAtIndexPath:)];
-    _asyncDelegateFlags.tableViewDidEndDisplayingNodeForRow = [_asyncDelegate respondsToSelector:@selector(tableView:didEndDisplayingNode:forRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidEndDisplayingNodeForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didEndDisplayingRowWithNode:)];
     _asyncDelegateFlags.scrollViewWillEndDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:)];
     _asyncDelegateFlags.scrollViewDidEndDecelerating = [_asyncDelegate respondsToSelector:@selector(scrollViewDidEndDecelerating:)];
@@ -1021,11 +1019,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     if (ASTableNode *tableNode = self.tableNode) {
     	[_asyncDelegate tableNode:tableNode didEndDisplayingRowWithNode:cellNode];
     }
-  } else if (_asyncDelegateFlags.tableViewDidEndDisplayingNodeForRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [_asyncDelegate tableView:self didEndDisplayingNode:cellNode forRowAtIndexPath:indexPath];
-#pragma clang diagnostic pop
   }
 
   [_cellsForVisibilityUpdates removeObject:cell];

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -244,7 +244,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableNodeWillDeselectRow:1;
     unsigned int tableViewDidDeselectRow:1;
     unsigned int tableNodeDidDeselectRow:1;
-    unsigned int tableViewShouldHighlightRow:1;
     unsigned int tableNodeShouldHighlightRow:1;
     unsigned int tableViewDidHighlightRow:1;
     unsigned int tableNodeDidHighlightRow:1;
@@ -474,7 +473,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.tableNodeWillDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willDeselectRowAtIndexPath:)];
     _asyncDelegateFlags.tableViewDidDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableView:didDeselectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didDeselectRowAtIndexPath:)];
-    _asyncDelegateFlags.tableViewShouldHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableView:shouldHighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeShouldHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:shouldHighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableViewDidHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableView:didHighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didHighlightRowAtIndexPath:)];
@@ -1090,11 +1088,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     if (indexPath != nil) {
       return [_asyncDelegate tableNode:tableNode shouldHighlightRowAtIndexPath:indexPath];
     }
-  } else if (_asyncDelegateFlags.tableViewShouldHighlightRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return [_asyncDelegate tableView:self shouldHighlightRowAtIndexPath:indexPath];
-#pragma clang diagnostic pop
   }
   return YES;
 }

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -235,8 +235,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableViewWillDisplayNodeForRowDeprecated:1;
     unsigned int tableNodeDidEndDisplayingNodeForRow:1;
     unsigned int tableNodeWillBeginBatchFetch:1;
-    unsigned int tableViewWillBeginBatchFetch:1;
-    unsigned int shouldBatchFetchForTableView:1;
     unsigned int shouldBatchFetchForTableNode:1;
     unsigned int tableViewConstrainedSizeForRow:1;
     unsigned int tableNodeConstrainedSizeForRow:1;
@@ -473,9 +471,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.tableNodeDidEndDisplayingNodeForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didEndDisplayingRowWithNode:)];
     _asyncDelegateFlags.scrollViewWillEndDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:)];
     _asyncDelegateFlags.scrollViewDidEndDecelerating = [_asyncDelegate respondsToSelector:@selector(scrollViewDidEndDecelerating:)];
-    _asyncDelegateFlags.tableViewWillBeginBatchFetch = [_asyncDelegate respondsToSelector:@selector(tableView:willBeginBatchFetchWithContext:)];
     _asyncDelegateFlags.tableNodeWillBeginBatchFetch = [_asyncDelegate respondsToSelector:@selector(tableNode:willBeginBatchFetchWithContext:)];
-    _asyncDelegateFlags.shouldBatchFetchForTableView = [_asyncDelegate respondsToSelector:@selector(shouldBatchFetchForTableView:)];
     _asyncDelegateFlags.shouldBatchFetchForTableNode = [_asyncDelegate respondsToSelector:@selector(shouldBatchFetchForTableNode:)];
     _asyncDelegateFlags.scrollViewWillBeginDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewWillBeginDragging:)];
     _asyncDelegateFlags.scrollViewDidEndDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewDidEndDragging:willDecelerate:)];
@@ -1386,15 +1382,10 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 - (BOOL)canBatchFetch
 {
   // if the delegate does not respond to this method, there is no point in starting to fetch
-  BOOL canFetch = _asyncDelegateFlags.tableNodeWillBeginBatchFetch || _asyncDelegateFlags.tableViewWillBeginBatchFetch;
+  BOOL canFetch = _asyncDelegateFlags.tableNodeWillBeginBatchFetch;
   if (canFetch && _asyncDelegateFlags.shouldBatchFetchForTableNode) {
     GET_TABLENODE_OR_RETURN(tableNode, NO);
     return [_asyncDelegate shouldBatchFetchForTableNode:tableNode];
-  } else if (canFetch && _asyncDelegateFlags.shouldBatchFetchForTableView) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return [_asyncDelegate shouldBatchFetchForTableView:self];
-#pragma clang diagnostic pop
   } else {
     return canFetch;
   }
@@ -1443,13 +1434,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
       GET_TABLENODE_OR_RETURN(tableNode, (void)0);
       [_asyncDelegate tableNode:tableNode willBeginBatchFetchWithContext:_batchContext];
-    });
-  } else if (_asyncDelegateFlags.tableViewWillBeginBatchFetch) {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      [_asyncDelegate tableView:self willBeginBatchFetchWithContext:_batchContext];
-#pragma clang diagnostic pop
     });
   }
 }

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -261,8 +261,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   struct {
     unsigned int numberOfSectionsInTableView:1;
     unsigned int numberOfSectionsInTableNode:1;
-    unsigned int tableNodeNumberOfRowsInSection:1;
-    unsigned int tableViewNumberOfRowsInSection:1;
     unsigned int tableNodeNodeBlockForRow:1;
     unsigned int tableNodeNodeForRow:1;
     unsigned int tableViewCanMoveRow:1;
@@ -419,8 +417,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     
     _asyncDataSourceFlags.numberOfSectionsInTableView = [_asyncDataSource respondsToSelector:@selector(numberOfSectionsInTableView:)];
     _asyncDataSourceFlags.numberOfSectionsInTableNode = [_asyncDataSource respondsToSelector:@selector(numberOfSectionsInTableNode:)];
-    _asyncDataSourceFlags.tableViewNumberOfRowsInSection = [_asyncDataSource respondsToSelector:@selector(tableView:numberOfRowsInSection:)];
-    _asyncDataSourceFlags.tableNodeNumberOfRowsInSection = [_asyncDataSource respondsToSelector:@selector(tableNode:numberOfRowsInSection:)];
     _asyncDataSourceFlags.tableNodeNodeForRow = [_asyncDataSource respondsToSelector:@selector(tableNode:nodeForRowAtIndexPath:)];
     _asyncDataSourceFlags.tableNodeNodeBlockForRow = [_asyncDataSource respondsToSelector:@selector(tableNode:nodeBlockForRowAtIndexPath:)];
     _asyncDataSourceFlags.tableViewCanMoveRow = [_asyncDataSource respondsToSelector:@selector(tableView:canMoveRowAtIndexPath:)];
@@ -430,7 +426,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     ASDisplayNodeAssert(_asyncDataSourceFlags.tableNodeNodeBlockForRow
                         || _asyncDataSourceFlags.tableNodeNodeForRow,
                         @"Data source must implement tableNode:nodeBlockForRowAtIndexPath: or tableNode:nodeForRowAtIndexPath:");
-    ASDisplayNodeAssert(_asyncDataSourceFlags.tableNodeNumberOfRowsInSection || _asyncDataSourceFlags.tableViewNumberOfRowsInSection, @"Data source must implement tableNode:numberOfRowsInSection:");
   }
   
   _dataController.validationErrorSource = asyncDataSource;
@@ -1674,17 +1669,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (NSUInteger)dataController:(ASDataController *)dataController rowsInSection:(NSUInteger)section
 {
-  if (_asyncDataSourceFlags.tableNodeNumberOfRowsInSection) {
-    GET_TABLENODE_OR_RETURN(tableNode, 0);
-    return [_asyncDataSource tableNode:tableNode numberOfRowsInSection:section];
-  } else if (_asyncDataSourceFlags.tableViewNumberOfRowsInSection) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return [_asyncDataSource tableView:self numberOfRowsInSection:section];
-#pragma clang diagnostic pop
-  } else {
-    return 0;
-  }
+  GET_TABLENODE_OR_RETURN(tableNode, 0);
+  return [_asyncDataSource tableNode:tableNode numberOfRowsInSection:section];
 }
 
 - (NSUInteger)numberOfSectionsInDataController:(ASDataController *)dataController

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -243,7 +243,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableNodeShouldHighlightRow:1;
     unsigned int tableNodeDidHighlightRow:1;
     unsigned int tableNodeDidUnhighlightRow:1;
-    unsigned int tableViewShouldShowMenuForRow:1;
     unsigned int tableNodeShouldShowMenuForRow:1;
     unsigned int tableViewCanPerformActionForRow:1;
     unsigned int tableNodeCanPerformActionForRow:1;
@@ -466,7 +465,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.tableNodeShouldHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:shouldHighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didHighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidUnhighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didUnhighlightRowAtIndexPath:)];
-    _asyncDelegateFlags.tableViewShouldShowMenuForRow = [_asyncDelegate respondsToSelector:@selector(tableView:shouldShowMenuForRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeShouldShowMenuForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:shouldShowMenuForRowAtIndexPath:)];
     _asyncDelegateFlags.tableViewCanPerformActionForRow = [_asyncDelegate respondsToSelector:@selector(tableView:canPerformAction:forRowAtIndexPath:withSender:)];
     _asyncDelegateFlags.tableNodeCanPerformActionForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:canPerformAction:forRowAtIndexPath:withSender:)];
@@ -1090,11 +1088,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     if (indexPath != nil) {
       return [_asyncDelegate tableNode:tableNode shouldShowMenuForRowAtIndexPath:indexPath];
     }
-  } else if (_asyncDelegateFlags.tableViewShouldShowMenuForRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return [_asyncDelegate tableView:self shouldShowMenuForRowAtIndexPath:indexPath];
-#pragma clang diagnostic pop
   }
   return NO;
 }

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -246,7 +246,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableNodeDidDeselectRow:1;
     unsigned int tableNodeShouldHighlightRow:1;
     unsigned int tableNodeDidHighlightRow:1;
-    unsigned int tableViewDidUnhighlightRow:1;
     unsigned int tableNodeDidUnhighlightRow:1;
     unsigned int tableViewShouldShowMenuForRow:1;
     unsigned int tableNodeShouldShowMenuForRow:1;
@@ -474,7 +473,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.tableNodeDidDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didDeselectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeShouldHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:shouldHighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didHighlightRowAtIndexPath:)];
-    _asyncDelegateFlags.tableViewDidUnhighlightRow = [_asyncDelegate respondsToSelector:@selector(tableView:didUnhighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidUnhighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didUnhighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableViewShouldShowMenuForRow = [_asyncDelegate respondsToSelector:@selector(tableView:shouldShowMenuForRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeShouldShowMenuForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:shouldShowMenuForRowAtIndexPath:)];
@@ -1109,11 +1107,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     if (indexPath != nil) {
       return [_asyncDelegate tableNode:tableNode didUnhighlightRowAtIndexPath:indexPath];
     }
-  } else if (_asyncDelegateFlags.tableViewDidUnhighlightRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [_asyncDelegate tableView:self didUnhighlightRowAtIndexPath:indexPath];
-#pragma clang diagnostic pop
   }
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -259,7 +259,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   } _asyncDelegateFlags;
   
   struct {
-    unsigned int numberOfSectionsInTableView:1;
     unsigned int numberOfSectionsInTableNode:1;
     unsigned int tableNodeNodeBlockForRow:1;
     unsigned int tableNodeNodeForRow:1;
@@ -415,7 +414,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDataSource = asyncDataSource;
     _proxyDataSource = [[ASTableViewProxy alloc] initWithTarget:_asyncDataSource interceptor:self];
     
-    _asyncDataSourceFlags.numberOfSectionsInTableView = [_asyncDataSource respondsToSelector:@selector(numberOfSectionsInTableView:)];
     _asyncDataSourceFlags.numberOfSectionsInTableNode = [_asyncDataSource respondsToSelector:@selector(numberOfSectionsInTableNode:)];
     _asyncDataSourceFlags.tableNodeNodeForRow = [_asyncDataSource respondsToSelector:@selector(tableNode:nodeForRowAtIndexPath:)];
     _asyncDataSourceFlags.tableNodeNodeBlockForRow = [_asyncDataSource respondsToSelector:@selector(tableNode:nodeBlockForRowAtIndexPath:)];
@@ -1678,11 +1676,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   if (_asyncDataSourceFlags.numberOfSectionsInTableNode) {
     GET_TABLENODE_OR_RETURN(tableNode, 0);
     return [_asyncDataSource numberOfSectionsInTableNode:tableNode];
-  } else if (_asyncDataSourceFlags.numberOfSectionsInTableView) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return [_asyncDataSource numberOfSectionsInTableView:self];
-#pragma clang diagnostic pop
   } else {
     return 1; // default section number
   }

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -245,7 +245,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableViewDidDeselectRow:1;
     unsigned int tableNodeDidDeselectRow:1;
     unsigned int tableNodeShouldHighlightRow:1;
-    unsigned int tableViewDidHighlightRow:1;
     unsigned int tableNodeDidHighlightRow:1;
     unsigned int tableViewDidUnhighlightRow:1;
     unsigned int tableNodeDidUnhighlightRow:1;
@@ -474,7 +473,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.tableViewDidDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableView:didDeselectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didDeselectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeShouldHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:shouldHighlightRowAtIndexPath:)];
-    _asyncDelegateFlags.tableViewDidHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableView:didHighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didHighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableViewDidUnhighlightRow = [_asyncDelegate respondsToSelector:@selector(tableView:didUnhighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidUnhighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didUnhighlightRowAtIndexPath:)];
@@ -1100,11 +1098,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     if (indexPath != nil) {
       return [_asyncDelegate tableNode:tableNode didHighlightRowAtIndexPath:indexPath];
     }
-  } else if (_asyncDelegateFlags.tableViewDidHighlightRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [_asyncDelegate tableView:self didHighlightRowAtIndexPath:indexPath];
-#pragma clang diagnostic pop
   }
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -244,7 +244,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableNodeDidHighlightRow:1;
     unsigned int tableNodeDidUnhighlightRow:1;
     unsigned int tableNodeShouldShowMenuForRow:1;
-    unsigned int tableViewCanPerformActionForRow:1;
     unsigned int tableNodeCanPerformActionForRow:1;
     unsigned int tableViewPerformActionForRow:1;
     unsigned int tableNodePerformActionForRow:1;
@@ -466,7 +465,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.tableNodeDidHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didHighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidUnhighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didUnhighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeShouldShowMenuForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:shouldShowMenuForRowAtIndexPath:)];
-    _asyncDelegateFlags.tableViewCanPerformActionForRow = [_asyncDelegate respondsToSelector:@selector(tableView:canPerformAction:forRowAtIndexPath:withSender:)];
     _asyncDelegateFlags.tableNodeCanPerformActionForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:canPerformAction:forRowAtIndexPath:withSender:)];
     _asyncDelegateFlags.tableViewPerformActionForRow = [_asyncDelegate respondsToSelector:@selector(tableView:performAction:forRowAtIndexPath:withSender:)];
     _asyncDelegateFlags.tableNodePerformActionForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:performAction:forRowAtIndexPath:withSender:)];
@@ -1100,11 +1098,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     if (indexPath != nil) {
       return [_asyncDelegate tableNode:tableNode canPerformAction:action forRowAtIndexPath:indexPath withSender:sender];
     }
-  } else if (_asyncDelegateFlags.tableViewCanPerformActionForRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return [_asyncDelegate tableView:self canPerformAction:action forRowAtIndexPath:indexPath withSender:sender];
-#pragma clang diagnostic pop
   }
   return NO;
 }

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -232,7 +232,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int scrollViewWillEndDragging:1;
     unsigned int scrollViewDidEndDecelerating:1;
     unsigned int tableNodeWillDisplayNodeForRow:1;
-    unsigned int tableViewWillDisplayNodeForRow:1;
     unsigned int tableViewWillDisplayNodeForRowDeprecated:1;
     unsigned int tableNodeDidEndDisplayingNodeForRow:1;
     unsigned int tableViewDidEndDisplayingNodeForRow:1;
@@ -470,11 +469,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     
     _asyncDelegateFlags.scrollViewDidScroll = [_asyncDelegate respondsToSelector:@selector(scrollViewDidScroll:)];
 
-    _asyncDelegateFlags.tableViewWillDisplayNodeForRow = [_asyncDelegate respondsToSelector:@selector(tableView:willDisplayNode:forRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeWillDisplayNodeForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willDisplayRowWithNode:)];
-    if (_asyncDelegateFlags.tableViewWillDisplayNodeForRow == NO) {
-      _asyncDelegateFlags.tableViewWillDisplayNodeForRowDeprecated = [_asyncDelegate respondsToSelector:@selector(tableView:willDisplayNodeForRowAtIndexPath:)];
-    }
+    _asyncDelegateFlags.tableViewWillDisplayNodeForRowDeprecated = [_asyncDelegate respondsToSelector:@selector(tableView:willDisplayNodeForRowAtIndexPath:)];
     _asyncDelegateFlags.tableViewDidEndDisplayingNodeForRow = [_asyncDelegate respondsToSelector:@selector(tableView:didEndDisplayingNode:forRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidEndDisplayingNodeForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didEndDisplayingRowWithNode:)];
     _asyncDelegateFlags.scrollViewWillEndDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:)];
@@ -991,10 +987,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   if (_asyncDelegateFlags.tableNodeWillDisplayNodeForRow) {
     GET_TABLENODE_OR_RETURN(tableNode, (void)0);
     [_asyncDelegate tableNode:tableNode willDisplayRowWithNode:cellNode];
-  } else if (_asyncDelegateFlags.tableViewWillDisplayNodeForRow) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [_asyncDelegate tableView:self willDisplayNode:cellNode forRowAtIndexPath:indexPath];
   } else if (_asyncDelegateFlags.tableViewWillDisplayNodeForRowDeprecated) {
     [_asyncDelegate tableView:self willDisplayNodeForRowAtIndexPath:indexPath];
   }

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -271,7 +271,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableViewNumberOfRowsInSection:1;
     unsigned int tableViewNodeBlockForRow:1;
     unsigned int tableNodeNodeBlockForRow:1;
-    unsigned int tableViewNodeForRow:1;
     unsigned int tableNodeNodeForRow:1;
     unsigned int tableViewCanMoveRow:1;
     unsigned int tableNodeCanMoveRow:1;
@@ -429,7 +428,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDataSourceFlags.numberOfSectionsInTableNode = [_asyncDataSource respondsToSelector:@selector(numberOfSectionsInTableNode:)];
     _asyncDataSourceFlags.tableViewNumberOfRowsInSection = [_asyncDataSource respondsToSelector:@selector(tableView:numberOfRowsInSection:)];
     _asyncDataSourceFlags.tableNodeNumberOfRowsInSection = [_asyncDataSource respondsToSelector:@selector(tableNode:numberOfRowsInSection:)];
-    _asyncDataSourceFlags.tableViewNodeForRow = [_asyncDataSource respondsToSelector:@selector(tableView:nodeForRowAtIndexPath:)];
     _asyncDataSourceFlags.tableNodeNodeForRow = [_asyncDataSource respondsToSelector:@selector(tableNode:nodeForRowAtIndexPath:)];
     _asyncDataSourceFlags.tableViewNodeBlockForRow = [_asyncDataSource respondsToSelector:@selector(tableView:nodeBlockForRowAtIndexPath:)];
     _asyncDataSourceFlags.tableNodeNodeBlockForRow = [_asyncDataSource respondsToSelector:@selector(tableNode:nodeBlockForRowAtIndexPath:)];
@@ -438,7 +436,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDataSourceFlags.sectionIndexMethods = [_asyncDataSource respondsToSelector:@selector(sectionIndexTitlesForTableView:)] && [_asyncDataSource respondsToSelector:@selector(tableView:sectionForSectionIndexTitle:atIndex:)];
     
     ASDisplayNodeAssert(_asyncDataSourceFlags.tableViewNodeBlockForRow
-                        || _asyncDataSourceFlags.tableViewNodeForRow
                         || _asyncDataSourceFlags.tableNodeNodeBlockForRow
                         || _asyncDataSourceFlags.tableNodeNodeForRow, @"Data source must implement tableNode:nodeBlockForRowAtIndexPath: or tableNode:nodeForRowAtIndexPath:");
     ASDisplayNodeAssert(_asyncDataSourceFlags.tableNodeNumberOfRowsInSection || _asyncDataSourceFlags.tableViewNumberOfRowsInSection, @"Data source must implement tableNode:numberOfRowsInSection:");
@@ -1677,16 +1674,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     block = [_asyncDataSource tableView:self nodeBlockForRowAtIndexPath:indexPath];
-  } else if (_asyncDataSourceFlags.tableViewNodeForRow) {
-    ASCellNode *node = [_asyncDataSource tableView:self nodeForRowAtIndexPath:indexPath];
-#pragma clang diagnostic pop
-    if ([node isKindOfClass:[ASCellNode class]]) {
-      block = ^{
-        return node;
-      };
-    } else {
-      ASDisplayNodeFailAssert(@"Data source returned invalid node from tableView:nodeForRowAtIndexPath:. Node: %@", node);
-    }
   }
 
   // Handle nil node block

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -236,7 +236,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableNodeDidEndDisplayingNodeForRow:1;
     unsigned int tableNodeWillBeginBatchFetch:1;
     unsigned int shouldBatchFetchForTableNode:1;
-    unsigned int tableViewConstrainedSizeForRow:1;
     unsigned int tableNodeConstrainedSizeForRow:1;
     unsigned int tableViewWillSelectRow:1;
     unsigned int tableNodeWillSelectRow:1;
@@ -475,9 +474,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.shouldBatchFetchForTableNode = [_asyncDelegate respondsToSelector:@selector(shouldBatchFetchForTableNode:)];
     _asyncDelegateFlags.scrollViewWillBeginDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewWillBeginDragging:)];
     _asyncDelegateFlags.scrollViewDidEndDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewDidEndDragging:willDecelerate:)];
-    _asyncDelegateFlags.tableViewConstrainedSizeForRow = [_asyncDelegate respondsToSelector:@selector(tableView:constrainedSizeForRowAtIndexPath:)];
-    _asyncDelegateFlags.tableNodeConstrainedSizeForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:constrainedSizeForRowAtIndexPath:)];
-
+    
     _asyncDelegateFlags.tableViewWillSelectRow = [_asyncDelegate respondsToSelector:@selector(tableView:willSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeWillSelectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableViewDidSelectRow = [_asyncDelegate respondsToSelector:@selector(tableView:didSelectRowAtIndexPath:)];
@@ -1672,14 +1669,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   if (_asyncDelegateFlags.tableNodeConstrainedSizeForRow) {
     GET_TABLENODE_OR_RETURN(tableNode, constrainedSize);
     ASSizeRange delegateConstrainedSize = [_asyncDelegate tableNode:tableNode constrainedSizeForRowAtIndexPath:indexPath];
-    // ignore widths in the returned size range (for TableView)
-    constrainedSize = ASSizeRangeMake(CGSizeMake(_nodesConstrainedWidth, delegateConstrainedSize.min.height),
-                                      CGSizeMake(_nodesConstrainedWidth, delegateConstrainedSize.max.height));
-  } else if (_asyncDelegateFlags.tableViewConstrainedSizeForRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    ASSizeRange delegateConstrainedSize = [_asyncDelegate tableView:self constrainedSizeForRowAtIndexPath:indexPath];
-#pragma clang diagnostic pop
     // ignore widths in the returned size range (for TableView)
     constrainedSize = ASSizeRangeMake(CGSizeMake(_nodesConstrainedWidth, delegateConstrainedSize.min.height),
                                       CGSizeMake(_nodesConstrainedWidth, delegateConstrainedSize.max.height));

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -269,7 +269,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int numberOfSectionsInTableNode:1;
     unsigned int tableNodeNumberOfRowsInSection:1;
     unsigned int tableViewNumberOfRowsInSection:1;
-    unsigned int tableViewNodeBlockForRow:1;
     unsigned int tableNodeNodeBlockForRow:1;
     unsigned int tableNodeNodeForRow:1;
     unsigned int tableViewCanMoveRow:1;
@@ -429,15 +428,14 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDataSourceFlags.tableViewNumberOfRowsInSection = [_asyncDataSource respondsToSelector:@selector(tableView:numberOfRowsInSection:)];
     _asyncDataSourceFlags.tableNodeNumberOfRowsInSection = [_asyncDataSource respondsToSelector:@selector(tableNode:numberOfRowsInSection:)];
     _asyncDataSourceFlags.tableNodeNodeForRow = [_asyncDataSource respondsToSelector:@selector(tableNode:nodeForRowAtIndexPath:)];
-    _asyncDataSourceFlags.tableViewNodeBlockForRow = [_asyncDataSource respondsToSelector:@selector(tableView:nodeBlockForRowAtIndexPath:)];
     _asyncDataSourceFlags.tableNodeNodeBlockForRow = [_asyncDataSource respondsToSelector:@selector(tableNode:nodeBlockForRowAtIndexPath:)];
     _asyncDataSourceFlags.tableViewCanMoveRow = [_asyncDataSource respondsToSelector:@selector(tableView:canMoveRowAtIndexPath:)];
     _asyncDataSourceFlags.tableViewMoveRow = [_asyncDataSource respondsToSelector:@selector(tableView:moveRowAtIndexPath:toIndexPath:)];
     _asyncDataSourceFlags.sectionIndexMethods = [_asyncDataSource respondsToSelector:@selector(sectionIndexTitlesForTableView:)] && [_asyncDataSource respondsToSelector:@selector(tableView:sectionForSectionIndexTitle:atIndex:)];
     
-    ASDisplayNodeAssert(_asyncDataSourceFlags.tableViewNodeBlockForRow
-                        || _asyncDataSourceFlags.tableNodeNodeBlockForRow
-                        || _asyncDataSourceFlags.tableNodeNodeForRow, @"Data source must implement tableNode:nodeBlockForRowAtIndexPath: or tableNode:nodeForRowAtIndexPath:");
+    ASDisplayNodeAssert(_asyncDataSourceFlags.tableNodeNodeBlockForRow
+                        || _asyncDataSourceFlags.tableNodeNodeForRow,
+                        @"Data source must implement tableNode:nodeBlockForRowAtIndexPath: or tableNode:nodeForRowAtIndexPath:");
     ASDisplayNodeAssert(_asyncDataSourceFlags.tableNodeNumberOfRowsInSection || _asyncDataSourceFlags.tableViewNumberOfRowsInSection, @"Data source must implement tableNode:numberOfRowsInSection:");
   }
   
@@ -1670,10 +1668,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     } else {
       ASDisplayNodeFailAssert(@"Data source returned invalid node from tableNode:nodeForRowAtIndexPath:. Node: %@", node);
     }
-  } else if (_asyncDataSourceFlags.tableViewNodeBlockForRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    block = [_asyncDataSource tableView:self nodeBlockForRowAtIndexPath:indexPath];
   }
 
   // Handle nil node block

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -236,7 +236,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableNodeWillBeginBatchFetch:1;
     unsigned int shouldBatchFetchForTableNode:1;
     unsigned int tableNodeConstrainedSizeForRow:1;
-    unsigned int tableViewWillSelectRow:1;
     unsigned int tableNodeWillSelectRow:1;
     unsigned int tableViewDidSelectRow:1;
     unsigned int tableNodeDidSelectRow:1;
@@ -463,7 +462,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.scrollViewWillBeginDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewWillBeginDragging:)];
     _asyncDelegateFlags.scrollViewDidEndDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewDidEndDragging:willDecelerate:)];
 
-    _asyncDelegateFlags.tableViewWillSelectRow = [_asyncDelegate respondsToSelector:@selector(tableView:willSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeWillSelectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableViewDidSelectRow = [_asyncDelegate respondsToSelector:@selector(tableView:didSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidSelectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didSelectRowAtIndexPath:)];
@@ -1012,11 +1010,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
       result = [self convertIndexPathFromTableNode:result waitingIfNeeded:YES];
       return result;
     }
-  } else if (_asyncDelegateFlags.tableViewWillSelectRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return [_asyncDelegate tableView:self willSelectRowAtIndexPath:indexPath];
-#pragma clang diagnostic pop
   } else {
     return indexPath;
   }

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -245,7 +245,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableNodeDidUnhighlightRow:1;
     unsigned int tableNodeShouldShowMenuForRow:1;
     unsigned int tableNodeCanPerformActionForRow:1;
-    unsigned int tableViewPerformActionForRow:1;
     unsigned int tableNodePerformActionForRow:1;
   } _asyncDelegateFlags;
   
@@ -466,7 +465,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.tableNodeDidUnhighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didUnhighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeShouldShowMenuForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:shouldShowMenuForRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeCanPerformActionForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:canPerformAction:forRowAtIndexPath:withSender:)];
-    _asyncDelegateFlags.tableViewPerformActionForRow = [_asyncDelegate respondsToSelector:@selector(tableView:performAction:forRowAtIndexPath:withSender:)];
     _asyncDelegateFlags.tableNodePerformActionForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:performAction:forRowAtIndexPath:withSender:)];
   }
   
@@ -1110,11 +1108,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     if (indexPath != nil) {
       [_asyncDelegate tableNode:tableNode performAction:action forRowAtIndexPath:indexPath withSender:sender];
     }
-  } else if (_asyncDelegateFlags.tableViewPerformActionForRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [_asyncDelegate tableView:self performAction:action forRowAtIndexPath:indexPath withSender:sender];
-#pragma clang diagnostic pop
   }
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -239,7 +239,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableNodeWillSelectRow:1;
     unsigned int tableViewDidSelectRow:1;
     unsigned int tableNodeDidSelectRow:1;
-    unsigned int tableViewWillDeselectRow:1;
     unsigned int tableNodeWillDeselectRow:1;
     unsigned int tableViewDidDeselectRow:1;
     unsigned int tableNodeDidDeselectRow:1;
@@ -465,7 +464,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.tableNodeWillSelectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableViewDidSelectRow = [_asyncDelegate respondsToSelector:@selector(tableView:didSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidSelectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didSelectRowAtIndexPath:)];
-    _asyncDelegateFlags.tableViewWillDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableView:willDeselectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeWillDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willDeselectRowAtIndexPath:)];
     _asyncDelegateFlags.tableViewDidDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableView:didDeselectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didDeselectRowAtIndexPath:)];
@@ -1044,11 +1042,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
       result = [self convertIndexPathFromTableNode:result waitingIfNeeded:YES];
       return result;
     }
-  } else if (_asyncDelegateFlags.tableViewWillDeselectRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return [_asyncDelegate tableView:self willDeselectRowAtIndexPath:indexPath];
-#pragma clang diagnostic pop
   }
   return indexPath;
 }

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -237,7 +237,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int shouldBatchFetchForTableNode:1;
     unsigned int tableNodeConstrainedSizeForRow:1;
     unsigned int tableNodeWillSelectRow:1;
-    unsigned int tableViewDidSelectRow:1;
     unsigned int tableNodeDidSelectRow:1;
     unsigned int tableNodeWillDeselectRow:1;
     unsigned int tableViewDidDeselectRow:1;
@@ -462,7 +461,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.scrollViewDidEndDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewDidEndDragging:willDecelerate:)];
 
     _asyncDelegateFlags.tableNodeWillSelectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willSelectRowAtIndexPath:)];
-    _asyncDelegateFlags.tableViewDidSelectRow = [_asyncDelegate respondsToSelector:@selector(tableView:didSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidSelectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeWillDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willDeselectRowAtIndexPath:)];
     _asyncDelegateFlags.tableViewDidDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableView:didDeselectRowAtIndexPath:)];
@@ -1021,11 +1019,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     if (indexPath != nil) {
       [_asyncDelegate tableNode:tableNode didSelectRowAtIndexPath:indexPath];
     }
-  } else if (_asyncDelegateFlags.tableViewDidSelectRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [_asyncDelegate tableView:self didSelectRowAtIndexPath:indexPath];
-#pragma clang diagnostic pop
   }
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -239,7 +239,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int tableNodeWillSelectRow:1;
     unsigned int tableNodeDidSelectRow:1;
     unsigned int tableNodeWillDeselectRow:1;
-    unsigned int tableViewDidDeselectRow:1;
     unsigned int tableNodeDidDeselectRow:1;
     unsigned int tableNodeShouldHighlightRow:1;
     unsigned int tableNodeDidHighlightRow:1;
@@ -463,7 +462,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.tableNodeWillSelectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidSelectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didSelectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeWillDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:willDeselectRowAtIndexPath:)];
-    _asyncDelegateFlags.tableViewDidDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableView:didDeselectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidDeselectRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didDeselectRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeShouldHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:shouldHighlightRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidHighlightRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didHighlightRowAtIndexPath:)];
@@ -1047,11 +1045,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     if (indexPath != nil) {
       [_asyncDelegate tableNode:tableNode didDeselectRowAtIndexPath:indexPath];
     }
-  } else if (_asyncDelegateFlags.tableViewDidDeselectRow) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [_asyncDelegate tableView:self didDeselectRowAtIndexPath:indexPath];
-#pragma clang diagnostic pop
   }
 }
 

--- a/Source/ASTableViewProtocols.h
+++ b/Source/ASTableViewProtocols.h
@@ -81,8 +81,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSInteger)tableView:(UITableView *)tableView indentationLevelForRowAtIndexPath:(NSIndexPath *)indexPath;
 
-- (void)tableView:(UITableView *)tableView performAction:(SEL)action forRowAtIndexPath:(NSIndexPath *)indexPath withSender:(nullable id)sender ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:performAction:forRowAtIndexPath:withSender: instead.");
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ASTableViewProtocols.h
+++ b/Source/ASTableViewProtocols.h
@@ -67,7 +67,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)tableView:(UITableView *)tableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath *)indexPath;
 
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didSelectRowAtIndexPath: instead.");
 - (void)tableView:(UITableView *)tableView didDeselectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didDeselectRowAtIndexPath: instead.");
 
 - (UITableViewCellEditingStyle)tableView:(UITableView *)tableView editingStyleForRowAtIndexPath:(NSIndexPath *)indexPath;

--- a/Source/ASTableViewProtocols.h
+++ b/Source/ASTableViewProtocols.h
@@ -67,7 +67,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)tableView:(UITableView *)tableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath *)indexPath;
 
-- (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:shouldHighlightRowAtIndexPath: instead.");
 - (void)tableView:(UITableView *)tableView didHighlightRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didHighlightRowAtIndexPath: instead.");
 - (void)tableView:(UITableView *)tableView didUnhighlightRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didUnhighlightRowAtIndexPath: instead.");
 

--- a/Source/ASTableViewProtocols.h
+++ b/Source/ASTableViewProtocols.h
@@ -28,8 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @optional
 
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:numberOfRowsInSection: instead.");
-
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView ASDISPLAYNODE_DEPRECATED_MSG("Implement numberOfSectionsInTableNode: instead.");
 
 - (nullable NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section;

--- a/Source/ASTableViewProtocols.h
+++ b/Source/ASTableViewProtocols.h
@@ -81,7 +81,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSInteger)tableView:(UITableView *)tableView indentationLevelForRowAtIndexPath:(NSIndexPath *)indexPath;
 
-- (BOOL)tableView:(UITableView *)tableView shouldShowMenuForRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:shouldShowMenuForRowAtIndexPath: instead.");
 - (BOOL)tableView:(UITableView *)tableView canPerformAction:(SEL)action forRowAtIndexPath:(NSIndexPath *)indexPath withSender:(nullable id)sender ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:canPerformAction:forRowAtIndexPath:withSender: instead.");
 - (void)tableView:(UITableView *)tableView performAction:(SEL)action forRowAtIndexPath:(NSIndexPath *)indexPath withSender:(nullable id)sender ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:performAction:forRowAtIndexPath:withSender: instead.");
 

--- a/Source/ASTableViewProtocols.h
+++ b/Source/ASTableViewProtocols.h
@@ -67,7 +67,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)tableView:(UITableView *)tableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath *)indexPath;
 
-- (nullable NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:willSelectRowAtIndexPath: instead.");
 - (nullable NSIndexPath *)tableView:(UITableView *)tableView willDeselectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:willDeselectRowAtIndexPath: instead.");
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didSelectRowAtIndexPath: instead.");
 - (void)tableView:(UITableView *)tableView didDeselectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didDeselectRowAtIndexPath: instead.");

--- a/Source/ASTableViewProtocols.h
+++ b/Source/ASTableViewProtocols.h
@@ -28,8 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @optional
 
-- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView ASDISPLAYNODE_DEPRECATED_MSG("Implement numberOfSectionsInTableNode: instead.");
-
 - (nullable NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section;
 - (nullable NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section;
 

--- a/Source/ASTableViewProtocols.h
+++ b/Source/ASTableViewProtocols.h
@@ -67,7 +67,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)tableView:(UITableView *)tableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath *)indexPath;
 
-- (void)tableView:(UITableView *)tableView didHighlightRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didHighlightRowAtIndexPath: instead.");
 - (void)tableView:(UITableView *)tableView didUnhighlightRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didUnhighlightRowAtIndexPath: instead.");
 
 - (nullable NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:willSelectRowAtIndexPath: instead.");

--- a/Source/ASTableViewProtocols.h
+++ b/Source/ASTableViewProtocols.h
@@ -67,8 +67,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)tableView:(UITableView *)tableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath *)indexPath;
 
-- (void)tableView:(UITableView *)tableView didDeselectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didDeselectRowAtIndexPath: instead.");
-
 - (UITableViewCellEditingStyle)tableView:(UITableView *)tableView editingStyleForRowAtIndexPath:(NSIndexPath *)indexPath;
 - (nullable NSString *)tableView:(UITableView *)tableView titleForDeleteConfirmationButtonForRowAtIndexPath:(NSIndexPath *)indexPath;
 #if TARGET_OS_IOS

--- a/Source/ASTableViewProtocols.h
+++ b/Source/ASTableViewProtocols.h
@@ -67,8 +67,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)tableView:(UITableView *)tableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath *)indexPath;
 
-- (void)tableView:(UITableView *)tableView didUnhighlightRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didUnhighlightRowAtIndexPath: instead.");
-
 - (nullable NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:willSelectRowAtIndexPath: instead.");
 - (nullable NSIndexPath *)tableView:(UITableView *)tableView willDeselectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:willDeselectRowAtIndexPath: instead.");
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didSelectRowAtIndexPath: instead.");

--- a/Source/ASTableViewProtocols.h
+++ b/Source/ASTableViewProtocols.h
@@ -67,7 +67,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)tableView:(UITableView *)tableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath *)indexPath;
 
-- (nullable NSIndexPath *)tableView:(UITableView *)tableView willDeselectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:willDeselectRowAtIndexPath: instead.");
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didSelectRowAtIndexPath: instead.");
 - (void)tableView:(UITableView *)tableView didDeselectRowAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:didDeselectRowAtIndexPath: instead.");
 

--- a/Source/ASTableViewProtocols.h
+++ b/Source/ASTableViewProtocols.h
@@ -81,7 +81,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSInteger)tableView:(UITableView *)tableView indentationLevelForRowAtIndexPath:(NSIndexPath *)indexPath;
 
-- (BOOL)tableView:(UITableView *)tableView canPerformAction:(SEL)action forRowAtIndexPath:(NSIndexPath *)indexPath withSender:(nullable id)sender ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:canPerformAction:forRowAtIndexPath:withSender: instead.");
 - (void)tableView:(UITableView *)tableView performAction:(SEL)action forRowAtIndexPath:(NSIndexPath *)indexPath withSender:(nullable id)sender ASDISPLAYNODE_DEPRECATED_MSG("Implement -tableNode:performAction:forRowAtIndexPath:withSender: instead.");
 
 @end

--- a/Tests/ASDisplayNodeLayoutTests.mm
+++ b/Tests/ASDisplayNodeLayoutTests.mm
@@ -103,7 +103,7 @@
   displayNode.frame = {.size = nodeSize};
   
   // Trigger initial layout pass without a measurement pass before
-  [displayNode.view layoutIfNeeded];
+  [displayNode layoutIfNeeded];
   XCTAssertEqual(numberOfLayoutSpecThatFitsCalls, 1, @"Should measure during layout if not measured");
   
   [displayNode layoutThatFits:ASSizeRangeMake(nodeSize, nodeSize)];
@@ -167,7 +167,7 @@
     [rootNode layoutThatFits:ASSizeRangeMake(kSize)];
     
     dispatch_async(dispatch_get_main_queue(), ^{
-      XCTAssertNoThrow([rootNode.view layoutIfNeeded]);
+      XCTAssertNoThrow([rootNode layoutIfNeeded]);
       [expectation fulfill];
     });
   });

--- a/Tests/ASDisplayNodeTests.mm
+++ b/Tests/ASDisplayNodeTests.mm
@@ -2283,7 +2283,7 @@ static bool stringContainsPointer(NSString *description, id p) {
   };
   
   ASDisplayNodeSizeToFitSize(node, CGSizeMake(100, 100));
-  [node.view layoutIfNeeded];
+  [node layoutIfNeeded];
   
   NSInteger underlayIndex = [node.subnodes indexOfObjectIdenticalTo:underlay];
   NSInteger overlayIndex = [node.subnodes indexOfObjectIdenticalTo:overlay];
@@ -2304,7 +2304,7 @@ static bool stringContainsPointer(NSString *description, id p) {
   };
   
   ASDisplayNodeSizeToFitSize(node, CGSizeMake(100, 100));
-  [node.view layoutIfNeeded];
+  [node layoutIfNeeded];
   
   NSInteger underlayIndex = [node.subnodes indexOfObjectIdenticalTo:underlay];
   NSInteger overlayIndex = [node.subnodes indexOfObjectIdenticalTo:overlay];

--- a/Tests/ASTableViewThrashTests.m
+++ b/Tests/ASTableViewThrashTests.m
@@ -234,12 +234,14 @@ static atomic_uint ASThrashTestSectionNextID = 1;
   return self;
 }
 
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+- (NSInteger)tableNode:(ASTableNode *)tableNode numberOfRowsInSection:(NSInteger)section
+{
   return self.data[section].items.count;
 }
 
 
-- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+- (NSInteger)numberOfSectionsInTableNode:(ASTableNode *)tableNode
+{
   return self.data.count;
 }
 
@@ -271,7 +273,7 @@ static atomic_uint ASThrashTestSectionNextID = 1;
 
 #else
 
-- (ASCellNode *)tableView:(ASTableView *)tableView nodeForRowAtIndexPath:(NSIndexPath *)indexPath
+- (ASCellNode *)tableNode:(ASTableNode *)tableNode nodeForRowAtIndexPath:(NSIndexPath *)indexPath
 {
   ASThrashTestNode *node = [[ASThrashTestNode alloc] init];
   node.item = self.data[indexPath.section].items[indexPath.item];


### PR DESCRIPTION
Those APIs were deprecated late last year (pre-2.0).