### PR TITLE
[ASTextNode2] Simplify Caching

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -310,7 +310,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   container.size = constrainedSize;
   [self _ensureTruncationText];
   
-  NSMutableAttributedString *mutableText = [attributedText mutableCopy];
+  NSMutableAttributedString *mutableText = [attributedText mutableCopy] ?: [[NSMutableAttributedString alloc] init];
   [self prepareAttributedString:mutableText];
   ASTextLayout *layout = [ASTextNode2 compatibleLayoutWithContainer:container text:mutableText];
   

--- a/Source/Private/TextExperiment/Component/ASTextLayout.m
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.m
@@ -13,7 +13,6 @@
 #import <AsyncDisplayKit/ASTextUtilities.h>
 #import <AsyncDisplayKit/ASTextAttribute.h>
 #import <AsyncDisplayKit/NSAttributedString+ASText.h>
-#import <AsyncDisplayKit/ASHashing.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 
 const CGSize ASTextContainerMaxSize = (CGSize){0x100000, 0x100000};
@@ -300,40 +299,6 @@ dispatch_semaphore_signal(_lock);
 
 - (id<ASTextLinePositionModifier>)linePositionModifier {
   Getter(id<ASTextLinePositionModifier> m = _linePositionModifier) return m;
-}
-
-#pragma mark - Hashing
-
-- (NSUInteger)hash
-{
-  // Don't include size in hash. Size -> layout mapping is many-to-one (fuzzy).
-#pragma clang diagnostic push
-#pragma clang diagnostic warning "-Wpadded"
-  struct {
-    UIEdgeInsets _insets;
-    NSUInteger _pathHash;
-    NSUInteger _exclusionPathsHash;
-    BOOL _pathFillEvenOdd;
-    CGFloat _pathLineWidth;
-    BOOL _verticalForm;
-    NSUInteger _maximumNumberOfRows;
-    ASTextTruncationType _truncationType;
-    NSUInteger _truncationTokenHash;
-    NSUInteger _linePositionModifierHash;
-#pragma clang diagnostic pop
-  } data = {
-    _insets,
-    [_path hash],
-    _exclusionPaths.hash,
-    _pathFillEvenOdd,
-    _pathLineWidth,
-    self.verticalForm,
-    _maximumNumberOfRows,
-    _truncationType,
-    [self.truncationToken hash],
-    [self.linePositionModifier hash]
-  };
-  return ASHashBytes(&data, sizeof(data));
 }
 
 #undef Getter

--- a/Source/Private/TextExperiment/Component/ASTextLayout.m
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.m
@@ -13,6 +13,7 @@
 #import <AsyncDisplayKit/ASTextUtilities.h>
 #import <AsyncDisplayKit/ASTextAttribute.h>
 #import <AsyncDisplayKit/NSAttributedString+ASText.h>
+#import <AsyncDisplayKit/ASHashing.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 
 const CGSize ASTextContainerMaxSize = (CGSize){0x100000, 0x100000};
@@ -299,6 +300,40 @@ dispatch_semaphore_signal(_lock);
 
 - (id<ASTextLinePositionModifier>)linePositionModifier {
   Getter(id<ASTextLinePositionModifier> m = _linePositionModifier) return m;
+}
+
+#pragma mark - Hashing
+
+- (NSUInteger)hash
+{
+  // Don't include size in hash. Size -> layout mapping is many-to-one (fuzzy).
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wpadded"
+  struct {
+    UIEdgeInsets _insets;
+    NSUInteger _pathHash;
+    NSUInteger _exclusionPathsHash;
+    BOOL _pathFillEvenOdd;
+    CGFloat _pathLineWidth;
+    BOOL _verticalForm;
+    NSUInteger _maximumNumberOfRows;
+    ASTextTruncationType _truncationType;
+    NSUInteger _truncationTokenHash;
+    NSUInteger _linePositionModifierHash;
+#pragma clang diagnostic pop
+  } data = {
+    _insets,
+    [_path hash],
+    _exclusionPaths.hash,
+    _pathFillEvenOdd,
+    _pathLineWidth,
+    self.verticalForm,
+    _maximumNumberOfRows,
+    _truncationType,
+    [self.truncationToken hash],
+    [self.linePositionModifier hash]
+  };
+  return ASHashBytes(&data, sizeof(data));
 }
 
 #undef Getter


### PR DESCRIPTION
This moves the bucketing behavior into the NSCache itself.

The cache which is currently `NSAttributedString -> ASTextCacheValue (a.k.a. [ASTextLayout])` becomes `ASTextCacheKey -> ASTextLayout` so that, instead of us doing the bucketing and scan, NSCache does it.

`ASTextCacheKey` is a pair of `(NSAttributedString, ASTextContainer)`, similar to `ASTextKitAttributes` in the ASTextNode1 world.

The fact is, a given pair of `(container, attributed string)` generates one layout, which can be used against multiple `(container, attributed string)` pairs, and this diff makes the `-hash` and `-isEqual` implementations reflect that.