### PR TITLE
[ASDisplayNode] Add unit tests for layout z-order changes (with an open issue to fix).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
+- [ASDisplayNode] Add unit tests for layout z-order changes (with an open issue to fix).
 - [ASDisplayNode] Consolidate main thread initialization and allow apps to invoke it manually instead of +load.
 - [ASRunloopQueue] Introduce new runloop queue(ASCATransactionQueue) to coalesce Interface state update calls for view controller transitions.
 - [ASRangeController] Fix stability of "minimum" rangeMode if the app has more than one layout before scrolling.

--- a/Tests/ASDisplayNodeTests.mm
+++ b/Tests/ASDisplayNodeTests.mm
@@ -33,6 +33,7 @@
 #import <AsyncDisplayKit/ASImageNode.h>
 #import <AsyncDisplayKit/ASOverlayLayoutSpec.h>
 #import <AsyncDisplayKit/ASInsetLayoutSpec.h>
+#import <AsyncDisplayKit/ASStackLayoutSpec.h>
 #import <AsyncDisplayKit/ASCenterLayoutSpec.h>
 #import <AsyncDisplayKit/ASBackgroundLayoutSpec.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
@@ -2372,6 +2373,46 @@ static bool stringContainsPointer(NSString *description, id p) {
     return [ASOverlayLayoutSpec overlayLayoutSpecWithChild:[ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:subnode] overlay:subnode];
   };
   XCTAssertThrowsSpecificNamed([node calculateLayoutThatFits:ASSizeRangeMake(CGSizeMake(100, 100))], NSException, NSInternalInconsistencyException);
+}
+
+- (void)testThatStackSpecOrdersSubnodesCorrectly
+{
+  // This test ensures that the z-order of nodes matches the stack spec, including after relayout / transition.
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  node.automaticallyManagesSubnodes = YES;
+
+  DeclareNodeNamed(a);
+  DeclareNodeNamed(b);
+  DeclareNodeNamed(c);
+  DeclareNodeNamed(d);
+
+  NSArray *nodesForwardOrder = @[a, b, c, d];
+  NSArray *nodesReverseOrder = @[d, c, b, a];
+  __block BOOL flipItemOrder = NO;
+
+  node.layoutSpecBlock = ^(ASDisplayNode *node, ASSizeRange size) {
+    ASStackLayoutSpec *stack = [ASStackLayoutSpec verticalStackLayoutSpec];
+    stack.children = flipItemOrder ? nodesReverseOrder : nodesForwardOrder;
+    return stack;
+  };
+
+  ASDisplayNodeSizeToFitSize(node, CGSizeMake(100, 100));
+  [node.view layoutIfNeeded];
+
+  // Because automaticallyManagesSubnodes is used, the subnodes array is constructed from the layout spec's children.
+  XCTAssert([node.subnodes isEqualToArray:nodesForwardOrder], @"subnodes: %@, array: %@", node.subnodes, nodesForwardOrder);
+  XCTAssertNodeSubnodeSubviewSublayerOrder(node, YES /* isLoaded */, NO /* isLayerBacked */,
+                                           @"a,b,c,d", @"Forward order");
+
+  flipItemOrder = YES;
+  [node invalidateCalculatedLayout];
+  [node.view layoutIfNeeded];
+
+  // In this case, it's critical that the items are in the new order so that event handling and apparent z-position are correct.
+  // FIXME: The reversal case is not currently passing.
+  // XCTAssert([node.subnodes isEqualToArray:nodesReverseOrder], @"subnodes: %@, array: %@", node.subnodes, nodesReverseOrder);
+  // XCTAssertNodeSubnodeSubviewSublayerOrder(node, YES /* isLoaded */, NO /* isLayerBacked */,
+  //                                          @"d,c,b,a", @"Reverse order");
 }
 
 - (void)testThatOverlaySpecOrdersSubnodesCorrectly

--- a/Tests/ArrayDiffingTests.m
+++ b/Tests/ArrayDiffingTests.m
@@ -65,10 +65,14 @@
     NSIndexSet *indexSet = [test[0] _asdk_commonIndexesWithArray:test[1] compareBlock:^BOOL(id lhs, id rhs) {
       return [lhs isEqual:rhs];
     }];
+    NSMutableIndexSet *mutableIndexSet = [indexSet mutableCopy];
     
     for (NSNumber *index in (NSArray *)test[2]) {
       XCTAssert([indexSet containsIndex:[index integerValue]]);
+      [mutableIndexSet removeIndex:[index integerValue]];
     }
+
+    XCTAssert([mutableIndexSet count] == 0, @"Unaccounted deletions: %@", mutableIndexSet);
   }
 }
 
@@ -79,6 +83,12 @@
         @[@"bob", @"alice", @"dave", @"gary"],
         @[@3],
         @[],
+      ],
+      @[
+        @[@"a", @"b", @"c", @"d"],
+        @[@"d", @"c", @"b", @"a"],
+        @[@1, @2, @3],
+        @[@0, @1, @2],
       ],
       @[
         @[@"bob", @"alice", @"dave"],
@@ -121,12 +131,20 @@
   for (NSArray *test in tests) {
     NSIndexSet *insertions, *deletions;
     [test[0] asdk_diffWithArray:test[1] insertions:&insertions deletions:&deletions];
+    NSMutableIndexSet *mutableInsertions = [insertions mutableCopy];
+    NSMutableIndexSet *mutableDeletions = [deletions mutableCopy];
+
     for (NSNumber *index in (NSArray *)test[2]) {
-      XCTAssert([insertions containsIndex:[index integerValue]]);
+      XCTAssert([mutableInsertions containsIndex:[index integerValue]]);
+      [mutableInsertions removeIndex:[index integerValue]];
     }
     for (NSNumber *index in (NSArray *)test[3]) {
-      XCTAssert([deletions containsIndex:[index integerValue]]);
+      XCTAssert([mutableDeletions containsIndex:[index integerValue]]);
+      [mutableDeletions removeIndex:[index integerValue]];
     }
+
+    XCTAssert([mutableInsertions count] == 0, @"Unaccounted insertions: %@", mutableInsertions);
+    XCTAssert([mutableDeletions count] == 0, @"Unaccounted deletions: %@", mutableDeletions);
   }
 }
 


### PR DESCRIPTION
Right now, automatic subnode management is not fixing up the z-order for nodes and their views, whenever existing subnodes are moved to a different place in the layout.

This can result in particularly weird issues when an existing layout changes with some additional nodes and some removed nodes that may displace or separate some existing nodes that also need to change order.

Once we fix, it will be easy to improve the Overlay and Background tests that are below this to also check the reversal / relayout case (I don't think they would pass currently). cc @maicki @nguyenhuy @Adlai-Holler 

```
ASDisplayNodeTests.mm:2410: error: -[ASDisplayNodeTests testThatStackSpecOrdersSubnodesCorrectly] : (([node.subnodes isEqualToArray:nodesReverseOrder]) is true) failed - subnodes: (
    "<ASDisplayNode: 0x7f8281101f90; a>",
    "<ASDisplayNode: 0x7f8281105b40; b>",
    "<ASDisplayNode: 0x7f8281105e80; c>",
    "<ASDisplayNode: 0x7f82811061c0; d>"
), reference array: (
    "<ASDisplayNode: 0x7f82811061c0; d>",
    "<ASDisplayNode: 0x7f8281105e80; c>",
    "<ASDisplayNode: 0x7f8281105b40; b>",
    "<ASDisplayNode: 0x7f8281101f90; a>"
)
Test Case '-[ASDisplayNodeTests testThatStackSpecOrdersSubnodesCorrectly]' failed (0.006 seconds).
```