### PR TITLE
Avoid triggering main thread assertions in collection/table dealloc

### DIFF
--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -172,12 +172,17 @@
   return self;
 }
 
+#if ASDISPLAYNODE_ASSERTIONS_ENABLED
 - (void)dealloc
 {
-  if ([self isNodeLoaded]) {
-    ASDisplayNodeAssert(self.view.superview == nil, @"Node's view should be removed from hierarchy.");
+  if (self.nodeLoaded) {
+    __weak UIView *view = self.view;
+    ASPerformBlockOnMainThread(^{
+      ASDisplayNodeCAssertNil(view.superview, @"Node's view should be removed from hierarchy.");
+    });
   }
 }
+#endif
 
 #pragma mark ASDisplayNode
 

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -104,12 +104,17 @@
   return [self initWithStyle:UITableViewStylePlain];
 }
 
+#if ASDISPLAYNODE_ASSERTIONS_ENABLED
 - (void)dealloc
 {
-  if ([self isNodeLoaded]) {
-    ASDisplayNodeAssert(self.view.superview == nil, @"Node's view should be removed from hierarchy.");
+  if (self.nodeLoaded) {
+    __weak UIView *view = self.view;
+    ASPerformBlockOnMainThread(^{
+      ASDisplayNodeCAssertNil(view.superview, @"Node's view should be removed from hierarchy.");
+    });
   }
 }
+#endif
 
 #pragma mark ASDisplayNode
 

--- a/Source/Base/ASAssert.h
+++ b/Source/Base/ASAssert.h
@@ -21,7 +21,7 @@
 #import <pthread.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
-#define ASDISPLAYNODE_ASSERTIONS_ENABLED (!defined(NS_BLOCK_ASSERTIONS))
+#define ASDISPLAYNODE_ASSERTIONS_ENABLED (!defined(NS_BLOCK_ASSERTIONS) || !NS_BLOCK_ASSERTIONS)
 
 /**
  * Note: In some cases it would be sufficient to do e.g.:


### PR DESCRIPTION
In #793 a new assertion was introduced that inadvertently triggered main thread checker failures. 

This avoids triggering the same thing. It also improves the definition of `ASDISPLAYNODE_ASSERTIONS_ENABLED` to cover cases where `NS_BLOCK_ASSERTIONS` is defined to be 0, as some build environments do.