### PR TITLE
Improve ASNetworkImageNode delegate callout behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Modified `ASImageDownloaderCompletion` to add an optional `id userInfo` field. Your custom downloader can pass `nil`.
   - Modified the last argument to `-[ASNetworkImageNodeDelegate imageNode:didLoadImage:info:]` method from a struct to an object of new class `ASNetworkImageLoadInfo` which includes other metadata about the load operation.
 - Removed +load static initializer from ASDisplayNode. [Adlai Holler](https://github.com/Adlai-Holler)
+- Optimized ASNetworkImageNode loading and resolved edge cases where the image provided to the delegate was not the image that was loaded. [Adlai Holler](https://github.com/Adlai-Holler) [#778](https://github.com/TextureGroup/Texture/pull/778/)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)


### PR DESCRIPTION
- Don't dispatch to main thread if there's no callout to run.
- Don't lock and then immediately unlock when we reach the main thread.
- Don't call out with `nil` image in the case of animated images.
- Call out using the exact image we loaded, instead of re-reading `self.image` at callout time, when it may have changed. If we loaded another image in the mean time, we will have scheduled that callout and it's important to preserve the serial nature here.

As I commented in #775, the docs say these callouts are off-main, but I decided to keep the on-main behavior for this diff.