### PR TITLE
Revert "Faster collection operations"

### DIFF
--- a/AsyncDisplayKit.xcodeproj/xcshareddata/xcschemes/AsyncDisplayKit.xcscheme
+++ b/AsyncDisplayKit.xcodeproj/xcshareddata/xcschemes/AsyncDisplayKit.xcscheme
@@ -60,7 +60,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      disableMainThreadChecker = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 - [ASCollectionNode] Added support for interactive item movement. [Adlai Holler](https://github.com/Adlai-Holler)
 - Added an experimental "no-copy" rendering API. See ASGraphicsContext.h for info. [Adlai Holler](https://github.com/Adlai-Holler)
 - Dropped support for iOS 8. [Adlai Holler](https://github.com/Adlai-Holler)
-- Optimize internal collection operations. [Adlai Holler](https://github.com/Adlai-Holler) [#748](https://github.com/TextureGroup/Texture/pull/748)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -158,12 +158,14 @@
 - (void)setupYogaCalculatedLayout
 {
   YGNodeRef yogaNode = self.style.yogaNode;
-  ASDisplayNodeAssert(YGNodeGetChildCount(yogaNode) == self.yogaChildren.count,
+  uint32_t childCount = YGNodeGetChildCount(yogaNode);
+  ASDisplayNodeAssert(childCount == self.yogaChildren.count,
                       @"Yoga tree should always be in sync with .yogaNodes array! %@", self.yogaChildren);
 
-  NSArray *sublayouts = ASArrayByFlatMapping(self.yogaChildren, ASDisplayNode *subnode, ({
-    [subnode layoutForYogaNode];
-  }));
+  NSMutableArray *sublayouts = [NSMutableArray arrayWithCapacity:childCount];
+  for (ASDisplayNode *subnode in self.yogaChildren) {
+    [sublayouts addObject:[subnode layoutForYogaNode]];
+  }
 
   // The layout for self should have position CGPointNull, but include the calculated size.
   CGSize size = CGSizeMake(YGNodeLayoutGetWidth(yogaNode), YGNodeLayoutGetHeight(yogaNode));

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -607,9 +607,15 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     return nil;
   }
 
-  return ASArrayByFlatMapping(indexPaths, NSIndexPath *indexPathInView, ({
-    [self convertIndexPathToTableNode:indexPathInView];
-  }));
+  NSMutableArray<NSIndexPath *> *indexPathsArray = [NSMutableArray new];
+
+  for (NSIndexPath *indexPathInView in indexPaths) {
+    NSIndexPath *indexPath = [self convertIndexPathToTableNode:indexPathInView];
+    if (indexPath != nil) {
+      [indexPathsArray addObject:indexPath];
+    }
+  }
+  return indexPathsArray;
 }
 
 - (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -132,6 +132,22 @@
 #define __has_attribute(x) 0 // Compatibility with non-clang compilers.
 #endif
 
+#ifndef NS_CONSUMED
+#if __has_feature(attribute_ns_consumed)
+#define NS_CONSUMED __attribute__((ns_consumed))
+#else
+#define NS_CONSUMED
+#endif
+#endif
+
+#ifndef NS_RETURNS_RETAINED
+#if __has_feature(attribute_ns_returns_retained)
+#define NS_RETURNS_RETAINED __attribute__((ns_returns_retained))
+#else
+#define NS_RETURNS_RETAINED
+#endif
+#endif
+
 #ifndef CF_RETURNS_RETAINED
 #if __has_feature(attribute_cf_returns_retained)
 #define CF_RETURNS_RETAINED __attribute__((cf_returns_retained))
@@ -229,38 +245,26 @@
  * Create a new set by mapping `collection` over `work`, ignoring nil.
  */
 #define ASSetByFlatMapping(collection, decl, work) ({ \
-  CFTypeRef _cArray[collection.count]; \
-  NSUInteger _i = 0; \
+  NSMutableSet *s = [NSMutableSet set]; \
   for (decl in collection) {\
-    if ((_cArray[_i] = (__bridge_retained CFTypeRef)work)) { \
-      _i++; \
+    id result = work; \
+    if (result != nil) { \
+      [s addObject:result]; \
     } \
   } \
-  NSSet *result; \
-  if (_i == 0) { \
-    /** Zero fast path. */ \
-    result = [NSSet set]; \
-  } else if (_i == 1) { \
-    /** NSSingleObjectSet is fast. Create one and release. */ \
-    CFTypeRef val = _cArray[0]; \
-    result = [NSSet setWithObject:(__bridge id)val]; \
-    CFBridgingRelease(val); \
-  } else { \
-    CFSetCallBacks cb = kCFTypeSetCallBacks; \
-    cb.retain = NULL; \
-    result = (__bridge NSSet *)CFSetCreate(kCFAllocatorDefault, _cArray, _i, &cb); \
-  } \
-  result; \
+  s; \
 })
 
 /**
  * Create a new ObjectPointerPersonality NSHashTable by mapping `collection` over `work`, ignoring nil.
  */
 #define ASPointerTableByFlatMapping(collection, decl, work) ({ \
-  NSHashTable *t = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:collection.count]; \
+  NSHashTable *t = [NSHashTable hashTableWithOptions:NSHashTableObjectPointerPersonality]; \
   for (decl in collection) {\
-    /* NSHashTable accepts nil and avoid extra retain/release. */ \
-    [t addObject:work]; \
+    id result = work; \
+    if (result != nil) { \
+      [t addObject:result]; \
+    } \
   } \
   t; \
 })
@@ -269,37 +273,12 @@
  * Create a new array by mapping `collection` over `work`, ignoring nil.
  */
 #define ASArrayByFlatMapping(collection, decl, work) ({ \
-  CFTypeRef _cArray[collection.count]; \
-  NSUInteger _i = 0; \
+  NSMutableArray *a = [NSMutableArray array]; \
   for (decl in collection) {\
-    if ((_cArray[_i] = (__bridge_retained CFTypeRef)work)) { \
-      _i++; \
+    id result = work; \
+    if (result != nil) { \
+      [a addObject:result]; \
     } \
   } \
-  NSArray *result; \
-  if (_i == 0) { \
-    /** Zero array fast path. */ \
-    result = @[]; \
-  } else if (_i == 1) { \
-    /** NSSingleObjectArray is fast. Create one and release. */ \
-    CFTypeRef val = _cArray[0]; \
-    result = [NSArray arrayWithObject:(__bridge id)val]; \
-    CFBridgingRelease(val); \
-  } else { \
-    CFArrayCallBacks cb = kCFTypeArrayCallBacks; \
-    cb.retain = NULL; \
-    result = (__bridge NSArray *)CFArrayCreate(kCFAllocatorDefault, _cArray, _i, &cb); \
-  } \
-  result; \
-})
-
-#define ASMutableArrayByFlatMapping(collection, decl, work) ({ \
-  id _cArray[collection.count]; \
-  NSUInteger _i = 0; \
-  for (decl in collection) {\
-    if ((_cArray[_i] = work)) { \
-      _i++; \
-    } \
-  } \
-  [[NSMutableArray alloc] initWithObjects:_cArray count:_i]; \
+  a; \
 })

--- a/Source/Details/ASCollectionFlowLayoutDelegate.m
+++ b/Source/Details/ASCollectionFlowLayoutDelegate.m
@@ -59,7 +59,7 @@
 + (ASCollectionLayoutState *)calculateLayoutWithContext:(ASCollectionLayoutContext *)context
 {
   ASElementMap *elements = context.elements;
-  NSArray<ASCellNode *> *children = ASArrayByFlatMapping(elements.itemElements, ASCollectionElement *element, element.node);
+  NSMutableArray<ASCellNode *> *children = ASArrayByFlatMapping(elements.itemElements, ASCollectionElement *element, element.node);
   if (children.count == 0) {
     return [[ASCollectionLayoutState alloc] initWithContext:context];
   }

--- a/Source/Details/ASCollectionGalleryLayoutDelegate.mm
+++ b/Source/Details/ASCollectionGalleryLayoutDelegate.mm
@@ -102,9 +102,9 @@
     return [[ASCollectionLayoutState alloc] initWithContext:context];
   }
 
-  NSArray<_ASGalleryLayoutItem *> *children = ASArrayByFlatMapping(elements.itemElements,
-                                                                   ASCollectionElement *element,
-                                                                   [[_ASGalleryLayoutItem alloc] initWithItemSize:itemSize collectionElement:element]);
+  NSMutableArray<_ASGalleryLayoutItem *> *children = ASArrayByFlatMapping(elements.itemElements,
+                                                                          ASCollectionElement *element,
+                                                                          [[_ASGalleryLayoutItem alloc] initWithItemSize:itemSize collectionElement:element]);
   if (children.count == 0) {
     return [[ASCollectionLayoutState alloc] initWithContext:context];
   }

--- a/Source/Details/ASElementMap.h
+++ b/Source/Details/ASElementMap.h
@@ -32,11 +32,6 @@ AS_SUBCLASSING_RESTRICTED
 @interface ASElementMap : NSObject <NSCopying, NSFastEnumeration>
 
 /**
- * The total number of elements in this map.
- */
-@property (readonly) NSUInteger count;
-
-/**
  * The number of sections (of items) in this map.
  */
 @property (readonly) NSInteger numberOfSections;

--- a/Source/Details/ASElementMap.m
+++ b/Source/Details/ASElementMap.m
@@ -75,11 +75,6 @@
   return self;
 }
 
-- (NSUInteger)count
-{
-  return _elementToIndexPathMap.count;
-}
-
 - (NSArray<NSIndexPath *> *)itemIndexPaths
 {
   return ASIndexPathsForTwoDimensionalArray(_sectionsOfItems);

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -295,15 +295,19 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
 {
+  NSArray *children = self.children;
+  NSMutableArray *sublayouts = [NSMutableArray arrayWithCapacity:children.count];
+  
   CGSize size = constrainedSize.min;
-  NSArray *sublayouts = ASArrayByFlatMapping(self.children, id<ASLayoutElement> child, ({
+  for (id<ASLayoutElement> child in children) {
     ASLayout *sublayout = [child layoutThatFits:constrainedSize parentSize:constrainedSize.max];
     sublayout.position = CGPointZero;
     
     size.width = MAX(size.width,  sublayout.size.width);
     size.height = MAX(size.height, sublayout.size.height);
-    sublayout;
-  }));
+    
+    [sublayouts addObject:sublayout];
+  }
   
   return [ASLayout layoutWithLayoutElement:self size:size sublayouts:sublayouts];
 }

--- a/Source/Private/ASTwoDimensionalArrayUtils.m
+++ b/Source/Private/ASTwoDimensionalArrayUtils.m
@@ -27,10 +27,13 @@
 
 NSMutableArray<NSMutableArray *> *ASTwoDimensionalArrayDeepMutableCopy(NSArray<NSArray *> *array)
 {
-  return ASMutableArrayByFlatMapping(array, NSArray *subarray, ({
+  NSMutableArray *newArray = [NSMutableArray arrayWithCapacity:array.count];
+  NSInteger i = 0;
+  for (NSArray *subarray in array) {
     ASDisplayNodeCAssert([subarray isKindOfClass:[NSArray class]], @"This function expects NSArray<NSArray *> *");
-    [subarray mutableCopy];
-  }));
+    newArray[i++] = [subarray mutableCopy];
+  }
+  return newArray;
 }
 
 void ASDeleteElementsInTwoDimensionalArrayAtIndexPaths(NSMutableArray *mutableArray, NSArray<NSIndexPath *> *indexPaths)

--- a/Source/_ASTransitionContext.m
+++ b/Source/_ASTransitionContext.m
@@ -69,9 +69,11 @@ NSString * const ASTransitionContextToLayoutKey = @"org.asyncdisplaykit.ASTransi
 
 - (NSArray<ASDisplayNode *> *)subnodesForKey:(NSString *)key
 {
-  return ASArrayByFlatMapping([self layoutForKey:key].sublayouts, ASLayout *sublayout, ({
-    (ASDisplayNode *)sublayout.layoutElement;
-  }));
+  NSMutableArray<ASDisplayNode *> *subnodes = [NSMutableArray array];
+  for (ASLayout *sublayout in [self layoutForKey:key].sublayouts) {
+    [subnodes addObject:(ASDisplayNode *)sublayout.layoutElement];
+  }
+  return subnodes;
 }
 
 - (NSArray<ASDisplayNode *> *)insertedSubnodes


### PR DESCRIPTION
Reverts TextureGroup/Texture#748

I should have  marked that diff is not ready to land. I need to address the issue that, if you call `mutableCopy` on an array created using our custom callbacks, the copy will not retain its objects.

I have a solution, but until I implement it (tonight?) this isn't 100% production-safe.