### PR TITLE
[ASTextNode] Avoid acquiring instance lock multiple times #trivial

### DIFF
--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -768,7 +768,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
       if (highlightTargetLayer != nil) {
         ASDN::MutexLocker l(__instanceLock__);
-        ASTextKitRenderer *renderer = [self _renderer];
+        ASTextKitRenderer *renderer = [self _locked_renderer];
 
         NSArray *highlightRects = [renderer rectsForTextRange:highlightRange measureOption:ASTextKitRendererMeasureOptionBlock];
         NSMutableArray *converted = [NSMutableArray arrayWithCapacity:highlightRects.count];


### PR DESCRIPTION
Since the lock was acquire before we try to access the renderer, we should call `-_locked_renderer` to avoid re-acquiring the same (recursive) lock.