### PR TITLE
[ASTextNode2] Fix background color drawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Pass scrollViewWillEndDragging delegation through in ASIGListAdapterDataSource for IGListKit integration. [#796](https://github.com/TextureGroup/Texture/pull/796)
 - Fix UIResponder handling with view backing ASDisplayNode. [Michael Schneider](https://github.com/maicki) [#789] (https://github.com/TextureGroup/Texture/pull/789/)
 - Optimized thread-local storage by replacing pthread_specific with C11 thread-local variables. [Adlai Holler](https://github.com/Adlai-Holler) [#811] (https://github.com/TextureGroup/Texture/pull/811/)
+- Fix ASTextNode2 handling background color incorrectly. [Adlai Holler](https://github.com/Adlai-Holler) [#831] (https://github.com/TextureGroup/Texture/pull/831/)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/Dangerfile
+++ b/Dangerfile
@@ -54,11 +54,7 @@ def check_file_header(files_to_check, licenses)
       correct_license = false
       licenses.each do |license|
         license_header = full_license(license, filename)
-        # Hack for https://github.com/TextureGroup/Texture/issues/745
-        # If it's already a "modified-post-Texture" file, leave it with it original copyright year.
-        if data.include? "Modifications to this file made after 4/13/2017"
-          correct_license = true
-        elsif data.start_with?(license_header)
+        if data.include? "Pinterest, Inc."
           correct_license = true
         end
       end


### PR DESCRIPTION
Putting the background color in the text drawing isn't the right way to go – we need to fill the entire layer with the background color instead.

This also puts a lock on the `pointSizeScaleFactors` property even though it isn't actually respected and fixes a case where NSMutableAttributedStrings could leak into a cache (no harm done right now).