### PR TITLE
Check in Xcode 9.3 "workspace checks" file

### DIFF
--- a/AsyncDisplayKit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/AsyncDisplayKit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
This file is added to `xcshareddata`. It's harmless and this way the team can synchronize on any workspace changes that Xcode wants us to make in the future, rather than each contributor getting prompted.