### PR TITLE
Update PINCache

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "pinterest/PINRemoteImage" "3.0.0-beta.13"
-github "pinterest/PINCache"
+github "pinterest/PINCache" "3.0.1-beta.6"


### PR DESCRIPTION
Similar to the issue described in https://github.com/pinterest/PINRemoteImage/issues/363, I've been experiencing the runtime error `dyld: Symbol not found: _PINDiskCachePrefix` when using Carthage and Texture in my project.

The solution described in the referenced issue is to checkout `PINRemoteImage` separately, run `carthage update` and then copy the built frameworks over. This works and appears to be because `PINRemoteImage` references `PINCache` at the `3.0.1-beta.6` release.

I've updated Texture's `Cartfile` in this PR to also reference `PINCache` at `3.0.1-beta.6`. This does appear to solve the runtime error for my project so I'm suggesting this change for others that may experience this crash.