### PR TITLE
Fixed: completeBatchFetching is called on a background thread

### DIFF
--- a/examples/ASDKgram/Sample/PhotoFeedModel.m
+++ b/examples/ASDKgram/Sample/PhotoFeedModel.m
@@ -184,9 +184,11 @@
   // early return if reached end of pages
   if (_totalPages) {
     if (_currentPage == _totalPages) {
-      if (block){
-        block(@[]);
-      }
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (block) {
+          block(@[]);
+        }
+      });
       return;
     }
   }

--- a/examples/ASDKgram/Sample/PhotoFeedModel.m
+++ b/examples/ASDKgram/Sample/PhotoFeedModel.m
@@ -1,20 +1,18 @@
 //
 //  PhotoFeedModel.m
-//  Sample
-//
-//  Created by Hannah Troisi on 2/28/16.
+//  Texture
 //
 //  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
 //  This source code is licensed under the BSD-style license found in the
-//  LICENSE file in the root directory of this source tree. An additional grant
-//  of patent rights can be found in the PATENTS file in the same directory.
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
 //
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-//  FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-//  ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) 2017-present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import "PhotoFeedModel.h"

--- a/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoFeedModel.swift
+++ b/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoFeedModel.swift
@@ -67,9 +67,9 @@ final class PhotoFeedModel {
 	private func fetchNextPageOfPopularPhotos(replaceData: Bool, numberOfAdditionsCompletion: @escaping (Int, NetworkingErrors?) -> ()) {
 
 		if currentPage == totalPages, currentPage != 0 {
-            DispatchQueue.main.async {
-                return numberOfAdditionsCompletion(0, .customError("No pages left to parse"))
-            }
+			DispatchQueue.main.async {
+				return numberOfAdditionsCompletion(0, .customError("No pages left to parse"))
+			}
 		}
 
 		var newPhotos: [PhotoModel] = []

--- a/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoFeedModel.swift
+++ b/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoFeedModel.swift
@@ -68,8 +68,9 @@ final class PhotoFeedModel {
 
 		if currentPage == totalPages, currentPage != 0 {
 			DispatchQueue.main.async {
-				return numberOfAdditionsCompletion(0, .customError("No pages left to parse"))
+				numberOfAdditionsCompletion(0, .customError("No pages left to parse"))
 			}
+            return
 		}
 
 		var newPhotos: [PhotoModel] = []

--- a/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoFeedModel.swift
+++ b/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoFeedModel.swift
@@ -109,7 +109,9 @@ final class PhotoFeedModel {
 
 				case .failure(let fail):
 				print(fail)
-				numberOfAdditionsCompletion(0, fail)
+                DispatchQueue.main.async {
+                    numberOfAdditionsCompletion(0, fail)
+                }
 			}
 		}
 	}

--- a/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoFeedModel.swift
+++ b/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoFeedModel.swift
@@ -67,7 +67,9 @@ final class PhotoFeedModel {
 	private func fetchNextPageOfPopularPhotos(replaceData: Bool, numberOfAdditionsCompletion: @escaping (Int, NetworkingErrors?) -> ()) {
 
 		if currentPage == totalPages, currentPage != 0 {
-			return numberOfAdditionsCompletion(0, .customError("No pages left to parse"))
+            DispatchQueue.main.async {
+                return numberOfAdditionsCompletion(0, .customError("No pages left to parse"))
+            }
 		}
 
 		var newPhotos: [PhotoModel] = []


### PR DESCRIPTION
When there are no additions to the collection, `numberOfAdditionsCompletion` (and therefore `completeBatchFetching`) is called on a background thread instead of the main thread.

This issue has not come up in this example because the user would have to scroll literally 1000 pages in order to experience it. This is important to fix to maintain consistency in the examples. 