### PR TITLE
[ASTextNode] Fix an race condition on ASTextKitAttributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
+- [ASTextNode] Fix an race condition on ASTextKitAttributes [Heberti Almeida](http://github.com/hebertialmeida) [#819]
 - [ASDisplayNode] Add unit tests for layout z-order changes (with an open issue to fix).
 - [ASDisplayNode] Consolidate main thread initialization and allow apps to invoke it manually instead of +load.
 - [ASRunloopQueue] Introduce new runloop queue(ASCATransactionQueue) to coalesce Interface state update calls for view controller transitions.


### PR DESCRIPTION
This problem was reported on #552 by @Kaspik some time ago.

Running the project with thread sanitizers enable show a bunch of errors due to a race condition on `ASTextKitAttributes`, I spent some time looking at that and I found out that the race condition is happening on `ASTextNode` when `rendererForAttributes` tries to get and set the object to cache.

This fixes the problem for me, I don't see any downsides to this implementation but of course, I would like to hear from your guys.

This could be false impressions, but I've noticed some performance improvement while rendering my app feed that has couple textNodes and I tried to measure that.

This is the average time (6 loads) to load a heavy cell with this code change: 
with: **0.119627775**
without: **0.141625549**