### PR TITLE
Faster collection operations

### DIFF
--- a/AsyncDisplayKit.xcodeproj/xcshareddata/xcschemes/AsyncDisplayKit.xcscheme
+++ b/AsyncDisplayKit.xcodeproj/xcshareddata/xcschemes/AsyncDisplayKit.xcscheme
@@ -60,6 +60,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [ASCollectionNode] Added support for interactive item movement. [Adlai Holler](https://github.com/Adlai-Holler)
 - Added an experimental "no-copy" rendering API. See ASGraphicsContext.h for info. [Adlai Holler](https://github.com/Adlai-Holler)
 - Dropped support for iOS 8. [Adlai Holler](https://github.com/Adlai-Holler)
+- Optimize internal collection operations. [Adlai Holler](https://github.com/Adlai-Holler) [#748](https://github.com/TextureGroup/Texture/pull/748)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -719,19 +719,9 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (NSArray<NSIndexPath *> *)convertIndexPathsToCollectionNode:(NSArray<NSIndexPath *> *)indexPaths
 {
-  if (indexPaths == nil) {
-    return nil;
-  }
-
-  NSMutableArray<NSIndexPath *> *indexPathsArray = [NSMutableArray arrayWithCapacity:indexPaths.count];
-
-  for (NSIndexPath *indexPathInView in indexPaths) {
-    NSIndexPath *indexPath = [self convertIndexPathToCollectionNode:indexPathInView];
-    if (indexPath != nil) {
-      [indexPathsArray addObject:indexPath];
-    }
-  }
-  return indexPathsArray;
+  return ASArrayByFlatMapping(indexPaths, NSIndexPath *indexPathInView, ({
+    [self convertIndexPathToCollectionNode:indexPathInView];
+  }));
 }
 
 - (ASCellNode *)supplementaryNodeForElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath
@@ -747,17 +737,10 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 - (NSArray *)visibleNodes
 {
   NSArray *indexPaths = [self indexPathsForVisibleItems];
-  NSMutableArray *visibleNodes = [[NSMutableArray alloc] init];
   
-  for (NSIndexPath *indexPath in indexPaths) {
-    ASCellNode *node = [self nodeForItemAtIndexPath:indexPath];
-    if (node) {
-      // It is possible for UICollectionView to return indexPaths before the node is completed.
-      [visibleNodes addObject:node];
-    }
-  }
-  
-  return visibleNodes;
+  return ASArrayByFlatMapping(indexPaths, NSIndexPath *indexPath, ({
+    [self nodeForItemAtIndexPath:indexPath];
+  }));
 }
 
 - (BOOL)usesSynchronousDataLoading
@@ -2176,13 +2159,9 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     return;
   }
 
-  NSMutableArray<NSIndexPath *> *uikitIndexPaths = [NSMutableArray arrayWithCapacity:nodes.count];
-  for (ASCellNode *node in nodes) {
-    NSIndexPath *uikitIndexPath = [self indexPathForNode:node];
-    if (uikitIndexPath != nil) {
-      [uikitIndexPaths addObject:uikitIndexPath];
-    }
-  }
+  NSArray *uikitIndexPaths = ASArrayByFlatMapping(nodes, ASCellNode *node, ({
+    [self indexPathForNode:node];
+  }));
   
   [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:uikitIndexPaths batched:NO];
   

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -163,7 +163,7 @@
                       @"Yoga tree should always be in sync with .yogaNodes array! %@", self.yogaChildren);
 
   NSArray *sublayouts = ASArrayByFlatMapping(self.yogaChildren, ASDisplayNode *subnode, ({
-    [subnode layoutForYogaNode]
+    [subnode layoutForYogaNode];
   }));
 
   // The layout for self should have position CGPointNull, but include the calculated size.

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -162,10 +162,9 @@
   ASDisplayNodeAssert(childCount == self.yogaChildren.count,
                       @"Yoga tree should always be in sync with .yogaNodes array! %@", self.yogaChildren);
 
-  NSMutableArray *sublayouts = [NSMutableArray arrayWithCapacity:childCount];
-  for (ASDisplayNode *subnode in self.yogaChildren) {
-    [sublayouts addObject:[subnode layoutForYogaNode]];
-  }
+  NSArray *sublayouts = ASArrayByFlatMapping(self.yogaChildren, ASDisplayNode *subnode, ({
+    [subnode layoutForYogaNode]
+  }));
 
   // The layout for self should have position CGPointNull, but include the calculated size.
   CGSize size = CGSizeMake(YGNodeLayoutGetWidth(yogaNode), YGNodeLayoutGetHeight(yogaNode));

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -158,8 +158,7 @@
 - (void)setupYogaCalculatedLayout
 {
   YGNodeRef yogaNode = self.style.yogaNode;
-  uint32_t childCount = YGNodeGetChildCount(yogaNode);
-  ASDisplayNodeAssert(childCount == self.yogaChildren.count,
+  ASDisplayNodeAssert(YGNodeGetChildCount(yogaNode) == self.yogaChildren.count,
                       @"Yoga tree should always be in sync with .yogaNodes array! %@", self.yogaChildren);
 
   NSArray *sublayouts = ASArrayByFlatMapping(self.yogaChildren, ASDisplayNode *subnode, ({

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -607,15 +607,9 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     return nil;
   }
 
-  NSMutableArray<NSIndexPath *> *indexPathsArray = [NSMutableArray new];
-
-  for (NSIndexPath *indexPathInView in indexPaths) {
-    NSIndexPath *indexPath = [self convertIndexPathToTableNode:indexPathInView];
-    if (indexPath != nil) {
-      [indexPathsArray addObject:indexPath];
-    }
-  }
-  return indexPathsArray;
+  return ASArrayByFlatMapping(indexPaths, NSIndexPath *indexPathInView, ({
+    [self convertIndexPathToTableNode:indexPathInView];
+  }));
 }
 
 - (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -230,6 +230,7 @@
  * Result class must have -initWithObjects:count:
  */
 #define ASCollectionByFlatMapping(resultClass, collection, decl, work) ({ \
+  /* Would love to make this unretained but not possible. Tried everything. */ \
   id _cArray[collection.count]; \
   NSUInteger _i = 0; \
   for (decl in collection) {\

--- a/Source/Details/ASCollectionFlowLayoutDelegate.m
+++ b/Source/Details/ASCollectionFlowLayoutDelegate.m
@@ -59,7 +59,7 @@
 + (ASCollectionLayoutState *)calculateLayoutWithContext:(ASCollectionLayoutContext *)context
 {
   ASElementMap *elements = context.elements;
-  NSMutableArray<ASCellNode *> *children = ASArrayByFlatMapping(elements.itemElements, ASCollectionElement *element, element.node);
+  NSArray<ASCellNode *> *children = ASArrayByFlatMapping(elements.itemElements, ASCollectionElement *element, element.node);
   if (children.count == 0) {
     return [[ASCollectionLayoutState alloc] initWithContext:context];
   }

--- a/Source/Details/ASCollectionGalleryLayoutDelegate.mm
+++ b/Source/Details/ASCollectionGalleryLayoutDelegate.mm
@@ -102,9 +102,9 @@
     return [[ASCollectionLayoutState alloc] initWithContext:context];
   }
 
-  NSMutableArray<_ASGalleryLayoutItem *> *children = ASArrayByFlatMapping(elements.itemElements,
-                                                                          ASCollectionElement *element,
-                                                                          [[_ASGalleryLayoutItem alloc] initWithItemSize:itemSize collectionElement:element]);
+  NSArray<_ASGalleryLayoutItem *> *children = ASArrayByFlatMapping(elements.itemElements,
+                                                                   ASCollectionElement *element,
+                                                                   [[_ASGalleryLayoutItem alloc] initWithItemSize:itemSize collectionElement:element]);
   if (children.count == 0) {
     return [[ASCollectionLayoutState alloc] initWithContext:context];
   }

--- a/Source/Details/ASElementMap.h
+++ b/Source/Details/ASElementMap.h
@@ -32,6 +32,11 @@ AS_SUBCLASSING_RESTRICTED
 @interface ASElementMap : NSObject <NSCopying, NSFastEnumeration>
 
 /**
+ * The total number of elements in this map.
+ */
+@property (readonly) NSUInteger count;
+
+/**
  * The number of sections (of items) in this map.
  */
 @property (readonly) NSInteger numberOfSections;

--- a/Source/Details/ASElementMap.m
+++ b/Source/Details/ASElementMap.m
@@ -75,6 +75,11 @@
   return self;
 }
 
+- (NSUInteger)count
+{
+  return _elementToIndexPathMap.count;
+}
+
 - (NSArray<NSIndexPath *> *)itemIndexPaths
 {
   return ASIndexPathsForTwoDimensionalArray(_sectionsOfItems);

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -203,13 +203,9 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
       _sublayoutLayoutElements = nil;
     } else {
       // Add sublayouts layout elements to an internal array to retain it while the layout lives
-      NSUInteger sublayoutCount = _sublayouts.count;
-      if (sublayoutCount > 0) {
-        _sublayoutLayoutElements = [NSMutableArray arrayWithCapacity:sublayoutCount];
-        for (ASLayout *sublayout in _sublayouts) {
-          [_sublayoutLayoutElements addObject:sublayout.layoutElement];
-        }
-      }
+      _sublayoutLayoutElements = ASArrayByFlatMapping(_sublayouts, ASLayout *sublayout, ({
+        sublayout.layoutElement;
+      }));
     }
   }
 }
@@ -236,7 +232,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
     queue.push_back({sublayout, sublayout.position});
   }
   
-  NSMutableArray *flattenedSublayouts = [NSMutableArray array];
+  std::vector<ASLayout *> flattenedSublayouts;
   
   while (!queue.empty()) {
     const Context context = queue.front();
@@ -255,7 +251,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
                                           position:absolutePosition
                                         sublayouts:@[]];
       }
-      [flattenedSublayouts addObject:layout];
+      flattenedSublayouts.push_back(layout);
     } else if (sublayoutsCount > 0){
       std::vector<Context> sublayoutContexts;
       for (ASLayout *sublayout in sublayouts) {
@@ -265,7 +261,8 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
     }
   }
   
-  ASLayout *layout = [ASLayout layoutWithLayoutElement:_layoutElement size:_size sublayouts:flattenedSublayouts];
+  NSArray *sublayoutsArray = [NSArray arrayWithObjects:flattenedSublayouts.data() count:flattenedSublayouts.size()];
+  ASLayout *layout = [ASLayout layoutWithLayoutElement:_layoutElement size:_size sublayouts:sublayoutsArray];
   // All flattened layouts must have this flag enabled
   // to ensure sublayout elements are retained until the layouts are applied.
   layout.retainSublayoutLayoutElements = YES;

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -203,7 +203,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
       _sublayoutLayoutElements = nil;
     } else {
       // Add sublayouts layout elements to an internal array to retain it while the layout lives
-      _sublayoutLayoutElements = ASArrayByFlatMapping(_sublayouts, ASLayout *sublayout, ({
+      _sublayoutLayoutElements = ASMutableArrayByFlatMapping(_sublayouts, ASLayout *sublayout, ({
         sublayout.layoutElement;
       }));
     }

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -295,19 +295,15 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
 {
-  NSArray *children = self.children;
-  NSMutableArray *sublayouts = [NSMutableArray arrayWithCapacity:children.count];
-  
   CGSize size = constrainedSize.min;
-  for (id<ASLayoutElement> child in children) {
+  NSArray *sublayouts = ASArrayByFlatMapping(self.children, id<ASLayoutElement> child, ({
     ASLayout *sublayout = [child layoutThatFits:constrainedSize parentSize:constrainedSize.max];
     sublayout.position = CGPointZero;
     
     size.width = MAX(size.width,  sublayout.size.width);
     size.height = MAX(size.height, sublayout.size.height);
-    
-    [sublayouts addObject:sublayout];
-  }
+    sublayout;
+  }));
   
   return [ASLayout layoutWithLayoutElement:self size:size sublayouts:sublayouts];
 }

--- a/Source/Private/ASTwoDimensionalArrayUtils.m
+++ b/Source/Private/ASTwoDimensionalArrayUtils.m
@@ -27,13 +27,10 @@
 
 NSMutableArray<NSMutableArray *> *ASTwoDimensionalArrayDeepMutableCopy(NSArray<NSArray *> *array)
 {
-  NSMutableArray *newArray = [NSMutableArray arrayWithCapacity:array.count];
-  NSInteger i = 0;
-  for (NSArray *subarray in array) {
+  return ASMutableArrayByFlatMapping(array, NSArray *subarray, ({
     ASDisplayNodeCAssert([subarray isKindOfClass:[NSArray class]], @"This function expects NSArray<NSArray *> *");
-    newArray[i++] = [subarray mutableCopy];
-  }
-  return newArray;
+    [subarray mutableCopy];
+  }));
 }
 
 void ASDeleteElementsInTwoDimensionalArrayAtIndexPaths(NSMutableArray *mutableArray, NSArray<NSIndexPath *> *indexPaths)

--- a/Source/_ASTransitionContext.m
+++ b/Source/_ASTransitionContext.m
@@ -69,11 +69,9 @@ NSString * const ASTransitionContextToLayoutKey = @"org.asyncdisplaykit.ASTransi
 
 - (NSArray<ASDisplayNode *> *)subnodesForKey:(NSString *)key
 {
-  NSMutableArray<ASDisplayNode *> *subnodes = [NSMutableArray array];
-  for (ASLayout *sublayout in [self layoutForKey:key].sublayouts) {
-    [subnodes addObject:(ASDisplayNode *)sublayout.layoutElement];
-  }
-  return subnodes;
+  return ASArrayByFlatMapping([self layoutForKey:key].sublayouts, ASLayout *sublayout, ({
+    (ASDisplayNode *)sublayout.layoutElement;
+  }));
 }
 
 - (NSArray<ASDisplayNode *> *)insertedSubnodes


### PR DESCRIPTION
The idea here is, standardize on `ASArrayByFlatMapping` and make that macro faster and return an immutable array.

Immutable arrays mean (1) free copying, and (2) free zero-arrays and optimized singleObjectArrays, which means less retaining/releasing. Yay!

I haven't profiled this yet. Just want to put it out there.