### PR TITLE
[ASDisplayNode] Consolidate main thread initialization and allow apps to invoke it manually instead of +load.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
+- [ASDisplayNode] Consolidate main thread initialization and allow apps to invoke it manually instead of +load.
 - [ASRangeController] Fix stability of "minimum" rangeMode if the app has more than one layout before scrolling.
 - **Important** ASDisplayNode's cornerRadius is a new thread-safe bridged property that should be preferred over CALayer's. Use the latter at your own risk! [Huy Nguyen](https://github.com/nguyenhuy) [#749](https://github.com/TextureGroup/Texture/pull/749).
 - [ASCellNode] Adds mapping for UITableViewCell focusStyle [Alex Hill](https://github.com/alexhillc) [#727](https://github.com/TextureGroup/Texture/pull/727)

--- a/Source/ASDisplayNode+Beta.h
+++ b/Source/ASDisplayNode+Beta.h
@@ -192,6 +192,8 @@ extern void ASDisplayNodePerformBlockOnEveryYogaChild(ASDisplayNode * _Nullable 
 @interface ASLayoutElementStyle (Yoga)
 
 - (YGNodeRef)yogaNodeCreateIfNeeded;
+- (void)destroyYogaNode;
+
 @property (nonatomic, assign, readonly) YGNodeRef yogaNode;
 
 @property (nonatomic, assign, readwrite) ASStackLayoutDirection flexDirection;

--- a/Source/ASDisplayNode+Subclasses.h
+++ b/Source/ASDisplayNode+Subclasses.h
@@ -103,6 +103,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)nodeDidLayout;
 
+/**
+ * @abstract Called when the node loads.
+ * @discussion Can be used for operations that are performed after the node's view is available.
+ * @note This method is guaranteed to be called on main.
+ */
+- (void)nodeDidLoad;
+
 @end
 
 @interface ASDisplayNode (Subclassing) <ASInterfaceStateDelegate>

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -157,6 +157,8 @@
 
 - (void)setupYogaCalculatedLayout
 {
+  ASDN::MutexLocker l(__instanceLock__);
+
   YGNodeRef yogaNode = self.style.yogaNode;
   uint32_t childCount = YGNodeGetChildCount(yogaNode);
   ASDisplayNodeAssert(childCount == self.yogaChildren.count,
@@ -213,7 +215,7 @@
     // For the root node in a Yoga tree, make sure to preserve the constrainedSize originally provided.
     // This will be used for all relayouts triggered by children, since they escalate to root.
     ASSizeRange range = parentNode ? ASSizeRangeUnconstrained : self.constrainedSizeForCalculatedLayout;
-    _pendingDisplayNodeLayout = std::make_shared<ASDisplayNodeLayout>(layout, range, parentSize);
+    _pendingDisplayNodeLayout = std::make_shared<ASDisplayNodeLayout>(layout, range, parentSize, _layoutVersion);
   }
 }
 

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -210,7 +210,10 @@
       parentSize.width = YGNodeLayoutGetWidth(parentNode);
       parentSize.height = YGNodeLayoutGetHeight(parentNode);
     }
-    _pendingDisplayNodeLayout = std::make_shared<ASDisplayNodeLayout>(layout, ASSizeRangeUnconstrained, parentSize, 0);
+    // For the root node in a Yoga tree, make sure to preserve the constrainedSize originally provided.
+    // This will be used for all relayouts triggered by children, since they escalate to root.
+    ASSizeRange range = parentNode ? ASSizeRangeUnconstrained : self.constrainedSizeForCalculatedLayout;
+    _pendingDisplayNodeLayout = std::make_shared<ASDisplayNodeLayout>(layout, range, parentSize);
   }
 }
 
@@ -235,9 +238,18 @@
 - (void)invalidateCalculatedYogaLayout
 {
   YGNodeRef yogaNode = self.style.yogaNode;
-  if (yogaNode && YGNodeGetMeasureFunc(yogaNode)) {
+  if (yogaNode && [self shouldHaveYogaMeasureFunc]) {
     // Yoga internally asserts that MarkDirty() may only be called on nodes with a measurement function.
+    BOOL needsTemporaryMeasureFunc = (YGNodeGetMeasureFunc(yogaNode) == NULL);
+    if (needsTemporaryMeasureFunc) {
+      ASDisplayNodeAssert(self.yogaLayoutInProgress == NO,
+                          @"shouldHaveYogaMeasureFunc == YES, and inside a layout pass, but no measure func pointer! %@", self);
+      YGNodeSetMeasureFunc(yogaNode, &ASLayoutElementYogaMeasureFunc);
+    }
     YGNodeMarkDirty(yogaNode);
+    if (needsTemporaryMeasureFunc) {
+      YGNodeSetMeasureFunc(yogaNode, NULL);
+    }
   }
   self.yogaCalculatedLayout = nil;
 }
@@ -305,7 +317,7 @@
       NSLog(@"node = %@", node);
       NSLog(@"style = %@", node.style);
       NSLog(@"layout = %@", node.yogaCalculatedLayout);
-      YGNodePrint(node.style.yogaNode, (YGPrintOptions)(YGPrintOptionsStyle | YGPrintOptionsLayout));
+      YGNodePrint(node.yogaNode, (YGPrintOptions)(YGPrintOptionsStyle | YGPrintOptionsLayout));
     });
   }
 #endif /* YOGA_LAYOUT_LOGGING */

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -226,6 +226,13 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   class_replaceMethod(self, @selector(_staticInitialize), staticInitialize, "v:@");
 }
 
+#if !AS_INITIALIZE_FRAMEWORK_MANUALLY
++ (void)load
+{
+  ASInitializeFrameworkMainThread();
+}
+#endif
+
 + (Class)viewClass
 {
   return [_ASDisplayView class];
@@ -629,6 +636,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   for (ASDisplayNodeDidLoadBlock block in onDidLoadBlocks) {
     block(self);
   }
+
+  [_interfaceStateDelegate nodeDidLoad];
 }
 
 - (void)didLoad

--- a/Source/ASNodeController+Beta.h
+++ b/Source/ASNodeController+Beta.h
@@ -31,6 +31,9 @@
 - (void)loadNode;
 
 // for descriptions see <ASInterfaceState> definition
+- (void)nodeDidLoad ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)nodeDidLayout ASDISPLAYNODE_REQUIRES_SUPER;
+
 - (void)didEnterVisibleState ASDISPLAYNODE_REQUIRES_SUPER;
 - (void)didExitVisibleState  ASDISPLAYNODE_REQUIRES_SUPER;
 

--- a/Source/ASNodeController+Beta.m
+++ b/Source/ASNodeController+Beta.m
@@ -93,6 +93,7 @@
 }
 
 // subclass overrides
+- (void)nodeDidLoad {}
 - (void)nodeDidLayout {}
 
 - (void)didEnterVisibleState {}

--- a/Source/AsyncDisplayKit.h
+++ b/Source/AsyncDisplayKit.h
@@ -16,6 +16,7 @@
 //
 
 #import <AsyncDisplayKit/ASAvailability.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASDisplayNode+Ancestry.h>
 #import <AsyncDisplayKit/ASDisplayNode+Convenience.h>

--- a/Source/Private/ASInternalHelpers.h
+++ b/Source/Private/ASInternalHelpers.h
@@ -25,6 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 ASDISPLAYNODE_EXTERN_C_BEGIN
 
+void ASInitializeFrameworkMainThread(void);
+
+BOOL ASDefaultAllowsGroupOpacity(void);
+BOOL ASDefaultAllowsEdgeAntialiasing(void);
+
 BOOL ASSubclassOverridesSelector(Class superclass, Class subclass, SEL selector);
 BOOL ASSubclassOverridesClassSelector(Class superclass, Class subclass, SEL selector);
 
@@ -100,3 +105,7 @@ ASDISPLAYNODE_INLINE void ASBoundsAndPositionForFrame(CGRect rect, CGPoint origi
 @end
 
 NS_ASSUME_NONNULL_END
+
+#ifndef AS_INITIALIZE_FRAMEWORK_MANUALLY
+#define AS_INITIALIZE_FRAMEWORK_MANUALLY 0
+#endif

--- a/Source/Private/ASInternalHelpers.m
+++ b/Source/Private/ASInternalHelpers.m
@@ -31,8 +31,7 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
 void ASInitializeFrameworkMainThread(void)
 {
   ASDisplayNodeThreadIsMain();
-  // Ensure this value is cached on the main thread before needed in the background.
-  ASScreenScale();
+  // Ensure these values are cached on the main thread before needed in the background.
   CALayer *layer = [[[UIView alloc] init] layer];
   defaultAllowsGroupOpacity = layer.allowsGroupOpacity;
   defaultAllowsEdgeAntialiasing = layer.allowsEdgeAntialiasing;

--- a/Source/Private/ASInternalHelpers.m
+++ b/Source/Private/ASInternalHelpers.m
@@ -25,6 +25,29 @@
 #import <AsyncDisplayKit/ASRunLoopQueue.h>
 #import <AsyncDisplayKit/ASThread.h>
 
+static BOOL defaultAllowsGroupOpacity = YES;
+static BOOL defaultAllowsEdgeAntialiasing = NO;
+
+void ASInitializeFrameworkMainThread(void)
+{
+  ASDisplayNodeThreadIsMain();
+  // Ensure this value is cached on the main thread before needed in the background.
+  ASScreenScale();
+  CALayer *layer = [[[UIView alloc] init] layer];
+  defaultAllowsGroupOpacity = layer.allowsGroupOpacity;
+  defaultAllowsEdgeAntialiasing = layer.allowsEdgeAntialiasing;
+}
+
+BOOL ASDefaultAllowsGroupOpacity(void)
+{
+  return defaultAllowsGroupOpacity;
+}
+
+BOOL ASDefaultAllowsEdgeAntialiasing(void)
+{
+  return defaultAllowsEdgeAntialiasing;
+}
+
 BOOL ASSubclassOverridesSelector(Class superclass, Class subclass, SEL selector)
 {
   if (superclass == subclass) return NO; // Even if the class implements the selector, it doesn't override itself.

--- a/Source/Private/_ASPendingState.mm
+++ b/Source/Private/_ASPendingState.mm
@@ -212,19 +212,6 @@ ASDISPLAYNODE_INLINE void ASPendingStateApplyMetricsToLayer(_ASPendingState *sta
 
 static CGColorRef blackColorRef = NULL;
 static UIColor *defaultTintColor = nil;
-static BOOL defaultAllowsGroupOpacity = YES;
-static BOOL defaultAllowsEdgeAntialiasing = NO;
-
-+ (void)load
-{
-  // Create temporary view to read default values that are based on linked SDK and Info.plist values
-  // Ensure this values cached on the main thread before needed
-  ASDisplayNodeCAssertMainThread();
-  UIView *view = [[UIView alloc] init];
-  defaultAllowsGroupOpacity = view.layer.allowsGroupOpacity;
-  defaultAllowsEdgeAntialiasing = view.layer.allowsEdgeAntialiasing;
-}
-
 
 - (instancetype)init
 {
@@ -251,8 +238,8 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   tintColor = defaultTintColor;
   isHidden = NO;
   needsDisplayOnBoundsChange = NO;
-  allowsGroupOpacity = defaultAllowsGroupOpacity;
-  allowsEdgeAntialiasing = defaultAllowsEdgeAntialiasing;
+  allowsGroupOpacity = ASDefaultAllowsGroupOpacity();
+  allowsEdgeAntialiasing = ASDefaultAllowsEdgeAntialiasing();
   autoresizesSubviews = YES;
   alpha = 1.0f;
   cornerRadius = 0.0f;


### PR DESCRIPTION
Additionally this has a few minor fixes for Yoga support, and adds some basic but universally valuable callbacks like -nodeDidLoad to ASNodeController.