### PR TITLE
Put back VM flag in ASCGImageBuffer

### DIFF
--- a/Source/ASCGImageBuffer.m
+++ b/Source/ASCGImageBuffer.m
@@ -36,7 +36,7 @@
 {
   if (self = [super init]) {
     _length = length;
-    _isVM = NO;//(length >= vm_page_size);
+    _isVM = (length >= vm_page_size);
     if (_isVM) {
       _mutableBytes = mmap(NULL, length, PROT_WRITE | PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, VM_MAKE_TAG(VM_MEMORY_COREGRAPHICS_DATA), 0);
       if (_mutableBytes == MAP_FAILED) {


### PR DESCRIPTION
I removed this for testing the non-VM path, but didn't mean to commit it.