### PR TITLE
Replace pthread specifics with C11 thread-local variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fix ASTextNode2 is accessing backgroundColor off main while sizing / layout is happening. [Michael Schneider](https://github.com/maicki) [#794](https://github.com/TextureGroup/Texture/pull/778/)
 - Pass scrollViewWillEndDragging delegation through in ASIGListAdapterDataSource for IGListKit integration. [#796](https://github.com/TextureGroup/Texture/pull/796)
 - Fix UIResponder handling with view backing ASDisplayNode. [Michael Schneider](https://github.com/maicki) [#789] (https://github.com/TextureGroup/Texture/pull/789/)
+- Optimized thread-local storage by replacing pthread_specific with C11 thread-local variables. [Adlai Holler](https://github.com/Adlai-Holler) [#811] (https://github.com/TextureGroup/Texture/pull/811/)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/ASDisplayNode+Subclasses.h
+++ b/Source/ASDisplayNode+Subclasses.h
@@ -15,8 +15,6 @@
 //      http://www.apache.org/licenses/LICENSE-2.0
 //
 
-#import <pthread.h>
-
 #import <AsyncDisplayKit/ASBlockTypes.h>
 #import <AsyncDisplayKit/ASDisplayNode.h>
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1046,15 +1046,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
                      restrictedToSize:(ASLayoutElementSize)size
                  relativeToParentSize:(CGSize)parentSize
 {
-  // Use a pthread specific to mark when this method is called re-entrant on same thread.
   // We only want one calculateLayout signpost interval per thread.
-  // This is fast enough to do it unconditionally.
-  auto key = ASPthreadStaticKey(NULL);
-  BOOL isRootCall = (pthread_getspecific(key) == NULL);
+  static _Thread_local NSInteger tls_callDepth;
   as_activity_scope_verbose(as_activity_create("Calculate node layout", AS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT));
   as_log_verbose(ASLayoutLog(), "Calculating layout for %@ sizeRange %@", self, NSStringFromASSizeRange(constrainedSize));
-  if (isRootCall) {
-    pthread_setspecific(key, kCFBooleanTrue);
+  if (tls_callDepth++ == 0) {
     ASSignpostStart(ASSignpostCalculateLayout);
   }
 
@@ -1063,8 +1059,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   ASLayout *result = [self calculateLayoutThatFits:resolvedRange];
   as_log_verbose(ASLayoutLog(), "Calculated layout %@", result);
 
-  if (isRootCall) {
-    pthread_setspecific(key, NULL);
+  if (--tls_callDepth == 0) {
     ASSignpostEnd(ASSignpostCalculateLayout);
   }
   return result;

--- a/Source/Base/ASAssert.m
+++ b/Source/Base/ASAssert.m
@@ -11,29 +11,18 @@
 //
 
 #import <AsyncDisplayKit/ASAssert.h>
-#import <Foundation/Foundation.h>
 
-static pthread_key_t ASMainThreadAssertionsDisabledKey()
-{
-  return ASPthreadStaticKey(NULL);
-}
+static _Thread_local int tls_mainThreadAssertionsDisabledCount;
 
 BOOL ASMainThreadAssertionsAreDisabled() {
-  return (size_t)pthread_getspecific(ASMainThreadAssertionsDisabledKey()) > 0;
+  return tls_mainThreadAssertionsDisabledCount > 0;
 }
 
 void ASPushMainThreadAssertionsDisabled() {
-  pthread_key_t key = ASMainThreadAssertionsDisabledKey();
-  size_t oldValue = (size_t)pthread_getspecific(key);
-  pthread_setspecific(key, (void *)(oldValue + 1));
+  tls_mainThreadAssertionsDisabledCount += 1;
 }
 
 void ASPopMainThreadAssertionsDisabled() {
-  pthread_key_t key = ASMainThreadAssertionsDisabledKey();
-  size_t oldValue = (size_t)pthread_getspecific(key);
-  if (oldValue > 0) {
-    pthread_setspecific(key, (void *)(oldValue - 1));
-  } else {
-    ASDisplayNodeCFailAssert(@"Attempt to pop thread assertion-disabling without corresponding push.");
-  }
+  tls_mainThreadAssertionsDisabledCount -= 1;
+  ASDisplayNodeCAssert(tls_mainThreadAssertionsDisabledCount >= 0, @"Attempt to pop thread assertion-disabling without corresponding push.");
 }

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -211,15 +211,6 @@
 #define AS_SUBCLASSING_RESTRICTED
 #endif
 
-#define ASPthreadStaticKey(dtor) ({ \
-  static dispatch_once_t onceToken; \
-  static pthread_key_t key; \
-  dispatch_once(&onceToken, ^{ \
-    pthread_key_create(&key, dtor); \
-  }); \
-  key; \
-})
-
 #define ASCreateOnce(expr) ({ \
   static dispatch_once_t onceToken; \
   static __typeof__(expr) staticVar; \

--- a/Source/Layout/ASLayoutElement.mm
+++ b/Source/Layout/ASLayoutElement.mm
@@ -50,38 +50,27 @@ CGSize const ASLayoutElementParentSizeUndefined = {ASLayoutElementParentDimensio
 int32_t const ASLayoutElementContextInvalidTransitionID = 0;
 int32_t const ASLayoutElementContextDefaultTransitionID = ASLayoutElementContextInvalidTransitionID + 1;
 
-static void ASLayoutElementDestructor(void *p) {
-  if (p != NULL) {
-    ASDisplayNodeCFailAssert(@"Thread exited without clearing layout element context!");
-    CFBridgingRelease(p);
-  }
-};
-
-pthread_key_t ASLayoutElementContextKey()
-{
-  return ASPthreadStaticKey(ASLayoutElementDestructor);
-}
+static _Thread_local __unsafe_unretained ASLayoutElementContext *tls_context;
 
 void ASLayoutElementPushContext(ASLayoutElementContext *context)
 {
   // NOTE: It would be easy to support nested contexts – just use an NSMutableArray here.
-  ASDisplayNodeCAssertNil(ASLayoutElementGetCurrentContext(), @"Nested ASLayoutElementContexts aren't supported.");
-  pthread_setspecific(ASLayoutElementContextKey(), CFBridgingRetain(context));
+  ASDisplayNodeCAssertNil(tls_context, @"Nested ASLayoutElementContexts aren't supported.");
+  
+  tls_context = (__bridge ASLayoutElementContext *)(__bridge_retained CFTypeRef)context;
 }
 
 ASLayoutElementContext *ASLayoutElementGetCurrentContext()
 {
   // Don't retain here. Caller will retain if it wants to!
-  return (__bridge __unsafe_unretained ASLayoutElementContext *)pthread_getspecific(ASLayoutElementContextKey());
+  return tls_context;
 }
 
 void ASLayoutElementPopContext()
 {
-  ASLayoutElementContextKey();
-  ASDisplayNodeCAssertNotNil(ASLayoutElementGetCurrentContext(), @"Attempt to pop context when there wasn't a context!");
-  auto key = ASLayoutElementContextKey();
-  CFBridgingRelease(pthread_getspecific(key));
-  pthread_setspecific(key, NULL);
+  ASDisplayNodeCAssertNotNil(tls_context, @"Attempt to pop context when there wasn't a context!");
+  CFRelease((__bridge CFTypeRef)tls_context);
+  tls_context = nil;
 }
 
 #pragma mark - ASLayoutElementStyle


### PR DESCRIPTION
C11 thread-local variables are faster and safer than pthread_specifics. Let's use them!

Unfortunately, the pretty alias `thread_local` is defined in `threads.h`, an optional part of C11 that Clang doesn't support yet. But the actual `_Thread_local` storage classifier works just fine. It calls into `tlv_get_addr` provided by `dyld`, and it's a lot faster than `pthread_getspecific`.

Docs: http://en.cppreference.com/w/c/language/storage_duration

Here's the latest source available:
https://opensource.apple.com/source/dyld/dyld-519.2.2/src/threadLocalHelpers.s.auto.html

So 32-bit ARM this is built on pthread_getspecific. 64-bit ARM uses some crazy assembly that I don't understand.