### PR TITLE
[ASDisplayNode] Don't force a layout pass on a visible node that enters preload state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [ASScrollNode] Ensure the node respects the given size range while calculating its layout. [#637](https://github.com/TextureGroup/Texture/pull/637) [Huy Nguyen](https://github.com/nguyenhuy)
 - [ASScrollNode] Invalidate the node's calculated layout if its scrollable directions changed. Also add unit tests for the class. [#637](https://github.com/TextureGroup/Texture/pull/637) [Huy Nguyen](https://github.com/nguyenhuy)
 - Add new unit testing to the layout engine. [Adlai Holler](https://github.com/Adlai-Holler) [#424](https://github.com/TextureGroup/Texture/pull/424)
-- [Automatic Subnode Management] Nodes with ASM enabled now insert/delete their subnodes as soon as they enter preload state, so the subnodes can preload too. [Huy Nguyen](https://github.com/nguyenhuy) [#706](https://github.com/TextureGroup/Texture/pull/706)
+- [Automatic Subnode Management] Nodes with ASM enabled now insert/delete their subnodes as soon as they enter preload state, so subnodes can start preloading right away. [Huy Nguyen](https://github.com/nguyenhuy) [#706](https://github.com/TextureGroup/Texture/pull/706)
 - [ASCollectionNode] Added support for interactive item movement. [Adlai Holler](https://github.com/Adlai-Holler)
 - Added an experimental "no-copy" rendering API. See ASGraphicsContext.h for info. [Adlai Holler](https://github.com/Adlai-Holler)
 - Dropped support for iOS 8. [Adlai Holler](https://github.com/Adlai-Holler)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [ASScrollNode] Ensure the node respects the given size range while calculating its layout. [#637](https://github.com/TextureGroup/Texture/pull/637) [Huy Nguyen](https://github.com/nguyenhuy)
 - [ASScrollNode] Invalidate the node's calculated layout if its scrollable directions changed. Also add unit tests for the class. [#637](https://github.com/TextureGroup/Texture/pull/637) [Huy Nguyen](https://github.com/nguyenhuy)
 - Add new unit testing to the layout engine. [Adlai Holler](https://github.com/Adlai-Holler) [#424](https://github.com/TextureGroup/Texture/pull/424)
-- [Automatic Subnode Management] Nodes with ASM enabled now insert/delete their subnodes as soon as they enter preload state, so subnodes can start preloading right away. [Huy Nguyen](https://github.com/nguyenhuy) [#706](https://github.com/TextureGroup/Texture/pull/706)
+- [Automatic Subnode Management] Nodes with ASM enabled now insert/delete their subnodes as soon as they enter preload state, so subnodes can start preloading right away. [Huy Nguyen](https://github.com/nguyenhuy) [#706](https://github.com/TextureGroup/Texture/pull/706) [#751](https://github.com/TextureGroup/Texture/pull/751)
 - [ASCollectionNode] Added support for interactive item movement. [Adlai Holler](https://github.com/Adlai-Holler)
 - Added an experimental "no-copy" rendering API. See ASGraphicsContext.h for info. [Adlai Holler](https://github.com/Adlai-Holler)
 - Dropped support for iOS 8. [Adlai Holler](https://github.com/Adlai-Holler)

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3079,17 +3079,17 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   ASDisplayNodeAssertMainThread();
   ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
 
-  // Force a layout pass on this node to apply its applicable pending layout, if any, so that its subnodes are inserted/deleted
-  // and start preloading right away.
+  // If this node has ASM enabled and is not yet visible, force a layout pass to apply its applicable pending layout, if any,
+  // so that its subnodes are inserted/deleted and start preloading right away.
   //
-  // - If the node has an up-to-date layout (and subnodes), calling layoutIfNeeded will be fast.
+  // - If it has an up-to-date layout (and subnodes), calling -layoutIfNeeded will be fast.
   //
-  // - If the node doesn't have a calculated or pending layout that fits its current bounds, a measurement pass will occur
-  // (see -__layout and -_u_measureNodeWithBoundsIfNecessary:). This scenario should be uncommon, and running a measurement
-  // pass here is a fine trade-off because preloading any time after this point would be late.
+  // - If it doesn't have a calculated or pending layout that fits its current bounds, a measurement pass will occur
+  // (see -__layout and -_u_measureNodeWithBoundsIfNecessary:). This scenario is uncommon,
+  // and running a measurement pass here is a fine trade-off because preloading any time after this point would be late.
   //
-  // Don't force if the node is already visible. CoreAnimation will soon trigger a (coaloesced) layout pass
-  // on the backing store, which is more efficient.
+  // Don't force a layout pass if the node is already visible. Soon CoreAnimation will trigger
+  // a (coaloesced, thus more efficient) pass on the backing store, so rely on it instead.
   BOOL shouldForceLayoutPass = NO;
   {
     ASDN::MutexLocker l(__instanceLock__);

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3089,7 +3089,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   // and running a measurement pass here is a fine trade-off because preloading any time after this point would be late.
   //
   // Don't force a layout pass if the node is already visible. Soon CoreAnimation will trigger
-  // a (coaloesced, thus more efficient) pass on the backing store, so rely on it instead.
+  // a (coalesced, thus more efficient) pass on the backing store. Rely on it instead.
   BOOL shouldForceLayoutPass = NO;
   {
     ASDN::MutexLocker l(__instanceLock__);

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3079,16 +3079,23 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   ASDisplayNodeAssertMainThread();
   ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
 
-  if (self.automaticallyManagesSubnodes) {
-    // Tell the node to apply its applicable pending layout, if any, so that its subnodes are inserted/deleted
-    // and start preloading right away.
-    //
-    // If this node has an up-to-date layout (and subnodes), calling layoutIfNeeded will be fast.
-    //
-    // If this node doesn't have a calculated or pending layout that fits its current bounds, a measurement pass will occur
-    // (see __layout and _u_measureNodeWithBoundsIfNecessary:).
-    // This scenario should be uncommon, and running a measurement pass here is a fine trade-off because preloading
-    // any time after this point would be late.
+  // Force a layout pass on the node to apply its applicable pending layout, if any, so that its subnodes are inserted/deleted
+  // and start preloading right away.
+  //
+  // - If this node has an up-to-date layout (and subnodes), calling layoutIfNeeded will be fast.
+  //
+  // - If this node doesn't have a calculated or pending layout that fits its current bounds, a measurement pass will occur
+  // (see -__layout and -_u_measureNodeWithBoundsIfNecessary:). This scenario should be uncommon, and running a measurement
+  // pass here is a fine trade-off because preloading any time after this point would be late.
+  //
+  // Don't force if the node is already visible. CoreAnimation will soon trigger a (coaloesced) layout pass
+  // on the backing store, which is more efficient.
+  BOOL shouldForceLayoutPass = NO;
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    shouldForceLayoutPass = _automaticallyManagesSubnodes && !ASInterfaceStateIncludesVisible(_interfaceState);
+  }
+  if (shouldForceLayoutPass) {
     [self layoutIfNeeded];
   }
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3079,12 +3079,12 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   ASDisplayNodeAssertMainThread();
   ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
 
-  // Force a layout pass on the node to apply its applicable pending layout, if any, so that its subnodes are inserted/deleted
+  // Force a layout pass on this node to apply its applicable pending layout, if any, so that its subnodes are inserted/deleted
   // and start preloading right away.
   //
-  // - If this node has an up-to-date layout (and subnodes), calling layoutIfNeeded will be fast.
+  // - If the node has an up-to-date layout (and subnodes), calling layoutIfNeeded will be fast.
   //
-  // - If this node doesn't have a calculated or pending layout that fits its current bounds, a measurement pass will occur
+  // - If the node doesn't have a calculated or pending layout that fits its current bounds, a measurement pass will occur
   // (see -__layout and -_u_measureNodeWithBoundsIfNecessary:). This scenario should be uncommon, and running a measurement
   // pass here is a fine trade-off because preloading any time after this point would be late.
   //


### PR DESCRIPTION
After #706, a layout pass is forced on an ASM-enabled node that enters preload state to make sure that its subnodes can start preloading as well. However, when the node is visible, a (coalesced, thus more efficient) layout pass will be triggered by CA soon anyways, so rely on it instead.