### PR TITLE
[Graphics contexts] Retain the reference color space #trivial

### DIFF
--- a/Source/Details/ASGraphicsContext.m
+++ b/Source/Details/ASGraphicsContext.m
@@ -154,7 +154,8 @@ extern UIImage * _Nullable ASGraphicsGetImageAndEndCurrentContext()
   dispatch_once(&onceToken, ^{
     UIGraphicsBeginImageContextWithOptions(CGSizeMake(1, 1), YES, 0);
     UIImage *refImage = UIGraphicsGetImageFromCurrentImageContext();
-    imageColorSpace = CGImageGetColorSpace(refImage.CGImage);
+    imageColorSpace = CGColorSpaceRetain(CGImageGetColorSpace(refImage.CGImage));
+    ASDisplayNodeCAssertNotNil(imageColorSpace, nil);
     UIGraphicsEndImageContext();
   });
   


### PR DESCRIPTION
We need to retain this since the image is about to go away.

There is however **no danger currently**, because the returned color space is a system constant so its retain count is always -1. This is just a matter of API correctness.