### PR TITLE
Expose asyncdisplaykit_node in _ASDisplayView same as in _ASDisplayLayer #trivial

### DIFF
--- a/Source/Details/_ASDisplayView.h
+++ b/Source/Details/_ASDisplayView.h
@@ -25,8 +25,8 @@
 @interface _ASDisplayView : UIView
 
 /**
- @discussion This property overrides the CALayer category method which implements this via associated objects.
- This should result in much better performance for _ASDisplayLayers.
+ @discussion This property overrides the UIView category method which implements this via associated objects.
+ This should result in much better performance for _ASDisplayView.
  */
 @property (nonatomic, weak) ASDisplayNode *asyncdisplaykit_node;
 

--- a/Source/Details/_ASDisplayView.h
+++ b/Source/Details/_ASDisplayView.h
@@ -20,7 +20,15 @@
 // This class is only for use by ASDisplayNode and should never be subclassed or used directly.
 // Note that the "node" property is added to UIView directly via a category in ASDisplayNode.
 
+@class ASDisplayNode;
+
 @interface _ASDisplayView : UIView
+
+/**
+ @discussion This property overrides the CALayer category method which implements this via associated objects.
+ This should result in much better performance for _ASDisplayLayers.
+ */
+@property (nonatomic, weak) ASDisplayNode *asyncdisplaykit_node;
 
 // These methods expose a way for ASDisplayNode touch events to let the view call super touch events
 // Some UIKit mechanisms, like UITableView and UICollectionView selection handling, require this to work

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -27,7 +27,6 @@
 #import <AsyncDisplayKit/ASLayout.h>
 
 @interface _ASDisplayView ()
-@property (nullable, atomic, weak, readwrite) ASDisplayNode *asyncdisplaykit_node;
 
 // Keep the node alive while its view is active.  If you create a view, add its layer to a layer hierarchy, then release
 // the view, the layer retains the view to prevent a crash.  This replicates this behaviour for the node abstraction.


### PR DESCRIPTION
For an upcoming diff I need to have access to the node of the `_ASDisplayView`. To be aligned with `_ASDisplayLayer` we should expose it the same way. We exposed it within https://github.com/facebookarchive/AsyncDisplayKit/pull/2346/files for `_ASDisplayLayer`