### PR TITLE
Fix Text Node Thread Sanitizer Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Pass scrollViewWillEndDragging delegation through in ASIGListAdapterDataSource for IGListKit integration. [#796](https://github.com/TextureGroup/Texture/pull/796)
 - Fix UIResponder handling with view backing ASDisplayNode. [Michael Schneider](https://github.com/maicki) [#789] (https://github.com/TextureGroup/Texture/pull/789/)
 - Optimized thread-local storage by replacing pthread_specific with C11 thread-local variables. [Adlai Holler](https://github.com/Adlai-Holler) [#811] (https://github.com/TextureGroup/Texture/pull/811/)
+- Fixed a thread-sanitizer warning in ASTextNode. [Adlai Holler](https://github.com/Adlai-Holler) [#830] (https://github.com/TextureGroup/Texture/pull/830/)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -88,6 +88,8 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
   if (self == object) {
     return YES;
   }
+  
+  // NOTE: Skip the class check for this specialized, internal Key object.
 
   // Lock both objects, avoiding deadlock.
   std::lock(_m, object->_m);


### PR DESCRIPTION
I made this before I saw that #819 exists, and while I think @hebertialmeida's solution may possibly be faster (though it could lead to thread explosion), I think this solution is more precise.

The race condition is in the C++ struct `ASTextKitAttributes` itself. Since there is no synchronization around the contents of that struct, the sanitizer is correctly warning us.

This has led me down a heck of a rabbit-hole with memory safety. In lieu of a more general fix for the problem of creating very fast, but flexible and thread-safe C++ structures that interoperate well with Objective-C, this fix solves the thread sanitizer warnings in an appropriate way, by protecting access to that structure, at least in the `hash` and `isEqual` methods, which seems sufficient since the class is specifically termed a `Key`.

Note that it's not sufficient to make the Objective-C property accessor atomic, since that seems only to protect the pointer. I don't know much about how synthesized atomic accessors treat c++ objects, but I wouldn't be surprised if they're not actually atomic.