### PR TITLE
Update Podspec

### DIFF
--- a/Texture.podspec
+++ b/Texture.podspec
@@ -61,4 +61,5 @@ Pod::Spec.new do |spec|
   # Include optional PINRemoteImage module
   spec.default_subspec = 'PINRemoteImage'
 
+  spec.social_media_url = 'https://twitter.com/TextureiOS'
 end

--- a/Texture.podspec
+++ b/Texture.podspec
@@ -14,8 +14,6 @@ Pod::Spec.new do |spec|
   spec.ios.weak_frameworks = 'AssetsLibrary'
   spec.weak_frameworks = 'Photos','MapKit'
 
-  spec.requires_arc = true
-
   spec.ios.deployment_target = '9.0'
   spec.tvos.deployment_target = '9.0'
 
@@ -41,7 +39,6 @@ Pod::Spec.new do |spec|
         # See https://github.com/facebook/AsyncDisplayKit/issues/1153
         'Source/TextKit/*.h',
     ]
-    core.xcconfig = { 'GCC_PRECOMPILE_PREFIX_HEADER' => 'YES' }
   end
   
   spec.subspec 'PINRemoteImage' do |pin|
@@ -63,12 +60,5 @@ Pod::Spec.new do |spec|
 
   # Include optional PINRemoteImage module
   spec.default_subspec = 'PINRemoteImage'
-
-  spec.social_media_url = 'https://twitter.com/TextureiOS'
-  spec.library = 'c++'
-  spec.pod_target_xcconfig = {
-       'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
-       'CLANG_CXX_LIBRARY' => 'libc++'
-  }
 
 end

--- a/Texture.podspec
+++ b/Texture.podspec
@@ -62,4 +62,5 @@ Pod::Spec.new do |spec|
   spec.default_subspec = 'PINRemoteImage'
 
   spec.social_media_url = 'https://twitter.com/TextureiOS'
+  spec.library = 'c++'
 end


### PR DESCRIPTION
See inline comments.

The motivating factor for this diff is that the explicit specification of C++ options forced Pinterest's build system (based on Bazel) to build all Texture files using a C++ compiler. The recent file `ASRecursiveUnfairLock.m` cannot be built with a C++ compiler and so that broke the build. Other clients are also using this "all-C++" workaround as well.

The default C++ options (currently GNU++14) will probably be fine indefinitely. We can always reintroduce these flags if we decide to lean on, say, c++17 options but for now let's toss them overboard.