### PR TITLE
Use NS_RETURNS_RETAINED macro to save time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,9 @@
 - Fix UIResponder handling with view backing ASDisplayNode. [Michael Schneider](https://github.com/maicki) [#789](https://github.com/TextureGroup/Texture/pull/789/)
 - Optimized thread-local storage by replacing pthread_specific with C11 thread-local variables. [Adlai Holler](https://github.com/Adlai-Holler) [#811](https://github.com/TextureGroup/Texture/pull/811/)
 - Fixed a thread-sanitizer warning in ASTextNode. [Adlai Holler](https://github.com/Adlai-Holler) [#830](https://github.com/TextureGroup/Texture/pull/830/)
-- Fix ASTextNode2 handling background color incorrectly. [Adlai Holler](https://github.com/Adlai-Holler) [#831] (https://github.com/TextureGroup/Texture/pull/831/)
+- Fix ASTextNode2 handling background color incorrectly. [Adlai Holler](https://github.com/Adlai-Holler) [#831](https://github.com/TextureGroup/Texture/pull/831/)
 - [NoCopyRendering] Improved performance & fixed image memory not being tagged in Instruments. [Adlai Holler](https://github.com/Adlai-Holler) [#833](https://github.com/TextureGroup/Texture/pull/833/)
+- Use `NS_RETURNS_RETAINED` macro to make our methods a tiny bit faster. [Adlai Holler](https://github.com/Adlai-Holler) [#843](https://github.com/TextureGroup/Texture/pull/843/)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -462,7 +462,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
  *
  * Result is of type NSValue<[Ivar]>
  */
-+ (NSValue * _Nonnull)_ivarsThatMayNeedMainDeallocation
++ (NSValue * _Nonnull)_ivarsThatMayNeedMainDeallocation NS_RETURNS_RETAINED
 {
   static NSCache<Class, NSValue *> *ivarsCache;
   static dispatch_once_t onceToken;

--- a/Source/ASMapNode.mm
+++ b/Source/ASMapNode.mm
@@ -263,7 +263,7 @@
   }];
 }
 
-+ (UIImage *)defaultPinImageWithCenterOffset:(CGPoint *)centerOffset
++ (UIImage *)defaultPinImageWithCenterOffset:(CGPoint *)centerOffset NS_RETURNS_RETAINED
 {
   static MKAnnotationView *pin;
   static dispatch_once_t onceToken;

--- a/Source/ASMultiplexImageNode.h
+++ b/Source/ASMultiplexImageNode.h
@@ -270,7 +270,7 @@ didFinishDownloadingImageWithIdentifier:(ASImageIdentifier)imageIdentifier
 + (NSURL *)URLWithAssetLocalIdentifier:(NSString *)assetLocalIdentifier
                             targetSize:(CGSize)targetSize
                            contentMode:(PHImageContentMode)contentMode
-                               options:(PHImageRequestOptions *)options AS_WARN_UNUSED_RESULT API_AVAILABLE(ios(8.0), tvos(10.0));
+                               options:(PHImageRequestOptions *)options NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT API_AVAILABLE(ios(8.0), tvos(10.0));
 
 @end
 

--- a/Source/ASMultiplexImageNode.mm
+++ b/Source/ASMultiplexImageNode.mm
@@ -894,7 +894,7 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 
 @implementation NSURL (ASPhotosFrameworkURLs)
 
-+ (NSURL *)URLWithAssetLocalIdentifier:(NSString *)assetLocalIdentifier targetSize:(CGSize)targetSize contentMode:(PHImageContentMode)contentMode options:(PHImageRequestOptions *)options
++ (NSURL *)URLWithAssetLocalIdentifier:(NSString *)assetLocalIdentifier targetSize:(CGSize)targetSize contentMode:(PHImageContentMode)contentMode options:(PHImageRequestOptions *)options NS_RETURNS_RETAINED
 {
   ASPhotosFrameworkImageRequest *request = [[ASPhotosFrameworkImageRequest alloc] initWithAssetIdentifier:assetLocalIdentifier];
   request.options = options;

--- a/Source/ASRunLoopQueue.h
+++ b/Source/ASRunLoopQueue.h
@@ -68,6 +68,7 @@ AS_SUBCLASSING_RESTRICTED
  * Each node will only be called once per transaction commit to reflect interface change.
  */
 @property (class, atomic, readonly) ASCATransactionQueue *sharedQueue;
++ (ASCATransactionQueue *)sharedQueue NS_RETURNS_RETAINED;
 
 - (void)enqueue:(id<ASCATransactionQueueObserving>)object;
 
@@ -83,6 +84,7 @@ AS_SUBCLASSING_RESTRICTED
 @interface ASDeallocQueue : NSObject
 
 @property (class, atomic, readonly) ASDeallocQueue *sharedDeallocationQueue;
++ (ASDeallocQueue *)sharedDeallocationQueue NS_RETURNS_RETAINED;
 
 - (void)test_drain;
 

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -45,7 +45,7 @@ static void runLoopSourceCallback(void *info) {
   ASDN::RecursiveMutex _queueLock;
 }
 
-+ (ASDeallocQueue *)sharedDeallocationQueue
++ (ASDeallocQueue *)sharedDeallocationQueue NS_RETURNS_RETAINED
 {
   static ASDeallocQueue *deallocQueue = nil;
   static dispatch_once_t onceToken;
@@ -516,7 +516,7 @@ static int const kASASCATransactionQueueOrder = 1000000;
 // and kASASCATransactionQueuePostOrder will apply interface change immediately.
 static int const kASASCATransactionQueuePostOrder = 3000000;
 
-+ (ASCATransactionQueue *)sharedQueue
++ (ASCATransactionQueue *)sharedQueue NS_RETURNS_RETAINED
 {
   static dispatch_once_t onceToken;
   static ASCATransactionQueue *sharedQueue;

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -372,7 +372,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
  * NOTE: Be careful to copy `text` if needed.
  */
 + (ASTextLayout *)compatibleLayoutWithContainer:(ASTextContainer *)container
-                                           text:(NSAttributedString *)text
+                                           text:(NSAttributedString *)text NS_RETURNS_RETAINED
 
 {
   // Allocate layoutCacheLock on the heap to prevent destruction at app exit (https://github.com/TextureGroup/Texture/issues/136)

--- a/Source/Debug/AsyncDisplayKit+Debug.m
+++ b/Source/Debug/AsyncDisplayKit+Debug.m
@@ -213,7 +213,7 @@ static BOOL __enableHitTestDebug = NO;
 
 @interface _ASRangeDebugOverlayView : UIView
 
-+ (instancetype)sharedInstance;
++ (instancetype)sharedInstance NS_RETURNS_RETAINED;
 
 - (void)addRangeController:(ASRangeController *)rangeController;
 
@@ -311,7 +311,7 @@ static BOOL __shouldShowRangeDebugOverlay = NO;
   return [[NSClassFromString(@"UIApplication") sharedApplication] keyWindow];
 }
 
-+ (instancetype)sharedInstance
++ (_ASRangeDebugOverlayView *)sharedInstance NS_RETURNS_RETAINED
 {
   static _ASRangeDebugOverlayView *__rangeDebugOverlay = nil;
   
@@ -752,7 +752,7 @@ static BOOL __shouldShowRangeDebugOverlay = NO;
     return rangeBarImageNode;
 }
 
-+ (NSAttributedString *)whiteAttributedStringFromString:(NSString *)string withSize:(CGFloat)size
++ (NSAttributedString *)whiteAttributedStringFromString:(NSString *)string withSize:(CGFloat)size NS_RETURNS_RETAINED
 {
   NSDictionary *attributes = @{NSForegroundColorAttributeName : [UIColor whiteColor],
                                NSFontAttributeName            : [UIFont systemFontOfSize:size]};

--- a/Source/Details/ASBasicImageDownloader.h
+++ b/Source/Details/ASBasicImageDownloader.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @note It is strongly recommended you include PINRemoteImage and use @c ASPINRemoteImageDownloader instead.
  */
 @property (class, readonly) ASBasicImageDownloader *sharedImageDownloader;
++ (ASBasicImageDownloader *)sharedImageDownloader NS_RETURNS_RETAINED;
 
 + (instancetype)new __attribute__((unavailable("+[ASBasicImageDownloader sharedImageDownloader] must be used.")));
 - (instancetype)init __attribute__((unavailable("+[ASBasicImageDownloader sharedImageDownloader] must be used.")));

--- a/Source/Details/ASIntegerMap.h
+++ b/Source/Details/ASIntegerMap.h
@@ -29,7 +29,7 @@ AS_SUBCLASSING_RESTRICTED
  */
 + (ASIntegerMap *)mapForUpdateWithOldCount:(NSInteger)oldCount
                                    deleted:(nullable NSIndexSet *)deleted
-                                  inserted:(nullable NSIndexSet *)inserted;
+                                  inserted:(nullable NSIndexSet *)inserted NS_RETURNS_RETAINED;
 
 /**
  * A singleton that maps each integer to itself. Its inverse is itself.
@@ -37,6 +37,7 @@ AS_SUBCLASSING_RESTRICTED
  * Note: You cannot mutate this.
  */
 @property (class, atomic, readonly) ASIntegerMap *identityMap;
++ (ASIntegerMap *)identityMap NS_RETURNS_RETAINED;
 
 /**
  * A singleton that returns NSNotFound for all keys. Its inverse is itself.
@@ -44,6 +45,7 @@ AS_SUBCLASSING_RESTRICTED
  * Note: You cannot mutate this.
  */
 @property (class, atomic, readonly) ASIntegerMap *emptyMap;
++ (ASIntegerMap *)emptyMap NS_RETURNS_RETAINED;
 
 /**
  * Retrieves the integer for a given key, or NSNotFound if the key is not found.

--- a/Source/Details/ASIntegerMap.mm
+++ b/Source/Details/ASIntegerMap.mm
@@ -31,7 +31,7 @@
 
 #pragma mark - Singleton
 
-+ (ASIntegerMap *)identityMap
++ (ASIntegerMap *)identityMap NS_RETURNS_RETAINED
 {
   static ASIntegerMap *identityMap;
   static dispatch_once_t onceToken;
@@ -43,7 +43,7 @@
   return identityMap;
 }
 
-+ (ASIntegerMap *)emptyMap
++ (ASIntegerMap *)emptyMap NS_RETURNS_RETAINED
 {
   static ASIntegerMap *emptyMap;
   static dispatch_once_t onceToken;
@@ -55,7 +55,7 @@
   return emptyMap;
 }
 
-+ (ASIntegerMap *)mapForUpdateWithOldCount:(NSInteger)oldCount deleted:(NSIndexSet *)deletions inserted:(NSIndexSet *)insertions
++ (ASIntegerMap *)mapForUpdateWithOldCount:(NSInteger)oldCount deleted:(NSIndexSet *)deletions inserted:(NSIndexSet *)insertions NS_RETURNS_RETAINED
 {
   if (oldCount == 0) {
     return ASIntegerMap.emptyMap;

--- a/Source/Details/ASPINRemoteImageDownloader.h
+++ b/Source/Details/ASPINRemoteImageDownloader.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  * available. It uses PINRemoteImage's features to provide caching and progressive image downloads.
  */
 @property (class, readonly) ASPINRemoteImageDownloader *sharedDownloader;
++ (ASPINRemoteImageDownloader *)sharedDownloader NS_RETURNS_RETAINED;
 
 
 /**

--- a/Source/Details/ASPINRemoteImageDownloader.m
+++ b/Source/Details/ASPINRemoteImageDownloader.m
@@ -114,7 +114,7 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
 
 @implementation ASPINRemoteImageDownloader
 
-+ (ASPINRemoteImageDownloader *)sharedDownloader
++ (ASPINRemoteImageDownloader *)sharedDownloader NS_RETURNS_RETAINED
 {
 
   static dispatch_once_t onceToken = 0;

--- a/Source/Details/ASPageTable.h
+++ b/Source/Details/ASPageTable.h
@@ -82,12 +82,12 @@ typedef ASPageTable<id, NSMutableArray<UICollectionViewLayoutAttributes *> *> AS
 /**
  * Creates a new page table with (NSMapTableStrongMemory | NSMapTableObjectPointerPersonality) for values.
  */
-+ (ASPageTable *)pageTableForStrongObjectPointers;
++ (ASPageTable *)pageTableForStrongObjectPointers NS_RETURNS_RETAINED;
 
 /**
  * Creates a new page table with (NSMapTableWeakMemory | NSMapTableObjectPointerPersonality) for values.
  */
-+ (ASPageTable *)pageTableForWeakObjectPointers;
++ (ASPageTable *)pageTableForWeakObjectPointers NS_RETURNS_RETAINED;
 
 /**
  * Builds a new page to layout attributes from the given layout attributes.
@@ -98,7 +98,7 @@ typedef ASPageTable<id, NSMutableArray<UICollectionViewLayoutAttributes *> *> AS
  *
  * @param pageSize The size of each page.
  */
-+ (ASPageToLayoutAttributesTable *)pageTableWithLayoutAttributes:(id<NSFastEnumeration>)layoutAttributesEnumerator contentSize:(CGSize)contentSize pageSize:(CGSize)pageSize;
++ (ASPageToLayoutAttributesTable *)pageTableWithLayoutAttributes:(id<NSFastEnumeration>)layoutAttributesEnumerator contentSize:(CGSize)contentSize pageSize:(CGSize)pageSize NS_RETURNS_RETAINED;
 
 /**
  * Retrieves the object for a given page, or nil if the page is not found.

--- a/Source/Details/ASPageTable.m
+++ b/Source/Details/ASPageTable.m
@@ -79,7 +79,7 @@ extern NSPointerArray *ASPageCoordinatesForPagesThatIntersectRect(CGRect rect, C
 
 @implementation NSMapTable (ASPageTableMethods)
 
-+ (instancetype)pageTableWithValuePointerFunctions:(NSPointerFunctions *)valueFuncs
++ (instancetype)pageTableWithValuePointerFunctions:(NSPointerFunctions *)valueFuncs NS_RETURNS_RETAINED
 {
   static NSPointerFunctions *pageCoordinatesFuncs;
   static dispatch_once_t onceToken;
@@ -90,7 +90,7 @@ extern NSPointerArray *ASPageCoordinatesForPagesThatIntersectRect(CGRect rect, C
   return [[NSMapTable alloc] initWithKeyPointerFunctions:pageCoordinatesFuncs valuePointerFunctions:valueFuncs capacity:0];
 }
 
-+ (ASPageTable *)pageTableForStrongObjectPointers
++ (ASPageTable *)pageTableForStrongObjectPointers NS_RETURNS_RETAINED
 {
   static NSPointerFunctions *strongObjectPointerFuncs;
   static dispatch_once_t onceToken;
@@ -100,7 +100,7 @@ extern NSPointerArray *ASPageCoordinatesForPagesThatIntersectRect(CGRect rect, C
   return [self pageTableWithValuePointerFunctions:strongObjectPointerFuncs];
 }
 
-+ (ASPageTable *)pageTableForWeakObjectPointers
++ (ASPageTable *)pageTableForWeakObjectPointers NS_RETURNS_RETAINED
 {
   static NSPointerFunctions *weakObjectPointerFuncs;
   static dispatch_once_t onceToken;
@@ -110,7 +110,7 @@ extern NSPointerArray *ASPageCoordinatesForPagesThatIntersectRect(CGRect rect, C
   return [self pageTableWithValuePointerFunctions:weakObjectPointerFuncs];
 }
 
-+ (ASPageToLayoutAttributesTable *)pageTableWithLayoutAttributes:(id<NSFastEnumeration>)layoutAttributesEnumerator contentSize:(CGSize)contentSize pageSize:(CGSize)pageSize
++ (ASPageToLayoutAttributesTable *)pageTableWithLayoutAttributes:(id<NSFastEnumeration>)layoutAttributesEnumerator contentSize:(CGSize)contentSize pageSize:(CGSize)pageSize NS_RETURNS_RETAINED
 {
   ASPageToLayoutAttributesTable *result = [ASPageTable pageTableForStrongObjectPointers];
   for (UICollectionViewLayoutAttributes *attrs in layoutAttributesEnumerator) {

--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -179,14 +179,14 @@ AS_SUBCLASSING_RESTRICTED
 
 @property (nonatomic, assign, readonly) CGSize containerSize;
 
-+ (ASTraitCollection *)traitCollectionWithASPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traits;
++ (ASTraitCollection *)traitCollectionWithASPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traits NS_RETURNS_RETAINED;
 
 + (ASTraitCollection *)traitCollectionWithUITraitCollection:(UITraitCollection *)traitCollection
-                                              containerSize:(CGSize)windowSize;
+                                              containerSize:(CGSize)windowSize NS_RETURNS_RETAINED;
 
 + (ASTraitCollection *)traitCollectionWithUITraitCollection:(UITraitCollection *)traitCollection
                                               containerSize:(CGSize)windowSize
-                                fallbackContentSizeCategory:(UIContentSizeCategory)fallbackContentSizeCategory;
+                                fallbackContentSizeCategory:(UIContentSizeCategory)fallbackContentSizeCategory NS_RETURNS_RETAINED;
 
 #if TARGET_OS_TV
 + (ASTraitCollection *)traitCollectionWithHorizontalSizeClass:(UIUserInterfaceSizeClass)horizontalSizeClass
@@ -198,7 +198,7 @@ AS_SUBCLASSING_RESTRICTED
                                               layoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
                                            userInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle
                                  preferredContentSizeCategory:(UIContentSizeCategory)preferredContentSizeCategory
-                                                containerSize:(CGSize)windowSize;
+                                                containerSize:(CGSize)windowSize NS_RETURNS_RETAINED;
 #else
 + (ASTraitCollection *)traitCollectionWithHorizontalSizeClass:(UIUserInterfaceSizeClass)horizontalSizeClass
                                             verticalSizeClass:(UIUserInterfaceSizeClass)verticalSizeClass
@@ -208,7 +208,7 @@ AS_SUBCLASSING_RESTRICTED
                                          forceTouchCapability:(UIForceTouchCapability)forceTouchCapability
                                               layoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
                                  preferredContentSizeCategory:(UIContentSizeCategory)preferredContentSizeCategory
-                                                containerSize:(CGSize)windowSize;
+                                                containerSize:(CGSize)windowSize NS_RETURNS_RETAINED;
 #endif
 
 - (ASPrimitiveTraitCollection)primitiveTraitCollection;
@@ -224,7 +224,7 @@ AS_SUBCLASSING_RESTRICTED
                                      verticalSizeClass:(UIUserInterfaceSizeClass)verticalSizeClass
                                   forceTouchCapability:(UIForceTouchCapability)forceTouchCapability
                                          containerSize:(CGSize)windowSize
-  ASDISPLAYNODE_DEPRECATED_MSG("Use full version of this method instead.");
+  NS_RETURNS_RETAINED ASDISPLAYNODE_DEPRECATED_MSG("Use full version of this method instead.");
 
 @end
 

--- a/Source/Details/ASTraitCollection.m
+++ b/Source/Details/ASTraitCollection.m
@@ -277,7 +277,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
                                        layoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
                                     userInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle
                           preferredContentSizeCategory:(UIContentSizeCategory)preferredContentSizeCategory
-                                         containerSize:(CGSize)windowSize
+                                         containerSize:(CGSize)windowSize NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithHorizontalSizeClass:horizontalSizeClass
                                  verticalSizeClass:verticalSizeClass
@@ -326,7 +326,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
                                   forceTouchCapability:(UIForceTouchCapability)forceTouchCapability
                                        layoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
                           preferredContentSizeCategory:(UIContentSizeCategory)preferredContentSizeCategory
-                                         containerSize:(CGSize)windowSize
+                                         containerSize:(CGSize)windowSize NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithHorizontalSizeClass:horizontalSizeClass
                                  verticalSizeClass:verticalSizeClass
@@ -346,7 +346,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
                                    horizontalSizeClass:(UIUserInterfaceSizeClass)horizontalSizeClass
                                      verticalSizeClass:(UIUserInterfaceSizeClass)verticalSizeClass
                                   forceTouchCapability:(UIForceTouchCapability)forceTouchCapability
-                                         containerSize:(CGSize)windowSize
+                                         containerSize:(CGSize)windowSize NS_RETURNS_RETAINED
 {
 #if TARGET_OS_TV
   return [self traitCollectionWithHorizontalSizeClass:horizontalSizeClass
@@ -372,7 +372,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
 #endif
 }
 
-+ (instancetype)traitCollectionWithASPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traits
++ (instancetype)traitCollectionWithASPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traits NS_RETURNS_RETAINED
 {
 #if TARGET_OS_TV
   return [self traitCollectionWithHorizontalSizeClass:traits.horizontalSizeClass
@@ -399,7 +399,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
 }
 
 + (instancetype)traitCollectionWithUITraitCollection:(UITraitCollection *)traitCollection
-                                       containerSize:(CGSize)windowSize
+                                       containerSize:(CGSize)windowSize NS_RETURNS_RETAINED
 {
   return [self traitCollectionWithUITraitCollection:traitCollection
                                       containerSize:windowSize
@@ -409,7 +409,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
 
 + (instancetype)traitCollectionWithUITraitCollection:(UITraitCollection *)traitCollection
                                        containerSize:(CGSize)windowSize
-                         fallbackContentSizeCategory:(UIContentSizeCategory)fallbackContentSizeCategory
+                         fallbackContentSizeCategory:(UIContentSizeCategory)fallbackContentSizeCategory NS_RETURNS_RETAINED
 {
   UIDisplayGamut displayGamut;
   UITraitEnvironmentLayoutDirection layoutDirection;

--- a/Source/Details/ASWeakProxy.h
+++ b/Source/Details/ASWeakProxy.h
@@ -35,6 +35,6 @@ AS_SUBCLASSING_RESTRICTED
  *
  * @return an instance of ASWeakProxy
  */
-+ (instancetype)weakProxyWithTarget:(id)target;
++ (instancetype)weakProxyWithTarget:(id)target NS_RETURNS_RETAINED;
 
 @end

--- a/Source/Details/ASWeakProxy.m
+++ b/Source/Details/ASWeakProxy.m
@@ -29,7 +29,7 @@
   return self;
 }
 
-+ (instancetype)weakProxyWithTarget:(id)target
++ (instancetype)weakProxyWithTarget:(id)target NS_RETURNS_RETAINED
 {
   return [[ASWeakProxy alloc] initWithTarget:target];
 }

--- a/Source/Layout/ASAbsoluteLayoutSpec.h
+++ b/Source/Layout/ASAbsoluteLayoutSpec.h
@@ -41,12 +41,12 @@ NS_ASSUME_NONNULL_BEGIN
  @param sizing How much space the spec will take up
  @param children Children to be positioned at fixed positions
  */
-+ (instancetype)absoluteLayoutSpecWithSizing:(ASAbsoluteLayoutSpecSizing)sizing children:(NSArray<id<ASLayoutElement>> *)children AS_WARN_UNUSED_RESULT;
++ (instancetype)absoluteLayoutSpecWithSizing:(ASAbsoluteLayoutSpecSizing)sizing children:(NSArray<id<ASLayoutElement>> *)children NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /**
  @param children Children to be positioned at fixed positions
  */
-+ (instancetype)absoluteLayoutSpecWithChildren:(NSArray<id<ASLayoutElement>> *)children AS_WARN_UNUSED_RESULT;
++ (instancetype)absoluteLayoutSpecWithChildren:(NSArray<id<ASLayoutElement>> *)children NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/Source/Layout/ASAbsoluteLayoutSpec.mm
+++ b/Source/Layout/ASAbsoluteLayoutSpec.mm
@@ -28,12 +28,12 @@
 
 #pragma mark - Class
 
-+ (instancetype)absoluteLayoutSpecWithChildren:(NSArray *)children
++ (instancetype)absoluteLayoutSpecWithChildren:(NSArray *)children NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithChildren:children];
 }
 
-+ (instancetype)absoluteLayoutSpecWithSizing:(ASAbsoluteLayoutSpecSizing)sizing children:(NSArray<id<ASLayoutElement>> *)children
++ (instancetype)absoluteLayoutSpecWithSizing:(ASAbsoluteLayoutSpecSizing)sizing children:(NSArray<id<ASLayoutElement>> *)children NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithSizing:sizing children:children];
 }

--- a/Source/Layout/ASAsciiArtBoxCreator.m
+++ b/Source/Layout/ASAsciiArtBoxCreator.m
@@ -35,7 +35,7 @@ typedef NS_ENUM(NSUInteger, PIDebugBoxPaddingLocation)
 
 @implementation NSString(PIDebugBox)
 
-+ (instancetype)debugbox_stringWithString:(NSString *)stringToRepeat repeatedCount:(NSUInteger)repeatCount
++ (instancetype)debugbox_stringWithString:(NSString *)stringToRepeat repeatedCount:(NSUInteger)repeatCount NS_RETURNS_RETAINED
 {
   NSMutableString *string = [[NSMutableString alloc] initWithCapacity:[stringToRepeat length]  * repeatCount];
   for (NSUInteger index = 0; index < repeatCount; index++) {

--- a/Source/Layout/ASBackgroundLayoutSpec.h
+++ b/Source/Layout/ASBackgroundLayoutSpec.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param child A child that is laid out to determine the size of this spec.
  * @param background A layoutElement object that is laid out behind the child.
  */
-+ (instancetype)backgroundLayoutSpecWithChild:(id<ASLayoutElement>)child background:(id<ASLayoutElement>)background AS_WARN_UNUSED_RESULT;
++ (instancetype)backgroundLayoutSpecWithChild:(id<ASLayoutElement>)child background:(id<ASLayoutElement>)background NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/Source/Layout/ASBackgroundLayoutSpec.mm
+++ b/Source/Layout/ASBackgroundLayoutSpec.mm
@@ -28,7 +28,7 @@ static NSUInteger const kBackgroundChildIndex = 1;
 
 #pragma mark - Class
 
-+ (instancetype)backgroundLayoutSpecWithChild:(id<ASLayoutElement>)child background:(id<ASLayoutElement>)background;
++ (instancetype)backgroundLayoutSpecWithChild:(id<ASLayoutElement>)child background:(id<ASLayoutElement>)background NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithChild:child background:background];
 }

--- a/Source/Layout/ASCenterLayoutSpec.h
+++ b/Source/Layout/ASCenterLayoutSpec.h
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)centerLayoutSpecWithCenteringOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions
                                        sizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions
-                                               child:(id<ASLayoutElement>)child AS_WARN_UNUSED_RESULT;
+                                               child:(id<ASLayoutElement>)child NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/Source/Layout/ASCenterLayoutSpec.mm
+++ b/Source/Layout/ASCenterLayoutSpec.mm
@@ -42,7 +42,7 @@
 
 + (instancetype)centerLayoutSpecWithCenteringOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions
                                        sizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions
-                                               child:(id<ASLayoutElement>)child
+                                               child:(id<ASLayoutElement>)child NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithCenteringOptions:centeringOptions sizingOptions:sizingOptions child:child];
 }

--- a/Source/Layout/ASCornerLayoutSpec.h
+++ b/Source/Layout/ASCornerLayoutSpec.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param location The corner position option.
  @return An ASCornerLayoutSpec object with a given child and an layoutElement that act as corner.
  */
-+ (instancetype)cornerLayoutSpecWithChild:(id <ASLayoutElement>)child corner:(id <ASLayoutElement>)corner location:(ASCornerLayoutLocation)location AS_WARN_UNUSED_RESULT;
++ (instancetype)cornerLayoutSpecWithChild:(id <ASLayoutElement>)child corner:(id <ASLayoutElement>)corner location:(ASCornerLayoutLocation)location NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /**
  A layoutElement object that is laid out to a corner on the child.

--- a/Source/Layout/ASCornerLayoutSpec.mm
+++ b/Source/Layout/ASCornerLayoutSpec.mm
@@ -65,7 +65,7 @@ static NSUInteger const kCornerChildIndex = 1;
   return self;
 }
 
-+ (instancetype)cornerLayoutSpecWithChild:(id <ASLayoutElement>)child corner:(id <ASLayoutElement>)corner location:(ASCornerLayoutLocation)location
++ (instancetype)cornerLayoutSpecWithChild:(id <ASLayoutElement>)child corner:(id <ASLayoutElement>)corner location:(ASCornerLayoutLocation)location NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithChild:child corner:corner location:location];
 }

--- a/Source/Layout/ASInsetLayoutSpec.h
+++ b/Source/Layout/ASInsetLayoutSpec.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param insets The amount of space to inset on each side.
  @param child The wrapped child to inset.
  */
-+ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutElement>)child AS_WARN_UNUSED_RESULT;
++ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutElement>)child NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/Source/Layout/ASInsetLayoutSpec.mm
+++ b/Source/Layout/ASInsetLayoutSpec.mm
@@ -59,7 +59,7 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
   return self;
 }
 
-+ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutElement>)child
++ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutElement>)child NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithInsets:insets child:child];
 }

--- a/Source/Layout/ASLayout.h
+++ b/Source/Layout/ASLayout.h
@@ -108,7 +108,7 @@ ASDISPLAYNODE_EXTERN_C_END
 + (instancetype)layoutWithLayoutElement:(id<ASLayoutElement>)layoutElement
                                    size:(CGSize)size
                                position:(CGPoint)position
-                             sublayouts:(nullable NSArray<ASLayout *> *)sublayouts AS_WARN_UNUSED_RESULT;
+                             sublayouts:(nullable NSArray<ASLayout *> *)sublayouts NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /**
  * Convenience initializer that has CGPointNull position.
@@ -122,7 +122,7 @@ ASDISPLAYNODE_EXTERN_C_END
  */
 + (instancetype)layoutWithLayoutElement:(id<ASLayoutElement>)layoutElement
                                    size:(CGSize)size
-                             sublayouts:(nullable NSArray<ASLayout *> *)sublayouts AS_WARN_UNUSED_RESULT;
+                             sublayouts:(nullable NSArray<ASLayout *> *)sublayouts NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /**
  * Convenience that has CGPointNull position and no sublayouts.
@@ -133,11 +133,11 @@ ASDISPLAYNODE_EXTERN_C_END
  * @param size             The size of this layout.
  */
 + (instancetype)layoutWithLayoutElement:(id<ASLayoutElement>)layoutElement
-                                   size:(CGSize)size AS_WARN_UNUSED_RESULT;
+                                   size:(CGSize)size NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 /**
  * Traverses the existing layout tree and generates a new tree that represents only ASDisplayNode layouts
  */
-- (ASLayout *)filteredNodeLayoutTree AS_WARN_UNUSED_RESULT;
+- (ASLayout *)filteredNodeLayoutTree NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -166,7 +166,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
 + (instancetype)layoutWithLayoutElement:(id<ASLayoutElement>)layoutElement
                                    size:(CGSize)size
                                position:(CGPoint)position
-                             sublayouts:(nullable NSArray<ASLayout *> *)sublayouts
+                             sublayouts:(nullable NSArray<ASLayout *> *)sublayouts NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithLayoutElement:layoutElement
                                         size:size
@@ -176,7 +176,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
 
 + (instancetype)layoutWithLayoutElement:(id<ASLayoutElement>)layoutElement
                                    size:(CGSize)size
-                             sublayouts:(nullable NSArray<ASLayout *> *)sublayouts
+                             sublayouts:(nullable NSArray<ASLayout *> *)sublayouts NS_RETURNS_RETAINED
 {
   return [self layoutWithLayoutElement:layoutElement
                                   size:size
@@ -184,7 +184,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
                             sublayouts:sublayouts];
 }
 
-+ (instancetype)layoutWithLayoutElement:(id<ASLayoutElement>)layoutElement size:(CGSize)size
++ (instancetype)layoutWithLayoutElement:(id<ASLayoutElement>)layoutElement size:(CGSize)size NS_RETURNS_RETAINED
 {
   return [self layoutWithLayoutElement:layoutElement
                                   size:size
@@ -216,7 +216,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
 
 #pragma mark - Layout Flattening
 
-- (ASLayout *)filteredNodeLayoutTree
+- (ASLayout *)filteredNodeLayoutTree NS_RETURNS_RETAINED
 {
   if (ASLayoutIsFlattened(self)) {
     // All flattened layouts must have this flag enabled

--- a/Source/Layout/ASLayoutSpec.h
+++ b/Source/Layout/ASLayoutSpec.h
@@ -71,12 +71,12 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * Returns an ASWrapperLayoutSpec object with the given layoutElement as child.
  */
-+ (instancetype)wrapperWithLayoutElement:(id<ASLayoutElement>)layoutElement AS_WARN_UNUSED_RESULT;
++ (instancetype)wrapperWithLayoutElement:(id<ASLayoutElement>)layoutElement NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /*
  * Returns an ASWrapperLayoutSpec object with the given layoutElements as children.
  */
-+ (instancetype)wrapperWithLayoutElements:(NSArray<id<ASLayoutElement>> *)layoutElements AS_WARN_UNUSED_RESULT;
++ (instancetype)wrapperWithLayoutElements:(NSArray<id<ASLayoutElement>> *)layoutElements NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /*
  * Returns an ASWrapperLayoutSpec object initialized with the given layoutElement as child.

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -265,7 +265,7 @@ ASLayoutElementStyleExtensibilityForwarding
 
 @implementation ASWrapperLayoutSpec
 
-+ (instancetype)wrapperWithLayoutElement:(id<ASLayoutElement>)layoutElement
++ (instancetype)wrapperWithLayoutElement:(id<ASLayoutElement>)layoutElement NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithLayoutElement:layoutElement];
 }
@@ -279,7 +279,7 @@ ASLayoutElementStyleExtensibilityForwarding
   return self;
 }
 
-+ (instancetype)wrapperWithLayoutElements:(NSArray<id<ASLayoutElement>> *)layoutElements
++ (instancetype)wrapperWithLayoutElements:(NSArray<id<ASLayoutElement>> *)layoutElements NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithLayoutElements:layoutElements];
 }

--- a/Source/Layout/ASOverlayLayoutSpec.h
+++ b/Source/Layout/ASOverlayLayoutSpec.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param child A child that is laid out to determine the size of this spec.
  * @param overlay A layoutElement object that is laid out over the child.
  */
-+ (instancetype)overlayLayoutSpecWithChild:(id<ASLayoutElement>)child overlay:(id<ASLayoutElement>)overlay AS_WARN_UNUSED_RESULT;
++ (instancetype)overlayLayoutSpecWithChild:(id<ASLayoutElement>)child overlay:(id<ASLayoutElement>)overlay NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/Source/Layout/ASOverlayLayoutSpec.mm
+++ b/Source/Layout/ASOverlayLayoutSpec.mm
@@ -26,7 +26,7 @@ static NSUInteger const kOverlayChildIndex = 1;
 
 #pragma mark - Class
 
-+ (instancetype)overlayLayoutSpecWithChild:(id<ASLayoutElement>)child overlay:(id<ASLayoutElement>)overlay
++ (instancetype)overlayLayoutSpecWithChild:(id<ASLayoutElement>)child overlay:(id<ASLayoutElement>)overlay NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithChild:child overlay:overlay];
 }

--- a/Source/Layout/ASRatioLayoutSpec.h
+++ b/Source/Layout/ASRatioLayoutSpec.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) CGFloat ratio;
 
-+ (instancetype)ratioLayoutSpecWithRatio:(CGFloat)ratio child:(id<ASLayoutElement>)child AS_WARN_UNUSED_RESULT;
++ (instancetype)ratioLayoutSpecWithRatio:(CGFloat)ratio child:(id<ASLayoutElement>)child NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/Source/Layout/ASRatioLayoutSpec.mm
+++ b/Source/Layout/ASRatioLayoutSpec.mm
@@ -35,7 +35,7 @@
 
 #pragma mark - Lifecycle
 
-+ (instancetype)ratioLayoutSpecWithRatio:(CGFloat)ratio child:(id<ASLayoutElement>)child
++ (instancetype)ratioLayoutSpecWithRatio:(CGFloat)ratio child:(id<ASLayoutElement>)child NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithRatio:ratio child:child];
 }

--- a/Source/Layout/ASRelativeLayoutSpec.h
+++ b/Source/Layout/ASRelativeLayoutSpec.h
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)relativePositionLayoutSpecWithHorizontalPosition:(ASRelativeLayoutSpecPosition)horizontalPosition
                                                 verticalPosition:(ASRelativeLayoutSpecPosition)verticalPosition
                                                     sizingOption:(ASRelativeLayoutSpecSizingOption)sizingOption
-                                                           child:(id<ASLayoutElement>)child AS_WARN_UNUSED_RESULT;
+                                                           child:(id<ASLayoutElement>)child NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /*!
  * @discussion convenience initializer for a ASRelativeLayoutSpec

--- a/Source/Layout/ASRelativeLayoutSpec.mm
+++ b/Source/Layout/ASRelativeLayoutSpec.mm
@@ -36,7 +36,7 @@
   return self;
 }
 
-+ (instancetype)relativePositionLayoutSpecWithHorizontalPosition:(ASRelativeLayoutSpecPosition)horizontalPosition verticalPosition:(ASRelativeLayoutSpecPosition)verticalPosition sizingOption:(ASRelativeLayoutSpecSizingOption)sizingOption child:(id<ASLayoutElement>)child
++ (instancetype)relativePositionLayoutSpecWithHorizontalPosition:(ASRelativeLayoutSpecPosition)horizontalPosition verticalPosition:(ASRelativeLayoutSpecPosition)verticalPosition sizingOption:(ASRelativeLayoutSpecSizingOption)sizingOption child:(id<ASLayoutElement>)child NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithHorizontalPosition:horizontalPosition verticalPosition:verticalPosition sizingOption:sizingOption child:child];
 }

--- a/Source/Layout/ASStackLayoutSpec.h
+++ b/Source/Layout/ASStackLayoutSpec.h
@@ -88,7 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
                                      spacing:(CGFloat)spacing
                               justifyContent:(ASStackLayoutJustifyContent)justifyContent
                                   alignItems:(ASStackLayoutAlignItems)alignItems
-                                    children:(NSArray<id<ASLayoutElement>> *)children AS_WARN_UNUSED_RESULT;
+                                    children:(NSArray<id<ASLayoutElement>> *)children NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /**
  @param direction The direction of the stack view (horizontal or vertical)
@@ -105,7 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   alignItems:(ASStackLayoutAlignItems)alignItems
                                     flexWrap:(ASStackLayoutFlexWrap)flexWrap
                                 alignContent:(ASStackLayoutAlignContent)alignContent
-                                    children:(NSArray<id<ASLayoutElement>> *)children AS_WARN_UNUSED_RESULT;
+                                    children:(NSArray<id<ASLayoutElement>> *)children NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /**
  @param direction The direction of the stack view (horizontal or vertical)
@@ -124,17 +124,17 @@ NS_ASSUME_NONNULL_BEGIN
                                     flexWrap:(ASStackLayoutFlexWrap)flexWrap
                                 alignContent:(ASStackLayoutAlignContent)alignContent
                                  lineSpacing:(CGFloat)lineSpacing
-                                    children:(NSArray<id<ASLayoutElement>> *)children AS_WARN_UNUSED_RESULT;
+                                    children:(NSArray<id<ASLayoutElement>> *)children NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /**
  * @return A stack layout spec with direction of ASStackLayoutDirectionVertical
  **/
-+ (instancetype)verticalStackLayoutSpec AS_WARN_UNUSED_RESULT;
++ (instancetype)verticalStackLayoutSpec NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /**
  * @return A stack layout spec with direction of ASStackLayoutDirectionHorizontal
  **/
-+ (instancetype)horizontalStackLayoutSpec AS_WARN_UNUSED_RESULT;
++ (instancetype)horizontalStackLayoutSpec NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/Source/Layout/ASStackLayoutSpec.mm
+++ b/Source/Layout/ASStackLayoutSpec.mm
@@ -36,29 +36,29 @@
   return [self initWithDirection:ASStackLayoutDirectionHorizontal spacing:0.0 justifyContent:ASStackLayoutJustifyContentStart alignItems:ASStackLayoutAlignItemsStretch flexWrap:ASStackLayoutFlexWrapNoWrap alignContent:ASStackLayoutAlignContentStart lineSpacing:0.0 children:nil];
 }
 
-+ (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems children:(NSArray *)children
++ (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems children:(NSArray *)children NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithDirection:direction spacing:spacing justifyContent:justifyContent alignItems:alignItems flexWrap:ASStackLayoutFlexWrapNoWrap alignContent:ASStackLayoutAlignContentStart lineSpacing: 0.0 children:children];
 }
 
-+ (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems flexWrap:(ASStackLayoutFlexWrap)flexWrap alignContent:(ASStackLayoutAlignContent)alignContent children:(NSArray<id<ASLayoutElement>> *)children
++ (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems flexWrap:(ASStackLayoutFlexWrap)flexWrap alignContent:(ASStackLayoutAlignContent)alignContent children:(NSArray<id<ASLayoutElement>> *)children NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithDirection:direction spacing:spacing justifyContent:justifyContent alignItems:alignItems flexWrap:flexWrap alignContent:alignContent lineSpacing:0.0 children:children];
 }
 
-+ (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems flexWrap:(ASStackLayoutFlexWrap)flexWrap alignContent:(ASStackLayoutAlignContent)alignContent lineSpacing:(CGFloat)lineSpacing children:(NSArray<id<ASLayoutElement>> *)children
++ (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems flexWrap:(ASStackLayoutFlexWrap)flexWrap alignContent:(ASStackLayoutAlignContent)alignContent lineSpacing:(CGFloat)lineSpacing children:(NSArray<id<ASLayoutElement>> *)children NS_RETURNS_RETAINED
 {
   return [[self alloc] initWithDirection:direction spacing:spacing justifyContent:justifyContent alignItems:alignItems flexWrap:flexWrap alignContent:alignContent lineSpacing:lineSpacing children:children];
 }
 
-+ (instancetype)verticalStackLayoutSpec
++ (instancetype)verticalStackLayoutSpec NS_RETURNS_RETAINED
 {
   ASStackLayoutSpec *stackLayoutSpec = [[self alloc] init];
   stackLayoutSpec.direction = ASStackLayoutDirectionVertical;
   return stackLayoutSpec;
 }
 
-+ (instancetype)horizontalStackLayoutSpec
++ (instancetype)horizontalStackLayoutSpec NS_RETURNS_RETAINED
 {
   ASStackLayoutSpec *stackLayoutSpec = [[self alloc] init];
   stackLayoutSpec.direction = ASStackLayoutDirectionHorizontal;

--- a/Source/Private/ASRectMap.h
+++ b/Source/Private/ASRectMap.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Creates a new rect map. The keys are never retained.
  */
-+ (ASRectMap *)rectMapForWeakObjectPointers;
++ (ASRectMap *)rectMapForWeakObjectPointers NS_RETURNS_RETAINED;
 
 /**
  * Retrieves the rect for a given key, or CGRectNull if the key is not found.

--- a/Source/Private/ASRectMap.mm
+++ b/Source/Private/ASRectMap.mm
@@ -19,7 +19,7 @@
   std::unordered_map<void *, CGRect> _map;
 }
 
-+ (ASRectMap *)rectMapForWeakObjectPointers
++ (ASRectMap *)rectMapForWeakObjectPointers NS_RETURNS_RETAINED
 {
   return [[self alloc] init];
 }

--- a/Source/Private/TextExperiment/Component/ASTextInput.h
+++ b/Source/Private/TextExperiment/Component/ASTextInput.h
@@ -36,8 +36,8 @@ typedef NS_ENUM(NSInteger, ASTextAffinity) {
 @property (nonatomic, readonly) NSInteger offset;
 @property (nonatomic, readonly) ASTextAffinity affinity;
 
-+ (instancetype)positionWithOffset:(NSInteger)offset;
-+ (instancetype)positionWithOffset:(NSInteger)offset affinity:(ASTextAffinity) affinity;
++ (instancetype)positionWithOffset:(NSInteger)offset NS_RETURNS_RETAINED;
++ (instancetype)positionWithOffset:(NSInteger)offset affinity:(ASTextAffinity) affinity NS_RETURNS_RETAINED;
 
 - (NSComparisonResult)compare:(id)otherPosition;
 
@@ -57,10 +57,10 @@ typedef NS_ENUM(NSInteger, ASTextAffinity) {
 @property (nonatomic, readonly) ASTextPosition *end;
 @property (nonatomic, readonly, getter=isEmpty) BOOL empty;
 
-+ (instancetype)rangeWithRange:(NSRange)range;
-+ (instancetype)rangeWithRange:(NSRange)range affinity:(ASTextAffinity) affinity;
-+ (instancetype)rangeWithStart:(ASTextPosition *)start end:(ASTextPosition *)end;
-+ (instancetype)defaultRange; ///< <{0,0} Forward>
++ (instancetype)rangeWithRange:(NSRange)range NS_RETURNS_RETAINED;
++ (instancetype)rangeWithRange:(NSRange)range affinity:(ASTextAffinity) affinity NS_RETURNS_RETAINED;
++ (instancetype)rangeWithStart:(ASTextPosition *)start end:(ASTextPosition *)end NS_RETURNS_RETAINED;
++ (instancetype)defaultRange NS_RETURNS_RETAINED; ///< <{0,0} Forward>
 
 - (NSRange)asRange;
 

--- a/Source/Private/TextExperiment/Component/ASTextInput.h
+++ b/Source/Private/TextExperiment/Component/ASTextInput.h
@@ -1,12 +1,18 @@
 //
 //  ASTextInput.h
-//  Modified from YYText <https://github.com/ibireme/YYText>
+//  Texture
 //
-//  Created by ibireme on 15/4/17.
-//  Copyright (c) 2015 ibireme.
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
 //
-//  This source code is licensed under the MIT-style license found in the
-//  LICENSE file in the root directory of this source tree.
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) through the present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <UIKit/UIKit.h>

--- a/Source/Private/TextExperiment/Component/ASTextInput.m
+++ b/Source/Private/TextExperiment/Component/ASTextInput.m
@@ -15,11 +15,11 @@
 
 @implementation ASTextPosition
 
-+ (instancetype)positionWithOffset:(NSInteger)offset {
++ (instancetype)positionWithOffset:(NSInteger)offset NS_RETURNS_RETAINED {
   return [self positionWithOffset:offset affinity:ASTextAffinityForward];
 }
 
-+ (instancetype)positionWithOffset:(NSInteger)offset affinity:(ASTextAffinity)affinity {
++ (instancetype)positionWithOffset:(NSInteger)offset affinity:(ASTextAffinity)affinity NS_RETURNS_RETAINED {
   ASTextPosition *p = [self new];
   p->_offset = offset;
   p->_affinity = affinity;
@@ -85,17 +85,17 @@
   return NSMakeRange(_start.offset, _end.offset - _start.offset);
 }
 
-+ (instancetype)rangeWithRange:(NSRange)range {
++ (instancetype)rangeWithRange:(NSRange)range NS_RETURNS_RETAINED {
   return [self rangeWithRange:range affinity:ASTextAffinityForward];
 }
 
-+ (instancetype)rangeWithRange:(NSRange)range affinity:(ASTextAffinity)affinity {
++ (instancetype)rangeWithRange:(NSRange)range affinity:(ASTextAffinity)affinity NS_RETURNS_RETAINED {
   ASTextPosition *start = [ASTextPosition positionWithOffset:range.location affinity:affinity];
   ASTextPosition *end = [ASTextPosition positionWithOffset:range.location + range.length affinity:affinity];
   return [self rangeWithStart:start end:end];
 }
 
-+ (instancetype)rangeWithStart:(ASTextPosition *)start end:(ASTextPosition *)end {
++ (instancetype)rangeWithStart:(ASTextPosition *)start end:(ASTextPosition *)end NS_RETURNS_RETAINED {
   if (!start || !end) return nil;
   if ([start compare:end] == NSOrderedDescending) {
     ASTEXT_SWAP(start, end);
@@ -106,7 +106,7 @@
   return range;
 }
 
-+ (instancetype)defaultRange {
++ (instancetype)defaultRange NS_RETURNS_RETAINED {
   return [self new];
 }
 

--- a/Source/Private/TextExperiment/Component/ASTextInput.m
+++ b/Source/Private/TextExperiment/Component/ASTextInput.m
@@ -1,12 +1,18 @@
 //
 //  ASTextInput.m
-//  Modified from YYText <https://github.com/ibireme/YYText>
+//  Texture
 //
-//  Created by ibireme on 15/4/17.
-//  Copyright (c) 2015 ibireme.
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
 //
-//  This source code is licensed under the MIT-style license found in the
-//  LICENSE file in the root directory of this source tree.
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) through the present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <AsyncDisplayKit/ASTextInput.h>

--- a/Source/Private/TextExperiment/Component/ASTextLayout.h
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.h
@@ -1,12 +1,18 @@
 //
 //  ASTextLayout.h
-//  Modified from YYText <https://github.com/ibireme/YYText>
+//  Texture
 //
-//  Created by ibireme on 15/3/3.
-//  Copyright (c) 2015 ibireme.
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
 //
-//  This source code is licensed under the MIT-style license found in the
-//  LICENSE file in the root directory of this source tree.
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) through the present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <UIKit/UIKit.h>

--- a/Source/Private/TextExperiment/Component/ASTextLayout.h
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.h
@@ -53,13 +53,13 @@ extern const CGSize ASTextContainerMaxSize;
 @interface ASTextContainer : NSObject <NSCoding, NSCopying>
 
 /// Creates a container with the specified size. @param size The size.
-+ (instancetype)containerWithSize:(CGSize)size;
++ (instancetype)containerWithSize:(CGSize)size NS_RETURNS_RETAINED;
 
 /// Creates a container with the specified size and insets. @param size The size. @param insets The text insets.
-+ (instancetype)containerWithSize:(CGSize)size insets:(UIEdgeInsets)insets;
++ (instancetype)containerWithSize:(CGSize)size insets:(UIEdgeInsets)insets NS_RETURNS_RETAINED;
 
 /// Creates a container with the specified path. @param path The path.
-+ (instancetype)containerWithPath:(nullable UIBezierPath *)path;
++ (instancetype)containerWithPath:(nullable UIBezierPath *)path NS_RETURNS_RETAINED;
 
 /// The constrained size. (if the size is larger than ASTextContainerMaxSize, it will be clipped)
 @property CGSize size;

--- a/Source/Private/TextExperiment/Component/ASTextLayout.m
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.m
@@ -99,18 +99,18 @@ static CGColorRef ASTextGetCGColor(CGColorRef color) {
   id<ASTextLinePositionModifier> _linePositionModifier;
 }
 
-+ (instancetype)containerWithSize:(CGSize)size {
++ (instancetype)containerWithSize:(CGSize)size NS_RETURNS_RETAINED {
   return [self containerWithSize:size insets:UIEdgeInsetsZero];
 }
 
-+ (instancetype)containerWithSize:(CGSize)size insets:(UIEdgeInsets)insets {
++ (instancetype)containerWithSize:(CGSize)size insets:(UIEdgeInsets)insets NS_RETURNS_RETAINED {
   ASTextContainer *one = [self new];
   one.size = ASTextClipCGSize(size);
   one.insets = insets;
   return one;
 }
 
-+ (instancetype)containerWithPath:(UIBezierPath *)path {
++ (instancetype)containerWithPath:(UIBezierPath *)path NS_RETURNS_RETAINED {
   ASTextContainer *one = [self new];
   one.path = path;
   return one;

--- a/Source/Private/TextExperiment/Component/ASTextLayout.m
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.m
@@ -1,12 +1,18 @@
 //
 //  ASTextLayout.m
-//  Modified from YYText <https://github.com/ibireme/YYText>
+//  Texture
 //
-//  Created by ibireme on 15/3/3.
-//  Copyright (c) 2015 ibireme.
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
 //
-//  This source code is licensed under the MIT-style license found in the
-//  LICENSE file in the root directory of this source tree.
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) through the present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <AsyncDisplayKit/ASTextLayout.h>

--- a/Source/Private/TextExperiment/Component/ASTextLine.h
+++ b/Source/Private/TextExperiment/Component/ASTextLine.h
@@ -1,12 +1,18 @@
 //
 //  ASTextLine.h
-//  Modified from YYText <https://github.com/ibireme/YYText>
+//  Texture
 //
-//  Created by ibireme on 15/3/10.
-//  Copyright (c) 2015 ibireme.
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
 //
-//  This source code is licensed under the MIT-style license found in the
-//  LICENSE file in the root directory of this source tree.
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) through the present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <UIKit/UIKit.h>

--- a/Source/Private/TextExperiment/Component/ASTextLine.h
+++ b/Source/Private/TextExperiment/Component/ASTextLine.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface ASTextLine : NSObject
 
-+ (instancetype)lineWithCTLine:(CTLineRef)CTLine position:(CGPoint)position vertical:(BOOL)isVertical;
++ (instancetype)lineWithCTLine:(CTLineRef)CTLine position:(CGPoint)position vertical:(BOOL)isVertical NS_RETURNS_RETAINED;
 
 @property (nonatomic) NSUInteger index;     ///< line index
 @property (nonatomic) NSUInteger row;       ///< line row
@@ -73,7 +73,7 @@ typedef NS_ENUM(NSUInteger, ASTextRunGlyphDrawMode) {
 @interface ASTextRunGlyphRange : NSObject
 @property (nonatomic) NSRange glyphRangeInRun;
 @property (nonatomic) ASTextRunGlyphDrawMode drawMode;
-+ (instancetype)rangeWithRange:(NSRange)range drawMode:(ASTextRunGlyphDrawMode)mode;
++ (instancetype)rangeWithRange:(NSRange)range drawMode:(ASTextRunGlyphDrawMode)mode NS_RETURNS_RETAINED;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Private/TextExperiment/Component/ASTextLine.m
+++ b/Source/Private/TextExperiment/Component/ASTextLine.m
@@ -16,7 +16,7 @@
   CGFloat _firstGlyphPos; // first glyph position for baseline, typically 0.
 }
 
-+ (instancetype)lineWithCTLine:(CTLineRef)CTLine position:(CGPoint)position vertical:(BOOL)isVertical {
++ (instancetype)lineWithCTLine:(CTLineRef)CTLine position:(CGPoint)position vertical:(BOOL)isVertical NS_RETURNS_RETAINED {
   if (!CTLine) return nil;
   ASTextLine *line = [self new];
   line->_position = position;
@@ -157,7 +157,7 @@
 
 
 @implementation ASTextRunGlyphRange
-+ (instancetype)rangeWithRange:(NSRange)range drawMode:(ASTextRunGlyphDrawMode)mode {
++ (instancetype)rangeWithRange:(NSRange)range drawMode:(ASTextRunGlyphDrawMode)mode NS_RETURNS_RETAINED {
   ASTextRunGlyphRange *one = [self new];
   one.glyphRangeInRun = range;
   one.drawMode = mode;

--- a/Source/Private/TextExperiment/Component/ASTextLine.m
+++ b/Source/Private/TextExperiment/Component/ASTextLine.m
@@ -1,12 +1,18 @@
 //
-//  ASYTextLine.m
-//  Modified from YYText <https://github.com/ibireme/YYText>
+//  ASTextLine.m
+//  Texture
 //
-//  Created by ibireme on 15/3/3.
-//  Copyright (c) 2015 ibireme.
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
 //
-//  This source code is licensed under the MIT-style license found in the
-//  LICENSE file in the root directory of this source tree.
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) through the present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <AsyncDisplayKit/ASTextLine.h>

--- a/Source/Private/TextExperiment/String/ASTextAttribute.h
+++ b/Source/Private/TextExperiment/String/ASTextAttribute.h
@@ -1,12 +1,18 @@
 //
 //  ASTextAttribute.h
-//  Modified from YYText <https://github.com/ibireme/YYText>
+//  Texture
 //
-//  Created by ibireme on 14/10/26.
-//  Copyright (c) 2015 ibireme.
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
 //
-//  This source code is licensed under the MIT-style license found in the
-//  LICENSE file in the root directory of this source tree.
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) through the present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <UIKit/UIKit.h>

--- a/Source/Private/TextExperiment/String/ASTextAttribute.h
+++ b/Source/Private/TextExperiment/String/ASTextAttribute.h
@@ -173,7 +173,7 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
  Example: If :) is replace by a custom emoji (such as😊), the backed string can be set to @":)".
  */
 @interface ASTextBackedString : NSObject <NSCoding, NSCopying>
-+ (instancetype)stringWithString:(nullable NSString *)string;
++ (instancetype)stringWithString:(nullable NSString *)string NS_RETURNS_RETAINED;
 @property (nullable, nonatomic, copy) NSString *string; ///< backed string
 @end
 
@@ -188,7 +188,7 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
  selection and edit.
  */
 @interface ASTextBinding : NSObject <NSCoding, NSCopying>
-+ (instancetype)bindingWithDeleteConfirm:(BOOL)deleteConfirm;
++ (instancetype)bindingWithDeleteConfirm:(BOOL)deleteConfirm NS_RETURNS_RETAINED;
 @property (nonatomic) BOOL deleteConfirm; ///< confirm the range when delete in ASTextView
 @end
 
@@ -201,7 +201,7 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
  It's similar to `NSShadow`, but offers more options.
  */
 @interface ASTextShadow : NSObject <NSCoding, NSCopying>
-+ (instancetype)shadowWithColor:(nullable UIColor *)color offset:(CGSize)offset radius:(CGFloat)radius;
++ (instancetype)shadowWithColor:(nullable UIColor *)color offset:(CGSize)offset radius:(CGFloat)radius NS_RETURNS_RETAINED;
 
 @property (nullable, nonatomic, strong) UIColor *color; ///< shadow color
 @property (nonatomic) CGSize offset;                    ///< shadow offset
@@ -209,7 +209,7 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
 @property (nonatomic) CGBlendMode blendMode;            ///< shadow blend mode
 @property (nullable, nonatomic, strong) ASTextShadow *subShadow;  ///< a sub shadow which will be added above the parent shadow
 
-+ (instancetype)shadowWithNSShadow:(NSShadow *)nsShadow; ///< convert NSShadow to ASTextShadow
++ (instancetype)shadowWithNSShadow:(NSShadow *)nsShadow NS_RETURNS_RETAINED; ///< convert NSShadow to ASTextShadow
 - (NSShadow *)nsShadow; ///< convert ASTextShadow to NSShadow
 @end
 
@@ -223,8 +223,8 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
  when it's used as strikethrough, the line is drawn above text glyphs.
  */
 @interface ASTextDecoration : NSObject <NSCoding, NSCopying>
-+ (instancetype)decorationWithStyle:(ASTextLineStyle)style;
-+ (instancetype)decorationWithStyle:(ASTextLineStyle)style width:(nullable NSNumber *)width color:(nullable UIColor *)color;
++ (instancetype)decorationWithStyle:(ASTextLineStyle)style NS_RETURNS_RETAINED;
++ (instancetype)decorationWithStyle:(ASTextLineStyle)style width:(nullable NSNumber *)width color:(nullable UIColor *)color NS_RETURNS_RETAINED;
 @property (nonatomic) ASTextLineStyle style;                   ///< line style
 @property (nullable, nonatomic, strong) NSNumber *width;       ///< line width (nil means automatic width)
 @property (nullable, nonatomic, strong) UIColor *color;        ///< line color (nil means automatic color)
@@ -246,8 +246,8 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
  ╰──────╯
  */
 @interface ASTextBorder : NSObject <NSCoding, NSCopying>
-+ (instancetype)borderWithLineStyle:(ASTextLineStyle)lineStyle lineWidth:(CGFloat)width strokeColor:(nullable UIColor *)color;
-+ (instancetype)borderWithFillColor:(nullable UIColor *)color cornerRadius:(CGFloat)cornerRadius;
++ (instancetype)borderWithLineStyle:(ASTextLineStyle)lineStyle lineWidth:(CGFloat)width strokeColor:(nullable UIColor *)color NS_RETURNS_RETAINED;
++ (instancetype)borderWithFillColor:(nullable UIColor *)color cornerRadius:(CGFloat)cornerRadius NS_RETURNS_RETAINED;
 @property (nonatomic) ASTextLineStyle lineStyle;              ///< border line style
 @property (nonatomic) CGFloat strokeWidth;                    ///< border line width
 @property (nullable, nonatomic, strong) UIColor *strokeColor; ///< border line color
@@ -270,7 +270,7 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
  then it will be added to the text container's view or layer.
  */
 @interface ASTextAttachment : NSObject<NSCoding, NSCopying>
-+ (instancetype)attachmentWithContent:(nullable id)content;
++ (instancetype)attachmentWithContent:(nullable id)content NS_RETURNS_RETAINED;
 @property (nullable, nonatomic, strong) id content;             ///< Supported type: UIImage, UIView, CALayer
 @property (nonatomic) UIViewContentMode contentMode;            ///< Content display mode.
 @property (nonatomic) UIEdgeInsets contentInsets;               ///< The insets when drawing content.
@@ -303,14 +303,14 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
  @param attributes The attributes which will replace original attributes when highlight,
  If the value is NSNull, it will removed when highlight.
  */
-+ (instancetype)highlightWithAttributes:(nullable NSDictionary<NSString *, id> *)attributes;
++ (instancetype)highlightWithAttributes:(nullable NSDictionary<NSString *, id> *)attributes NS_RETURNS_RETAINED;
 
 /**
  Convenience methods to create a default highlight with the specifeid background color.
  
  @param color The background border color.
  */
-+ (instancetype)highlightWithBackgroundColor:(nullable UIColor *)color;
++ (instancetype)highlightWithBackgroundColor:(nullable UIColor *)color NS_RETURNS_RETAINED;
 
 // Convenience methods below to set the `attributes`.
 - (void)setFont:(nullable UIFont *)font;

--- a/Source/Private/TextExperiment/String/ASTextAttribute.m
+++ b/Source/Private/TextExperiment/String/ASTextAttribute.m
@@ -1,12 +1,18 @@
 //
 //  ASTextAttribute.m
-//  Modified from YYText <https://github.com/ibireme/YYText>
+//  Texture
 //
-//  Created by ibireme on 14/10/26.
-//  Copyright (c) 2015 ibireme.
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
 //
-//  This source code is licensed under the MIT-style license found in the
-//  LICENSE file in the root directory of this source tree.
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) through the present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import "ASTextAttribute.h"

--- a/Source/Private/TextExperiment/String/ASTextAttribute.m
+++ b/Source/Private/TextExperiment/String/ASTextAttribute.m
@@ -109,7 +109,7 @@ ASTextAttributeType ASTextAttributeGetType(NSString *name){
 
 @implementation ASTextBackedString
 
-+ (instancetype)stringWithString:(NSString *)string {
++ (instancetype)stringWithString:(NSString *)string NS_RETURNS_RETAINED {
   ASTextBackedString *one = [self new];
   one.string = string;
   return one;
@@ -136,7 +136,7 @@ ASTextAttributeType ASTextAttributeGetType(NSString *name){
 
 @implementation ASTextBinding
 
-+ (instancetype)bindingWithDeleteConfirm:(BOOL)deleteConfirm {
++ (instancetype)bindingWithDeleteConfirm:(BOOL)deleteConfirm NS_RETURNS_RETAINED {
   ASTextBinding *one = [self new];
   one.deleteConfirm = deleteConfirm;
   return one;
@@ -163,7 +163,7 @@ ASTextAttributeType ASTextAttributeGetType(NSString *name){
 
 @implementation ASTextShadow
 
-+ (instancetype)shadowWithColor:(UIColor *)color offset:(CGSize)offset radius:(CGFloat)radius {
++ (instancetype)shadowWithColor:(UIColor *)color offset:(CGSize)offset radius:(CGFloat)radius NS_RETURNS_RETAINED {
   ASTextShadow *one = [self new];
   one.color = color;
   one.offset = offset;
@@ -171,7 +171,7 @@ ASTextAttributeType ASTextAttributeGetType(NSString *name){
   return one;
 }
 
-+ (instancetype)shadowWithNSShadow:(NSShadow *)nsShadow {
++ (instancetype)shadowWithNSShadow:(NSShadow *)nsShadow NS_RETURNS_RETAINED {
   if (!nsShadow) return nil;
   ASTextShadow *shadow = [self new];
   shadow.offset = nsShadow.shadowOffset;
@@ -232,12 +232,12 @@ ASTextAttributeType ASTextAttributeGetType(NSString *name){
   return self;
 }
 
-+ (instancetype)decorationWithStyle:(ASTextLineStyle)style {
++ (instancetype)decorationWithStyle:(ASTextLineStyle)style NS_RETURNS_RETAINED {
   ASTextDecoration *one = [self new];
   one.style = style;
   return one;
 }
-+ (instancetype)decorationWithStyle:(ASTextLineStyle)style width:(NSNumber *)width color:(UIColor *)color {
++ (instancetype)decorationWithStyle:(ASTextLineStyle)style width:(NSNumber *)width color:(UIColor *)color NS_RETURNS_RETAINED {
   ASTextDecoration *one = [self new];
   one.style = style;
   one.width = width;
@@ -272,7 +272,7 @@ ASTextAttributeType ASTextAttributeGetType(NSString *name){
 
 @implementation ASTextBorder
 
-+ (instancetype)borderWithLineStyle:(ASTextLineStyle)lineStyle lineWidth:(CGFloat)width strokeColor:(UIColor *)color {
++ (instancetype)borderWithLineStyle:(ASTextLineStyle)lineStyle lineWidth:(CGFloat)width strokeColor:(UIColor *)color NS_RETURNS_RETAINED {
   ASTextBorder *one = [self new];
   one.lineStyle = lineStyle;
   one.strokeWidth = width;
@@ -280,7 +280,7 @@ ASTextAttributeType ASTextAttributeGetType(NSString *name){
   return one;
 }
 
-+ (instancetype)borderWithFillColor:(UIColor *)color cornerRadius:(CGFloat)cornerRadius {
++ (instancetype)borderWithFillColor:(UIColor *)color cornerRadius:(CGFloat)cornerRadius NS_RETURNS_RETAINED {
   ASTextBorder *one = [self new];
   one.fillColor = color;
   one.cornerRadius = cornerRadius;
@@ -336,7 +336,7 @@ ASTextAttributeType ASTextAttributeGetType(NSString *name){
 
 @implementation ASTextAttachment
 
-+ (instancetype)attachmentWithContent:(id)content {
++ (instancetype)attachmentWithContent:(id)content NS_RETURNS_RETAINED {
   ASTextAttachment *one = [self new];
   one.content = content;
   return one;
@@ -373,13 +373,13 @@ ASTextAttributeType ASTextAttributeGetType(NSString *name){
 
 @implementation ASTextHighlight
 
-+ (instancetype)highlightWithAttributes:(NSDictionary *)attributes {
++ (instancetype)highlightWithAttributes:(NSDictionary *)attributes NS_RETURNS_RETAINED {
   ASTextHighlight *one = [self new];
   one.attributes = attributes;
   return one;
 }
 
-+ (instancetype)highlightWithBackgroundColor:(UIColor *)color {
++ (instancetype)highlightWithBackgroundColor:(UIColor *)color NS_RETURNS_RETAINED {
   ASTextBorder *highlightBorder = [ASTextBorder new];
   highlightBorder.insets = UIEdgeInsetsMake(-2, -1, -2, -1);
   highlightBorder.cornerRadius = 3;

--- a/Source/TextKit/ASTextKitComponents.h
+++ b/Source/TextKit/ASTextKitComponents.h
@@ -37,7 +37,7 @@ AS_SUBCLASSING_RESTRICTED
  @discussion The returned components will be hooked up together, so they are ready for use as a system upon return.
  */
 + (instancetype)componentsWithAttributedSeedString:(nullable NSAttributedString *)attributedSeedString
-                                 textContainerSize:(CGSize)textContainerSize;
+                                 textContainerSize:(CGSize)textContainerSize NS_RETURNS_RETAINED;
 
 /**
  @abstract Creates the stack of TextKit components.
@@ -49,7 +49,7 @@ AS_SUBCLASSING_RESTRICTED
  */
 + (instancetype)componentsWithTextStorage:(NSTextStorage *)textStorage
                         textContainerSize:(CGSize)textContainerSize
-                            layoutManager:(NSLayoutManager *)layoutManager;
+                            layoutManager:(NSLayoutManager *)layoutManager NS_RETURNS_RETAINED;
 
 /**
  @abstract Returns the bounding size for the text view's text.

--- a/Source/TextKit/ASTextKitComponents.mm
+++ b/Source/TextKit/ASTextKitComponents.mm
@@ -65,7 +65,7 @@
 #pragma mark - Class
 
 + (instancetype)componentsWithAttributedSeedString:(NSAttributedString *)attributedSeedString
-                                 textContainerSize:(CGSize)textContainerSize
+                                 textContainerSize:(CGSize)textContainerSize NS_RETURNS_RETAINED
 {
   NSTextStorage *textStorage = attributedSeedString ? [[NSTextStorage alloc] initWithAttributedString:attributedSeedString] : [[NSTextStorage alloc] init];
 
@@ -76,7 +76,7 @@
 
 + (instancetype)componentsWithTextStorage:(NSTextStorage *)textStorage
                         textContainerSize:(CGSize)textContainerSize
-                            layoutManager:(NSLayoutManager *)layoutManager
+                            layoutManager:(NSLayoutManager *)layoutManager NS_RETURNS_RETAINED
 {
   ASTextKitComponents *components = [[self alloc] init];
 

--- a/Source/TextKit/ASTextKitCoreTextAdditions.h
+++ b/Source/TextKit/ASTextKitCoreTextAdditions.h
@@ -88,7 +88,7 @@ ASDISPLAYNODE_EXTERN_C_END
   @result An NSParagraphStyle initialized with as many of the paragraph specifiers from `coreTextParagraphStyle` as possible.
 
  */
-+ (instancetype)paragraphStyleWithCTParagraphStyle:(CTParagraphStyleRef)coreTextParagraphStyle;
++ (instancetype)paragraphStyleWithCTParagraphStyle:(CTParagraphStyleRef)coreTextParagraphStyle NS_RETURNS_RETAINED;
 
 @end
 

--- a/Source/TextKit/ASTextKitCoreTextAdditions.m
+++ b/Source/TextKit/ASTextKitCoreTextAdditions.m
@@ -172,7 +172,7 @@ NSAttributedString *ASCleanseAttributedStringOfCoreTextAttributes(NSAttributedSt
 #pragma mark -
 @implementation NSParagraphStyle (ASTextKitCoreTextAdditions)
 
-+ (instancetype)paragraphStyleWithCTParagraphStyle:(CTParagraphStyleRef)coreTextParagraphStyle;
++ (instancetype)paragraphStyleWithCTParagraphStyle:(CTParagraphStyleRef)coreTextParagraphStyle NS_RETURNS_RETAINED
 {
   NSMutableParagraphStyle *newParagraphStyle = [[NSMutableParagraphStyle alloc] init];
 

--- a/Source/UIImage+ASConvenience.h
+++ b/Source/UIImage+ASConvenience.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param imageName The name of the image to load
  *  @return The loaded image or nil
  */
-+ (UIImage *)as_imageNamed:(NSString *)imageName;
++ (UIImage *)as_imageNamed:(NSString *)imageName NS_RETURNS_RETAINED;
 
 /**
  *  A version of imageNamed that caches results because loading an image is expensive.
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param traitCollection The traits associated with the intended environment for the image.
  *  @return The loaded image or nil
  */
-+ (UIImage *)as_imageNamed:(NSString *)imageName compatibleWithTraitCollection:(nullable UITraitCollection *)traitCollection;
++ (UIImage *)as_imageNamed:(NSString *)imageName compatibleWithTraitCollection:(nullable UITraitCollection *)traitCollection NS_RETURNS_RETAINED;
 
 @end
 
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (UIImage *)as_resizableRoundedImageWithCornerRadius:(CGFloat)cornerRadius
                                           cornerColor:(nullable UIColor *)cornerColor
-                                            fillColor:(UIColor *)fillColor AS_WARN_UNUSED_RESULT;
+                                            fillColor:(UIColor *)fillColor NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /**
  * This generates a flat-color, rounded-corner resizeable image with a border
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
                                           cornerColor:(UIColor *)cornerColor
                                             fillColor:(UIColor *)fillColor
                                           borderColor:(nullable UIColor *)borderColor
-                                          borderWidth:(CGFloat)borderWidth AS_WARN_UNUSED_RESULT;
+                                          borderWidth:(CGFloat)borderWidth NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 /**
  * This generates a flat-color, rounded-corner resizeable image with a border
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
                                           borderColor:(nullable UIColor *)borderColor
                                           borderWidth:(CGFloat)borderWidth
                                        roundedCorners:(UIRectCorner)roundedCorners
-                                                scale:(CGFloat)scale AS_WARN_UNUSED_RESULT;
+                                                scale:(CGFloat)scale NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/Source/UIImage+ASConvenience.m
+++ b/Source/UIImage+ASConvenience.m
@@ -24,7 +24,7 @@
 
 @implementation UIImage (ASDKFastImageNamed)
 
-UIImage *cachedImageNamed(NSString *imageName, UITraitCollection *traitCollection)
+UIImage *cachedImageNamed(NSString *imageName, UITraitCollection *traitCollection) NS_RETURNS_RETAINED
 {
   static NSCache *imageCache = nil;
   static dispatch_once_t onceToken;
@@ -55,12 +55,12 @@ UIImage *cachedImageNamed(NSString *imageName, UITraitCollection *traitCollectio
   return image;
 }
 
-+ (UIImage *)as_imageNamed:(NSString *)imageName
++ (UIImage *)as_imageNamed:(NSString *)imageName NS_RETURNS_RETAINED
 {
   return cachedImageNamed(imageName, nil);
 }
 
-+ (UIImage *)as_imageNamed:(NSString *)imageName compatibleWithTraitCollection:(UITraitCollection *)traitCollection
++ (UIImage *)as_imageNamed:(NSString *)imageName compatibleWithTraitCollection:(UITraitCollection *)traitCollection NS_RETURNS_RETAINED
 {
   return cachedImageNamed(imageName, traitCollection);
 }
@@ -73,7 +73,7 @@ UIImage *cachedImageNamed(NSString *imageName, UITraitCollection *traitCollectio
 
 + (UIImage *)as_resizableRoundedImageWithCornerRadius:(CGFloat)cornerRadius
                                           cornerColor:(UIColor *)cornerColor
-                                            fillColor:(UIColor *)fillColor
+                                            fillColor:(UIColor *)fillColor NS_RETURNS_RETAINED
 {
   return [self as_resizableRoundedImageWithCornerRadius:cornerRadius
                                             cornerColor:cornerColor
@@ -88,7 +88,7 @@ UIImage *cachedImageNamed(NSString *imageName, UITraitCollection *traitCollectio
                                           cornerColor:(UIColor *)cornerColor
                                             fillColor:(UIColor *)fillColor
                                           borderColor:(UIColor *)borderColor
-                                          borderWidth:(CGFloat)borderWidth
+                                          borderWidth:(CGFloat)borderWidth NS_RETURNS_RETAINED
 {
   return [self as_resizableRoundedImageWithCornerRadius:cornerRadius
                                             cornerColor:cornerColor
@@ -105,7 +105,7 @@ UIImage *cachedImageNamed(NSString *imageName, UITraitCollection *traitCollectio
                                           borderColor:(UIColor *)borderColor
                                           borderWidth:(CGFloat)borderWidth
                                        roundedCorners:(UIRectCorner)roundedCorners
-                                                scale:(CGFloat)scale
+                                                scale:(CGFloat)scale NS_RETURNS_RETAINED
 {
   static NSCache *__pathCache = nil;
   static dispatch_once_t onceToken;

--- a/Source/_ASTransitionContext.h
+++ b/Source/_ASTransitionContext.h
@@ -53,5 +53,5 @@
 @interface _ASAnimatedTransitionContext : NSObject
 @property (nonatomic, strong, readonly) ASDisplayNode *node;
 @property (nonatomic, assign, readonly) CGFloat alpha;
-+ (instancetype)contextForNode:(ASDisplayNode *)node alpha:(CGFloat)alphaValue;
++ (instancetype)contextForNode:(ASDisplayNode *)node alpha:(CGFloat)alphaValue NS_RETURNS_RETAINED;
 @end

--- a/Source/_ASTransitionContext.m
+++ b/Source/_ASTransitionContext.m
@@ -101,7 +101,7 @@ NSString * const ASTransitionContextToLayoutKey = @"org.asyncdisplaykit.ASTransi
 
 @implementation _ASAnimatedTransitionContext
 
-+ (instancetype)contextForNode:(ASDisplayNode *)node alpha:(CGFloat)alpha
++ (instancetype)contextForNode:(ASDisplayNode *)node alpha:(CGFloat)alpha NS_RETURNS_RETAINED
 {
   _ASAnimatedTransitionContext *context = [[_ASAnimatedTransitionContext alloc] init];
   context.node = node;


### PR DESCRIPTION
ARC has a tricky time returning stuff, since it doesn't know whether the caller was written with ARC or not. Under ARC, you don't really need the autorelease pool, but under MRR it's really useful. So when ARC goes to return something from a non-`init/copy/create/new` method, it uses two functions `objc_retainAutoreleaseReturnValue` and `objc_retainAutoreleasedReturnValue`. The first one, on the callee side, unwinds the stack and checks if the second one is present on the caller side. If so, it skips the autorelease pool to save resources. Great trick!

But we don't need to spend that effort. We can annotate methods to say "yeah despite the name, I'm going to return you a +1 straight up." Then ARC will skip those two functions and just do the right thing. **So, if we have users who are writing in MRR then this is breaking API** since we'll be giving them +1s, not autoreleased objects. But obviously nobody is writing client code in MRR now.

It would be very nice to make, say `-layoutSpecThatFits` use this attribute, but that would require all implementors to add the `NS_RETURNS_RETAINED` macro to their implementations, since the macro HAS to be present on both the declaration and implementation sides. Maybe worth doing if we have a big release, but otherwise not worth irritating our users for.