### PR TITLE
Fix UIResponder handling with view backing ASDisplayNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Make `ASCellNode` tint color apply to table view cell accessories. [Vladyslav Chapaev](https://github.com/ShogunPhyched) [#764](https://github.com/TextureGroup/Texture/pull/764)
 - Fix ASTextNode2 is accessing backgroundColor off main while sizing / layout is happening. [Michael Schneider](https://github.com/maicki) [#794](https://github.com/TextureGroup/Texture/pull/778/)
 - Pass scrollViewWillEndDragging delegation through in ASIGListAdapterDataSource for IGListKit integration. [#796](https://github.com/TextureGroup/Texture/pull/796)
+- Fix UIResponder handling with view backing ASDisplayNode. [Michael Schneider](https://github.com/maicki) [#789] (https://github.com/TextureGroup/Texture/pull/789/)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -856,7 +856,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     return NO;
   }
   
-  if (checkFlag(Synchronous)) {
+  if (checkFlag(Synchronous)
+      || ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(canBecomeFirstResponder))) {
     return [_view canBecomeFirstResponder];
   } else {
     return [(_ASDisplayView *)_view __canBecomeFirstResponder];
@@ -865,15 +866,19 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (BOOL)__becomeFirstResponder
 {
-  if (self.isLayerBacked || ![self __canBecomeFirstResponder]) {
+  
+  if (self.isLayerBacked || ![self canBecomeFirstResponder]) {
     return NO;
   }
-
+  
   // We explicitly create the view in here
-  if (checkFlag(Synchronous)) {
+  [self view];
+
+  if (checkFlag(Synchronous)
+      || ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(becomeFirstResponder))) {
     return [_view becomeFirstResponder];
   } else {
-    return [(_ASDisplayView *)_view __canBecomeFirstResponder];
+    return [(_ASDisplayView *)_view __becomeFirstResponder];
   }
 }
 
@@ -884,7 +889,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     return YES;
   }
 
-  if (checkFlag(Synchronous)) {
+  if (checkFlag(Synchronous)
+      || ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(canResignFirstResponder))) {
     return [_view canResignFirstResponder];
   } else {
     return [(_ASDisplayView *)_view __canResignFirstResponder];
@@ -897,7 +903,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     return NO;
   }
   
-  if (checkFlag(Synchronous)) {
+  // We explicitly create the view in here
+  [self view];
+  
+  if (checkFlag(Synchronous)
+      || ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(resignFirstResponder))) {
     return [_view resignFirstResponder];
   } else {
     return [(_ASDisplayView *)_view __resignFirstResponder];
@@ -911,7 +921,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     return NO;
   }
   
-  if (checkFlag(Synchronous)) {
+  if (checkFlag(Synchronous)
+      || ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(isFirstResponder))) {
     return [_view isFirstResponder];
   } else {
     return [(_ASDisplayView *)_view __isFirstResponder];

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -874,7 +874,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (BOOL)__becomeFirstResponder
 {
-  
   if (self.isLayerBacked || ![self canBecomeFirstResponder]) {
     return NO;
   }

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -856,11 +856,19 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     return NO;
   }
   
-  if (checkFlag(Synchronous)
-      || ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(canBecomeFirstResponder))) {
+  if (checkFlag(Synchronous)) {
+    // If the view is not a _ASDisplayView subclass (Synchronous) just call through to the view as we
+    // expect it's a non _ASDisplayView subclass that will respond
     return [_view canBecomeFirstResponder];
-  } else {
-    return [(_ASDisplayView *)_view __canBecomeFirstResponder];
+  } else{
+    if (ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(canBecomeFirstResponder))) {
+      // If the subclass overwrites canBecomeFirstResponder just call through
+      // to it as we expect it will handle it
+      return [_view canBecomeFirstResponder];
+    } else {
+      // Call through to _ASDisplayView's superclass to get it handled
+      return [(_ASDisplayView *)_view __canBecomeFirstResponder];
+    }
   }
 }
 
@@ -871,14 +879,17 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     return NO;
   }
   
-  // We explicitly create the view in here
+  // We explicitly create the view in here as it's supposed to become a first responder
   [self view];
 
-  if (checkFlag(Synchronous)
-      || ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(becomeFirstResponder))) {
+  if (checkFlag(Synchronous)) {
     return [_view becomeFirstResponder];
-  } else {
-    return [(_ASDisplayView *)_view __becomeFirstResponder];
+  } else{
+    if (ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(becomeFirstResponder))) {
+      return [_view becomeFirstResponder];
+    } else {
+      return [(_ASDisplayView *)_view __becomeFirstResponder];
+    }
   }
 }
 
@@ -889,11 +900,14 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     return YES;
   }
 
-  if (checkFlag(Synchronous)
-      || ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(canResignFirstResponder))) {
+  if (checkFlag(Synchronous)) {
     return [_view canResignFirstResponder];
-  } else {
-    return [(_ASDisplayView *)_view __canResignFirstResponder];
+  } else{
+    if (ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(canResignFirstResponder))) {
+      return [_view canResignFirstResponder];
+    } else {
+      return [(_ASDisplayView *)_view __canResignFirstResponder];
+    }
   }
 }
 
@@ -906,11 +920,14 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   // We explicitly create the view in here
   [self view];
   
-  if (checkFlag(Synchronous)
-      || ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(resignFirstResponder))) {
+  if (checkFlag(Synchronous)) {
     return [_view resignFirstResponder];
-  } else {
-    return [(_ASDisplayView *)_view __resignFirstResponder];
+  } else{
+    if (ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(resignFirstResponder))) {
+      return [_view resignFirstResponder];
+    } else {
+      return [(_ASDisplayView *)_view __resignFirstResponder];
+    }
   }
 }
 
@@ -921,11 +938,14 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     return NO;
   }
   
-  if (checkFlag(Synchronous)
-      || ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(isFirstResponder))) {
+  if (checkFlag(Synchronous)) {
     return [_view isFirstResponder];
-  } else {
-    return [(_ASDisplayView *)_view __isFirstResponder];
+  } else{
+    if (ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(isFirstResponder))) {
+      return [_view isFirstResponder];
+    } else {
+      return [(_ASDisplayView *)_view __isFirstResponder];
+    }
   }
 }
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -833,6 +833,22 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 #pragma mark UIResponder
 
+#define HANDLE_RESPONDER_METHOD(__sel) \
+  if (checkFlag(Synchronous)) { \
+    /* If the view is not a _ASDisplayView subclass (Synchronous) just call through to the view as we
+     expect it's a non _ASDisplayView subclass that will respond */ \
+    return [_view __sel]; \
+  } else { \
+    if (ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(__sel))) { \
+    /* If the subclass overwrites canBecomeFirstResponder just call through
+       to it as we expect it will handle it */ \
+      return [_view __sel]; \
+    } else { \
+      /* Call through to _ASDisplayView's superclass to get it handled */ \
+      return [(_ASDisplayView *)_view __##__sel]; \
+    } \
+  } \
+
 - (void)checkResponderCompatibility
 {
 #if ASDISPLAYNODE_ASSERTIONS_ENABLED
@@ -856,20 +872,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     return NO;
   }
   
-  if (checkFlag(Synchronous)) {
-    // If the view is not a _ASDisplayView subclass (Synchronous) just call through to the view as we
-    // expect it's a non _ASDisplayView subclass that will respond
-    return [_view canBecomeFirstResponder];
-  } else{
-    if (ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(canBecomeFirstResponder))) {
-      // If the subclass overwrites canBecomeFirstResponder just call through
-      // to it as we expect it will handle it
-      return [_view canBecomeFirstResponder];
-    } else {
-      // Call through to _ASDisplayView's superclass to get it handled
-      return [(_ASDisplayView *)_view __canBecomeFirstResponder];
-    }
-  }
+  HANDLE_RESPONDER_METHOD(canBecomeFirstResponder);
 }
 
 - (BOOL)__becomeFirstResponder
@@ -881,15 +884,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   // We explicitly create the view in here as it's supposed to become a first responder
   [self view];
 
-  if (checkFlag(Synchronous)) {
-    return [_view becomeFirstResponder];
-  } else{
-    if (ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(becomeFirstResponder))) {
-      return [_view becomeFirstResponder];
-    } else {
-      return [(_ASDisplayView *)_view __becomeFirstResponder];
-    }
-  }
+  HANDLE_RESPONDER_METHOD(becomeFirstResponder);
 }
 
 - (BOOL)__canResignFirstResponder
@@ -898,16 +893,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     // By default we return YES if no view is created yet
     return YES;
   }
-
-  if (checkFlag(Synchronous)) {
-    return [_view canResignFirstResponder];
-  } else{
-    if (ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(canResignFirstResponder))) {
-      return [_view canResignFirstResponder];
-    } else {
-      return [(_ASDisplayView *)_view __canResignFirstResponder];
-    }
-  }
+  
+  HANDLE_RESPONDER_METHOD(canResignFirstResponder);
 }
 
 - (BOOL)__resignFirstResponder
@@ -919,15 +906,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   // We explicitly create the view in here
   [self view];
   
-  if (checkFlag(Synchronous)) {
-    return [_view resignFirstResponder];
-  } else{
-    if (ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(resignFirstResponder))) {
-      return [_view resignFirstResponder];
-    } else {
-      return [(_ASDisplayView *)_view __resignFirstResponder];
-    }
-  }
+  HANDLE_RESPONDER_METHOD(resignFirstResponder);
 }
 
 - (BOOL)__isFirstResponder
@@ -937,15 +916,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     return NO;
   }
   
-  if (checkFlag(Synchronous)) {
-    return [_view isFirstResponder];
-  } else{
-    if (ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(isFirstResponder))) {
-      return [_view isFirstResponder];
-    } else {
-      return [(_ASDisplayView *)_view __isFirstResponder];
-    }
-  }
+  HANDLE_RESPONDER_METHOD(isFirstResponder);
 }
 
 #pragma mark <ASDebugNameProvider>

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -540,7 +540,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     _viewBlock = nil;
     _viewClass = [view class];
   } else {
-    
     view = [[_viewClass alloc] init];
   }
   

--- a/Source/Details/_ASDisplayView.h
+++ b/Source/Details/_ASDisplayView.h
@@ -39,6 +39,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)__forwardTouchesEnded:(NSSet *)touches withEvent:(UIEvent *)event;
 - (void)__forwardTouchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event;
 
+// These methods expose a way for ASDisplayNode responder methods to let the view call super responder methods
+// They are called from ASDisplayNode to pass through UIResponder methods to the view
+- (BOOL)__canBecomeFirstResponder;
+- (BOOL)__becomeFirstResponder;
+- (BOOL)__canResignFirstResponder;
+- (BOOL)__resignFirstResponder;
+- (BOOL)__isFirstResponder;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -358,14 +358,64 @@
   [node tintColorDidChange];
 }
 
-- (BOOL)canBecomeFirstResponder {
-  ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  return [node canBecomeFirstResponder];
+// We forward every UIResponder method to give the node a change to overwrite it
+
+- (BOOL)canBecomeFirstResponder
+{
+    ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+    return [node __canBecomeFirstResponder];
 }
 
-- (BOOL)canResignFirstResponder {
-  ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  return [node canResignFirstResponder];
+- (BOOL)becomeFirstResponder
+{
+    ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+    return [node __becomeFirstResponder];
+}
+
+- (BOOL)canResignFirstResponder
+{
+    ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+    return [node __canResignFirstResponder];
+}
+
+- (BOOL)resignFirstResponder
+{
+    ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+    return [node __resignFirstResponder];
+}
+
+- (BOOL)isFirstResponder
+{
+    ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+    return [node __isFirstResponder];
+}
+
+// This methods are called from ASDisplayNode to let the view decide in what UIResponder state they are not overwritten
+// by a ASDisplayNode subclass
+
+- (BOOL)__canBecomeFirstResponder
+{
+    return [super canBecomeFirstResponder];
+}
+
+- (BOOL)__becomeFirstResponder
+{
+    return [super becomeFirstResponder];
+}
+
+- (BOOL)__canResignFirstResponder
+{
+    return [super canResignFirstResponder];
+}
+
+- (BOOL)__resignFirstResponder
+{
+    return [super resignFirstResponder];
+}
+
+- (BOOL)__isFirstResponder
+{
+    return [super isFirstResponder];
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -23,6 +23,7 @@
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h>
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 #import <AsyncDisplayKit/ASLayout.h>
 
@@ -358,36 +359,82 @@
   [node tintColorDidChange];
 }
 
-// We forward every UIResponder method to give the node a change to overwrite it
+#pragma mark UIResponder Handling
 
 - (BOOL)canBecomeFirstResponder
 {
-    ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+  ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+  // Prevent an infinite loop in here if [super canBecomeFirstResponder] was called on a
+  // _ASDisplayView subclass
+  if (ASSubclassOverridesSelector([_ASDisplayView class], self.class, @selector(canBecomeFirstResponder))) {
+    // Check if we can call through to ASDisplayNode subclass directly
+    if (ASDisplayNodeSubclassOverridesSelector([node class], @selector(canBecomeFirstResponder))) {
+      return [node canBecomeFirstResponder];
+    } else {
+      // Call through to views superclass as we expect super was called from the
+      // _ASDisplayView subclass and a node subclass does not overwrite canBecomeFirstResponder
+      return [self __canBecomeFirstResponder];
+    }
+  } else {
+    // Call through to internal node __canBecomeFirstResponder that will consider the view in responding
     return [node __canBecomeFirstResponder];
+  }
 }
 
 - (BOOL)becomeFirstResponder
 {
-    ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+  ASDisplayNode *node = _asyncdisplaykit_node;
+  if (ASSubclassOverridesSelector([_ASDisplayView class], self.class, @selector(becomeFirstResponder))) {
+    if (ASDisplayNodeSubclassOverridesSelector([node class], @selector(becomeFirstResponder))) {
+      return [node becomeFirstResponder];
+    } else {
+      return [self __becomeFirstResponder];
+    }
+  } else {
     return [node __becomeFirstResponder];
+  }
 }
 
 - (BOOL)canResignFirstResponder
 {
-    ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+  ASDisplayNode *node = _asyncdisplaykit_node;
+  if (ASSubclassOverridesSelector([_ASDisplayView class], self.class, @selector(canResignFirstResponder))) {
+    if (ASDisplayNodeSubclassOverridesSelector([node class], @selector(canResignFirstResponder))) {
+      return [node canResignFirstResponder];
+    } else {
+      return [self __canResignFirstResponder];
+    }
+  } else {
     return [node __canResignFirstResponder];
+  }
 }
 
 - (BOOL)resignFirstResponder
 {
-    ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+  ASDisplayNode *node = _asyncdisplaykit_node;
+  if (ASSubclassOverridesSelector([_ASDisplayView class], self.class, @selector(resignFirstResponder))) {
+    if (ASDisplayNodeSubclassOverridesSelector([node class], @selector(resignFirstResponder))) {
+      return [node resignFirstResponder];
+    } else {
+      return [self __resignFirstResponder];
+    }
+  } else {
     return [node __resignFirstResponder];
+  }
 }
 
 - (BOOL)isFirstResponder
 {
-    ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+  ASDisplayNode *node = _asyncdisplaykit_node;
+  if (ASSubclassOverridesSelector([_ASDisplayView class], self.class, @selector(isFirstResponder))) {
+    if (ASDisplayNodeSubclassOverridesSelector([node class], @selector(isFirstResponder))) {
+      return [node isFirstResponder];
+    } else {
+      return [self __isFirstResponder];
+    }
+  } else {
     return [node __isFirstResponder];
+  }
 }
 
 // This methods are called from ASDisplayNode to let the view decide in what UIResponder state they are not overwritten

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -361,8 +361,8 @@
 
 #pragma mark UIResponder Handling
 
-#define HANDLE_RESPONDER_METHOD(__sel) \
-  ASDisplayNode *node = _asyncdisplaykit_node; \
+#define HANDLE_VIEW_RESPONDER_METHOD(__sel) \
+  ASDisplayNode *node = _asyncdisplaykit_node; /* Create strong reference to weak ivar. */ \
   SEL sel = @selector(__sel); \
   /* Prevent an infinite loop in here if [super canBecomeFirstResponder] was called on a
   / _ASDisplayView subclass */ \
@@ -383,55 +383,55 @@
 
 - (BOOL)canBecomeFirstResponder
 {
-  HANDLE_RESPONDER_METHOD(canBecomeFirstResponder);
+  HANDLE_VIEW_RESPONDER_METHOD(canBecomeFirstResponder);
 }
 
 - (BOOL)becomeFirstResponder
 {
-  HANDLE_RESPONDER_METHOD(becomeFirstResponder);
+  HANDLE_VIEW_RESPONDER_METHOD(becomeFirstResponder);
 }
 
 - (BOOL)canResignFirstResponder
 {
-  HANDLE_RESPONDER_METHOD(canResignFirstResponder);
+  HANDLE_VIEW_RESPONDER_METHOD(canResignFirstResponder);
 }
 
 - (BOOL)resignFirstResponder
 {
-  HANDLE_RESPONDER_METHOD(resignFirstResponder);
+  HANDLE_VIEW_RESPONDER_METHOD(resignFirstResponder);
 }
 
 - (BOOL)isFirstResponder
 {
-  HANDLE_RESPONDER_METHOD(isFirstResponder);
+  HANDLE_VIEW_RESPONDER_METHOD(isFirstResponder);
 }
 
-// This methods are called from ASDisplayNode to let the view decide in what UIResponder state they are not overwritten
+// This methods are called from ASDisplayNode to let the view decide in what UIResponder state they are not overridden
 // by a ASDisplayNode subclass
 
 - (BOOL)__canBecomeFirstResponder
 {
-    return [super canBecomeFirstResponder];
+  return [super canBecomeFirstResponder];
 }
 
 - (BOOL)__becomeFirstResponder
 {
-    return [super becomeFirstResponder];
+  return [super becomeFirstResponder];
 }
 
 - (BOOL)__canResignFirstResponder
 {
-    return [super canResignFirstResponder];
+  return [super canResignFirstResponder];
 }
 
 - (BOOL)__resignFirstResponder
 {
-    return [super resignFirstResponder];
+  return [super resignFirstResponder];
 }
 
 - (BOOL)__isFirstResponder
 {
-    return [super isFirstResponder];
+  return [super isFirstResponder];
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -361,80 +361,49 @@
 
 #pragma mark UIResponder Handling
 
+#define HANDLE_RESPONDER_METHOD(__sel) \
+  ASDisplayNode *node = _asyncdisplaykit_node; \
+  SEL sel = @selector(__sel); \
+  /* Prevent an infinite loop in here if [super canBecomeFirstResponder] was called on a
+  / _ASDisplayView subclass */ \
+  if (ASSubclassOverridesSelector([_ASDisplayView class], [self class], sel)) { \
+    /* Check if we can call through to ASDisplayNode subclass directly */ \
+    if (ASDisplayNodeSubclassOverridesSelector([node class], sel)) { \
+      return [node __sel]; \
+    } else { \
+    /* Call through to views superclass as we expect super was called from the
+      _ASDisplayView subclass and a node subclass does not overwrite canBecomeFirstResponder */ \
+      return [self __##__sel]; \
+    } \
+  } else { \
+    /* Call through to internal node __canBecomeFirstResponder that will consider the view in responding */ \
+    return [node __##__sel]; \
+  } \
+
+
 - (BOOL)canBecomeFirstResponder
 {
-  ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  // Prevent an infinite loop in here if [super canBecomeFirstResponder] was called on a
-  // _ASDisplayView subclass
-  if (ASSubclassOverridesSelector([_ASDisplayView class], self.class, @selector(canBecomeFirstResponder))) {
-    // Check if we can call through to ASDisplayNode subclass directly
-    if (ASDisplayNodeSubclassOverridesSelector([node class], @selector(canBecomeFirstResponder))) {
-      return [node canBecomeFirstResponder];
-    } else {
-      // Call through to views superclass as we expect super was called from the
-      // _ASDisplayView subclass and a node subclass does not overwrite canBecomeFirstResponder
-      return [self __canBecomeFirstResponder];
-    }
-  } else {
-    // Call through to internal node __canBecomeFirstResponder that will consider the view in responding
-    return [node __canBecomeFirstResponder];
-  }
+  HANDLE_RESPONDER_METHOD(canBecomeFirstResponder);
 }
 
 - (BOOL)becomeFirstResponder
 {
-  ASDisplayNode *node = _asyncdisplaykit_node;
-  if (ASSubclassOverridesSelector([_ASDisplayView class], self.class, @selector(becomeFirstResponder))) {
-    if (ASDisplayNodeSubclassOverridesSelector([node class], @selector(becomeFirstResponder))) {
-      return [node becomeFirstResponder];
-    } else {
-      return [self __becomeFirstResponder];
-    }
-  } else {
-    return [node __becomeFirstResponder];
-  }
+  HANDLE_RESPONDER_METHOD(becomeFirstResponder);
 }
 
 - (BOOL)canResignFirstResponder
 {
-  ASDisplayNode *node = _asyncdisplaykit_node;
-  if (ASSubclassOverridesSelector([_ASDisplayView class], self.class, @selector(canResignFirstResponder))) {
-    if (ASDisplayNodeSubclassOverridesSelector([node class], @selector(canResignFirstResponder))) {
-      return [node canResignFirstResponder];
-    } else {
-      return [self __canResignFirstResponder];
-    }
-  } else {
-    return [node __canResignFirstResponder];
-  }
+  HANDLE_RESPONDER_METHOD(canResignFirstResponder);
 }
 
 - (BOOL)resignFirstResponder
 {
-  ASDisplayNode *node = _asyncdisplaykit_node;
-  if (ASSubclassOverridesSelector([_ASDisplayView class], self.class, @selector(resignFirstResponder))) {
-    if (ASDisplayNodeSubclassOverridesSelector([node class], @selector(resignFirstResponder))) {
-      return [node resignFirstResponder];
-    } else {
-      return [self __resignFirstResponder];
-    }
-  } else {
-    return [node __resignFirstResponder];
-  }
+  HANDLE_RESPONDER_METHOD(resignFirstResponder);
 }
 
 - (BOOL)isFirstResponder
 {
-  ASDisplayNode *node = _asyncdisplaykit_node;
-  if (ASSubclassOverridesSelector([_ASDisplayView class], self.class, @selector(isFirstResponder))) {
-    if (ASDisplayNodeSubclassOverridesSelector([node class], @selector(isFirstResponder))) {
-      return [node isFirstResponder];
-    } else {
-      return [self __isFirstResponder];
-    }
-  } else {
-    return [node __isFirstResponder];
-  }
+  HANDLE_RESPONDER_METHOD(isFirstResponder);
 }
 
 // This methods are called from ASDisplayNode to let the view decide in what UIResponder state they are not overwritten

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -27,6 +27,50 @@
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 #import <AsyncDisplayKit/ASLayout.h>
 
+#pragma mark - _ASDisplayViewMethodOverrides
+
+typedef NS_OPTIONS(NSUInteger, _ASDisplayViewMethodOverrides)
+{
+  _ASDisplayViewMethodOverrideNone                          = 0,
+  _ASDisplayViewMethodOverrideCanBecomeFirstResponder       = 1 << 0,
+  _ASDisplayViewMethodOverrideBecomeFirstResponder          = 1 << 1,
+  _ASDisplayViewMethodOverrideCanResignFirstResponder       = 1 << 2,
+  _ASDisplayViewMethodOverrideResignFirstResponder          = 1 << 3,
+  _ASDisplayViewMethodOverrideIsFirstResponder              = 1 << 4,
+};
+
+/**
+ *  Returns _ASDisplayViewMethodOverrides for the given class
+ *
+ *  @param c the class, required.
+ *
+ *  @return _ASDisplayViewMethodOverrides.
+ */
+static _ASDisplayViewMethodOverrides GetASDisplayViewMethodOverrides(Class c)
+{
+  ASDisplayNodeCAssertNotNil(c, @"class is required");
+  
+  _ASDisplayViewMethodOverrides overrides = _ASDisplayViewMethodOverrideNone;
+  if (ASSubclassOverridesSelector([_ASDisplayView class], c, @selector(canBecomeFirstResponder))) {
+    overrides |= _ASDisplayViewMethodOverrideCanBecomeFirstResponder;
+  }
+  if (ASSubclassOverridesSelector([_ASDisplayView class], c, @selector(becomeFirstResponder))) {
+    overrides |= _ASDisplayViewMethodOverrideBecomeFirstResponder;
+  }
+  if (ASSubclassOverridesSelector([_ASDisplayView class], c, @selector(canResignFirstResponder))) {
+    overrides |= _ASDisplayViewMethodOverrideCanResignFirstResponder;
+  }
+  if (ASSubclassOverridesSelector([_ASDisplayView class], c, @selector(resignFirstResponder))) {
+    overrides |= _ASDisplayViewMethodOverrideResignFirstResponder;
+  }
+  if (ASSubclassOverridesSelector([_ASDisplayView class], c, @selector(isFirstResponder))) {
+    overrides |= _ASDisplayViewMethodOverrideIsFirstResponder;
+  }
+  return overrides;
+}
+
+#pragma mark - _ASDisplayView
+
 @interface _ASDisplayView ()
 
 // Keep the node alive while its view is active.  If you create a view, add its layer to a layer hierarchy, then release
@@ -41,6 +85,21 @@
 
   NSArray *_accessibleElements;
   CGRect _lastAccessibleElementsFrame;
+  
+  _ASDisplayViewMethodOverrides _methodOverrides;
+}
+
+#pragma mark - Class
+
++ (void)initialize
+{
+  __unused Class initializeSelf = self;
+  IMP staticInitialize = imp_implementationWithBlock(^(_ASDisplayView *view) {
+    ASDisplayNodeAssert(view.class == initializeSelf, @"View class %@ does not have a matching _staticInitialize method; check to ensure [super initialize] is called within any custom +initialize implementations!  Overridden methods will not be called unless they are also implemented by superclass %@", view.class, initializeSelf);
+    view->_methodOverrides = GetASDisplayViewMethodOverrides(view.class);
+  });
+  
+  class_replaceMethod(self, @selector(_staticInitialize), staticInitialize, "v:@");
 }
 
 + (Class)layerClass
@@ -49,6 +108,26 @@
 }
 
 #pragma mark - NSObject Overrides
+
+- (instancetype)init
+{
+  if (!(self = [super init]))
+    return nil;
+  
+  [self _initializeInstance];
+  
+  return self;
+}
+
+- (void)_initializeInstance
+{
+  [self _staticInitialize];
+}
+
+- (void)_staticInitialize
+{
+  ASDisplayNodeAssert(NO, @"_staticInitialize must be overridden");
+}
 
 // e.g. <MYPhotoNodeView: 0xFFFFFF; node = <MYPhotoNode: 0xFFFFFE>; frame = ...>
 - (NSString *)description
@@ -361,12 +440,14 @@
 
 #pragma mark UIResponder Handling
 
-#define HANDLE_VIEW_RESPONDER_METHOD(__sel) \
+#define IMPLEMENT_RESPONDER_METHOD(__sel, __methodOverride) \
+- (BOOL)__sel\
+{\
   ASDisplayNode *node = _asyncdisplaykit_node; /* Create strong reference to weak ivar. */ \
   SEL sel = @selector(__sel); \
   /* Prevent an infinite loop in here if [super canBecomeFirstResponder] was called on a
   / _ASDisplayView subclass */ \
-  if (ASSubclassOverridesSelector([_ASDisplayView class], [self class], sel)) { \
+  if (self->_methodOverrides & __methodOverride) { \
     /* Check if we can call through to ASDisplayNode subclass directly */ \
     if (ASDisplayNodeSubclassOverridesSelector([node class], sel)) { \
       return [node __sel]; \
@@ -379,60 +460,19 @@
     /* Call through to internal node __canBecomeFirstResponder that will consider the view in responding */ \
     return [node __##__sel]; \
   } \
+}\
+/* All __ prefixed methods are called from ASDisplayNode to let the view decide in what UIResponder state they \
+are not overridden by a ASDisplayNode subclass */ \
+- (BOOL)__##__sel \
+{ \
+  return [super __sel]; \
+} \
 
-
-- (BOOL)canBecomeFirstResponder
-{
-  HANDLE_VIEW_RESPONDER_METHOD(canBecomeFirstResponder);
-}
-
-- (BOOL)becomeFirstResponder
-{
-  HANDLE_VIEW_RESPONDER_METHOD(becomeFirstResponder);
-}
-
-- (BOOL)canResignFirstResponder
-{
-  HANDLE_VIEW_RESPONDER_METHOD(canResignFirstResponder);
-}
-
-- (BOOL)resignFirstResponder
-{
-  HANDLE_VIEW_RESPONDER_METHOD(resignFirstResponder);
-}
-
-- (BOOL)isFirstResponder
-{
-  HANDLE_VIEW_RESPONDER_METHOD(isFirstResponder);
-}
-
-// This methods are called from ASDisplayNode to let the view decide in what UIResponder state they are not overridden
-// by a ASDisplayNode subclass
-
-- (BOOL)__canBecomeFirstResponder
-{
-  return [super canBecomeFirstResponder];
-}
-
-- (BOOL)__becomeFirstResponder
-{
-  return [super becomeFirstResponder];
-}
-
-- (BOOL)__canResignFirstResponder
-{
-  return [super canResignFirstResponder];
-}
-
-- (BOOL)__resignFirstResponder
-{
-  return [super resignFirstResponder];
-}
-
-- (BOOL)__isFirstResponder
-{
-  return [super isFirstResponder];
-}
+IMPLEMENT_RESPONDER_METHOD(canBecomeFirstResponder, _ASDisplayViewMethodOverrideCanBecomeFirstResponder);
+IMPLEMENT_RESPONDER_METHOD(becomeFirstResponder, _ASDisplayViewMethodOverrideBecomeFirstResponder);
+IMPLEMENT_RESPONDER_METHOD(canResignFirstResponder, _ASDisplayViewMethodOverrideCanResignFirstResponder);
+IMPLEMENT_RESPONDER_METHOD(resignFirstResponder, _ASDisplayViewMethodOverrideResignFirstResponder);
+IMPLEMENT_RESPONDER_METHOD(isFirstResponder, _ASDisplayViewMethodOverrideIsFirstResponder);
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -96,16 +96,6 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
  */
 @implementation ASDisplayNode (UIViewBridge)
 
-- (BOOL)canBecomeFirstResponder
-{
-  return NO;
-}
-
-- (BOOL)canResignFirstResponder
-{
-  return YES;
-}
-
 #if TARGET_OS_TV
 // Focus Engine
 - (BOOL)canBecomeFocused
@@ -146,23 +136,34 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
 }
 #endif
 
+- (BOOL)canBecomeFirstResponder
+{
+  ASDisplayNodeAssertMainThread();
+  return [self __canBecomeFirstResponder];
+}
+
+- (BOOL)canResignFirstResponder
+{
+  ASDisplayNodeAssertMainThread();
+  return [self __canResignFirstResponder];
+}
+
 - (BOOL)isFirstResponder
 {
   ASDisplayNodeAssertMainThread();
-  return _view != nil && [_view isFirstResponder];
+  return [self __isFirstResponder];
 }
 
-// Note: this implicitly loads the view if it hasn't been loaded yet.
 - (BOOL)becomeFirstResponder
 {
   ASDisplayNodeAssertMainThread();
-  return !self.layerBacked && [self canBecomeFirstResponder] && [self.view becomeFirstResponder];
+  return [self __becomeFirstResponder];
 }
 
 - (BOOL)resignFirstResponder
 {
   ASDisplayNodeAssertMainThread();
-  return !self.layerBacked && [self canResignFirstResponder] && [_view resignFirstResponder];
+  return [self __resignFirstResponder];
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -275,6 +275,13 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 - (void)__incrementVisibilityNotificationsDisabled;
 - (void)__decrementVisibilityNotificationsDisabled;
 
+// Helper methods for UIResponder forwarding
+- (BOOL)__canBecomeFirstResponder;
+- (BOOL)__becomeFirstResponder;
+- (BOOL)__canResignFirstResponder;
+- (BOOL)__resignFirstResponder;
+- (BOOL)__isFirstResponder;
+
 /// Helper method to summarize whether or not the node run through the display process
 - (BOOL)_implementsDisplay;
 

--- a/Tests/ASDisplayNodeTests.mm
+++ b/Tests/ASDisplayNodeTests.mm
@@ -265,19 +265,14 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 @end
 @implementation UIResponderNodeTestDisplayViewCallingSuper
 - (BOOL)canBecomeFirstResponder { return YES; }
-- (BOOL)becomeFirstResponder {
-  return [super becomeFirstResponder];
-}
+- (BOOL)becomeFirstResponder { return [super becomeFirstResponder]; }
 @end
 
 @interface UIResponderNodeTestViewCallingSuper : UIView
 @end
 @implementation UIResponderNodeTestViewCallingSuper
 - (BOOL)canBecomeFirstResponder { return YES; }
-- (BOOL)becomeFirstResponder {
-  return [super becomeFirstResponder];
-  
-}
+- (BOOL)becomeFirstResponder { return [super becomeFirstResponder]; }
 @end
 
 @interface ASDisplayNodeTests : XCTestCase

--- a/Tests/ASDisplayNodeTests.mm
+++ b/Tests/ASDisplayNodeTests.mm
@@ -261,6 +261,25 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 
 @end
 
+@interface UIResponderNodeTestDisplayViewCallingSuper : _ASDisplayView
+@end
+@implementation UIResponderNodeTestDisplayViewCallingSuper
+- (BOOL)canBecomeFirstResponder { return YES; }
+- (BOOL)becomeFirstResponder {
+  return [super becomeFirstResponder];
+}
+@end
+
+@interface UIResponderNodeTestViewCallingSuper : UIView
+@end
+@implementation UIResponderNodeTestViewCallingSuper
+- (BOOL)canBecomeFirstResponder { return YES; }
+- (BOOL)becomeFirstResponder {
+  return [super becomeFirstResponder];
+  
+}
+@end
+
 @interface ASDisplayNodeTests : XCTestCase
 @end
 
@@ -269,9 +288,37 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   dispatch_queue_t queue;
 }
 
-- (void)testOverriddenFirstResponderBehavior
+- (void)testOverriddenNodeFirstResponderBehavior
 {
   ASTestDisplayNode *node = [[ASTestResponderNode alloc] init];
+  XCTAssertTrue([node canBecomeFirstResponder]);
+  XCTAssertTrue([node becomeFirstResponder]);
+}
+
+- (void)testOverriddenDisplayViewFirstResponderBehavior
+{
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  ASDisplayNode *node = [[ASDisplayNode alloc] initWithViewClass:[UIResponderNodeTestDisplayViewCallingSuper class]];
+  
+  // We have to add the node to a window otherwise the super responder methods call responses are undefined
+  // This will also create the backing view of the node
+  [window addSubnode:node];
+  [window makeKeyAndVisible];
+  
+  XCTAssertTrue([node canBecomeFirstResponder]);
+  XCTAssertTrue([node becomeFirstResponder]);
+}
+
+- (void)testOverriddenViewFirstResponderBehavior
+{
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  ASDisplayNode *node = [[ASDisplayNode alloc] initWithViewClass:[UIResponderNodeTestViewCallingSuper class]];
+  
+  // We have to add the node to a window otherwise the super responder methods call responses are undefined
+  // This will also create the backing view of the node
+  [window addSubnode:node];
+  [window makeKeyAndVisible];
+  
   XCTAssertTrue([node canBecomeFirstResponder]);
   XCTAssertTrue([node becomeFirstResponder]);
 }

--- a/Tests/ASDisplayNodeTests.mm
+++ b/Tests/ASDisplayNodeTests.mm
@@ -303,6 +303,15 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   XCTAssertFalse([textNode.view isFirstResponder]);
 }
 
+- (void)testUnsupportedResponderSetupWillThrow
+{
+  ASTestResponderNode *node = [[ASTestResponderNode alloc] init];
+  [node setViewBlock:^UIView * _Nonnull{
+    return [[UIView alloc] init];
+  }];
+  XCTAssertThrows([node view], @"Externally provided views should be synchronous");
+}
+
 - (void)setUp
 {
   [super setUp];

--- a/Tests/ASDisplayNodeTests.mm
+++ b/Tests/ASDisplayNodeTests.mm
@@ -288,7 +288,7 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   ASEditableTextNode *textNode = [[ASEditableTextNode alloc] init];
   
-  // We have to add the text node to a window otherwise the responder methods are undefined
+  // We have to add the text node to a window otherwise the responder methods responses are undefined
   // This will also create the backing view of the node
   [window addSubnode:textNode];
   [window makeKeyAndVisible];

--- a/Tests/ASTableViewTests.mm
+++ b/Tests/ASTableViewTests.mm
@@ -139,6 +139,7 @@
 
 @interface ASTableViewFilledDataSource : NSObject <ASTableDataSource, ASTableDelegate>
 @property (nonatomic) BOOL usesSectionIndex;
+@property (nonatomic) NSInteger numberOfSections;
 @property (nonatomic) NSInteger rowsPerSection;
 @property (nonatomic, nullable, copy) ASCellNodeBlock(^nodeBlockForItem)(NSIndexPath *);
 @end
@@ -149,6 +150,7 @@
 {
   self = [super init];
   if (self != nil) {
+    _numberOfSections = NumberOfSections;
     _rowsPerSection = 20;
   }
   return self;
@@ -165,7 +167,7 @@
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
-  return NumberOfSections;
+  return _numberOfSections;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
@@ -831,6 +833,52 @@
   // Now that row (0,0) is deleted, we should have slid up to be at just 10
   // i.e. we should have subtracted the deleted row height from our content offset.
   XCTAssertEqual(node.contentOffset.y, 10);
+}
+
+- (void)testTableViewReloadDoesReloadIfEditableTextNodeIsFirstResponder
+{
+  ASEditableTextNode *editableTextNode = [[ASEditableTextNode alloc] init];
+  
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 375, 667)];
+  ASTableNode *node = [[ASTableNode alloc] initWithStyle:UITableViewStyleGrouped];
+  node.frame = window.bounds;
+  [window addSubnode:node];
+  
+  ASTableViewFilledDataSource *dataSource = [ASTableViewFilledDataSource new];
+  dataSource.rowsPerSection = 1;
+  dataSource.numberOfSections = 1;
+  // Currently this test requires that the text in the cell node fills the
+  // visible width, so we use the long description for the index path.
+  dataSource.nodeBlockForItem = ^(NSIndexPath *indexPath) {
+    return (ASCellNodeBlock)^{
+      ASCellNode *cellNode = [[ASCellNode alloc] init];
+      cellNode.automaticallyManagesSubnodes = YES;
+      cellNode.layoutSpecBlock = ^ASLayoutSpec * _Nonnull(__kindof ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
+        return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsMake(10, 10, 10, 10) child:editableTextNode];
+      };
+      return cellNode;
+    };
+  };
+  node.delegate = dataSource;
+  node.dataSource = dataSource;
+  
+  // Reload the data for the initial load
+  [node reloadData];
+  [node waitUntilAllUpdatesAreProcessed];
+  [node setNeedsLayout];
+  [node layoutIfNeeded];
+ 
+  // Set the textView as first responder
+  [editableTextNode.textView becomeFirstResponder];
+  
+  // Change data source count and try to reload a second time
+  dataSource.rowsPerSection = 2;
+  [node reloadData];
+  [node waitUntilAllUpdatesAreProcessed];
+  
+  // Check that numberOfRows in section 0 is 2
+  XCTAssertTrue([node numberOfRowsInSection:0] == 2, @"Number of rows in section 0 should be 2 after reload");
+  XCTAssertTrue([node.view numberOfRowsInSection:0] == 2, @"Number of rows in section 0 should be 2 after reload");
 }
 
 @end

--- a/Tests/ASTableViewTests.mm
+++ b/Tests/ASTableViewTests.mm
@@ -877,8 +877,8 @@
   [node waitUntilAllUpdatesAreProcessed];
   
   // Check that numberOfRows in section 0 is 2
-  XCTAssertTrue([node numberOfRowsInSection:0] == 2, @"Number of rows in section 0 should be 2 after reload");
-  XCTAssertTrue([node.view numberOfRowsInSection:0] == 2, @"Number of rows in section 0 should be 2 after reload");
+  XCTAssertEqual([node numberOfRowsInSection:0], 2);
+  XCTAssertEqual([node.view numberOfRowsInSection:0], 2);
 }
 
 @end


### PR DESCRIPTION
### What is the problem?
If certain `UIResponder` methods are overwritten in a `ASDisplayNode` subclass they are not considered. The only two methods that are currently properly forwarded are: `canBecomeFirstResponder` and `canResignFirstResponder` in _ASDisplayView.mm. Every other UIResponder method will never reach any `_ASDisplayView`. This especially is problem for `ASEditableTextNode` as we overwrite these methods in there and expect to be considered.

Example repo: https://github.com/maicki/TextureResponderChain

### Tests
I added a test that show's this invalid behavior. You can find them under `ASDisplayNodeTests.mm` and `ASTableViewTests.mm`

###  Some more details
The way I actually stumbled upon the issue is that as soon as an `ASEditableTextNode` is a subnode of a `ASCellNode` as well as a first responder, calling `reloadData` on an `ASTableNode` will **not** reload the `UITableView`. UIKit will bail out within the process.
Internally UIKit's `UITableView` is trying to resign the first responder from the current first responder on an `reloadData` what is the `textView` of the `ASEditableTextNode` and afterwards expects no view in the `UITableView` hierarchy is the first responder anymore. That will not be case if `UITableView` is calling `resignFirstResponder` on the `ASEditableTextNode.textView` as we push only the first responder to the `ASEditableTextNode.view`. `UITableView` has an ivar called `_firstResponderView` where it determines if the first responder view is a view in the `UITableView` hierarchy. If this is ivar != null it will bail out if `reloadData` is called, before actually reloading the data (I verified that within Hopper).
And so if the `UITableView` is calling `resignFirstResponder` on the `ASEditableTextNode.textView` the `_firstResponderView` will just be `ASEditableTextNode.view`, but it should be nil. If we properly forward all responder methods `_firstResponderView` will be nil as the `ASEditableTextNode.view` will not become the first responder if the table view calls `resignFirstResponder` on the `ASEditableTextNode.textView`.

### Current solution
```
// Called canBecomeFirstResponder on _ASDisplayView
-> [_ASDisplayView canBecomeFirstResponder]
  -> if subclass of _ASDisplayView overwrites canBecomeFirstResponder
      // Prevent an infinite loop in here if [super canBecomeFirstResponder] was called
      -> if subclass of ASDisplayNode overwrites canBecomeFirstResponder
        -> [ASDisplayNode canBecomeFirstResponder];
      -> else
        // Call through to views superclass as we expect super was called from the
        // _ASDisplayView subclass and node does not implement canBecomeFirstResponder
        -> [_ASDisplayView __canBecomeFirstResponder]
          -> [super canBecomeFirstResponder]
  -> else
      // Call through to the display node to give a chance to dive in
    -> [ASDisplayNode __canBecomeFirstResponder]

// Called canBecomeFirstResponder on ASDisplayNode
-> [ASDisplayNode+UIViewBridge canBecomeFirstResponder]
  // Just call through to our internal method
  -> [ASDisplayNode (self) __canBecomeFirstResponder]

// Called form _ASDisplayView and ASDisplayNode from ASDisplayNode+UIViewBridge
-> [ASDisplayNode __canBecomeFirstResponder]
  -> if view it is a subclass of _ASDisplayView (synchronous == TRUE)
    // If it's synchronous just call through to the view as we expect it's
    // a non _ASDisplayView subclass that will respond
    -> [_view canBecomeFirstResponder]
  -> else
      -> if subclass of _ASDisplayView overwrites canBecomeFirstResponder
        // If the subclass overwrites canBecomeFirstResponder just call through
        // to it as we expect it will handle it
        [_view canBecomeFirstResponder];
      -> else
        // Call through to _ASDisplayView to get it handled
        -> [_ASDisplayView __canBecomeFirstResponder]
          -> [super canBecomeFirstResponder]
```