### PR TITLE
[NoCopyRendering] In non-VM case, use calloc to get a zerod buffer #trivial

### DIFF
--- a/Source/ASCGImageBuffer.h
+++ b/Source/ASCGImageBuffer.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED
 @interface ASCGImageBuffer : NSObject
 
+/// Init a zero-filled buffer with the given length.
 - (instancetype)initWithLength:(NSUInteger)length;
 
 @property (readonly) void *mutableBytes NS_RETURNS_INNER_POINTER;

--- a/Source/ASCGImageBuffer.m
+++ b/Source/ASCGImageBuffer.m
@@ -47,7 +47,7 @@
     
     // Check the VM flag again because we may have failed above.
     if (!_isVM) {
-      _mutableBytes = malloc(length);
+      _mutableBytes = calloc(1, length);
     }
   }
   return self;


### PR DESCRIPTION
This fixes a bug when no-copy rendering is enabled where small images may be corrupt.

Marked trivial because this is a bugfix for a change that's unreleased (already in the master section of changelog).