### PR TITLE
NoCopyRendering experiment: Fix possible memory leak if image node rendering is canceled #trivial

### DIFF
--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -525,7 +525,7 @@ static ASDN::StaticMutex& cacheLock = *new ASDN::StaticMutex;
   // The following `UIGraphicsGetImageFromCurrentImageContext` call will commonly take more than 20ms on an
   // A5 processor.  Check for cancellation before we call it.
   if (isCancelled()) {
-    UIGraphicsEndImageContext();
+    ASGraphicsEndImageContext();
     return nil;
   }
 

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -522,8 +522,7 @@ static ASDN::StaticMutex& cacheLock = *new ASDN::StaticMutex;
     key.didDisplayNodeContentWithRenderingContext(context, drawParameters);
   }
 
-  // The following `UIGraphicsGetImageFromCurrentImageContext` call will commonly take more than 20ms on an
-  // A5 processor.  Check for cancellation before we call it.
+  // Check cancellation one last time before forming image.
   if (isCancelled()) {
     ASGraphicsEndImageContext();
     return nil;

--- a/Source/Details/ASGraphicsContext.h
+++ b/Source/Details/ASGraphicsContext.h
@@ -23,6 +23,9 @@
  *
  * The API mirrors the UIGraphics API, with the exception that forming an image
  * ends the context as well.
+ *
+ * Note: You must not mix-and-match between ASGraphics* and UIGraphics* functions
+ * within the same drawing operation.
  */
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
Because I forgot to replace this `UIGraphicsEndImageContext` call with its `ASGraphics` version, if you have the experiment enabled and this branch is taken then the image buffer will not be freed.