### PR TITLE
[ASPrimitiveTraitCollection] Always treat preferredContentSize as a potential nil #trivial

### DIFF
--- a/Source/ASViewController.h
+++ b/Source/ASViewController.h
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Set this block to customize the ASDisplayTraits returned when the VC transitions to the given window size.
  */
-@property (nonatomic, copy) ASDisplayTraitsForTraitWindowSizeBlock overrideDisplayTraitsWithWindowSize;
+@property (nonatomic, copy) ASDisplayTraitsForTraitWindowSizeBlock overrideDisplayTraitsWithWindowSize ASDISPLAYNODE_DEPRECATED_MSG("This property is actually never accessed inside the framework");
 
 /**
  * @abstract Passthrough property to the the .interfaceState of the node.

--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -58,6 +58,12 @@ extern ASPrimitiveContentSizeCategory ASPrimitiveContentSizeCategoryMake(UIConte
 
 #pragma mark - ASPrimitiveTraitCollection
 
+/**
+ * @abstract This is a struct equivalent of ASTraitCollection.
+ *
+ * @discussion It may be not safe to use this structure uninitialized. Please initialize it with ASPrimitiveTraitCollectionMakeDefault()
+ * or ASPrimitiveTraitCollectionFromUITraitCollection(UITraitCollection*).
+ */
 typedef struct ASPrimitiveTraitCollection {
   UIUserInterfaceSizeClass horizontalSizeClass;
   UIUserInterfaceSizeClass verticalSizeClass;
@@ -175,7 +181,7 @@ AS_SUBCLASSING_RESTRICTED
 @property (nonatomic, assign, readonly) UIUserInterfaceStyle userInterfaceStyle;
 #endif
 
-@property (nonatomic, assign, readonly) UIContentSizeCategory preferredContentSizeCategory;
+@property (nonatomic, assign, readonly) UIContentSizeCategory _Nonnull preferredContentSizeCategory;
 
 @property (nonatomic, assign, readonly) CGSize containerSize;
 
@@ -186,7 +192,7 @@ AS_SUBCLASSING_RESTRICTED
 
 + (ASTraitCollection *)traitCollectionWithUITraitCollection:(UITraitCollection *)traitCollection
                                               containerSize:(CGSize)windowSize
-                                fallbackContentSizeCategory:(UIContentSizeCategory)fallbackContentSizeCategory;
+                                fallbackContentSizeCategory:(UIContentSizeCategory _Nonnull)fallbackContentSizeCategory;
 
 #if TARGET_OS_TV
 + (ASTraitCollection *)traitCollectionWithHorizontalSizeClass:(UIUserInterfaceSizeClass)horizontalSizeClass
@@ -197,7 +203,7 @@ AS_SUBCLASSING_RESTRICTED
                                          forceTouchCapability:(UIForceTouchCapability)forceTouchCapability
                                               layoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
                                            userInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle
-                                 preferredContentSizeCategory:(UIContentSizeCategory)preferredContentSizeCategory
+                                 preferredContentSizeCategory:(UIContentSizeCategory _Nonnull)preferredContentSizeCategory
                                                 containerSize:(CGSize)windowSize;
 #else
 + (ASTraitCollection *)traitCollectionWithHorizontalSizeClass:(UIUserInterfaceSizeClass)horizontalSizeClass
@@ -207,7 +213,7 @@ AS_SUBCLASSING_RESTRICTED
                                            userInterfaceIdiom:(UIUserInterfaceIdiom)userInterfaceIdiom
                                          forceTouchCapability:(UIForceTouchCapability)forceTouchCapability
                                               layoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
-                                 preferredContentSizeCategory:(UIContentSizeCategory)preferredContentSizeCategory
+                                 preferredContentSizeCategory:(UIContentSizeCategory _Nonnull)preferredContentSizeCategory
                                                 containerSize:(CGSize)windowSize;
 #endif
 

--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -59,9 +59,11 @@ extern ASPrimitiveContentSizeCategory ASPrimitiveContentSizeCategoryMake(UIConte
 #pragma mark - ASPrimitiveTraitCollection
 
 /**
- * @abstract This is a struct equivalent of ASTraitCollection.
+ * @abstract This is an internal struct-representation of ASTraitCollection.
  *
- * @discussion It may be not safe to use this structure uninitialized. Please initialize it with ASPrimitiveTraitCollectionMakeDefault()
+ * @discussion This struct is for internal use only. Framework users should always use ASTraitCollection.
+ *
+ * If you use ASPrimitiveTraitCollection, please do make sure to initialize it with ASPrimitiveTraitCollectionMakeDefault()
  * or ASPrimitiveTraitCollectionFromUITraitCollection(UITraitCollection*).
  */
 typedef struct ASPrimitiveTraitCollection {
@@ -118,17 +120,23 @@ ASDISPLAYNODE_EXTERN_C_END
 @protocol ASTraitEnvironment <NSObject>
 
 /**
- * Returns a struct-representation of the environment's ASEnvironmentDisplayTraits. This only exists as a internal
- * convenience method. Users should access the trait collections through the NSObject based asyncTraitCollection API
+ * @abstract Returns a struct-representation of the environment's ASEnvironmentDisplayTraits.
+ *
+ * @discussion This only exists as an internal convenience method. Users should access the trait collections through
+ * the NSObject based asyncTraitCollection API
  */
 - (ASPrimitiveTraitCollection)primitiveTraitCollection;
 
 /**
- * Sets a trait collection on this environment state.
+ * @abstract Sets a trait collection on this environment state.
+ *
+ * @discussion This only exists as an internal convenience method. Users should not override trait collection using it.
+ * Use [ASViewController overrideDisplayTraitsWithTraitCollection] block instead.
  */
 - (void)setPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traitCollection;
 
 /**
+ * @abstract Returns the thread-safe UITraitCollection equivalent.
  */
 - (ASTraitCollection *)asyncTraitCollection;
 
@@ -181,18 +189,16 @@ AS_SUBCLASSING_RESTRICTED
 @property (nonatomic, assign, readonly) UIUserInterfaceStyle userInterfaceStyle;
 #endif
 
-@property (nonatomic, assign, readonly) UIContentSizeCategory _Nonnull preferredContentSizeCategory;
+@property (nonatomic, assign, readonly) UIContentSizeCategory preferredContentSizeCategory;
 
 @property (nonatomic, assign, readonly) CGSize containerSize;
-
-+ (ASTraitCollection *)traitCollectionWithASPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traits;
 
 + (ASTraitCollection *)traitCollectionWithUITraitCollection:(UITraitCollection *)traitCollection
                                               containerSize:(CGSize)windowSize;
 
 + (ASTraitCollection *)traitCollectionWithUITraitCollection:(UITraitCollection *)traitCollection
                                               containerSize:(CGSize)windowSize
-                                fallbackContentSizeCategory:(UIContentSizeCategory _Nonnull)fallbackContentSizeCategory;
+                                fallbackContentSizeCategory:(UIContentSizeCategory)fallbackContentSizeCategory;
 
 #if TARGET_OS_TV
 + (ASTraitCollection *)traitCollectionWithHorizontalSizeClass:(UIUserInterfaceSizeClass)horizontalSizeClass
@@ -203,7 +209,7 @@ AS_SUBCLASSING_RESTRICTED
                                          forceTouchCapability:(UIForceTouchCapability)forceTouchCapability
                                               layoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
                                            userInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle
-                                 preferredContentSizeCategory:(UIContentSizeCategory _Nonnull)preferredContentSizeCategory
+                                 preferredContentSizeCategory:(UIContentSizeCategory)preferredContentSizeCategory
                                                 containerSize:(CGSize)windowSize;
 #else
 + (ASTraitCollection *)traitCollectionWithHorizontalSizeClass:(UIUserInterfaceSizeClass)horizontalSizeClass
@@ -213,16 +219,28 @@ AS_SUBCLASSING_RESTRICTED
                                            userInterfaceIdiom:(UIUserInterfaceIdiom)userInterfaceIdiom
                                          forceTouchCapability:(UIForceTouchCapability)forceTouchCapability
                                               layoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
-                                 preferredContentSizeCategory:(UIContentSizeCategory _Nonnull)preferredContentSizeCategory
+                                 preferredContentSizeCategory:(UIContentSizeCategory)preferredContentSizeCategory
                                                 containerSize:(CGSize)windowSize;
 #endif
 
-- (ASPrimitiveTraitCollection)primitiveTraitCollection;
 - (BOOL)isEqualToTraitCollection:(ASTraitCollection *)traitCollection;
 
 @end
 
+/**
+ * These are internal helper methods. Should never be called by the framework users.
+ */
+@interface ASTraitCollection (PrimitiveTraits)
+
++ (ASTraitCollection *)traitCollectionWithASPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traits;
+
+- (ASPrimitiveTraitCollection)primitiveTraitCollection;
+
+@end
+
 @interface ASTraitCollection (Deprecated)
+
+- (instancetype)init ASDISPLAYNODE_DEPRECATED_MSG("The default constructor of this class is going to become unavailable. Use other constructors instead.");
 
 + (ASTraitCollection *)traitCollectionWithDisplayScale:(CGFloat)displayScale
                                     userInterfaceIdiom:(UIUserInterfaceIdiom)userInterfaceIdiom

--- a/Source/Details/ASTraitCollection.m
+++ b/Source/Details/ASTraitCollection.m
@@ -32,11 +32,7 @@ ASDISPLAYNODE_INLINE UIContentSizeCategory AS_UIContentSizeCategoryUnspecified()
   }
 }
 
-ASDISPLAYNODE_INLINE ASPrimitiveContentSizeCategory safePrimitiveContentSizeCategory(ASPrimitiveContentSizeCategory sizeCategory) {
-  return sizeCategory ? sizeCategory : AS_UIContentSizeCategoryUnspecified();
-}
-
-ASDISPLAYNODE_INLINE UIContentSizeCategory safeContentSizeCategory(UIContentSizeCategory sizeCategory) {
+ASDISPLAYNODE_INLINE UIContentSizeCategory _Nonnull AS_safeContentSizeCategory(UIContentSizeCategory _Nullable sizeCategory) {
   return sizeCategory ? sizeCategory : AS_UIContentSizeCategoryUnspecified();
 }
 
@@ -100,7 +96,7 @@ ASPrimitiveTraitCollection ASPrimitiveTraitCollectionMakeDefault() {
     .displayGamut = UIDisplayGamutUnspecified,
     .userInterfaceIdiom = UIUserInterfaceIdiomUnspecified,
     .layoutDirection = UITraitEnvironmentLayoutDirectionUnspecified,
-    .preferredContentSizeCategory = AS_UIContentSizeCategoryUnspecified(),
+    .preferredContentSizeCategory = ASPrimitiveContentSizeCategoryMake(AS_UIContentSizeCategoryUnspecified()),
     .containerSize = CGSizeZero,
   };
 }
@@ -130,8 +126,8 @@ ASPrimitiveTraitCollection ASPrimitiveTraitCollectionFromUITraitCollection(UITra
 }
 
 BOOL ASPrimitiveTraitCollectionIsEqualToASPrimitiveTraitCollection(ASPrimitiveTraitCollection lhs, ASPrimitiveTraitCollection rhs) {
-  UIContentSizeCategory leftSizeCategory = (UIContentSizeCategory)safePrimitiveContentSizeCategory(lhs.preferredContentSizeCategory);
-  UIContentSizeCategory rightSizeCategory = (UIContentSizeCategory)safePrimitiveContentSizeCategory(rhs.preferredContentSizeCategory);
+  UIContentSizeCategory leftSizeCategory = AS_safeContentSizeCategory(lhs.preferredContentSizeCategory);
+  UIContentSizeCategory rightSizeCategory = AS_safeContentSizeCategory(rhs.preferredContentSizeCategory);
 
   return
     lhs.verticalSizeClass == rhs.verticalSizeClass &&
@@ -240,7 +236,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
   #if TARGET_OS_TV
     [props addObject:@{ @"userInterfaceStyle": AS_NSStringFromUIUserInterfaceStyle(traits.userInterfaceStyle) }];
   #endif
-  [props addObject:@{ @"preferredContentSizeCategory": (UIContentSizeCategory)safePrimitiveContentSizeCategory(traits.preferredContentSizeCategory) }];
+  [props addObject:@{ @"preferredContentSizeCategory": AS_safeContentSizeCategory(traits.preferredContentSizeCategory) }];
   [props addObject:@{ @"containerSize": NSStringFromCGSize(traits.containerSize) }];
   return ASObjectDescriptionMakeWithoutObject(props);
 }
@@ -272,7 +268,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
       _forceTouchCapability = forceTouchCapability;
       _layoutDirection = layoutDirection;
       _userInterfaceStyle = userInterfaceStyle;
-      _preferredContentSizeCategory = safeContentSizeCategory(preferredContentSizeCategory); // guard against misuse
+      _preferredContentSizeCategory = AS_safeContentSizeCategory(preferredContentSizeCategory); // guard against misuse
       _containerSize = windowSize;
     }
     return self;
@@ -322,7 +318,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
     _userInterfaceIdiom = userInterfaceIdiom;
     _forceTouchCapability = forceTouchCapability;
     _layoutDirection = layoutDirection;
-    _preferredContentSizeCategory = safeContentSizeCategory(preferredContentSizeCategory); // guard against misuse
+    _preferredContentSizeCategory = AS_safeContentSizeCategory(preferredContentSizeCategory); // guard against misuse
     _containerSize = windowSize;
   }
   return self;
@@ -450,7 +446,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
                                  forceTouchCapability:traits.forceTouchCapability
                                       layoutDirection:traits.layoutDirection
                                    userInterfaceStyle:traits.userInterfaceStyle
-                         preferredContentSizeCategory:(UIContentSizeCategory _Nonnull)safePrimitiveContentSizeCategory(traits.preferredContentSizeCategory)
+                         preferredContentSizeCategory:AS_safeContentSizeCategory(traits.preferredContentSizeCategory)
                                         containerSize:traits.containerSize];
 #else
   return [self traitCollectionWithHorizontalSizeClass:traits.horizontalSizeClass
@@ -460,7 +456,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
                                    userInterfaceIdiom:traits.userInterfaceIdiom
                                  forceTouchCapability:traits.forceTouchCapability
                                       layoutDirection:traits.layoutDirection
-                         preferredContentSizeCategory:(UIContentSizeCategory _Nonnull)safePrimitiveContentSizeCategory(traits.preferredContentSizeCategory)
+                         preferredContentSizeCategory:AS_safeContentSizeCategory(traits.preferredContentSizeCategory)
                                         containerSize:traits.containerSize];
 #endif
 }

--- a/Source/Details/ASTraitCollection.m
+++ b/Source/Details/ASTraitCollection.m
@@ -32,6 +32,14 @@ ASDISPLAYNODE_INLINE UIContentSizeCategory AS_UIContentSizeCategoryUnspecified()
   }
 }
 
+ASDISPLAYNODE_INLINE ASPrimitiveContentSizeCategory safePrimitiveContentSizeCategory(ASPrimitiveContentSizeCategory sizeCategory) {
+  if (sizeCategory) {
+    return sizeCategory;
+  } else {
+    return AS_UIContentSizeCategoryUnspecified();
+  }
+}
+
 ASPrimitiveContentSizeCategory ASPrimitiveContentSizeCategoryMake(UIContentSizeCategory sizeCategory) {
   if ([sizeCategory isEqualToString:UIContentSizeCategoryExtraSmall]) {
     return UIContentSizeCategoryExtraSmall;
@@ -92,7 +100,7 @@ ASPrimitiveTraitCollection ASPrimitiveTraitCollectionMakeDefault() {
     .displayGamut = UIDisplayGamutUnspecified,
     .userInterfaceIdiom = UIUserInterfaceIdiomUnspecified,
     .layoutDirection = UITraitEnvironmentLayoutDirectionUnspecified,
-    .preferredContentSizeCategory = ASPrimitiveContentSizeCategoryMake(AS_UIContentSizeCategoryUnspecified()),
+    .preferredContentSizeCategory = AS_UIContentSizeCategoryUnspecified(),
     .containerSize = CGSizeZero,
   };
 }
@@ -115,13 +123,15 @@ ASPrimitiveTraitCollection ASPrimitiveTraitCollectionFromUITraitCollection(UITra
     #if TARGET_OS_TV
       environmentTraitCollection.userInterfaceStyle = traitCollection.userInterfaceStyle;
     #endif
+  } else {
+    environmentTraitCollection.displayGamut = UIDisplayGamutSRGB; // We're on iOS 9 or lower, so this is not a P3 device.
   }
   return environmentTraitCollection;
 }
 
 BOOL ASPrimitiveTraitCollectionIsEqualToASPrimitiveTraitCollection(ASPrimitiveTraitCollection lhs, ASPrimitiveTraitCollection rhs) {
-  UIContentSizeCategory leftSizeCategory = (UIContentSizeCategory)lhs.preferredContentSizeCategory;
-  UIContentSizeCategory rightSizeCategory = (UIContentSizeCategory)rhs.preferredContentSizeCategory;
+  UIContentSizeCategory leftSizeCategory = (UIContentSizeCategory)safePrimitiveContentSizeCategory(lhs.preferredContentSizeCategory);
+  UIContentSizeCategory rightSizeCategory = (UIContentSizeCategory)safePrimitiveContentSizeCategory(rhs.preferredContentSizeCategory);
 
   return
     lhs.verticalSizeClass == rhs.verticalSizeClass &&
@@ -230,7 +240,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
   #if TARGET_OS_TV
     [props addObject:@{ @"userInterfaceStyle": AS_NSStringFromUIUserInterfaceStyle(traits.userInterfaceStyle) }];
   #endif
-  [props addObject:@{ @"preferredContentSizeCategory": (UIContentSizeCategory)traits.preferredContentSizeCategory }];
+  [props addObject:@{ @"preferredContentSizeCategory": (UIContentSizeCategory)safePrimitiveContentSizeCategory(traits.preferredContentSizeCategory) }];
   [props addObject:@{ @"containerSize": NSStringFromCGSize(traits.containerSize) }];
   return ASObjectDescriptionMakeWithoutObject(props);
 }
@@ -249,7 +259,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
                        forceTouchCapability:(UIForceTouchCapability)forceTouchCapability
                             layoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
                          userInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle
-               preferredContentSizeCategory:(UIContentSizeCategory)preferredContentSizeCategory
+               preferredContentSizeCategory:(UIContentSizeCategory _Nonnull)preferredContentSizeCategory
                               containerSize:(CGSize)windowSize
 {
     self = [super init];
@@ -276,7 +286,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
                                   forceTouchCapability:(UIForceTouchCapability)forceTouchCapability
                                        layoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
                                     userInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle
-                          preferredContentSizeCategory:(UIContentSizeCategory)preferredContentSizeCategory
+                          preferredContentSizeCategory:(UIContentSizeCategory _Nonnull)preferredContentSizeCategory
                                          containerSize:(CGSize)windowSize
 {
   return [[self alloc] initWithHorizontalSizeClass:horizontalSizeClass
@@ -300,7 +310,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
                          userInterfaceIdiom:(UIUserInterfaceIdiom)userInterfaceIdiom
                        forceTouchCapability:(UIForceTouchCapability)forceTouchCapability
                             layoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
-               preferredContentSizeCategory:(UIContentSizeCategory)preferredContentSizeCategory
+               preferredContentSizeCategory:(UIContentSizeCategory _Nonnull)preferredContentSizeCategory
                               containerSize:(CGSize)windowSize
 {
   self = [super init];
@@ -325,7 +335,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
                                     userInterfaceIdiom:(UIUserInterfaceIdiom)userInterfaceIdiom
                                   forceTouchCapability:(UIForceTouchCapability)forceTouchCapability
                                        layoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
-                          preferredContentSizeCategory:(UIContentSizeCategory)preferredContentSizeCategory
+                          preferredContentSizeCategory:(UIContentSizeCategory _Nonnull)preferredContentSizeCategory
                                          containerSize:(CGSize)windowSize
 {
   return [[self alloc] initWithHorizontalSizeClass:horizontalSizeClass
@@ -383,7 +393,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
                                  forceTouchCapability:traits.forceTouchCapability
                                       layoutDirection:traits.layoutDirection
                                    userInterfaceStyle:traits.userInterfaceStyle
-                         preferredContentSizeCategory:(UIContentSizeCategory)traits.preferredContentSizeCategory
+                         preferredContentSizeCategory:(UIContentSizeCategory _Nonnull)safePrimitiveContentSizeCategory(traits.preferredContentSizeCategory)
                                         containerSize:traits.containerSize];
 #else
   return [self traitCollectionWithHorizontalSizeClass:traits.horizontalSizeClass
@@ -393,7 +403,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
                                    userInterfaceIdiom:traits.userInterfaceIdiom
                                  forceTouchCapability:traits.forceTouchCapability
                                       layoutDirection:traits.layoutDirection
-                         preferredContentSizeCategory:(UIContentSizeCategory)traits.preferredContentSizeCategory
+                         preferredContentSizeCategory:(UIContentSizeCategory _Nonnull)safePrimitiveContentSizeCategory(traits.preferredContentSizeCategory)
                                         containerSize:traits.containerSize];
 #endif
 }
@@ -409,7 +419,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
 
 + (instancetype)traitCollectionWithUITraitCollection:(UITraitCollection *)traitCollection
                                        containerSize:(CGSize)windowSize
-                         fallbackContentSizeCategory:(UIContentSizeCategory)fallbackContentSizeCategory
+                         fallbackContentSizeCategory:(UIContentSizeCategory _Nonnull)fallbackContentSizeCategory
 {
   UIDisplayGamut displayGamut;
   UITraitEnvironmentLayoutDirection layoutDirection;
@@ -425,7 +435,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
       userInterfaceStyle = traitCollection.userInterfaceStyle;
     #endif
   } else {
-    displayGamut = UIDisplayGamutUnspecified;
+    displayGamut = UIDisplayGamutSRGB; // We're on iOS 9 or lower, so this is not a P3 device.
     layoutDirection = UITraitEnvironmentLayoutDirectionUnspecified;
     sizeCategory = fallbackContentSizeCategory;
     #if TARGET_OS_TV


### PR DESCRIPTION
As `ASPrimitiveTraitCollection` is a struct, the application can always initialize it in its own way, without using Texture-provided initialization functions. This may lead to `preferredContentSize` field being `nil`, which, in turn, may lead to frustrating crashes when the struct is given to Texture.

While simply advising the user to always use the provided initialization functions should solve the problem, it's better to always treat this structure as possibly improperly initialized and guard against `nil` value in this field.

Additionally this PR explicitly marks all `UIContentSizeCategory` usage in `ASTraitCollection` class as non-null.