### PR TITLE
Update IGListKit dependency to allow for updated versions

### DIFF
--- a/Texture.podspec
+++ b/Texture.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |spec|
   end
 
   spec.subspec 'IGListKit' do |igl|
-      igl.dependency 'IGListKit', '3.0.0'
+      igl.dependency 'IGListKit', '~> 3.0'
       igl.dependency 'Texture/Core'
   end
 


### PR DESCRIPTION
The IGListKit subspec currently has the dependency hardcoded to version `3.0.0`. I've come across a need to use a later version of IGListKit, so in the process I thought it would be nice for the podspec to allow a little more flexibility in versioning of the dependency. This PR will default to the latest 3.x version, but would also allow consumers to override the IGListKit dependency in their Podfiles to be anything in the 3.x.x range.