### PR TITLE
[ASDisplayNode] Always return the thread-safe cornerRadius property, even in slow CALayer rounding mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
-- [ASTraitCollection] Add new properties of UITraitCollection to ASTraitCollection. [Yevgen Pogribnyi](https://github.com/ypogribnyi)
+- [ATTENTION] ASDisplayNode's cornerRadius is a new thread-safe bridged property that should be preferred over CALayer's. Use the latter at your own risk! [Huy Nguyen](https://github.com/nguyenhuy) [#749](https://github.com/TextureGroup/Texture/pull/749).
+- [ASTraitCollection] Add new properties of UITraitCollection to ASTraitCollecti
+on. [Yevgen Pogribnyi](https://github.com/ypogribnyi)
 - [ASRectMap] Replace implementation of ASRectTable with a simpler one based on unordered_map.[Scott Goodson](https://github.com/appleguy) [#719](https://github.com/TextureGroup/Texture/pull/719)
 - [ASCollectionView] Add missing flags for ASCollectionDelegate [Ilya Zheleznikov](https://github.com/ilyailya) [#718](https://github.com/TextureGroup/Texture/pull/718)
 - [ASNetworkImageNode] Deprecates .URLs in favor of .URL [Garrett Moon](https://github.com/garrettmoon) [#699](https://github.com/TextureGroup/Texture/pull/699)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
 - [ATTENTION] ASDisplayNode's cornerRadius is a new thread-safe bridged property that should be preferred over CALayer's. Use the latter at your own risk! [Huy Nguyen](https://github.com/nguyenhuy) [#749](https://github.com/TextureGroup/Texture/pull/749).
-- [ASTraitCollection] Add new properties of UITraitCollection to ASTraitCollecti
-on. [Yevgen Pogribnyi](https://github.com/ypogribnyi)
+- [ASTraitCollection] Add new properties of UITraitCollection to ASTraitCollection. [Yevgen Pogribnyi](https://github.com/ypogribnyi)
 - [ASRectMap] Replace implementation of ASRectTable with a simpler one based on unordered_map.[Scott Goodson](https://github.com/appleguy) [#719](https://github.com/TextureGroup/Texture/pull/719)
 - [ASCollectionView] Add missing flags for ASCollectionDelegate [Ilya Zheleznikov](https://github.com/ilyailya) [#718](https://github.com/TextureGroup/Texture/pull/718)
 - [ASNetworkImageNode] Deprecates .URLs in favor of .URL [Garrett Moon](https://github.com/garrettmoon) [#699](https://github.com/TextureGroup/Texture/pull/699)

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -659,6 +659,12 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @default ASCornerRoundingTypeDefaultSlowCALayer
  */
 @property (nonatomic, assign)           ASCornerRoundingType cornerRoundingType;  // default=Slow CALayer .cornerRadius (offscreen rendering)
+
+/** @abstract The radius to use when rounding corners of the ASDisplayNode.
+ *
+ * @discussion This property is thread-safe and should always be preferred over CALayer's cornerRadius property,
+ * even if corner rounding type is ASCornerRoundingTypeDefaultSlowCALayer.
+ */
 @property (nonatomic, assign)           CGFloat cornerRadius;                     // default=0.0
 
 @property (nonatomic, assign)           BOOL clipsToBounds;                    // default==NO

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -186,16 +186,11 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
 - (CGFloat)cornerRadius
 {
   ASDN::MutexLocker l(__instanceLock__);
-  if (_cornerRoundingType == ASCornerRoundingTypeDefaultSlowCALayer) {
-    return self.layerCornerRadius;
-  } else {
-    return _cornerRadius;
-  }
+  return _cornerRadius;
 }
 
 - (void)setCornerRadius:(CGFloat)newCornerRadius
 {
-  ASDN::MutexLocker l(__instanceLock__);
   [self updateCornerRoundingWithType:_cornerRoundingType cornerRadius:newCornerRadius];
 }
 
@@ -207,7 +202,6 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
 
 - (void)setCornerRoundingType:(ASCornerRoundingType)newRoundingType
 {
-  ASDN::MutexLocker l(__instanceLock__);
   [self updateCornerRoundingWithType:newRoundingType cornerRadius:_cornerRadius];
 }
 

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -191,7 +191,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
 
 - (void)setCornerRadius:(CGFloat)newCornerRadius
 {
-  [self updateCornerRoundingWithType:_cornerRoundingType cornerRadius:newCornerRadius];
+  [self updateCornerRoundingWithType:self.cornerRoundingType cornerRadius:newCornerRadius];
 }
 
 - (ASCornerRoundingType)cornerRoundingType
@@ -202,7 +202,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
 
 - (void)setCornerRoundingType:(ASCornerRoundingType)newRoundingType
 {
-  [self updateCornerRoundingWithType:newRoundingType cornerRadius:_cornerRadius];
+  [self updateCornerRoundingWithType:newRoundingType cornerRadius:self.cornerRadius];
 }
 
 - (NSString *)contentsGravity


### PR DESCRIPTION
- If the node's property was updated on a background thread and main thread has not executed the block that updates `cornerRadius` of the node's layer, the layer's property is out-of-date and shouldn't be used.
- After this change, ASDisplayNode's cornerRadius is the only source of truth and users must always use it instead of CALayer's.

Relevant PR: #465.
Recorded bug [here](https://cl.ly/osDG) - Pay attention to the "Save" button on the top right corner.