### PR TITLE
Standardize Property Declaration Style in Core Classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Fix an issue where ASConfigurationDelegate would not call out for "control" users. If set, it now receives events whenever an experimental feature decision point occurs, whether it's enabled or not. [Adlai Holler](https://github.com/Adlai-Holler)
 - [ASDisplayNode] Fix an issue that causes a node to sometimes return an outdated calculated size or size range. [Huy Nguyen](https://github.com/nguyenhuy) [#808](https://github.com/TextureGroup/Texture/pull/808)
 - Add an experimental deallocation queue implementation that's more efficient. [Adlai Holler](https://github.com/Adlai-Holler)
+- Standardize property declaration style. [Adlai Holler](https://github.com/Adlai-Holler)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,10 @@ static void someFunction() {
   - There is mostly no sense using nullability annotations outside of interface declarations.
 ```objc
 // Properties
-@property(nonatomic, strong, nullable) NSNumber *status
+// Never include: `atomic`, `readwrite`, `strong`, `assign`.
+// Only specify nullability if it isn't assumed from NS_ASSUME.
+// (nullability, atomicity, storage class, writability, custom getter, custom setter)
+@property (nullable, copy) NSNumber *status
 
 // Methods
 - (nullable NSNumber *)doSomethingWithString:(nullable NSString *)str;

--- a/Source/ASButtonNode.h
+++ b/Source/ASButtonNode.h
@@ -34,41 +34,41 @@ typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
 
 @interface ASButtonNode : ASControlNode
 
-@property (atomic, readonly) ASTextNode  * titleNode;
-@property (atomic, readonly) ASImageNode * imageNode;
-@property (atomic, readonly) ASImageNode * backgroundImageNode;
+@property (readonly) ASTextNode  * titleNode;
+@property (readonly) ASImageNode * imageNode;
+@property (readonly) ASImageNode * backgroundImageNode;
 
 /**
  Spacing between image and title. Defaults to 8.0.
  */
-@property (atomic) CGFloat contentSpacing;
+@property CGFloat contentSpacing;
 
 /**
  Whether button should be laid out vertically (image on top of text) or horizontally (image to the left of text).
  ASButton node does not yet support RTL but it should be fairly easy to implement.
  Defaults to YES.
  */
-@property (atomic) BOOL laysOutHorizontally;
+@property BOOL laysOutHorizontally;
 
 /** Horizontally align content (text or image).
  Defaults to ASHorizontalAlignmentMiddle.
  */
-@property (atomic) ASHorizontalAlignment contentHorizontalAlignment;
+@property ASHorizontalAlignment contentHorizontalAlignment;
 
 /** Vertically align content (text or image).
  Defaults to ASVerticalAlignmentCenter.
  */
-@property (atomic) ASVerticalAlignment contentVerticalAlignment;
+@property ASVerticalAlignment contentVerticalAlignment;
 
 /**
  * @discussion The insets used around the title and image node
  */
-@property (atomic) UIEdgeInsets contentEdgeInsets;
+@property UIEdgeInsets contentEdgeInsets;
 
 /**
  * @discusstion Whether the image should be aligned at the beginning or at the end of node. Default is `ASButtonNodeImageAlignmentBeginning`.
  */
-@property (atomic) ASButtonNodeImageAlignment imageAlignment;
+@property ASButtonNodeImageAlignment imageAlignment;
 
 /**
  *  Returns the styled title associated with the specified state.

--- a/Source/ASButtonNode.h
+++ b/Source/ASButtonNode.h
@@ -34,41 +34,41 @@ typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
 
 @interface ASButtonNode : ASControlNode
 
-@property (nonatomic, readonly) ASTextNode  * titleNode;
-@property (nonatomic, readonly) ASImageNode * imageNode;
-@property (nonatomic, readonly) ASImageNode * backgroundImageNode;
+@property (atomic, readonly) ASTextNode  * titleNode;
+@property (atomic, readonly) ASImageNode * imageNode;
+@property (atomic, readonly) ASImageNode * backgroundImageNode;
 
 /**
  Spacing between image and title. Defaults to 8.0.
  */
-@property (nonatomic, assign) CGFloat contentSpacing;
+@property (atomic) CGFloat contentSpacing;
 
 /**
  Whether button should be laid out vertically (image on top of text) or horizontally (image to the left of text).
  ASButton node does not yet support RTL but it should be fairly easy to implement.
  Defaults to YES.
  */
-@property (nonatomic, assign) BOOL laysOutHorizontally;
+@property (atomic) BOOL laysOutHorizontally;
 
 /** Horizontally align content (text or image).
  Defaults to ASHorizontalAlignmentMiddle.
  */
-@property (nonatomic, assign) ASHorizontalAlignment contentHorizontalAlignment;
+@property (atomic) ASHorizontalAlignment contentHorizontalAlignment;
 
 /** Vertically align content (text or image).
  Defaults to ASVerticalAlignmentCenter.
  */
-@property (nonatomic, assign) ASVerticalAlignment contentVerticalAlignment;
+@property (atomic) ASVerticalAlignment contentVerticalAlignment;
 
 /**
  * @discussion The insets used around the title and image node
  */
-@property (nonatomic, assign) UIEdgeInsets contentEdgeInsets;
+@property (atomic) UIEdgeInsets contentEdgeInsets;
 
 /**
  * @discusstion Whether the image should be aligned at the beginning or at the end of node. Default is `ASButtonNodeImageAlignmentBeginning`.
  */
-@property (nonatomic, assign) ASButtonNodeImageAlignment imageAlignment;
+@property (atomic) ASButtonNodeImageAlignment imageAlignment;
 
 /**
  *  Returns the styled title associated with the specified state.

--- a/Source/ASButtonNode.mm
+++ b/Source/ASButtonNode.mm
@@ -78,6 +78,7 @@
 
 - (ASTextNode *)titleNode
 {
+  ASLockScopeSelf();
   if (!_titleNode) {
     _titleNode = [[ASTextNode alloc] init];
 #if TARGET_OS_IOS 
@@ -92,6 +93,7 @@
 
 - (ASImageNode *)imageNode
 {
+  ASLockScopeSelf();
   if (!_imageNode) {
     _imageNode = [[ASImageNode alloc] init];
     [_imageNode setLayerBacked:YES];
@@ -101,6 +103,7 @@
 
 - (ASImageNode *)backgroundImageNode
 {
+  ASLockScopeSelf();
   if (!_backgroundImageNode) {
     _backgroundImageNode = [[ASImageNode alloc] init];
     [_backgroundImageNode setLayerBacked:YES];
@@ -162,7 +165,7 @@
 - (void)updateImage
 {
   [self lock];
-
+  
   UIImage *newImage;
   if (self.enabled == NO && _disabledImage) {
     newImage = _disabledImage;
@@ -253,16 +256,9 @@
 
 - (void)setContentSpacing:(CGFloat)contentSpacing
 {
-  {
-    ASLockScopeSelf();
-    if (contentSpacing == _contentSpacing) {
-      return;
-    }
-    
-    _contentSpacing = contentSpacing;
+  if (ASLockedSelfCompareAssign(_contentSpacing, contentSpacing)) {
+    [self setNeedsLayout];
   }
-
-  [self setNeedsLayout];
 }
 
 - (BOOL)laysOutHorizontally
@@ -273,16 +269,9 @@
 
 - (void)setLaysOutHorizontally:(BOOL)laysOutHorizontally
 {
-  {
-    ASLockScopeSelf();
-    if (laysOutHorizontally == _laysOutHorizontally) {
-      return;
-    }
-  
-    _laysOutHorizontally = laysOutHorizontally;
+  if (ASLockedSelfCompareAssign(_laysOutHorizontally, laysOutHorizontally)) {
+    [self setNeedsLayout];
   }
-
-  [self setNeedsLayout];
 }
 
 - (ASVerticalAlignment)contentVerticalAlignment

--- a/Source/ASCellNode.h
+++ b/Source/ASCellNode.h
@@ -80,14 +80,14 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  * blocking time is very short.  If the rangeTuningParameters are set to 0, still this option
  * outperforms UIKit: while the main thread is waiting, subnode display executes concurrently.
  */
-@property (nonatomic, assign) BOOL neverShowPlaceholders;
+@property (atomic) BOOL neverShowPlaceholders;
 
 /*
  * The kind of supplementary element this node represents, if any.
  *
  * @return The supplementary element kind, or @c nil if this node does not represent a supplementary element.
  */
-@property (atomic, copy, readonly, nullable) NSString *supplementaryElementKind;
+@property (nullable, atomic, copy, readonly) NSString *supplementaryElementKind;
 
 /*
  * The layout attributes currently assigned to this node, if any.
@@ -96,25 +96,25 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  *   is called, when the node is not yet in the hierarchy and its frame cannot be converted to/from other nodes. Instead
  *   you can use the layout attributes object to learn where and how the cell will be displayed.
  */
-@property (nonatomic, strong, readonly, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
+@property (nullable, atomic, copy, readonly) UICollectionViewLayoutAttributes *layoutAttributes;
 
 /**
  * A Boolean value that is synchronized with the underlying collection or tableView cell property.
  * Setting this value is equivalent to calling selectItem / deselectItem on the collection or table.
  */
-@property (nonatomic, assign, getter=isSelected) BOOL selected;
+@property (atomic, getter=isSelected) BOOL selected;
 
 /**
  * A Boolean value that is synchronized with the underlying collection or tableView cell property.
  * Setting this value is equivalent to calling highlightItem / unHighlightItem on the collection or table.
  */
-@property (nonatomic, assign, getter=isHighlighted) BOOL highlighted;
+@property (atomic, getter=isHighlighted) BOOL highlighted;
 
 /**
  * The current index path of this cell node, or @c nil if this node is
  * not a valid item inside a table node or collection node.
  */
-@property (atomic, readonly, nullable) NSIndexPath *indexPath;
+@property (nullable, atomic, copy, readonly) NSIndexPath *indexPath;
 
 /**
  * BETA: API is under development. We will attempt to provide an easy migration pathway for any changes.
@@ -123,7 +123,7 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  *
  * This property may be set off the main thread, but this method will never be invoked concurrently on the 
  */
-@property (atomic, nullable) id nodeModel;
+@property (nullable, atomic) id nodeModel;
 
 /**
  * Asks the node whether it can be updated to the given node model.
@@ -136,13 +136,13 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  * The backing view controller, or @c nil if the node wasn't initialized with backing view controller
  * @note This property must be accessed on the main thread.
  */
-@property (nonatomic, readonly, nullable) UIViewController *viewController;
+@property (nullable, nonatomic, readonly) UIViewController *viewController;
 
 
 /**
  * The table- or collection-node that this cell is a member of, if any.
  */
-@property (atomic, weak, readonly, nullable) id<ASRangeManagingNode> owningNode;
+@property (nullable, atomic, weak, readonly) id<ASRangeManagingNode> owningNode;
 
 /*
  * ASCellNode must forward touch events in order for UITableView and UICollectionView tap handling to work. Overriding
@@ -188,38 +188,38 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  * @default UITableViewCellSelectionStyleDefault
  * ASTableView uses these properties when configuring UITableViewCells that host ASCellNodes.
  */
-@property (nonatomic) UITableViewCellSelectionStyle selectionStyle;
+@property (atomic) UITableViewCellSelectionStyle selectionStyle;
 
 /* @abstract The focus style when a cell is focused
  * @default UITableViewCellFocusStyleDefault
  * ASTableView uses these properties when configuring UITableViewCells that host ASCellNodes.
  */
-@property (nonatomic) UITableViewCellFocusStyle focusStyle;
+@property (atomic) UITableViewCellFocusStyle focusStyle;
 
 /* @abstract The view used as the background of the cell when it is selected.
  * ASTableView uses these properties when configuring UITableViewCells that host ASCellNodes.
  * ASCollectionView uses these properties when configuring UICollectionViewCells that host ASCellNodes.
  */
-@property (nonatomic, strong, nullable) UIView *selectedBackgroundView;
+@property (nullable, atomic) UIView *selectedBackgroundView;
 
 /* @abstract The accessory type view on the right side of the cell. Please take care of your ASLayoutSpec so that doesn't overlay the accessoryView
  * @default UITableViewCellAccessoryNone
  * ASTableView uses these properties when configuring UITableViewCells that host ASCellNodes.
  */
-@property (nonatomic) UITableViewCellAccessoryType accessoryType;
+@property (atomic) UITableViewCellAccessoryType accessoryType;
 
 /* @abstract The inset of the cell separator line
  * ASTableView uses these properties when configuring UITableViewCells that host ASCellNodes.
  */
-@property (nonatomic) UIEdgeInsets separatorInset;
+@property (atomic) UIEdgeInsets separatorInset;
 
 @end
 
 @interface ASCellNode (Unavailable)
 
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 - (void)setLayerBacked:(BOOL)layerBacked AS_UNAVAILABLE("ASCellNode does not support layer-backing, although subnodes may be layer-backed.");
 
@@ -239,22 +239,22 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
 /**
  * Text to display.
  */
-@property (nonatomic, copy) NSString *text;
+@property (nullable, atomic, copy) NSString *text;
 
 /**
  * A dictionary containing key-value pairs for text attributes. You can specify the font, text color, text shadow color, and text shadow offset using the keys listed in NSString UIKit Additions Reference.
  */
-@property (nonatomic, copy) NSDictionary *textAttributes;
+@property (atomic, copy) NSDictionary<NSAttributedStringKey, id> *textAttributes;
 
 /**
  * The text inset or outset for each edge. The default value is 15.0 horizontal and 11.0 vertical padding.
  */
-@property (nonatomic, assign) UIEdgeInsets textInsets;
+@property (atomic) UIEdgeInsets textInsets;
 
 /**
  * The text node used by this cell node.
  */
-@property (nonatomic, strong, readonly) ASTextNode *textNode;
+@property (atomic, readonly) ASTextNode *textNode;
 
 @end
 

--- a/Source/ASCellNode.h
+++ b/Source/ASCellNode.h
@@ -80,14 +80,14 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  * blocking time is very short.  If the rangeTuningParameters are set to 0, still this option
  * outperforms UIKit: while the main thread is waiting, subnode display executes concurrently.
  */
-@property (atomic) BOOL neverShowPlaceholders;
+@property BOOL neverShowPlaceholders;
 
 /*
  * The kind of supplementary element this node represents, if any.
  *
  * @return The supplementary element kind, or @c nil if this node does not represent a supplementary element.
  */
-@property (nullable, atomic, copy, readonly) NSString *supplementaryElementKind;
+@property (nullable, copy, readonly) NSString *supplementaryElementKind;
 
 /*
  * The layout attributes currently assigned to this node, if any.
@@ -96,25 +96,25 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  *   is called, when the node is not yet in the hierarchy and its frame cannot be converted to/from other nodes. Instead
  *   you can use the layout attributes object to learn where and how the cell will be displayed.
  */
-@property (nullable, atomic, copy, readonly) UICollectionViewLayoutAttributes *layoutAttributes;
+@property (nullable, copy, readonly) UICollectionViewLayoutAttributes *layoutAttributes;
 
 /**
  * A Boolean value that is synchronized with the underlying collection or tableView cell property.
  * Setting this value is equivalent to calling selectItem / deselectItem on the collection or table.
  */
-@property (atomic, getter=isSelected) BOOL selected;
+@property (getter=isSelected) BOOL selected;
 
 /**
  * A Boolean value that is synchronized with the underlying collection or tableView cell property.
  * Setting this value is equivalent to calling highlightItem / unHighlightItem on the collection or table.
  */
-@property (atomic, getter=isHighlighted) BOOL highlighted;
+@property (getter=isHighlighted) BOOL highlighted;
 
 /**
  * The current index path of this cell node, or @c nil if this node is
  * not a valid item inside a table node or collection node.
  */
-@property (nullable, atomic, copy, readonly) NSIndexPath *indexPath;
+@property (nullable, copy, readonly) NSIndexPath *indexPath;
 
 /**
  * BETA: API is under development. We will attempt to provide an easy migration pathway for any changes.
@@ -123,7 +123,7 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  *
  * This property may be set off the main thread, but this method will never be invoked concurrently on the 
  */
-@property (nullable, atomic) id nodeModel;
+@property (nullable) id nodeModel;
 
 /**
  * Asks the node whether it can be updated to the given node model.
@@ -142,7 +142,7 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
 /**
  * The table- or collection-node that this cell is a member of, if any.
  */
-@property (nullable, atomic, weak, readonly) id<ASRangeManagingNode> owningNode;
+@property (nullable, weak, readonly) id<ASRangeManagingNode> owningNode;
 
 /*
  * ASCellNode must forward touch events in order for UITableView and UICollectionView tap handling to work. Overriding
@@ -188,30 +188,30 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  * @default UITableViewCellSelectionStyleDefault
  * ASTableView uses these properties when configuring UITableViewCells that host ASCellNodes.
  */
-@property (atomic) UITableViewCellSelectionStyle selectionStyle;
+@property UITableViewCellSelectionStyle selectionStyle;
 
 /* @abstract The focus style when a cell is focused
  * @default UITableViewCellFocusStyleDefault
  * ASTableView uses these properties when configuring UITableViewCells that host ASCellNodes.
  */
-@property (atomic) UITableViewCellFocusStyle focusStyle;
+@property UITableViewCellFocusStyle focusStyle;
 
 /* @abstract The view used as the background of the cell when it is selected.
  * ASTableView uses these properties when configuring UITableViewCells that host ASCellNodes.
  * ASCollectionView uses these properties when configuring UICollectionViewCells that host ASCellNodes.
  */
-@property (nullable, atomic) UIView *selectedBackgroundView;
+@property (nullable) UIView *selectedBackgroundView;
 
 /* @abstract The accessory type view on the right side of the cell. Please take care of your ASLayoutSpec so that doesn't overlay the accessoryView
  * @default UITableViewCellAccessoryNone
  * ASTableView uses these properties when configuring UITableViewCells that host ASCellNodes.
  */
-@property (atomic) UITableViewCellAccessoryType accessoryType;
+@property UITableViewCellAccessoryType accessoryType;
 
 /* @abstract The inset of the cell separator line
  * ASTableView uses these properties when configuring UITableViewCells that host ASCellNodes.
  */
-@property (atomic) UIEdgeInsets separatorInset;
+@property UIEdgeInsets separatorInset;
 
 @end
 
@@ -239,22 +239,22 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
 /**
  * Text to display.
  */
-@property (nullable, atomic, copy) NSString *text;
+@property (nullable, copy) NSString *text;
 
 /**
  * A dictionary containing key-value pairs for text attributes. You can specify the font, text color, text shadow color, and text shadow offset using the keys listed in NSString UIKit Additions Reference.
  */
-@property (atomic, copy) NSDictionary<NSAttributedStringKey, id> *textAttributes;
+@property (copy) NSDictionary<NSAttributedStringKey, id> *textAttributes;
 
 /**
  * The text inset or outset for each edge. The default value is 15.0 horizontal and 11.0 vertical padding.
  */
-@property (atomic) UIEdgeInsets textInsets;
+@property UIEdgeInsets textInsets;
 
 /**
  * The text node used by this cell node.
  */
-@property (atomic, readonly) ASTextNode *textNode;
+@property (readonly) ASTextNode *textNode;
 
 @end
 

--- a/Source/ASCellNode.mm
+++ b/Source/ASCellNode.mm
@@ -44,6 +44,9 @@
   ASDisplayNode *_viewControllerNode;
   UIViewController *_viewController;
   BOOL _suspendInteractionDelegate;
+  BOOL _selected;
+  BOOL _highlighted;
+  UICollectionViewLayoutAttributes *_layoutAttributes;
 }
 
 @end
@@ -133,29 +136,42 @@
   }
 }
 
+- (BOOL)isSelected
+{
+  return ASLockedSelf(_selected);
+}
+
 - (void)setSelected:(BOOL)selected
 {
-  if (_selected != selected) {
-    _selected = selected;
+  if (ASLockedSelfCompareAssign(_selected, selected)) {
     if (!_suspendInteractionDelegate) {
-      [_interactionDelegate nodeSelectedStateDidChange:self];
+      ASPerformBlockOnMainThread(^{
+        [_interactionDelegate nodeSelectedStateDidChange:self];
+      });
     }
   }
 }
 
+- (BOOL)isHighlighted
+{
+  return ASLockedSelf(_highlighted);
+}
+
 - (void)setHighlighted:(BOOL)highlighted
 {
-  if (_highlighted != highlighted) {
-    _highlighted = highlighted;
+  if (ASLockedSelfCompareAssign(_highlighted, highlighted)) {
     if (!_suspendInteractionDelegate) {
-      [_interactionDelegate nodeHighlightedStateDidChange:self];
+      ASPerformBlockOnMainThread(^{
+        [_interactionDelegate nodeHighlightedStateDidChange:self];
+      });
     }
   }
 }
 
 - (void)__setSelectedFromUIKit:(BOOL)selected;
 {
-  if (selected != _selected) {
+  // Note: Race condition could mean redundant sets. Risk is low.
+  if (ASLockedSelf(_selected != selected)) {
     _suspendInteractionDelegate = YES;
     self.selected = selected;
     _suspendInteractionDelegate = NO;
@@ -164,7 +180,8 @@
 
 - (void)__setHighlightedFromUIKit:(BOOL)highlighted;
 {
-  if (highlighted != _highlighted) {
+  // Note: Race condition could mean redundant sets. Risk is low.
+  if (ASLockedSelf(_highlighted != highlighted)) {
     _suspendInteractionDelegate = YES;
     self.highlighted = highlighted;
     _suspendInteractionDelegate = NO;
@@ -225,11 +242,15 @@
 
 #pragma clang diagnostic pop
 
+- (UICollectionViewLayoutAttributes *)layoutAttributes
+{
+  return ASLockedSelf(_layoutAttributes);
+}
+
 - (void)setLayoutAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes
 {
   ASDisplayNodeAssertMainThread();
-  if (ASObjectIsEqual(layoutAttributes, _layoutAttributes) == NO) {
-    _layoutAttributes = layoutAttributes;
+  if (ASLockedSelfCompareAssignObjects(_layoutAttributes, layoutAttributes)) {
     if (layoutAttributes != nil) {
       [self applyLayoutAttributes:layoutAttributes];
     }
@@ -377,7 +398,11 @@
 #pragma mark -
 #pragma mark ASTextCellNode
 
-@implementation ASTextCellNode
+@implementation ASTextCellNode {
+  NSDictionary<NSAttributedStringKey, id> *_textAttributes;
+  UIEdgeInsets _textInsets;
+  NSString *_text;
+}
 
 static const CGFloat kASTextCellNodeDefaultFontSize = 18.0f;
 static const CGFloat kASTextCellNodeDefaultHorizontalPadding = 15.0f;
@@ -415,39 +440,53 @@ static const CGFloat kASTextCellNodeDefaultVerticalPadding = 11.0f;
     return UIEdgeInsetsMake(kASTextCellNodeDefaultVerticalPadding, kASTextCellNodeDefaultHorizontalPadding, kASTextCellNodeDefaultVerticalPadding, kASTextCellNodeDefaultHorizontalPadding);
 }
 
+- (NSDictionary *)textAttributes
+{
+  return ASLockedSelf(_textAttributes);
+}
+
 - (void)setTextAttributes:(NSDictionary *)textAttributes
 {
   ASDisplayNodeAssertNotNil(textAttributes, @"Invalid text attributes");
-  
-  _textAttributes = [textAttributes copy];
-  
-  [self updateAttributedText];
+  ASLockScopeSelf();
+  if (ASCompareAssignCopy(_textAttributes, textAttributes)) {
+    [self locked_updateAttributedText];
+  }
+}
+
+- (UIEdgeInsets)textInsets
+{
+  return ASLockedSelf(_textInsets);
 }
 
 - (void)setTextInsets:(UIEdgeInsets)textInsets
 {
-  _textInsets = textInsets;
+  if (ASLockedSelfCompareAssignCustom(_textInsets, textInsets, UIEdgeInsetsEqualToEdgeInsets)) {
+    [self setNeedsLayout];
+  }
+}
 
-  [self setNeedsLayout];
+- (NSString *)text
+{
+  return ASLockedSelf(_text);
 }
 
 - (void)setText:(NSString *)text
 {
-  if (ASObjectIsEqual(_text, text)) return;
-
-  _text = [text copy];
-  
-  [self updateAttributedText];
+  ASLockScopeSelf();
+  if (ASCompareAssignCopy(_text, text)) {
+    [self locked_updateAttributedText];
+  }
 }
 
-- (void)updateAttributedText
+- (void)locked_updateAttributedText
 {
   if (_text == nil) {
     _textNode.attributedText = nil;
     return;
   }
   
-  _textNode.attributedText = [[NSAttributedString alloc] initWithString:self.text attributes:self.textAttributes];
+  _textNode.attributedText = [[NSAttributedString alloc] initWithString:_text attributes:_textAttributes];
   [self setNeedsLayout];
 }
 

--- a/Source/ASCollectionNode+Beta.h
+++ b/Source/ASCollectionNode+Beta.h
@@ -29,14 +29,14 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @default [ASCollectionView class] is used whenever this property is unset or nil.
  */
-@property (strong, nonatomic, nullable) Class collectionViewClass;
+@property (nonatomic, nullable) Class collectionViewClass;
 
 /**
  * The elements that are currently displayed. The "UIKit index space". Must be accessed on main thread.
  */
-@property (strong, nonatomic, readonly) ASElementMap *visibleElements;
+@property (nonatomic, readonly) ASElementMap *visibleElements;
 
-@property (strong, readonly, nullable) id<ASCollectionLayoutDelegate> layoutDelegate;
+@property (atomic, readonly, nullable) id<ASCollectionLayoutDelegate> layoutDelegate;
 
 @property (nonatomic, weak) id<ASBatchFetchingDelegate> batchFetchingDelegate;
 
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @default defaults to NO.
  */
-@property (nonatomic, assign) BOOL usesSynchronousDataLoading;
+@property (nonatomic) BOOL usesSynchronousDataLoading;
 
 /**
  *  Returns YES if the ASCollectionNode contents are completely synchronized with the underlying collection-view layout.

--- a/Source/ASCollectionNode+Beta.h
+++ b/Source/ASCollectionNode+Beta.h
@@ -29,16 +29,16 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @default [ASCollectionView class] is used whenever this property is unset or nil.
  */
-@property (nonatomic, nullable) Class collectionViewClass;
+@property (nullable, nonatomic) Class collectionViewClass;
 
 /**
  * The elements that are currently displayed. The "UIKit index space". Must be accessed on main thread.
  */
 @property (nonatomic, readonly) ASElementMap *visibleElements;
 
-@property (atomic, readonly, nullable) id<ASCollectionLayoutDelegate> layoutDelegate;
+@property (nullable, readonly) id<ASCollectionLayoutDelegate> layoutDelegate;
 
-@property (nonatomic, weak) id<ASBatchFetchingDelegate> batchFetchingDelegate;
+@property (nullable, nonatomic, weak) id<ASBatchFetchingDelegate> batchFetchingDelegate;
 
 /**
  * When this mode is enabled, ASCollectionView matches the timing of UICollectionView as closely as possible, 

--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return view The corresponding ASCollectionView.
  */
-@property (strong, nonatomic, readonly) ASCollectionView *view;
+@property (atomic, readonly) ASCollectionView *view;
 
 /**
  * The object that acts as the asynchronous delegate of the collection view
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
  * The delegate object is responsible for providing size constraints for nodes and indicating whether batch fetching should begin.
  * @note This is a convenience method which sets the asyncDelegate on the collection node's collection view.
  */
-@property (weak, nonatomic) id <ASCollectionDelegate>   delegate;
+@property (nullable, atomic, weak) id <ASCollectionDelegate>   delegate;
 
 /**
  * The object that acts as the asynchronous data source of the collection view
@@ -81,64 +81,64 @@ NS_ASSUME_NONNULL_BEGIN
  * The datasource object is responsible for providing nodes or node creation blocks to the collection view.
  * @note This is a convenience method which sets the asyncDatasource on the collection node's collection view.
  */
-@property (weak, nonatomic) id <ASCollectionDataSource> dataSource;
+@property (nullable, atomic, weak) id <ASCollectionDataSource> dataSource;
 
 /**
  * The number of screens left to scroll before the delegate -collectionNode:beginBatchFetchingWithContext: is called.
  *
  * Defaults to two screenfuls.
  */
-@property (nonatomic, assign) CGFloat leadingScreensForBatching;
+@property (nonatomic) CGFloat leadingScreensForBatching;
 
 /*
  * A Boolean value that determines whether the collection node will be flipped.
  * If the value of this property is YES, the first cell node will be at the bottom of the collection node (as opposed to the top by default). This is useful for chat/messaging apps. The default value is NO.
  */
-@property (nonatomic, assign) BOOL inverted;
+@property (nonatomic) BOOL inverted;
 
 /**
  * A Boolean value that indicates whether users can select items in the collection node.
  * If the value of this property is YES (the default), users can select items. If you want more fine-grained control over the selection of items, you must provide a delegate object and implement the appropriate methods of the UICollectionNodeDelegate protocol.
  */
-@property (nonatomic, assign) BOOL allowsSelection;
+@property (nonatomic) BOOL allowsSelection;
 
 /**
  * A Boolean value that determines whether users can select more than one item in the collection node.
  * This property controls whether multiple items can be selected simultaneously. The default value of this property is NO.
  * When the value of this property is YES, tapping a cell adds it to the current selection (assuming the delegate permits the cell to be selected). Tapping the cell again removes it from the selection.
  */
-@property (nonatomic, assign) BOOL allowsMultipleSelection;
+@property (nonatomic) BOOL allowsMultipleSelection;
 
 /**
  * A Boolean value that determines whether bouncing always occurs when vertical scrolling reaches the end of the content.
  * The default value of this property is NO.
  */
-@property (nonatomic, assign) BOOL alwaysBounceVertical;
+@property (nonatomic) BOOL alwaysBounceVertical;
 
 /**
  * A Boolean value that determines whether bouncing always occurs when horizontal scrolling reaches the end of the content view.
  * The default value of this property is NO.
  */
-@property (nonatomic, assign) BOOL alwaysBounceHorizontal;
+@property (nonatomic) BOOL alwaysBounceHorizontal;
 
 /**
  * A Boolean value that controls whether the vertical scroll indicator is visible.
  * The default value of this property is YES.
  */
-@property (nonatomic, assign) BOOL showsVerticalScrollIndicator;
+@property (nonatomic) BOOL showsVerticalScrollIndicator;
 
 /**
  * A Boolean value that controls whether the horizontal scroll indicator is visible.
  * The default value of this property is NO.
  */
-@property (nonatomic, assign) BOOL showsHorizontalScrollIndicator;
+@property (nonatomic) BOOL showsHorizontalScrollIndicator;
 
 /**
  * The layout used to organize the node's items.
  *
  * @discussion Assigning a new layout object to this property causes the new layout to be applied (without animations) to the node’s items.
  */
-@property (nonatomic, strong) UICollectionViewLayout *collectionViewLayout;
+@property (nonatomic) UICollectionViewLayout *collectionViewLayout;
 
 /**
  * Optional introspection object for the collection node's layout.
@@ -155,12 +155,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The distance that the content view is inset from the collection node edges. Defaults to UIEdgeInsetsZero.
  */
-@property (nonatomic, assign) UIEdgeInsets contentInset;
+@property (nonatomic) UIEdgeInsets contentInset;
 
 /**
  * The offset of the content view's origin from the collection node's origin. Defaults to CGPointZero.
  */
-@property (nonatomic, assign) CGPoint contentOffset;
+@property (nonatomic) CGPoint contentOffset;
 
 /**
  * Sets the offset from the content node’s origin to the collection node’s origin.

--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return view The corresponding ASCollectionView.
  */
-@property (atomic, readonly) ASCollectionView *view;
+@property (readonly) ASCollectionView *view;
 
 /**
  * The object that acts as the asynchronous delegate of the collection view
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
  * The delegate object is responsible for providing size constraints for nodes and indicating whether batch fetching should begin.
  * @note This is a convenience method which sets the asyncDelegate on the collection node's collection view.
  */
-@property (nullable, atomic, weak) id <ASCollectionDelegate>   delegate;
+@property (nullable, weak) id <ASCollectionDelegate>   delegate;
 
 /**
  * The object that acts as the asynchronous data source of the collection view
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
  * The datasource object is responsible for providing nodes or node creation blocks to the collection view.
  * @note This is a convenience method which sets the asyncDatasource on the collection node's collection view.
  */
-@property (nullable, atomic, weak) id <ASCollectionDataSource> dataSource;
+@property (nullable, weak) id <ASCollectionDataSource> dataSource;
 
 /**
  * The number of screens left to scroll before the delegate -collectionNode:beginBatchFetchingWithContext: is called.
@@ -428,7 +428,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The index paths of the selected items, or @c nil if no items are selected.
  */
-@property (nonatomic, readonly, nullable) NSArray<NSIndexPath *> *indexPathsForSelectedItems;
+@property (nullable, nonatomic, copy, readonly) NSArray<NSIndexPath *> *indexPathsForSelectedItems;
 
 /**
  * Selects the item at the specified index path and optionally scrolls it into view.

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -41,21 +41,21 @@
 @interface _ASCollectionPendingState : NSObject
 @property (weak, nonatomic) id <ASCollectionDelegate>   delegate;
 @property (weak, nonatomic) id <ASCollectionDataSource> dataSource;
-@property (strong, nonatomic) UICollectionViewLayout *collectionViewLayout;
-@property (nonatomic, assign) ASLayoutRangeMode rangeMode;
-@property (nonatomic, assign) BOOL allowsSelection; // default is YES
-@property (nonatomic, assign) BOOL allowsMultipleSelection; // default is NO
-@property (nonatomic, assign) BOOL inverted; //default is NO
-@property (nonatomic, assign) BOOL usesSynchronousDataLoading;
-@property (nonatomic, assign) CGFloat leadingScreensForBatching;
+@property (nonatomic) UICollectionViewLayout *collectionViewLayout;
+@property (nonatomic) ASLayoutRangeMode rangeMode;
+@property (nonatomic) BOOL allowsSelection; // default is YES
+@property (nonatomic) BOOL allowsMultipleSelection; // default is NO
+@property (nonatomic) BOOL inverted; //default is NO
+@property (nonatomic) BOOL usesSynchronousDataLoading;
+@property (nonatomic) CGFloat leadingScreensForBatching;
 @property (weak, nonatomic) id <ASCollectionViewLayoutInspecting> layoutInspector;
-@property (nonatomic, assign) BOOL alwaysBounceVertical;
-@property (nonatomic, assign) BOOL alwaysBounceHorizontal;
-@property (nonatomic, assign) UIEdgeInsets contentInset;
-@property (nonatomic, assign) CGPoint contentOffset;
-@property (nonatomic, assign) BOOL animatesContentOffset;
-@property (nonatomic, assign) BOOL showsVerticalScrollIndicator;
-@property (nonatomic, assign) BOOL showsHorizontalScrollIndicator;
+@property (nonatomic) BOOL alwaysBounceVertical;
+@property (nonatomic) BOOL alwaysBounceHorizontal;
+@property (nonatomic) UIEdgeInsets contentInset;
+@property (nonatomic) CGPoint contentOffset;
+@property (nonatomic) BOOL animatesContentOffset;
+@property (nonatomic) BOOL showsVerticalScrollIndicator;
+@property (nonatomic) BOOL showsHorizontalScrollIndicator;
 @end
 
 @implementation _ASCollectionPendingState

--- a/Source/ASCollectionView.h
+++ b/Source/ASCollectionView.h
@@ -96,14 +96,14 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * A Boolean value that determines whether the nodes that the data source renders will be flipped.
  */
-@property (nonatomic, assign) BOOL inverted ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode property instead.");
+@property (nonatomic) BOOL inverted ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode property instead.");
 
 /**
  * The number of screens left to scroll before the delegate -collectionView:beginBatchFetchingWithContext: is called.
  *
  * Defaults to two screenfuls.
  */
-@property (nonatomic, assign) CGFloat leadingScreensForBatching ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode property instead.");
+@property (nonatomic) CGFloat leadingScreensForBatching ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode property instead.");
 
 /**
  * Optional introspection object for the collection view's layout.
@@ -144,12 +144,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The distance that the content view is inset from the collection view edges. Defaults to UIEdgeInsetsZero.
  */
-@property (nonatomic, assign) UIEdgeInsets contentInset ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode property instead");
+@property (nonatomic) UIEdgeInsets contentInset ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode property instead");
 
 /**
  * The point at which the origin of the content view is offset from the origin of the collection view.
  */
-@property (nonatomic, assign) CGPoint contentOffset ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode property instead.");
+@property (nonatomic) CGPoint contentOffset ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode property instead.");
 
 /**
  * The object that acts as the asynchronous delegate of the collection view

--- a/Source/ASCollectionView.h
+++ b/Source/ASCollectionView.h
@@ -242,9 +242,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)selectItemAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated scrollPosition:(UICollectionViewScrollPosition)scrollPosition ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode method instead.");
 
-@property (nonatomic, readonly) NSArray<NSIndexPath *> *indexPathsForVisibleItems ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode property instead.");
+@property (nonatomic, copy, readonly) NSArray<NSIndexPath *> *indexPathsForVisibleItems ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode property instead.");
 
-@property (nonatomic, readonly, nullable) NSArray<NSIndexPath *> *indexPathsForSelectedItems ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode property instead.");
+@property (nullable, nonatomic, copy, readonly) NSArray<NSIndexPath *> *indexPathsForSelectedItems ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode property instead.");
 
 /**
  *  Perform a batch of updates asynchronously, optionally disabling all animations in the batch. This method must be called from the main thread.

--- a/Source/ASConfiguration.h
+++ b/Source/ASConfiguration.h
@@ -35,7 +35,7 @@ AS_SUBCLASSING_RESTRICTED
  * The delegate for configuration-related events.
  * Delegate methods are called from a serial queue.
  */
-@property (nonatomic, strong, nullable) id<ASConfigurationDelegate> delegate;
+@property (nonatomic, nullable) id<ASConfigurationDelegate> delegate;
 
 /**
  * The experimental features to enable in Texture.

--- a/Source/ASControlNode+Subclasses.h
+++ b/Source/ASControlNode+Subclasses.h
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract Settable version of highlighted property.
  */
-@property (atomic, getter=isHighlighted) BOOL highlighted;
+@property (getter=isHighlighted) BOOL highlighted;
 
 @end
 

--- a/Source/ASControlNode+Subclasses.h
+++ b/Source/ASControlNode+Subclasses.h
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract Settable version of highlighted property.
  */
-@property (nonatomic, readwrite, assign, getter=isHighlighted) BOOL highlighted;
+@property (atomic, getter=isHighlighted) BOOL highlighted;
 
 @end
 

--- a/Source/ASControlNode.h
+++ b/Source/ASControlNode.h
@@ -76,32 +76,32 @@ static UIControlState const ASControlStateSelected ASDISPLAYNODE_DEPRECATED_MSG(
   @abstract Indicates whether or not the receiver is enabled.
   @discussion Specify YES to make the control enabled; otherwise, specify NO to make it disabled. The default value is YES. If the enabled state is NO, the control ignores touch events and subclasses may draw differently.
  */
-@property (nonatomic, assign, getter=isEnabled) BOOL enabled;
+@property (atomic, getter=isEnabled) BOOL enabled;
 
 /**
   @abstract Indicates whether or not the receiver is highlighted.
   @discussion This is set automatically when the there is a touch inside the control and removed on exit or touch up. This is different from touchInside in that it includes an area around the control, rather than just for touches inside the control.
  */
-@property (nonatomic, assign, getter=isHighlighted) BOOL highlighted;
+@property (atomic, getter=isHighlighted) BOOL highlighted;
 
 /**
  @abstract Indicates whether or not the receiver is highlighted.
  @discussion This is set automatically when the receiver is tapped.
  */
-@property (nonatomic, assign, getter=isSelected) BOOL selected;
+@property (atomic, getter=isSelected) BOOL selected;
 
 #pragma mark - Tracking Touches
 /**
   @abstract Indicates whether or not the receiver is currently tracking touches related to an event.
   @discussion YES if the receiver is tracking touches; NO otherwise.
  */
-@property (nonatomic, readonly, assign, getter=isTracking) BOOL tracking;
+@property (atomic, readonly, getter=isTracking) BOOL tracking;
 
 /**
   @abstract Indicates whether or not a touch is inside the bounds of the receiver.
   @discussion YES if a touch is inside the receiver's bounds; NO otherwise.
  */
-@property (nonatomic, readonly, assign, getter=isTouchInside) BOOL touchInside;
+@property (atomic, readonly, getter=isTouchInside) BOOL touchInside;
 
 #pragma mark - Action Messages
 /**

--- a/Source/ASControlNode.h
+++ b/Source/ASControlNode.h
@@ -76,32 +76,32 @@ static UIControlState const ASControlStateSelected ASDISPLAYNODE_DEPRECATED_MSG(
   @abstract Indicates whether or not the receiver is enabled.
   @discussion Specify YES to make the control enabled; otherwise, specify NO to make it disabled. The default value is YES. If the enabled state is NO, the control ignores touch events and subclasses may draw differently.
  */
-@property (atomic, getter=isEnabled) BOOL enabled;
+@property (getter=isEnabled) BOOL enabled;
 
 /**
   @abstract Indicates whether or not the receiver is highlighted.
   @discussion This is set automatically when the there is a touch inside the control and removed on exit or touch up. This is different from touchInside in that it includes an area around the control, rather than just for touches inside the control.
  */
-@property (atomic, getter=isHighlighted) BOOL highlighted;
+@property (getter=isHighlighted) BOOL highlighted;
 
 /**
  @abstract Indicates whether or not the receiver is highlighted.
  @discussion This is set automatically when the receiver is tapped.
  */
-@property (atomic, getter=isSelected) BOOL selected;
+@property (getter=isSelected) BOOL selected;
 
 #pragma mark - Tracking Touches
 /**
   @abstract Indicates whether or not the receiver is currently tracking touches related to an event.
   @discussion YES if the receiver is tracking touches; NO otherwise.
  */
-@property (atomic, readonly, getter=isTracking) BOOL tracking;
+@property (readonly, getter=isTracking) BOOL tracking;
 
 /**
   @abstract Indicates whether or not a touch is inside the bounds of the receiver.
   @discussion YES if a touch is inside the receiver's bounds; NO otherwise.
  */
-@property (atomic, readonly, getter=isTouchInside) BOOL touchInside;
+@property (readonly, getter=isTouchInside) BOOL touchInside;
 
 #pragma mark - Action Messages
 /**

--- a/Source/ASControlNode.mm
+++ b/Source/ASControlNode.mm
@@ -52,8 +52,8 @@
 }
 
 // Read-write overrides.
-@property (nonatomic, readwrite, assign, getter=isTracking) BOOL tracking;
-@property (nonatomic, readwrite, assign, getter=isTouchInside) BOOL touchInside;
+@property (atomic, getter=isTracking) BOOL tracking;
+@property (atomic, getter=isTouchInside) BOOL touchInside;
 
 /**
   @abstract Returns a key to be used in _controlEventDispatchTable that identifies the control event.

--- a/Source/ASControlNode.mm
+++ b/Source/ASControlNode.mm
@@ -52,8 +52,8 @@
 }
 
 // Read-write overrides.
-@property (atomic, getter=isTracking) BOOL tracking;
-@property (atomic, getter=isTouchInside) BOOL touchInside;
+@property (getter=isTracking) BOOL tracking;
+@property (getter=isTouchInside) BOOL touchInside;
 
 /**
   @abstract Returns a key to be used in _controlEventDispatchTable that identifies the control event.

--- a/Source/ASDisplayNode+Beta.h
+++ b/Source/ASDisplayNode+Beta.h
@@ -75,22 +75,22 @@ typedef struct {
  * restoring context if necessary. Restoring can be done in contextDidDisplayNodeContent
  * This block can be called from *any* thread and it is unsafe to access any UIKit main thread properties from it.
  */
-@property (nullable, atomic) ASDisplayNodeContextModifier willDisplayNodeContentWithRenderingContext;
+@property (nullable) ASDisplayNodeContextModifier willDisplayNodeContentWithRenderingContext;
 
 /**
  * @abstract allow modification of a context after the node's content is drawn
  */
-@property (nullable, atomic) ASDisplayNodeContextModifier didDisplayNodeContentWithRenderingContext;
+@property (nullable) ASDisplayNodeContextModifier didDisplayNodeContentWithRenderingContext;
 
 /**
  * @abstract A bitmask representing which actions (layout spec, layout generation) should be measured.
  */
-@property (atomic) ASDisplayNodePerformanceMeasurementOptions measurementOptions;
+@property ASDisplayNodePerformanceMeasurementOptions measurementOptions;
 
 /**
  * @abstract A simple struct representing performance measurements collected.
  */
-@property (atomic, readonly) ASDisplayNodePerformanceMeasurements performanceMeasurements;
+@property (readonly) ASDisplayNodePerformanceMeasurements performanceMeasurements;
 
 #if ASEVENTLOG_ENABLE
 /*
@@ -104,7 +104,7 @@ typedef struct {
  * an aggregation of all child nodes' accessibility labels. Nodes in this node's subtree that are also accessibility containers will
  * not be included in this aggregation, and will be exposed as separate accessibility elements to UIKit.
  */
-@property (atomic) BOOL isAccessibilityContainer;
+@property BOOL isAccessibilityContainer;
 
 /**
  * @abstract Invoked when a user performs a custom action on an accessible node. Nodes that are children of accessibility containers, have
@@ -180,7 +180,7 @@ extern void ASDisplayNodePerformBlockOnEveryYogaChild(ASDisplayNode * _Nullable 
 
 - (void)semanticContentAttributeDidChange:(UISemanticContentAttribute)attribute;
 
-@property (atomic) BOOL yogaLayoutInProgress;
+@property BOOL yogaLayoutInProgress;
 @property (nullable, nonatomic) ASLayout *yogaCalculatedLayout;
 
 // These methods are intended to be used internally to Texture, and should not be called directly.
@@ -195,19 +195,19 @@ extern void ASDisplayNodePerformBlockOnEveryYogaChild(ASDisplayNode * _Nullable 
 - (YGNodeRef)yogaNodeCreateIfNeeded;
 - (void)destroyYogaNode;
 
-@property (atomic, readonly) YGNodeRef yogaNode;
+@property (readonly) YGNodeRef yogaNode;
 
-@property (atomic) ASStackLayoutDirection flexDirection;
-@property (atomic) YGDirection direction;
-@property (atomic) ASStackLayoutJustifyContent justifyContent;
-@property (atomic) ASStackLayoutAlignItems alignItems;
-@property (atomic) YGPositionType positionType;
-@property (atomic) ASEdgeInsets position;
-@property (atomic) ASEdgeInsets margin;
-@property (atomic) ASEdgeInsets padding;
-@property (atomic) ASEdgeInsets border;
-@property (atomic) CGFloat aspectRatio;
-@property (atomic) YGWrap flexWrap;
+@property ASStackLayoutDirection flexDirection;
+@property YGDirection direction;
+@property ASStackLayoutJustifyContent justifyContent;
+@property ASStackLayoutAlignItems alignItems;
+@property YGPositionType positionType;
+@property ASEdgeInsets position;
+@property ASEdgeInsets margin;
+@property ASEdgeInsets padding;
+@property ASEdgeInsets border;
+@property CGFloat aspectRatio;
+@property YGWrap flexWrap;
 
 @end
 

--- a/Source/ASDisplayNode+Beta.h
+++ b/Source/ASDisplayNode+Beta.h
@@ -75,28 +75,28 @@ typedef struct {
  * restoring context if necessary. Restoring can be done in contextDidDisplayNodeContent
  * This block can be called from *any* thread and it is unsafe to access any UIKit main thread properties from it.
  */
-@property (nonatomic, copy, nullable) ASDisplayNodeContextModifier willDisplayNodeContentWithRenderingContext;
+@property (nullable, atomic) ASDisplayNodeContextModifier willDisplayNodeContentWithRenderingContext;
 
 /**
  * @abstract allow modification of a context after the node's content is drawn
  */
-@property (nonatomic, copy, nullable) ASDisplayNodeContextModifier didDisplayNodeContentWithRenderingContext;
+@property (nullable, atomic) ASDisplayNodeContextModifier didDisplayNodeContentWithRenderingContext;
 
 /**
  * @abstract A bitmask representing which actions (layout spec, layout generation) should be measured.
  */
-@property (nonatomic, assign) ASDisplayNodePerformanceMeasurementOptions measurementOptions;
+@property (atomic) ASDisplayNodePerformanceMeasurementOptions measurementOptions;
 
 /**
  * @abstract A simple struct representing performance measurements collected.
  */
-@property (nonatomic, assign, readonly) ASDisplayNodePerformanceMeasurements performanceMeasurements;
+@property (atomic, readonly) ASDisplayNodePerformanceMeasurements performanceMeasurements;
 
 #if ASEVENTLOG_ENABLE
 /*
  * @abstract The primitive event tracing object. You shouldn't directly use it to log event. Use the ASDisplayNodeLogEvent macro instead.
  */
-@property (nonatomic, strong, readonly) ASEventLog *eventLog;
+@property (nonatomic, readonly) ASEventLog *eventLog;
 #endif
 
 /**
@@ -104,7 +104,7 @@ typedef struct {
  * an aggregation of all child nodes' accessibility labels. Nodes in this node's subtree that are also accessibility containers will
  * not be included in this aggregation, and will be exposed as separate accessibility elements to UIKit.
  */
-@property (nonatomic, assign) BOOL isAccessibilityContainer;
+@property (atomic) BOOL isAccessibilityContainer;
 
 /**
  * @abstract Invoked when a user performs a custom action on an accessible node. Nodes that are children of accessibility containers, have
@@ -171,7 +171,8 @@ extern void ASDisplayNodePerformBlockOnEveryYogaChild(ASDisplayNode * _Nullable 
 
 @interface ASDisplayNode (Yoga)
 
-@property (nonatomic, strong, nullable) NSArray *yogaChildren;
+// TODO: Make this and yogaCalculatedLayout atomic (lock).
+@property (nullable, nonatomic) NSArray *yogaChildren;
 
 - (void)addYogaChild:(ASDisplayNode *)child;
 - (void)removeYogaChild:(ASDisplayNode *)child;
@@ -179,8 +180,8 @@ extern void ASDisplayNodePerformBlockOnEveryYogaChild(ASDisplayNode * _Nullable 
 
 - (void)semanticContentAttributeDidChange:(UISemanticContentAttribute)attribute;
 
-@property (nonatomic, assign) BOOL yogaLayoutInProgress;
-@property (nonatomic, strong, nullable) ASLayout *yogaCalculatedLayout;
+@property (atomic) BOOL yogaLayoutInProgress;
+@property (nullable, nonatomic) ASLayout *yogaCalculatedLayout;
 
 // These methods are intended to be used internally to Texture, and should not be called directly.
 - (BOOL)shouldHaveYogaMeasureFunc;
@@ -194,19 +195,19 @@ extern void ASDisplayNodePerformBlockOnEveryYogaChild(ASDisplayNode * _Nullable 
 - (YGNodeRef)yogaNodeCreateIfNeeded;
 - (void)destroyYogaNode;
 
-@property (nonatomic, assign, readonly) YGNodeRef yogaNode;
+@property (atomic, readonly) YGNodeRef yogaNode;
 
-@property (nonatomic, assign, readwrite) ASStackLayoutDirection flexDirection;
-@property (nonatomic, assign, readwrite) YGDirection direction;
-@property (nonatomic, assign, readwrite) ASStackLayoutJustifyContent justifyContent;
-@property (nonatomic, assign, readwrite) ASStackLayoutAlignItems alignItems;
-@property (nonatomic, assign, readwrite) YGPositionType positionType;
-@property (nonatomic, assign, readwrite) ASEdgeInsets position;
-@property (nonatomic, assign, readwrite) ASEdgeInsets margin;
-@property (nonatomic, assign, readwrite) ASEdgeInsets padding;
-@property (nonatomic, assign, readwrite) ASEdgeInsets border;
-@property (nonatomic, assign, readwrite) CGFloat aspectRatio;
-@property (nonatomic, assign, readwrite) YGWrap flexWrap;
+@property (atomic) ASStackLayoutDirection flexDirection;
+@property (atomic) YGDirection direction;
+@property (atomic) ASStackLayoutJustifyContent justifyContent;
+@property (atomic) ASStackLayoutAlignItems alignItems;
+@property (atomic) YGPositionType positionType;
+@property (atomic) ASEdgeInsets position;
+@property (atomic) ASEdgeInsets margin;
+@property (atomic) ASEdgeInsets padding;
+@property (atomic) ASEdgeInsets border;
+@property (atomic) CGFloat aspectRatio;
+@property (atomic) YGWrap flexWrap;
 
 @end
 

--- a/Source/ASDisplayNode+Subclasses.h
+++ b/Source/ASDisplayNode+Subclasses.h
@@ -134,7 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @warning Subclasses must not override this; it returns the last cached layout and is never expensive.
  */
-@property (nullable, atomic, readonly) ASLayout *calculatedLayout;
+@property (nullable, readonly) ASLayout *calculatedLayout;
 
 #pragma mark - View Lifecycle
 /** @name View Lifecycle */
@@ -371,7 +371,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @abstract Whether the view or layer of this display node is currently in a window
  */
-@property (atomic, readonly, getter=isInHierarchy) BOOL inHierarchy;
+@property (readonly, getter=isInHierarchy) BOOL inHierarchy;
 
 /**
  * Provides an opportunity to clear backing store and other memory-intensive intermediates, such as text layout managers
@@ -440,7 +440,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @see setNeedsDisplayAtScale:
  */
-@property (atomic, readonly) CGFloat contentsScaleForDisplay;
+@property (readonly) CGFloat contentsScaleForDisplay;
 
 
 #pragma mark - Touch handling

--- a/Source/ASDisplayNode+Subclasses.h
+++ b/Source/ASDisplayNode+Subclasses.h
@@ -134,7 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @warning Subclasses must not override this; it returns the last cached layout and is never expensive.
  */
-@property (nullable, nonatomic, readonly, strong) ASLayout *calculatedLayout;
+@property (nullable, atomic, readonly) ASLayout *calculatedLayout;
 
 #pragma mark - View Lifecycle
 /** @name View Lifecycle */
@@ -371,7 +371,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @abstract Whether the view or layer of this display node is currently in a window
  */
-@property (nonatomic, readonly, assign, getter=isInHierarchy) BOOL inHierarchy;
+@property (atomic, readonly, getter=isInHierarchy) BOOL inHierarchy;
 
 /**
  * Provides an opportunity to clear backing store and other memory-intensive intermediates, such as text layout managers
@@ -440,7 +440,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @see setNeedsDisplayAtScale:
  */
-@property (nonatomic, assign, readonly) CGFloat contentsScaleForDisplay;
+@property (atomic, readonly) CGFloat contentsScaleForDisplay;
 
 
 #pragma mark - Touch handling

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -221,7 +221,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @return NO if the node wraps a _ASDisplayView, YES otherwise.
  */
-@property (atomic, readonly, getter=isSynchronous) BOOL synchronous;
+@property (readonly, getter=isSynchronous) BOOL synchronous;
 
 /** @name Getting view and layer */
 
@@ -234,21 +234,21 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @warning The first access to it must be on the main thread, and should only be used on the main thread thereafter as 
  * well.
  */
-@property (atomic, readonly) UIView *view;
+@property (readonly) UIView *view;
 
 /** 
  * @abstract Returns whether a node's backing view or layer is loaded.
  *
  * @return YES if a view is loaded, or if layerBacked is YES and layer is not nil; NO otherwise.
  */
-@property (atomic, readonly, getter=isNodeLoaded) BOOL nodeLoaded;
+@property (readonly, getter=isNodeLoaded) BOOL nodeLoaded;
 
 /** 
  * @abstract Returns whether the node rely on a layer instead of a view.
  *
  * @return YES if the node rely on a layer, NO otherwise.
  */
-@property (atomic, getter=isLayerBacked) BOOL layerBacked;
+@property (getter=isLayerBacked) BOOL layerBacked;
 
 /** 
  * @abstract Returns a layer.
@@ -259,28 +259,28 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @warning The first access to it must be on the main thread, and should only be used on the main thread thereafter as 
  * well.
  */
-@property (atomic, readonly) CALayer * layer;
+@property (readonly) CALayer * layer;
 
 /**
  * Returns YES if the node is – at least partially – visible in a window.
  *
  * @see didEnterVisibleState and didExitVisibleState
  */
-@property (atomic, readonly, getter=isVisible) BOOL visible;
+@property (readonly, getter=isVisible) BOOL visible;
 
 /**
  * Returns YES if the node is in the preloading interface state.
  *
  * @see didEnterPreloadState and didExitPreloadState
  */
-@property (atomic, readonly, getter=isInPreloadState) BOOL inPreloadState;
+@property (readonly, getter=isInPreloadState) BOOL inPreloadState;
 
 /**
  * Returns YES if the node is in the displaying interface state.
  *
  * @see didEnterDisplayState and didExitDisplayState
  */
-@property (atomic, readonly, getter=isInDisplayState) BOOL inDisplayState;
+@property (readonly, getter=isInDisplayState) BOOL inDisplayState;
 
 /**
  * @abstract Returns the Interface State of the node.
@@ -289,7 +289,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @see ASInterfaceState
  */
-@property (atomic, readonly) ASInterfaceState interfaceState;
+@property (readonly) ASInterfaceState interfaceState;
 
 /**
  * @abstract Class property that allows to set a block that can be called on non-fatal errors. This
@@ -299,7 +299,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @warning This method is not thread-safe.
  */
-@property (nonatomic, class, copy) ASDisplayNodeNonFatalErrorBlock nonFatalErrorBlock;
+@property (class, nonatomic) ASDisplayNodeNonFatalErrorBlock nonFatalErrorBlock;
 
 /** @name Managing the nodes hierarchy */
 
@@ -371,12 +371,12 @@ extern NSInteger const ASDefaultDrawingPriority;
 /** 
  * @abstract The receiver's immediate subnodes.
  */
-@property (nullable, atomic, readonly, copy) NSArray<ASDisplayNode *> *subnodes;
+@property (nullable, readonly, copy) NSArray<ASDisplayNode *> *subnodes;
 
 /** 
  * @abstract The receiver's supernode.
  */
-@property (nullable, atomic, readonly, weak) ASDisplayNode *supernode;
+@property (nullable, readonly, weak) ASDisplayNode *supernode;
 
 
 /** @name Drawing and Updating the View */
@@ -409,7 +409,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * Note: this has nothing to do with -[CALayer drawsAsynchronously].
  */
-@property (atomic) BOOL displaysAsynchronously;
+@property BOOL displaysAsynchronously;
 
 /** 
  * @abstract Prevent the node's layer from displaying.
@@ -423,12 +423,12 @@ extern NSInteger const ASDefaultDrawingPriority;
  * If a setNeedsDisplay occurs while displaySuspended is YES, and displaySuspended is set to NO, then the 
  * layer will be automatically displayed.
  */
-@property (atomic) BOOL displaySuspended;
+@property BOOL displaySuspended;
 
 /**
  * @abstract Whether size changes should be animated. Default to YES.
  */
-@property (atomic) BOOL shouldAnimateSizeChanges;
+@property BOOL shouldAnimateSizeChanges;
 
 /** 
  * @abstract Prevent the node and its descendants' layer from displaying.
@@ -457,14 +457,14 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @discussion Defaults to NO.
  */
-@property (atomic) BOOL placeholderEnabled;
+@property BOOL placeholderEnabled;
 
 /**
  * @abstract Set the time it takes to fade out the placeholder when a node's contents are finished displaying.
  *
  * @discussion Defaults to 0 seconds.
  */
-@property (atomic) NSTimeInterval placeholderFadeDuration;
+@property NSTimeInterval placeholderFadeDuration;
 
 /**
  * @abstract Determines drawing priority of the node. Nodes with higher priority will be drawn earlier.
@@ -472,7 +472,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @discussion Defaults to ASDefaultDrawingPriority. There may be multiple drawing threads, and some of them may
  * decide to perform operations in queued order (regardless of drawingPriority)
  */
-@property (atomic) NSInteger drawingPriority;
+@property NSInteger drawingPriority;
 
 /** @name Hit Testing */
 
@@ -486,7 +486,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * This affects the default implementation of -hitTest and -pointInside, so subclasses should call super if you override 
  * it and want hitTestSlop applied.
  */
-@property (atomic) UIEdgeInsets hitTestSlop;
+@property UIEdgeInsets hitTestSlop;
 
 /** 
  * @abstract Returns a Boolean value indicating whether the receiver contains the specified point.
@@ -549,21 +549,21 @@ extern NSInteger const ASDefaultDrawingPriority;
 /**
  * Whether or not the node would support having .layerBacked = YES.
  */
-@property (atomic, readonly) BOOL supportsLayerBacking;
+@property (readonly) BOOL supportsLayerBacking;
 
 /**
  * Whether or not the node layout should be automatically updated when it receives safeAreaInsetsDidChange.
  *
  * Defaults to NO.
  */
-@property (atomic) BOOL automaticallyRelayoutOnSafeAreaChanges;
+@property BOOL automaticallyRelayoutOnSafeAreaChanges;
 
 /**
  * Whether or not the node layout should be automatically updated when it receives layoutMarginsDidChange.
  *
  * Defaults to NO.
  */
-@property (atomic) BOOL automaticallyRelayoutOnLayoutMarginsChanges;
+@property BOOL automaticallyRelayoutOnLayoutMarginsChanges;
 
 @end
 
@@ -573,28 +573,18 @@ extern NSInteger const ASDefaultDrawingPriority;
 @interface ASDisplayNode (Debugging) <ASDebugNameProvider>
 
 /**
- * Set to YES to tell all ASDisplayNode instances to store their unflattened layouts.
+ * Whether or not ASDisplayNode instances should store their unflattened layouts.
  *
  * The layout can be accessed via `-unflattenedCalculatedLayout`.
  *
- * Flattened layouts use less memory and are faster to lookup. On the other hand, unflattened layouts are useful for debugging
- * because they preserve original information.
- */
-+ (void)setShouldStoreUnflattenedLayouts:(BOOL)shouldStore;
-
-/**
- * Whether or not ASDisplayNode instances should store their unflattened layouts. 
- *
- * The layout can be accessed via `-unflattenedCalculatedLayout`.
- * 
  * Flattened layouts use less memory and are faster to lookup. On the other hand, unflattened layouts are useful for debugging
  * because they preserve original information.
  *
  * Defaults to NO.
  */
-+ (BOOL)shouldStoreUnflattenedLayouts;
+@property (class) BOOL shouldStoreUnflattenedLayouts;
 
-@property (atomic, readonly, nullable) ASLayout *unflattenedCalculatedLayout;
+@property (nullable, readonly) ASLayout *unflattenedCalculatedLayout;
 
 /**
  * @abstract Return a description of the node hierarchy.
@@ -606,7 +596,7 @@ extern NSInteger const ASDefaultDrawingPriority;
 /**
  * A detailed description of this node's layout state. This is useful when debugging.
  */
-@property (atomic, copy, readonly) NSString *detailedLayoutDescription;
+@property (copy, readonly) NSString *detailedLayoutDescription;
 
 @end
 
@@ -645,10 +635,10 @@ extern NSInteger const ASDefaultDrawingPriority;
  */
 - (void)layoutIfNeeded;
 
-@property (atomic)           CGRect frame;                          // default=CGRectZero
-@property (atomic)           CGRect bounds;                         // default=CGRectZero
-@property (atomic)           CGPoint position;                      // default=CGPointZero
-@property (atomic)           CGFloat alpha;                         // default=1.0f
+@property           CGRect frame;                          // default=CGRectZero
+@property           CGRect bounds;                         // default=CGRectZero
+@property           CGPoint position;                      // default=CGPointZero
+@property           CGFloat alpha;                         // default=1.0f
 
 /* @abstract Sets the corner rounding method to use on the ASDisplayNode.
  * There are three types of corner rounding provided by Texture: CALayer, Precomposited, and Clipping.
@@ -672,33 +662,33 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @default ASCornerRoundingTypeDefaultSlowCALayer
  */
-@property (atomic)           ASCornerRoundingType cornerRoundingType;  // default=Slow CALayer .cornerRadius (offscreen rendering)
+@property           ASCornerRoundingType cornerRoundingType;  // default=Slow CALayer .cornerRadius (offscreen rendering)
 
 /** @abstract The radius to use when rounding corners of the ASDisplayNode.
  *
  * @discussion This property is thread-safe and should always be preferred over CALayer's cornerRadius property,
  * even if corner rounding type is ASCornerRoundingTypeDefaultSlowCALayer.
  */
-@property (atomic)           CGFloat cornerRadius;                     // default=0.0
+@property           CGFloat cornerRadius;                     // default=0.0
 
-@property (atomic)           BOOL clipsToBounds;                    // default==NO
-@property (atomic, getter=isHidden)  BOOL hidden;                           // default==NO
-@property (atomic, getter=isOpaque)  BOOL opaque;                           // default==YES
+@property           BOOL clipsToBounds;                    // default==NO
+@property (getter=isHidden)  BOOL hidden;                           // default==NO
+@property (getter=isOpaque)  BOOL opaque;                           // default==YES
 
-@property (nullable, atomic) id contents;                           // default=nil
-@property (atomic)           CGRect contentsRect;                   // default={0,0,1,1}. @see CALayer.h for details.
-@property (atomic)           CGRect contentsCenter;                 // default={0,0,1,1}. @see CALayer.h for details.
-@property (atomic)           CGFloat contentsScale;                 // default=1.0f. See @contentsScaleForDisplay for details.
-@property (atomic)           CGFloat rasterizationScale;            // default=1.0f.
+@property (nullable) id contents;                           // default=nil
+@property           CGRect contentsRect;                   // default={0,0,1,1}. @see CALayer.h for details.
+@property           CGRect contentsCenter;                 // default={0,0,1,1}. @see CALayer.h for details.
+@property           CGFloat contentsScale;                 // default=1.0f. See @contentsScaleForDisplay for details.
+@property           CGFloat rasterizationScale;            // default=1.0f.
 
-@property (atomic)           CGPoint anchorPoint;                   // default={0.5, 0.5}
-@property (atomic)           CGFloat zPosition;                     // default=0.0
-@property (atomic)           CATransform3D transform;               // default=CATransform3DIdentity
-@property (atomic)           CATransform3D subnodeTransform;        // default=CATransform3DIdentity
+@property           CGPoint anchorPoint;                   // default={0.5, 0.5}
+@property           CGFloat zPosition;                     // default=0.0
+@property           CATransform3D transform;               // default=CATransform3DIdentity
+@property           CATransform3D subnodeTransform;        // default=CATransform3DIdentity
 
-@property (atomic, getter=isUserInteractionEnabled) BOOL userInteractionEnabled; // default=YES (NO for layer-backed nodes)
+@property (getter=isUserInteractionEnabled) BOOL userInteractionEnabled; // default=YES (NO for layer-backed nodes)
 #if TARGET_OS_IOS
-@property (atomic, getter=isExclusiveTouch) BOOL exclusiveTouch;    // default=NO
+@property (getter=isExclusiveTouch) BOOL exclusiveTouch;    // default=NO
 #endif
 
 /**
@@ -707,9 +697,9 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @discussion In contrast to UIView, setting a transparent color will not set opaque = NO.
  * This only affects nodes that implement +drawRect like ASTextNode.
 */
-@property (nullable, atomic, copy) UIColor *backgroundColor;              // default=nil
+@property (nullable, copy) UIColor *backgroundColor;              // default=nil
 
-@property (null_resettable, atomic, copy) UIColor *tintColor;             // default=Blue
+@property (null_resettable, copy) UIColor *tintColor;             // default=Blue
 - (void)tintColorDidChange;                                                    // Notifies the node when the tintColor has changed.
 
 /**
@@ -720,24 +710,24 @@ extern NSInteger const ASDefaultDrawingPriority;
  * Thus, UIViewContentModeRedraw is not allowed; use needsDisplayOnBoundsChange = YES instead, and pick an appropriate 
  * contentMode for your content while it's being re-rendered.
  */
-@property (atomic)           UIViewContentMode contentMode;         // default=UIViewContentModeScaleToFill
-@property (atomic, copy)             NSString *contentsGravity;             // Use .contentMode in preference when possible.
-@property (atomic)           UISemanticContentAttribute semanticContentAttribute;
+@property           UIViewContentMode contentMode;         // default=UIViewContentModeScaleToFill
+@property (copy)             NSString *contentsGravity;             // Use .contentMode in preference when possible.
+@property           UISemanticContentAttribute semanticContentAttribute;
 
-@property (nullable, atomic)         CGColorRef shadowColor;                // default=opaque rgb black
-@property (atomic)           CGFloat shadowOpacity;                 // default=0.0
-@property (atomic)           CGSize shadowOffset;                   // default=(0, -3)
-@property (atomic)           CGFloat shadowRadius;                  // default=3
-@property (atomic)           CGFloat borderWidth;                   // default=0
-@property (nullable, atomic)         CGColorRef borderColor;                // default=opaque rgb black
+@property (nullable)         CGColorRef shadowColor;                // default=opaque rgb black
+@property           CGFloat shadowOpacity;                 // default=0.0
+@property           CGSize shadowOffset;                   // default=(0, -3)
+@property           CGFloat shadowRadius;                  // default=3
+@property           CGFloat borderWidth;                   // default=0
+@property (nullable)         CGColorRef borderColor;                // default=opaque rgb black
 
-@property (atomic)           BOOL allowsGroupOpacity;
-@property (atomic)           BOOL allowsEdgeAntialiasing;
-@property (atomic)           unsigned int edgeAntialiasingMask;     // default==all values from CAEdgeAntialiasingMask
+@property           BOOL allowsGroupOpacity;
+@property           BOOL allowsEdgeAntialiasing;
+@property           unsigned int edgeAntialiasingMask;     // default==all values from CAEdgeAntialiasingMask
 
-@property (atomic)           BOOL needsDisplayOnBoundsChange;       // default==NO
-@property (atomic)           BOOL autoresizesSubviews;              // default==YES (undefined for layer-backed nodes)
-@property (atomic)           UIViewAutoresizing autoresizingMask;   // default==UIViewAutoresizingNone (undefined for layer-backed nodes)
+@property           BOOL needsDisplayOnBoundsChange;       // default==NO
+@property           BOOL autoresizesSubviews;              // default==YES (undefined for layer-backed nodes)
+@property           UIViewAutoresizing autoresizingMask;   // default==UIViewAutoresizingNone (undefined for layer-backed nodes)
 
 /**
  * @abstract Content margins
@@ -748,8 +738,8 @@ extern NSInteger const ASDefaultDrawingPriority;
  * that the layout gets automatically updated when the value of this property changes. Or you can override layoutMarginsDidChange
  * and make all the necessary updates manually.
  */
-@property (atomic)           UIEdgeInsets layoutMargins;
-@property (atomic)           BOOL preservesSuperviewLayoutMargins;  // default is NO - set to enable pass-through or cascading behavior of margins from this view’s parent to its children
+@property           UIEdgeInsets layoutMargins;
+@property           BOOL preservesSuperviewLayoutMargins;  // default is NO - set to enable pass-through or cascading behavior of margins from this view’s parent to its children
 - (void)layoutMarginsDidChange;
 
 /**
@@ -761,8 +751,8 @@ extern NSInteger const ASDefaultDrawingPriority;
  * that the layout gets automatically updated when the value of this property changes. Or you can override safeAreaInsetsDidChange
  * and make all the necessary updates manually.
  */
-@property (atomic, readonly)         UIEdgeInsets safeAreaInsets;
-@property (atomic)           BOOL insetsLayoutMarginsFromSafeArea;  // Default: YES
+@property (readonly)         UIEdgeInsets safeAreaInsets;
+@property           BOOL insetsLayoutMarginsFromSafeArea;  // Default: YES
 - (void)safeAreaInsetsDidChange;
 
 
@@ -773,15 +763,15 @@ extern NSInteger const ASDefaultDrawingPriority;
 - (BOOL)canResignFirstResponder;                                            // default==YES
 - (BOOL)resignFirstResponder;                                               // default==NO (no-op)
 - (BOOL)isFirstResponder;
-- (BOOL)canPerformAction:(nonnull SEL)action withSender:(nonnull id)sender;
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
 
 #if TARGET_OS_TV
 //Focus Engine
 - (void)setNeedsFocusUpdate;
 - (BOOL)canBecomeFocused;
 - (void)updateFocusIfNeeded;
-- (void)didUpdateFocusInContext:(nonnull UIFocusUpdateContext *)context withAnimationCoordinator:(nonnull UIFocusAnimationCoordinator *)coordinator;
-- (BOOL)shouldUpdateFocusInContext:(nonnull UIFocusUpdateContext *)context;
+- (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator;
+- (BOOL)shouldUpdateFocusInContext:(UIFocusUpdateContext *)context;
 - (nullable UIView *)preferredFocusedView;
 #endif
 
@@ -790,28 +780,28 @@ extern NSInteger const ASDefaultDrawingPriority;
 @interface ASDisplayNode (UIViewBridgeAccessibility)
 
 // Accessibility support
-@property (atomic)           BOOL isAccessibilityElement;
-@property (nullable, atomic, copy)   NSString *accessibilityLabel;
-@property (nullable, atomic, copy)   NSAttributedString *accessibilityAttributedLabel API_AVAILABLE(ios(11.0),tvos(11.0));
-@property (nullable, atomic, copy)   NSString *accessibilityHint;
-@property (nullable, atomic, copy)   NSAttributedString *accessibilityAttributedHint API_AVAILABLE(ios(11.0),tvos(11.0));
-@property (nullable, atomic, copy)   NSString *accessibilityValue;
-@property (nullable, atomic, copy)   NSAttributedString *accessibilityAttributedValue API_AVAILABLE(ios(11.0),tvos(11.0));
-@property (atomic)           UIAccessibilityTraits accessibilityTraits;
-@property (atomic)           CGRect accessibilityFrame;
-@property (nullable, atomic, copy)   UIBezierPath *accessibilityPath;
-@property (atomic)           CGPoint accessibilityActivationPoint;
-@property (nullable, atomic, copy)   NSString *accessibilityLanguage;
-@property (atomic)           BOOL accessibilityElementsHidden;
-@property (atomic)           BOOL accessibilityViewIsModal;
-@property (atomic)           BOOL shouldGroupAccessibilityChildren;
-@property (atomic)           UIAccessibilityNavigationStyle accessibilityNavigationStyle;
+@property           BOOL isAccessibilityElement;
+@property (nullable, copy)   NSString *accessibilityLabel;
+@property (nullable, copy)   NSAttributedString *accessibilityAttributedLabel API_AVAILABLE(ios(11.0),tvos(11.0));
+@property (nullable, copy)   NSString *accessibilityHint;
+@property (nullable, copy)   NSAttributedString *accessibilityAttributedHint API_AVAILABLE(ios(11.0),tvos(11.0));
+@property (nullable, copy)   NSString *accessibilityValue;
+@property (nullable, copy)   NSAttributedString *accessibilityAttributedValue API_AVAILABLE(ios(11.0),tvos(11.0));
+@property           UIAccessibilityTraits accessibilityTraits;
+@property           CGRect accessibilityFrame;
+@property (nullable, copy)   UIBezierPath *accessibilityPath;
+@property           CGPoint accessibilityActivationPoint;
+@property (nullable, copy)   NSString *accessibilityLanguage;
+@property           BOOL accessibilityElementsHidden;
+@property           BOOL accessibilityViewIsModal;
+@property           BOOL shouldGroupAccessibilityChildren;
+@property           UIAccessibilityNavigationStyle accessibilityNavigationStyle;
 #if TARGET_OS_TV
-@property(nullable, atomic, copy) 	NSArray *accessibilityHeaderElements;
+@property (nullable, copy) 	NSArray *accessibilityHeaderElements;
 #endif
 
 // Accessibility identification support
-@property (nullable, atomic, copy)   NSString *accessibilityIdentifier;
+@property (nullable, copy)   NSString *accessibilityIdentifier;
 
 @end
 
@@ -858,7 +848,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @code ^ASLayoutSpec *(__kindof ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {};
  */
-@property (nullable, atomic, copy) ASLayoutSpecBlock layoutSpecBlock;
+@property (nullable) ASLayoutSpecBlock layoutSpecBlock;
 
 /** 
  * @abstract Return the calculated size.
@@ -870,14 +860,14 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @warning Subclasses must not override this; it returns the last cached measurement and is never expensive.
  */
-@property (atomic, readonly) CGSize calculatedSize;
+@property (readonly) CGSize calculatedSize;
 
 /** 
  * @abstract Return the constrained size range used for calculating layout.
  *
  * @return The minimum and maximum constrained sizes used by calculateLayoutThatFits:.
  */
-@property (atomic, readonly) ASSizeRange constrainedSizeForCalculatedLayout;
+@property (readonly) ASSizeRange constrainedSizeForCalculatedLayout;
 
 
 @end
@@ -887,19 +877,19 @@ extern NSInteger const ASDefaultDrawingPriority;
 /**
  * @abstract The amount of time it takes to complete the default transition animation. Default is 0.2.
  */
-@property (atomic) NSTimeInterval defaultLayoutTransitionDuration;
+@property NSTimeInterval defaultLayoutTransitionDuration;
 
 /**
  * @abstract The amount of time (measured in seconds) to wait before beginning the default transition animation.
  *           Default is 0.0.
  */
-@property (atomic) NSTimeInterval defaultLayoutTransitionDelay;
+@property NSTimeInterval defaultLayoutTransitionDelay;
 
 /**
  * @abstract A mask of options indicating how you want to perform the default transition animations.
  *           For a list of valid constants, see UIViewAnimationOptions.
  */
-@property (atomic) UIViewAnimationOptions defaultLayoutTransitionOptions;
+@property UIViewAnimationOptions defaultLayoutTransitionOptions;
 
 /**
  * @discussion A place to perform your animation. New nodes have been inserted here. You can also use this time to re-order the hierarchy.
@@ -965,7 +955,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @discussion If flag is YES the node no longer require addSubnode: or removeFromSupernode method calls. The presence
  * or absence of subnodes is completely determined in its layoutSpecThatFits: method.
  */
-@property (atomic) BOOL automaticallyManagesSubnodes;
+@property BOOL automaticallyManagesSubnodes;
 
 @end
 
@@ -983,7 +973,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @param node The node to be added.
  */
-- (void)addSubnode:(nonnull ASDisplayNode *)node;
+- (void)addSubnode:(ASDisplayNode *)node;
 @end
 
 /*
@@ -995,7 +985,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @param node The node to be added.
  */
-- (void)addSubnode:(nonnull ASDisplayNode *)node;
+- (void)addSubnode:(ASDisplayNode *)node;
 
 @end
 

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -61,13 +61,13 @@ typedef void (^ASDisplayNodeContextModifier)(CGContextRef context, id _Nullable 
 /**
  * ASDisplayNode layout spec block. This block can be used instead of implementing layoutSpecThatFits: in subclass
  */
-typedef ASLayoutSpec * _Nonnull(^ASLayoutSpecBlock)(__kindof ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize);
+typedef ASLayoutSpec * _Nonnull(^ASLayoutSpecBlock)(__kindof ASDisplayNode *node, ASSizeRange constrainedSize);
 
 /**
  * AsyncDisplayKit non-fatal error block. This block can be used for handling non-fatal errors. Useful for reporting
  * errors that happens in production.
  */
-typedef void (^ASDisplayNodeNonFatalErrorBlock)(__kindof NSError * _Nonnull error);
+typedef void (^ASDisplayNodeNonFatalErrorBlock)(NSError *error);
 
 /**
  * Interface state is available on ASDisplayNode and ASViewController, and
@@ -221,7 +221,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @return NO if the node wraps a _ASDisplayView, YES otherwise.
  */
-@property (atomic, readonly, assign, getter=isSynchronous) BOOL synchronous;
+@property (atomic, readonly, getter=isSynchronous) BOOL synchronous;
 
 /** @name Getting view and layer */
 
@@ -234,21 +234,21 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @warning The first access to it must be on the main thread, and should only be used on the main thread thereafter as 
  * well.
  */
-@property (nonatomic, readonly, strong) UIView *view;
+@property (atomic, readonly) UIView *view;
 
 /** 
  * @abstract Returns whether a node's backing view or layer is loaded.
  *
  * @return YES if a view is loaded, or if layerBacked is YES and layer is not nil; NO otherwise.
  */
-@property (nonatomic, readonly, assign, getter=isNodeLoaded) BOOL nodeLoaded;
+@property (atomic, readonly, getter=isNodeLoaded) BOOL nodeLoaded;
 
 /** 
  * @abstract Returns whether the node rely on a layer instead of a view.
  *
  * @return YES if the node rely on a layer, NO otherwise.
  */
-@property (nonatomic, assign, getter=isLayerBacked) BOOL layerBacked;
+@property (atomic, getter=isLayerBacked) BOOL layerBacked;
 
 /** 
  * @abstract Returns a layer.
@@ -259,28 +259,28 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @warning The first access to it must be on the main thread, and should only be used on the main thread thereafter as 
  * well.
  */
-@property (nonatomic, readonly, strong) CALayer * _Nonnull layer;
+@property (atomic, readonly) CALayer * layer;
 
 /**
  * Returns YES if the node is – at least partially – visible in a window.
  *
  * @see didEnterVisibleState and didExitVisibleState
  */
-@property (readonly, getter=isVisible) BOOL visible;
+@property (atomic, readonly, getter=isVisible) BOOL visible;
 
 /**
  * Returns YES if the node is in the preloading interface state.
  *
  * @see didEnterPreloadState and didExitPreloadState
  */
-@property (readonly, getter=isInPreloadState) BOOL inPreloadState;
+@property (atomic, readonly, getter=isInPreloadState) BOOL inPreloadState;
 
 /**
  * Returns YES if the node is in the displaying interface state.
  *
  * @see didEnterDisplayState and didExitDisplayState
  */
-@property (readonly, getter=isInDisplayState) BOOL inDisplayState;
+@property (atomic, readonly, getter=isInDisplayState) BOOL inDisplayState;
 
 /**
  * @abstract Returns the Interface State of the node.
@@ -289,7 +289,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @see ASInterfaceState
  */
-@property (readonly) ASInterfaceState interfaceState;
+@property (atomic, readonly) ASInterfaceState interfaceState;
 
 /**
  * @abstract Class property that allows to set a block that can be called on non-fatal errors. This
@@ -371,12 +371,12 @@ extern NSInteger const ASDefaultDrawingPriority;
 /** 
  * @abstract The receiver's immediate subnodes.
  */
-@property (nonatomic, readonly, copy) NSArray<ASDisplayNode *> *subnodes;
+@property (nullable, atomic, readonly, copy) NSArray<ASDisplayNode *> *subnodes;
 
 /** 
  * @abstract The receiver's supernode.
  */
-@property (nonatomic, readonly, weak) ASDisplayNode *supernode;
+@property (nullable, atomic, readonly, weak) ASDisplayNode *supernode;
 
 
 /** @name Drawing and Updating the View */
@@ -409,7 +409,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * Note: this has nothing to do with -[CALayer drawsAsynchronously].
  */
-@property (nonatomic, assign) BOOL displaysAsynchronously;
+@property (atomic) BOOL displaysAsynchronously;
 
 /** 
  * @abstract Prevent the node's layer from displaying.
@@ -423,12 +423,12 @@ extern NSInteger const ASDefaultDrawingPriority;
  * If a setNeedsDisplay occurs while displaySuspended is YES, and displaySuspended is set to NO, then the 
  * layer will be automatically displayed.
  */
-@property (nonatomic, assign) BOOL displaySuspended;
+@property (atomic) BOOL displaySuspended;
 
 /**
  * @abstract Whether size changes should be animated. Default to YES.
  */
-@property (nonatomic, assign) BOOL shouldAnimateSizeChanges;
+@property (atomic) BOOL shouldAnimateSizeChanges;
 
 /** 
  * @abstract Prevent the node and its descendants' layer from displaying.
@@ -457,14 +457,14 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @discussion Defaults to NO.
  */
-@property (nonatomic, assign) BOOL placeholderEnabled;
+@property (atomic) BOOL placeholderEnabled;
 
 /**
  * @abstract Set the time it takes to fade out the placeholder when a node's contents are finished displaying.
  *
  * @discussion Defaults to 0 seconds.
  */
-@property (nonatomic, assign) NSTimeInterval placeholderFadeDuration;
+@property (atomic) NSTimeInterval placeholderFadeDuration;
 
 /**
  * @abstract Determines drawing priority of the node. Nodes with higher priority will be drawn earlier.
@@ -472,7 +472,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @discussion Defaults to ASDefaultDrawingPriority. There may be multiple drawing threads, and some of them may
  * decide to perform operations in queued order (regardless of drawingPriority)
  */
-@property (atomic, assign) NSInteger drawingPriority;
+@property (atomic) NSInteger drawingPriority;
 
 /** @name Hit Testing */
 
@@ -486,7 +486,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * This affects the default implementation of -hitTest and -pointInside, so subclasses should call super if you override 
  * it and want hitTestSlop applied.
  */
-@property (nonatomic, assign) UIEdgeInsets hitTestSlop;
+@property (atomic) UIEdgeInsets hitTestSlop;
 
 /** 
  * @abstract Returns a Boolean value indicating whether the receiver contains the specified point.
@@ -549,21 +549,21 @@ extern NSInteger const ASDefaultDrawingPriority;
 /**
  * Whether or not the node would support having .layerBacked = YES.
  */
-@property (nonatomic, readonly) BOOL supportsLayerBacking;
+@property (atomic, readonly) BOOL supportsLayerBacking;
 
 /**
  * Whether or not the node layout should be automatically updated when it receives safeAreaInsetsDidChange.
  *
  * Defaults to NO.
  */
-@property (nonatomic, assign) BOOL automaticallyRelayoutOnSafeAreaChanges;
+@property (atomic) BOOL automaticallyRelayoutOnSafeAreaChanges;
 
 /**
  * Whether or not the node layout should be automatically updated when it receives layoutMarginsDidChange.
  *
  * Defaults to NO.
  */
-@property (nonatomic, assign) BOOL automaticallyRelayoutOnLayoutMarginsChanges;
+@property (atomic) BOOL automaticallyRelayoutOnLayoutMarginsChanges;
 
 @end
 
@@ -594,7 +594,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  */
 + (BOOL)shouldStoreUnflattenedLayouts;
 
-@property (nonatomic, strong, readonly, nullable) ASLayout *unflattenedCalculatedLayout;
+@property (atomic, readonly, nullable) ASLayout *unflattenedCalculatedLayout;
 
 /**
  * @abstract Return a description of the node hierarchy.
@@ -645,10 +645,10 @@ extern NSInteger const ASDefaultDrawingPriority;
  */
 - (void)layoutIfNeeded;
 
-@property (nonatomic, assign)           CGRect frame;                          // default=CGRectZero
-@property (nonatomic, assign)           CGRect bounds;                         // default=CGRectZero
-@property (nonatomic, assign)           CGPoint position;                      // default=CGPointZero
-@property (nonatomic, assign)           CGFloat alpha;                         // default=1.0f
+@property (atomic)           CGRect frame;                          // default=CGRectZero
+@property (atomic)           CGRect bounds;                         // default=CGRectZero
+@property (atomic)           CGPoint position;                      // default=CGPointZero
+@property (atomic)           CGFloat alpha;                         // default=1.0f
 
 /* @abstract Sets the corner rounding method to use on the ASDisplayNode.
  * There are three types of corner rounding provided by Texture: CALayer, Precomposited, and Clipping.
@@ -672,33 +672,33 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @default ASCornerRoundingTypeDefaultSlowCALayer
  */
-@property (nonatomic, assign)           ASCornerRoundingType cornerRoundingType;  // default=Slow CALayer .cornerRadius (offscreen rendering)
+@property (atomic)           ASCornerRoundingType cornerRoundingType;  // default=Slow CALayer .cornerRadius (offscreen rendering)
 
 /** @abstract The radius to use when rounding corners of the ASDisplayNode.
  *
  * @discussion This property is thread-safe and should always be preferred over CALayer's cornerRadius property,
  * even if corner rounding type is ASCornerRoundingTypeDefaultSlowCALayer.
  */
-@property (nonatomic, assign)           CGFloat cornerRadius;                     // default=0.0
+@property (atomic)           CGFloat cornerRadius;                     // default=0.0
 
-@property (nonatomic, assign)           BOOL clipsToBounds;                    // default==NO
-@property (nonatomic, getter=isHidden)  BOOL hidden;                           // default==NO
-@property (nonatomic, getter=isOpaque)  BOOL opaque;                           // default==YES
+@property (atomic)           BOOL clipsToBounds;                    // default==NO
+@property (atomic, getter=isHidden)  BOOL hidden;                           // default==NO
+@property (atomic, getter=isOpaque)  BOOL opaque;                           // default==YES
 
-@property (nonatomic, strong, nullable) id contents;                           // default=nil
-@property (nonatomic, assign)           CGRect contentsRect;                   // default={0,0,1,1}. @see CALayer.h for details.
-@property (nonatomic, assign)           CGRect contentsCenter;                 // default={0,0,1,1}. @see CALayer.h for details.
-@property (nonatomic, assign)           CGFloat contentsScale;                 // default=1.0f. See @contentsScaleForDisplay for details.
-@property (nonatomic, assign)           CGFloat rasterizationScale;            // default=1.0f.
+@property (nullable, atomic) id contents;                           // default=nil
+@property (atomic)           CGRect contentsRect;                   // default={0,0,1,1}. @see CALayer.h for details.
+@property (atomic)           CGRect contentsCenter;                 // default={0,0,1,1}. @see CALayer.h for details.
+@property (atomic)           CGFloat contentsScale;                 // default=1.0f. See @contentsScaleForDisplay for details.
+@property (atomic)           CGFloat rasterizationScale;            // default=1.0f.
 
-@property (nonatomic, assign)           CGPoint anchorPoint;                   // default={0.5, 0.5}
-@property (nonatomic, assign)           CGFloat zPosition;                     // default=0.0
-@property (nonatomic, assign)           CATransform3D transform;               // default=CATransform3DIdentity
-@property (nonatomic, assign)           CATransform3D subnodeTransform;        // default=CATransform3DIdentity
+@property (atomic)           CGPoint anchorPoint;                   // default={0.5, 0.5}
+@property (atomic)           CGFloat zPosition;                     // default=0.0
+@property (atomic)           CATransform3D transform;               // default=CATransform3DIdentity
+@property (atomic)           CATransform3D subnodeTransform;        // default=CATransform3DIdentity
 
-@property (nonatomic, assign, getter=isUserInteractionEnabled) BOOL userInteractionEnabled; // default=YES (NO for layer-backed nodes)
+@property (atomic, getter=isUserInteractionEnabled) BOOL userInteractionEnabled; // default=YES (NO for layer-backed nodes)
 #if TARGET_OS_IOS
-@property (nonatomic, assign, getter=isExclusiveTouch) BOOL exclusiveTouch;    // default=NO
+@property (atomic, getter=isExclusiveTouch) BOOL exclusiveTouch;    // default=NO
 #endif
 
 /**
@@ -707,9 +707,9 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @discussion In contrast to UIView, setting a transparent color will not set opaque = NO.
  * This only affects nodes that implement +drawRect like ASTextNode.
 */
-@property (nonatomic, strong, nullable) UIColor *backgroundColor;              // default=nil
+@property (nullable, atomic, copy) UIColor *backgroundColor;              // default=nil
 
-@property (nonatomic, strong, null_resettable) UIColor *tintColor;             // default=Blue
+@property (null_resettable, atomic, copy) UIColor *tintColor;             // default=Blue
 - (void)tintColorDidChange;                                                    // Notifies the node when the tintColor has changed.
 
 /**
@@ -720,24 +720,24 @@ extern NSInteger const ASDefaultDrawingPriority;
  * Thus, UIViewContentModeRedraw is not allowed; use needsDisplayOnBoundsChange = YES instead, and pick an appropriate 
  * contentMode for your content while it's being re-rendered.
  */
-@property (nonatomic, assign)           UIViewContentMode contentMode;         // default=UIViewContentModeScaleToFill
-@property (nonatomic, copy)             NSString *contentsGravity;             // Use .contentMode in preference when possible.
-@property (nonatomic, assign)           UISemanticContentAttribute semanticContentAttribute API_AVAILABLE(ios(9.0), tvos(9.0)); // default=Unspecified
+@property (atomic)           UIViewContentMode contentMode;         // default=UIViewContentModeScaleToFill
+@property (atomic, copy)             NSString *contentsGravity;             // Use .contentMode in preference when possible.
+@property (atomic)           UISemanticContentAttribute semanticContentAttribute;
 
-@property (nonatomic, nullable)         CGColorRef shadowColor;                // default=opaque rgb black
-@property (nonatomic, assign)           CGFloat shadowOpacity;                 // default=0.0
-@property (nonatomic, assign)           CGSize shadowOffset;                   // default=(0, -3)
-@property (nonatomic, assign)           CGFloat shadowRadius;                  // default=3
-@property (nonatomic, assign)           CGFloat borderWidth;                   // default=0
-@property (nonatomic, nullable)         CGColorRef borderColor;                // default=opaque rgb black
+@property (nullable, atomic)         CGColorRef shadowColor;                // default=opaque rgb black
+@property (atomic)           CGFloat shadowOpacity;                 // default=0.0
+@property (atomic)           CGSize shadowOffset;                   // default=(0, -3)
+@property (atomic)           CGFloat shadowRadius;                  // default=3
+@property (atomic)           CGFloat borderWidth;                   // default=0
+@property (nullable, atomic)         CGColorRef borderColor;                // default=opaque rgb black
 
-@property (nonatomic, assign)           BOOL allowsGroupOpacity;
-@property (nonatomic, assign)           BOOL allowsEdgeAntialiasing;
-@property (nonatomic, assign)           unsigned int edgeAntialiasingMask;     // default==all values from CAEdgeAntialiasingMask
+@property (atomic)           BOOL allowsGroupOpacity;
+@property (atomic)           BOOL allowsEdgeAntialiasing;
+@property (atomic)           unsigned int edgeAntialiasingMask;     // default==all values from CAEdgeAntialiasingMask
 
-@property (nonatomic, assign)           BOOL needsDisplayOnBoundsChange;       // default==NO
-@property (nonatomic, assign)           BOOL autoresizesSubviews;              // default==YES (undefined for layer-backed nodes)
-@property (nonatomic, assign)           UIViewAutoresizing autoresizingMask;   // default==UIViewAutoresizingNone (undefined for layer-backed nodes)
+@property (atomic)           BOOL needsDisplayOnBoundsChange;       // default==NO
+@property (atomic)           BOOL autoresizesSubviews;              // default==YES (undefined for layer-backed nodes)
+@property (atomic)           UIViewAutoresizing autoresizingMask;   // default==UIViewAutoresizingNone (undefined for layer-backed nodes)
 
 /**
  * @abstract Content margins
@@ -748,8 +748,8 @@ extern NSInteger const ASDefaultDrawingPriority;
  * that the layout gets automatically updated when the value of this property changes. Or you can override layoutMarginsDidChange
  * and make all the necessary updates manually.
  */
-@property (nonatomic, assign)           UIEdgeInsets layoutMargins;
-@property (nonatomic, assign)           BOOL preservesSuperviewLayoutMargins;  // default is NO - set to enable pass-through or cascading behavior of margins from this view’s parent to its children
+@property (atomic)           UIEdgeInsets layoutMargins;
+@property (atomic)           BOOL preservesSuperviewLayoutMargins;  // default is NO - set to enable pass-through or cascading behavior of margins from this view’s parent to its children
 - (void)layoutMarginsDidChange;
 
 /**
@@ -761,8 +761,8 @@ extern NSInteger const ASDefaultDrawingPriority;
  * that the layout gets automatically updated when the value of this property changes. Or you can override safeAreaInsetsDidChange
  * and make all the necessary updates manually.
  */
-@property (nonatomic, readonly)         UIEdgeInsets safeAreaInsets;
-@property (nonatomic, assign)           BOOL insetsLayoutMarginsFromSafeArea;  // Default: YES
+@property (atomic, readonly)         UIEdgeInsets safeAreaInsets;
+@property (atomic)           BOOL insetsLayoutMarginsFromSafeArea;  // Default: YES
 - (void)safeAreaInsetsDidChange;
 
 
@@ -790,28 +790,28 @@ extern NSInteger const ASDefaultDrawingPriority;
 @interface ASDisplayNode (UIViewBridgeAccessibility)
 
 // Accessibility support
-@property (nonatomic, assign)           BOOL isAccessibilityElement;
-@property (nonatomic, copy, nullable)   NSString *accessibilityLabel;
-@property (nonatomic, copy, nullable)   NSAttributedString *accessibilityAttributedLabel API_AVAILABLE(ios(11.0),tvos(11.0));
-@property (nonatomic, copy, nullable)   NSString *accessibilityHint;
-@property (nonatomic, copy, nullable)   NSAttributedString *accessibilityAttributedHint API_AVAILABLE(ios(11.0),tvos(11.0));
-@property (nonatomic, copy, nullable)   NSString *accessibilityValue;
-@property (nonatomic, copy, nullable)   NSAttributedString *accessibilityAttributedValue API_AVAILABLE(ios(11.0),tvos(11.0));
-@property (nonatomic, assign)           UIAccessibilityTraits accessibilityTraits;
-@property (nonatomic, assign)           CGRect accessibilityFrame;
-@property (nonatomic, copy, nullable)   UIBezierPath *accessibilityPath;
-@property (nonatomic, assign)           CGPoint accessibilityActivationPoint;
-@property (nonatomic, copy, nullable)   NSString *accessibilityLanguage;
-@property (nonatomic, assign)           BOOL accessibilityElementsHidden;
-@property (nonatomic, assign)           BOOL accessibilityViewIsModal;
-@property (nonatomic, assign)           BOOL shouldGroupAccessibilityChildren;
-@property (nonatomic, assign)           UIAccessibilityNavigationStyle accessibilityNavigationStyle;
+@property (atomic)           BOOL isAccessibilityElement;
+@property (nullable, atomic, copy)   NSString *accessibilityLabel;
+@property (nullable, atomic, copy)   NSAttributedString *accessibilityAttributedLabel API_AVAILABLE(ios(11.0),tvos(11.0));
+@property (nullable, atomic, copy)   NSString *accessibilityHint;
+@property (nullable, atomic, copy)   NSAttributedString *accessibilityAttributedHint API_AVAILABLE(ios(11.0),tvos(11.0));
+@property (nullable, atomic, copy)   NSString *accessibilityValue;
+@property (nullable, atomic, copy)   NSAttributedString *accessibilityAttributedValue API_AVAILABLE(ios(11.0),tvos(11.0));
+@property (atomic)           UIAccessibilityTraits accessibilityTraits;
+@property (atomic)           CGRect accessibilityFrame;
+@property (nullable, atomic, copy)   UIBezierPath *accessibilityPath;
+@property (atomic)           CGPoint accessibilityActivationPoint;
+@property (nullable, atomic, copy)   NSString *accessibilityLanguage;
+@property (atomic)           BOOL accessibilityElementsHidden;
+@property (atomic)           BOOL accessibilityViewIsModal;
+@property (atomic)           BOOL shouldGroupAccessibilityChildren;
+@property (atomic)           UIAccessibilityNavigationStyle accessibilityNavigationStyle;
 #if TARGET_OS_TV
-@property(nonatomic, copy, nullable) 	NSArray *accessibilityHeaderElements;
+@property(nullable, atomic, copy) 	NSArray *accessibilityHeaderElements;
 #endif
 
 // Accessibility identification support
-@property (nonatomic, copy, nullable)   NSString *accessibilityIdentifier;
+@property (nullable, atomic, copy)   NSString *accessibilityIdentifier;
 
 @end
 
@@ -858,7 +858,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @code ^ASLayoutSpec *(__kindof ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {};
  */
-@property (nonatomic, readwrite, copy, nullable) ASLayoutSpecBlock layoutSpecBlock;
+@property (nullable, atomic, copy) ASLayoutSpecBlock layoutSpecBlock;
 
 /** 
  * @abstract Return the calculated size.
@@ -870,14 +870,14 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @warning Subclasses must not override this; it returns the last cached measurement and is never expensive.
  */
-@property (nonatomic, readonly, assign) CGSize calculatedSize;
+@property (atomic, readonly) CGSize calculatedSize;
 
 /** 
  * @abstract Return the constrained size range used for calculating layout.
  *
  * @return The minimum and maximum constrained sizes used by calculateLayoutThatFits:.
  */
-@property (nonatomic, readonly, assign) ASSizeRange constrainedSizeForCalculatedLayout;
+@property (atomic, readonly) ASSizeRange constrainedSizeForCalculatedLayout;
 
 
 @end
@@ -887,19 +887,19 @@ extern NSInteger const ASDefaultDrawingPriority;
 /**
  * @abstract The amount of time it takes to complete the default transition animation. Default is 0.2.
  */
-@property (nonatomic, assign) NSTimeInterval defaultLayoutTransitionDuration;
+@property (atomic) NSTimeInterval defaultLayoutTransitionDuration;
 
 /**
  * @abstract The amount of time (measured in seconds) to wait before beginning the default transition animation.
  *           Default is 0.0.
  */
-@property (nonatomic, assign) NSTimeInterval defaultLayoutTransitionDelay;
+@property (atomic) NSTimeInterval defaultLayoutTransitionDelay;
 
 /**
  * @abstract A mask of options indicating how you want to perform the default transition animations.
  *           For a list of valid constants, see UIViewAnimationOptions.
  */
-@property (nonatomic, assign) UIViewAnimationOptions defaultLayoutTransitionOptions;
+@property (atomic) UIViewAnimationOptions defaultLayoutTransitionOptions;
 
 /**
  * @discussion A place to perform your animation. New nodes have been inserted here. You can also use this time to re-order the hierarchy.
@@ -965,7 +965,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @discussion If flag is YES the node no longer require addSubnode: or removeFromSupernode method calls. The presence
  * or absence of subnodes is completely determined in its layoutSpecThatFits: method.
  */
-@property (nonatomic, assign) BOOL automaticallyManagesSubnodes;
+@property (atomic) BOOL automaticallyManagesSubnodes;
 
 @end
 

--- a/Source/ASEditableTextNode.h
+++ b/Source/ASEditableTextNode.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
              placeholderTextKitComponents:(ASTextKitComponents *)placeholderTextKitComponents;
 
 //! @abstract The text node's delegate, which must conform to the <ASEditableTextNodeDelegate> protocol.
-@property (nullable, atomic, weak) id <ASEditableTextNodeDelegate> delegate;
+@property (nullable, weak) id <ASEditableTextNodeDelegate> delegate;
 
 #pragma mark - Configuration
 
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, copy) NSDictionary<NSString *, id> *typingAttributes;
 
 //! @abstract The range of text currently selected. If length is zero, the range is the cursor location.
-@property (atomic) NSRange selectedRange;
+@property NSRange selectedRange;
 
 #pragma mark - Placeholder
 /**

--- a/Source/ASEditableTextNode.h
+++ b/Source/ASEditableTextNode.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
              placeholderTextKitComponents:(ASTextKitComponents *)placeholderTextKitComponents;
 
 //! @abstract The text node's delegate, which must conform to the <ASEditableTextNodeDelegate> protocol.
-@property (nonatomic, readwrite, weak) id <ASEditableTextNodeDelegate> delegate;
+@property (nullable, atomic, weak) id <ASEditableTextNodeDelegate> delegate;
 
 #pragma mark - Configuration
 
@@ -62,13 +62,13 @@ NS_ASSUME_NONNULL_BEGIN
   @abstract Access to underlying UITextView for more configuration options.
   @warning This property should only be used on the main thread and should not be accessed before the editable text node's view is created.
  */
-@property (nonatomic, readonly, strong) UITextView *textView;
+@property (nonatomic, readonly) UITextView *textView;
 
 //! @abstract The attributes to apply to new text being entered by the user.
-@property (nonatomic, readwrite, strong, nullable) NSDictionary<NSString *, id> *typingAttributes;
+@property (nullable, nonatomic, copy) NSDictionary<NSString *, id> *typingAttributes;
 
 //! @abstract The range of text currently selected. If length is zero, the range is the cursor location.
-@property (nonatomic, readwrite, assign) NSRange selectedRange;
+@property (atomic) NSRange selectedRange;
 
 #pragma mark - Placeholder
 /**
@@ -82,14 +82,14 @@ NS_ASSUME_NONNULL_BEGIN
   @abstract The styled placeholder text displayed by the text node while no text is entered
   @discussion The placeholder is displayed when the user has not entered any text and the keyboard is not visible.
  */
-@property (nonatomic, readwrite, strong, nullable) NSAttributedString *attributedPlaceholderText;
+@property (nullable, nonatomic, copy) NSAttributedString *attributedPlaceholderText;
 
 #pragma mark - Modifying User Text
 /**
   @abstract The styled text displayed by the receiver.
   @discussion When the placeholder is displayed (as indicated by -isDisplayingPlaceholder), this value is nil. Otherwise, this value is the attributed text the user has entered. This value can be modified regardless of whether the receiver is the first responder (and thus, editing) or not. Changing this value from nil to non-nil will result in the placeholder being hidden, and the new value being displayed.
  */
-@property (nonatomic, readwrite, copy, nullable) NSAttributedString *attributedText;
+@property (nullable, nonatomic, copy) NSAttributedString *attributedText;
 
 #pragma mark - Managing The Keyboard
 //! @abstract The text input mode used by the receiver's keyboard, if it is visible. This value is undefined if the receiver is not the first responder.
@@ -98,13 +98,13 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract The textContainerInset of both the placeholder and typed textView. This value defaults to UIEdgeInsetsZero.
  */
-@property (nonatomic, readwrite) UIEdgeInsets textContainerInset;
+@property (nonatomic) UIEdgeInsets textContainerInset;
 
 /**
  @abstract The maximum number of lines to display. Additional lines will require scrolling.
  @default 0 (No limit)
  */
-@property (nonatomic, assign) NSUInteger maximumLinesToDisplay;
+@property (nonatomic) NSUInteger maximumLinesToDisplay;
 
 /**
   @abstract Indicates whether the receiver's text view is the first responder, and thus has the keyboard visible and is prepared for editing by the user.
@@ -130,22 +130,22 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract <UITextInputTraits> properties.
  */
-@property(nonatomic, readwrite, assign) UITextAutocapitalizationType autocapitalizationType; // default is UITextAutocapitalizationTypeSentences
-@property(nonatomic, readwrite, assign) UITextAutocorrectionType autocorrectionType;         // default is UITextAutocorrectionTypeDefault
-@property(nonatomic, readwrite, assign) UITextSpellCheckingType spellCheckingType;           // default is UITextSpellCheckingTypeDefault;
-@property(nonatomic, readwrite, assign) UIKeyboardType keyboardType;                         // default is UIKeyboardTypeDefault
-@property(nonatomic, readwrite, assign) UIKeyboardAppearance keyboardAppearance;             // default is UIKeyboardAppearanceDefault
-@property(nonatomic, readwrite, assign) UIReturnKeyType returnKeyType;                       // default is UIReturnKeyDefault (See note under UIReturnKeyType enum)
-@property(nonatomic, readwrite, assign) BOOL enablesReturnKeyAutomatically;                  // default is NO (when YES, will automatically disable return key when text widget has zero-length contents, and will automatically enable when text widget has non-zero-length contents)
-@property(nonatomic, readwrite, assign, getter=isSecureTextEntry) BOOL secureTextEntry;      // default is NO
+@property (nonatomic) UITextAutocapitalizationType autocapitalizationType; // default is UITextAutocapitalizationTypeSentences
+@property (nonatomic) UITextAutocorrectionType autocorrectionType;         // default is UITextAutocorrectionTypeDefault
+@property (nonatomic) UITextSpellCheckingType spellCheckingType;           // default is UITextSpellCheckingTypeDefault;
+@property (nonatomic) UIKeyboardType keyboardType;                         // default is UIKeyboardTypeDefault
+@property (nonatomic) UIKeyboardAppearance keyboardAppearance;             // default is UIKeyboardAppearanceDefault
+@property (nonatomic) UIReturnKeyType returnKeyType;                       // default is UIReturnKeyDefault (See note under UIReturnKeyType enum)
+@property (nonatomic) BOOL enablesReturnKeyAutomatically;                  // default is NO (when YES, will automatically disable return key when text widget has zero-length contents, and will automatically enable when text widget has non-zero-length contents)
+@property (nonatomic, getter=isSecureTextEntry) BOOL secureTextEntry;      // default is NO
 
 @end
 
 @interface ASEditableTextNode (Unavailable)
 
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 @end
 

--- a/Source/ASEditableTextNode.mm
+++ b/Source/ASEditableTextNode.mm
@@ -31,14 +31,14 @@
 **/
 @interface _ASTextInputTraitsPendingState : NSObject
 
-@property (nonatomic, readwrite, assign) UITextAutocapitalizationType autocapitalizationType;
-@property (nonatomic, readwrite, assign) UITextAutocorrectionType autocorrectionType;
-@property (nonatomic, readwrite, assign) UITextSpellCheckingType spellCheckingType;
-@property (nonatomic, readwrite, assign) UIKeyboardAppearance keyboardAppearance;
-@property (nonatomic, readwrite, assign) UIKeyboardType keyboardType;
-@property (nonatomic, readwrite, assign) UIReturnKeyType returnKeyType;
-@property (nonatomic, readwrite, assign) BOOL enablesReturnKeyAutomatically;
-@property (nonatomic, readwrite, assign, getter=isSecureTextEntry) BOOL secureTextEntry;
+@property (atomic) UITextAutocapitalizationType autocapitalizationType;
+@property (atomic) UITextAutocorrectionType autocorrectionType;
+@property (atomic) UITextSpellCheckingType spellCheckingType;
+@property (atomic) UIKeyboardAppearance keyboardAppearance;
+@property (atomic) UIKeyboardType keyboardType;
+@property (atomic) UIReturnKeyType returnKeyType;
+@property (atomic) BOOL enablesReturnKeyAutomatically;
+@property (atomic, getter=isSecureTextEntry) BOOL secureTextEntry;
 
 @end
 
@@ -142,7 +142,7 @@
   NSRange _previousSelectedRange;
 }
 
-@property (nonatomic, strong, readonly) _ASTextInputTraitsPendingState *textInputTraits;
+@property (nonatomic, readonly) _ASTextInputTraitsPendingState *textInputTraits;
 
 @end
 

--- a/Source/ASEditableTextNode.mm
+++ b/Source/ASEditableTextNode.mm
@@ -31,14 +31,14 @@
 **/
 @interface _ASTextInputTraitsPendingState : NSObject
 
-@property (atomic) UITextAutocapitalizationType autocapitalizationType;
-@property (atomic) UITextAutocorrectionType autocorrectionType;
-@property (atomic) UITextSpellCheckingType spellCheckingType;
-@property (atomic) UIKeyboardAppearance keyboardAppearance;
-@property (atomic) UIKeyboardType keyboardType;
-@property (atomic) UIReturnKeyType returnKeyType;
-@property (atomic) BOOL enablesReturnKeyAutomatically;
-@property (atomic, getter=isSecureTextEntry) BOOL secureTextEntry;
+@property UITextAutocapitalizationType autocapitalizationType;
+@property UITextAutocorrectionType autocorrectionType;
+@property UITextSpellCheckingType spellCheckingType;
+@property UIKeyboardAppearance keyboardAppearance;
+@property UIKeyboardType keyboardType;
+@property UIReturnKeyType returnKeyType;
+@property BOOL enablesReturnKeyAutomatically;
+@property (getter=isSecureTextEntry) BOOL secureTextEntry;
 
 @end
 

--- a/Source/ASImageNode+AnimatedImage.mm
+++ b/Source/ASImageNode+AnimatedImage.mm
@@ -171,7 +171,7 @@ NSString *const ASAnimatedImageDefaultRunLoopMode = NSRunLoopCommonModes;
     [_displayLink removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:_animatedImageRunLoopMode];
     [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:runLoopMode];
   }
-  _animatedImageRunLoopMode = runLoopMode;
+  _animatedImageRunLoopMode = [runLoopMode copy];
 }
 
 - (void)setShouldAnimate:(BOOL)shouldAnimate

--- a/Source/ASImageNode.h
+++ b/Source/ASImageNode.h
@@ -45,12 +45,12 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * the layer's contentsCenter property.  Non-stretchable images work too, of
  * course.
  */
-@property (nullable, atomic) UIImage *image;
+@property (nullable) UIImage *image;
 
 /**
  @abstract The placeholder color.
  */
-@property (nullable, atomic, copy) UIColor *placeholderColor;
+@property (nullable, copy) UIColor *placeholderColor;
 
 /**
  * @abstract Indicates whether efficient cropping of the receiver is enabled.
@@ -58,7 +58,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * @discussion Defaults to YES. See -setCropEnabled:recropImmediately:inBounds: for more
  * information.
  */
-@property (atomic, getter=isCropEnabled) BOOL cropEnabled;
+@property (getter=isCropEnabled) BOOL cropEnabled;
 
 /**
  * @abstract Indicates that efficient downsizing of backing store should *not* be enabled.
@@ -66,7 +66,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * @discussion Defaults to NO. @see ASCroppedImageBackingSizeAndDrawRectInBounds for more
  * information.
  */
-@property (atomic) BOOL forceUpscaling;
+@property BOOL forceUpscaling;
 
 /**
  * @abstract Forces image to be rendered at forcedSize.
@@ -74,7 +74,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * Setting forcedSize to non-CGSizeZero will force the backing of the layer contents to 
  * be forcedSize (automatically adjusted for contentsSize).
  */
-@property (atomic) CGSize forcedSize;
+@property CGSize forcedSize;
 
 /**
  * @abstract Enables or disables efficient cropping.
@@ -105,7 +105,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * dimensions, and only the cropRect's origin will be used for positioning. The
  * default value of this property is CGRectMake(0.5, 0.5, 0.0, 0.0).
  */
-@property (atomic) CGRect cropRect;
+@property CGRect cropRect;
 
 /**
  * @abstract An optional block which can perform drawing operations on image
@@ -114,7 +114,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * @discussion Can be used to add image effects (such as rounding, adding
  * borders, or other pattern overlays) without extraneous display calls.
  */
-@property (nullable, atomic, copy) asimagenode_modification_block_t imageModificationBlock;
+@property (nullable) asimagenode_modification_block_t imageModificationBlock;
 
 /**
  * @abstract Marks the receiver as needing display and performs a block after
@@ -136,7 +136,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * is the default focus appearance.
  * Exposed here so the category methods can set it.
  */
-@property (atomic) BOOL isDefaultFocusAppearance;
+@property BOOL isDefaultFocusAppearance;
 #endif
 
 @end
@@ -157,7 +157,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * another method is used internally. If you need to know when the animatedImage
  * is set, override @c animatedImageSet:previousAnimatedImage:
  */
-@property (nullable, atomic) id <ASAnimatedImageProtocol> animatedImage;
+@property (nullable) id <ASAnimatedImageProtocol> animatedImage;
 
 /**
  * @abstract Pause the playback of an animated image.
@@ -165,7 +165,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * @discussion Set to YES to pause playback of an animated image and NO to resume
  * playback.
  */
-@property (atomic) BOOL animatedImagePaused;
+@property BOOL animatedImagePaused;
 
 /**
  * @abstract The runloop mode used to animate the image.
@@ -174,7 +174,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * Setting NSDefaultRunLoopMode will cause animation to pause while scrolling (if the ASImageNode is
  * in a scroll view), which may improve scroll performance in some use cases.
  */
-@property (atomic, copy) NSString *animatedImageRunLoopMode;
+@property (copy) NSString *animatedImageRunLoopMode;
 
 /**
  * @abstract Method called when animated image has been set

--- a/Source/ASImageNode.h
+++ b/Source/ASImageNode.h
@@ -45,12 +45,12 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * the layer's contentsCenter property.  Non-stretchable images work too, of
  * course.
  */
-@property (nullable, nonatomic, strong) UIImage *image;
+@property (nullable, atomic) UIImage *image;
 
 /**
  @abstract The placeholder color.
  */
-@property (nullable, nonatomic, strong) UIColor *placeholderColor;
+@property (nullable, atomic, copy) UIColor *placeholderColor;
 
 /**
  * @abstract Indicates whether efficient cropping of the receiver is enabled.
@@ -58,7 +58,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * @discussion Defaults to YES. See -setCropEnabled:recropImmediately:inBounds: for more
  * information.
  */
-@property (nonatomic, assign, getter=isCropEnabled) BOOL cropEnabled;
+@property (atomic, getter=isCropEnabled) BOOL cropEnabled;
 
 /**
  * @abstract Indicates that efficient downsizing of backing store should *not* be enabled.
@@ -66,7 +66,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * @discussion Defaults to NO. @see ASCroppedImageBackingSizeAndDrawRectInBounds for more
  * information.
  */
-@property (nonatomic, assign) BOOL forceUpscaling;
+@property (atomic) BOOL forceUpscaling;
 
 /**
  * @abstract Forces image to be rendered at forcedSize.
@@ -74,7 +74,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * Setting forcedSize to non-CGSizeZero will force the backing of the layer contents to 
  * be forcedSize (automatically adjusted for contentsSize).
  */
-@property (nonatomic, assign) CGSize forcedSize;
+@property (atomic) CGSize forcedSize;
 
 /**
  * @abstract Enables or disables efficient cropping.
@@ -105,7 +105,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * dimensions, and only the cropRect's origin will be used for positioning. The
  * default value of this property is CGRectMake(0.5, 0.5, 0.0, 0.0).
  */
-@property (nonatomic, readwrite, assign) CGRect cropRect;
+@property (atomic) CGRect cropRect;
 
 /**
  * @abstract An optional block which can perform drawing operations on image
@@ -114,7 +114,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * @discussion Can be used to add image effects (such as rounding, adding
  * borders, or other pattern overlays) without extraneous display calls.
  */
-@property (nullable, nonatomic, readwrite, copy) asimagenode_modification_block_t imageModificationBlock;
+@property (nullable, atomic, copy) asimagenode_modification_block_t imageModificationBlock;
 
 /**
  * @abstract Marks the receiver as needing display and performs a block after
@@ -136,7 +136,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * is the default focus appearance.
  * Exposed here so the category methods can set it.
  */
-@property (nonatomic, assign) BOOL isDefaultFocusAppearance;
+@property (atomic) BOOL isDefaultFocusAppearance;
 #endif
 
 @end
@@ -157,7 +157,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * another method is used internally. If you need to know when the animatedImage
  * is set, override @c animatedImageSet:previousAnimatedImage:
  */
-@property (nullable, nonatomic, strong) id <ASAnimatedImageProtocol> animatedImage;
+@property (nullable, atomic) id <ASAnimatedImageProtocol> animatedImage;
 
 /**
  * @abstract Pause the playback of an animated image.
@@ -165,7 +165,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * @discussion Set to YES to pause playback of an animated image and NO to resume
  * playback.
  */
-@property (nonatomic, assign) BOOL animatedImagePaused;
+@property (atomic) BOOL animatedImagePaused;
 
 /**
  * @abstract The runloop mode used to animate the image.
@@ -174,7 +174,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * Setting NSDefaultRunLoopMode will cause animation to pause while scrolling (if the ASImageNode is
  * in a scroll view), which may improve scroll performance in some use cases.
  */
-@property (nonatomic, strong) NSString *animatedImageRunLoopMode;
+@property (atomic, copy) NSString *animatedImageRunLoopMode;
 
 /**
  * @abstract Method called when animated image has been set

--- a/Source/ASMapNode.h
+++ b/Source/ASMapNode.h
@@ -47,46 +47,48 @@ typedef NS_OPTIONS(NSUInteger, ASMapNodeShowAnnotationsOptions)
     this will in effect be overwritten and become the value of the .region property on that object.
     Defaults to MKCoordinateRegionForMapRect(MKMapRectWorld).
  */
-@property (nonatomic, assign) MKCoordinateRegion region;
+@property (nonatomic) MKCoordinateRegion region;
 
 /**
  This is the MKMapView that is the live map part of ASMapNode. This will be nil if .liveMap = NO. Note, MKMapView is *not* thread-safe.
  */
-@property (nullable, nonatomic, readonly) MKMapView *mapView;
+@property (nullable, atomic, readonly) MKMapView *mapView;
 
 /**
  Set this to YES to turn the snapshot into an interactive MKMapView and vice versa. Defaults to NO. This property may be set on a background thread before the node is loaded, and will automatically be actioned, once the node is loaded. 
  */
-@property (nonatomic, assign, getter=isLiveMap) BOOL liveMap;
+@property (atomic, getter=isLiveMap) BOOL liveMap;
 
 /**
  @abstract Whether ASMapNode should automatically request a new map snapshot to correspond to the new node size.
  @default Default value is YES.
  @discussion If mapSize is set then this will be set to NO, since the size will be the same in all orientations.
  */
-@property (nonatomic, assign) BOOL needsMapReloadOnBoundsChange;
+@property (atomic) BOOL needsMapReloadOnBoundsChange;
 
 /**
  Set the delegate of the MKMapView. This can be set even before mapView is created and will be set on the map in the case that the liveMap mode is engaged.
+ 
+ If the live map view has been created, this may only be set on the main thread.
  */
 @property (nonatomic, weak) id <MKMapViewDelegate> mapDelegate;
 
 /**
  * @abstract The annotations to display on the map.
  */
-@property (nonatomic, copy) NSArray<id<MKAnnotation>> *annotations;
+@property (atomic, copy) NSArray<id<MKAnnotation>> *annotations;
 
 /**
  * @abstract This property specifies how to show the annotations.
  * @default Default value is ASMapNodeShowAnnotationsIgnored
  */
-@property (nonatomic, assign) ASMapNodeShowAnnotationsOptions showAnnotationsOptions;
+@property (atomic) ASMapNodeShowAnnotationsOptions showAnnotationsOptions;
 
 /**
  * @abstract The block which should return annotation image for static map based on provided annotation.
  * @discussion This block is executed on an arbitrary serial queue. If this block is nil, standard pin is used.
  */
-@property (nonatomic, copy, nullable) UIImage * _Nullable (^imageForStaticMapAnnotationBlock)(id<MKAnnotation> annotation, CGPoint *centerOffset);
+@property (nullable, atomic, copy) UIImage * _Nullable (^imageForStaticMapAnnotationBlock)(id<MKAnnotation> annotation, CGPoint *centerOffset);
 
 @end
 

--- a/Source/ASMapNode.h
+++ b/Source/ASMapNode.h
@@ -41,7 +41,7 @@ typedef NS_OPTIONS(NSUInteger, ASMapNodeShowAnnotationsOptions)
 /**
  The current options of ASMapNode. This can be set at any time and ASMapNode will animate the change.<br><br>This property may be set from a background thread before the node is loaded, and will automatically be applied to define the behavior of the static snapshot (if .liveMap = NO) or the internal MKMapView (otherwise).<br><br> Changes to the region and camera options will only be animated when when the liveMap mode is enabled, otherwise these options will be applied statically to the new snapshot. <br><br> The options object is used to specify properties even when the liveMap mode is enabled, allowing seamless transitions between the snapshot and liveMap (as well as back to the snapshot).
  */
-@property (nonatomic, strong) MKMapSnapshotOptions *options;
+@property (nonatomic) MKMapSnapshotOptions *options;
 
 /** The region is simply the sub-field on the options object.  If the objects object is reset,
     this will in effect be overwritten and become the value of the .region property on that object.
@@ -52,19 +52,19 @@ typedef NS_OPTIONS(NSUInteger, ASMapNodeShowAnnotationsOptions)
 /**
  This is the MKMapView that is the live map part of ASMapNode. This will be nil if .liveMap = NO. Note, MKMapView is *not* thread-safe.
  */
-@property (nullable, atomic, readonly) MKMapView *mapView;
+@property (nullable, readonly) MKMapView *mapView;
 
 /**
  Set this to YES to turn the snapshot into an interactive MKMapView and vice versa. Defaults to NO. This property may be set on a background thread before the node is loaded, and will automatically be actioned, once the node is loaded. 
  */
-@property (atomic, getter=isLiveMap) BOOL liveMap;
+@property (getter=isLiveMap) BOOL liveMap;
 
 /**
  @abstract Whether ASMapNode should automatically request a new map snapshot to correspond to the new node size.
  @default Default value is YES.
  @discussion If mapSize is set then this will be set to NO, since the size will be the same in all orientations.
  */
-@property (atomic) BOOL needsMapReloadOnBoundsChange;
+@property BOOL needsMapReloadOnBoundsChange;
 
 /**
  Set the delegate of the MKMapView. This can be set even before mapView is created and will be set on the map in the case that the liveMap mode is engaged.
@@ -76,19 +76,19 @@ typedef NS_OPTIONS(NSUInteger, ASMapNodeShowAnnotationsOptions)
 /**
  * @abstract The annotations to display on the map.
  */
-@property (atomic, copy) NSArray<id<MKAnnotation>> *annotations;
+@property (copy) NSArray<id<MKAnnotation>> *annotations;
 
 /**
  * @abstract This property specifies how to show the annotations.
  * @default Default value is ASMapNodeShowAnnotationsIgnored
  */
-@property (atomic) ASMapNodeShowAnnotationsOptions showAnnotationsOptions;
+@property ASMapNodeShowAnnotationsOptions showAnnotationsOptions;
 
 /**
  * @abstract The block which should return annotation image for static map based on provided annotation.
  * @discussion This block is executed on an arbitrary serial queue. If this block is nil, standard pin is used.
  */
-@property (nullable, atomic, copy) UIImage * _Nullable (^imageForStaticMapAnnotationBlock)(id<MKAnnotation> annotation, CGPoint *centerOffset);
+@property (nullable) UIImage * _Nullable (^imageForStaticMapAnnotationBlock)(id<MKAnnotation> annotation, CGPoint *centerOffset);
 
 @end
 

--- a/Source/ASMapNode.mm
+++ b/Source/ASMapNode.mm
@@ -177,10 +177,17 @@
   self.options = options;
 }
 
+- (id<MKMapViewDelegate>)mapDelegate
+{
+  return ASLockedSelf(_mapDelegate);
+}
+
 - (void)setMapDelegate:(id<MKMapViewDelegate>)mapDelegate {
+  ASLockScopeSelf();
   _mapDelegate = mapDelegate;
   
   if (_mapView) {
+    ASDisplayNodeAssertMainThread();
     _mapView.delegate = mapDelegate;
   }
 }

--- a/Source/ASMultiplexImageNode.h
+++ b/Source/ASMultiplexImageNode.h
@@ -93,7 +93,7 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
  * highest-quality image).  If that image is not immediately available or cached, the node can download and display
  * lesser-quality images.  Set `downloadsIntermediateImages` to YES to enable this behaviour.
  */
-@property (nonatomic, readwrite, assign) BOOL downloadsIntermediateImages;
+@property (nonatomic, readwrite) BOOL downloadsIntermediateImages;
 
 /**
  * @abstract An array of identifiers representing various versions of an image for ASMultiplexImageNode to display.
@@ -129,7 +129,7 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
  * image will be displayed as the image downloads. Regardless of this properties value, progress renders will
  * only occur when the node is visible. Defaults to YES.
  */
-@property (nonatomic, assign, readwrite) BOOL shouldRenderProgressImages;
+@property (nonatomic, readwrite) BOOL shouldRenderProgressImages;
 
 /**
  * @abstract The image manager that this image node should use when requesting images from the Photos framework. If this is `nil` (the default), then `PHImageManager.defaultManager` is used.

--- a/Source/ASMultiplexImageNode.h
+++ b/Source/ASMultiplexImageNode.h
@@ -78,13 +78,13 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
 /**
  * @abstract The delegate, which must conform to the <ASMultiplexImageNodeDelegate> protocol.
  */
-@property (nonatomic, readwrite, weak) id <ASMultiplexImageNodeDelegate> delegate;
+@property (nonatomic, weak) id <ASMultiplexImageNodeDelegate> delegate;
 
 /**
  * @abstract The data source, which must conform to the <ASMultiplexImageNodeDataSource> protocol.
  * @discussion This value is required for ASMultiplexImageNode to load images.
  */
-@property (nonatomic, readwrite, weak) id <ASMultiplexImageNodeDataSource> dataSource;
+@property (nonatomic, weak) id <ASMultiplexImageNodeDataSource> dataSource;
 
 /**
  * @abstract Whether the receiver should download more than just its highest-quality image.  Defaults to NO.
@@ -93,7 +93,7 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
  * highest-quality image).  If that image is not immediately available or cached, the node can download and display
  * lesser-quality images.  Set `downloadsIntermediateImages` to YES to enable this behaviour.
  */
-@property (nonatomic, readwrite) BOOL downloadsIntermediateImages;
+@property (nonatomic) BOOL downloadsIntermediateImages;
 
 /**
  * @abstract An array of identifiers representing various versions of an image for ASMultiplexImageNode to display.
@@ -103,7 +103,7 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
  *
  * @see <downloadsIntermediateImages> for more information on the image loading process.
  */
-@property (nonatomic, readwrite, copy) NSArray<ASImageIdentifier> *imageIdentifiers;
+@property (nonatomic, copy) NSArray<ASImageIdentifier> *imageIdentifiers;
 
 /**
  * @abstract Notify the receiver SSAA that its data source has new UIImages or NSURLs available for <imageIdentifiers>.
@@ -129,14 +129,14 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
  * image will be displayed as the image downloads. Regardless of this properties value, progress renders will
  * only occur when the node is visible. Defaults to YES.
  */
-@property (nonatomic, readwrite) BOOL shouldRenderProgressImages;
+@property (nonatomic) BOOL shouldRenderProgressImages;
 
 /**
  * @abstract The image manager that this image node should use when requesting images from the Photos framework. If this is `nil` (the default), then `PHImageManager.defaultManager` is used.
  
  * @see `+[NSURL URLWithAssetLocalIdentifier:targetSize:contentMode:options:]` below.
  */
-@property (nullable, nonatomic, strong) PHImageManager *imageManager API_AVAILABLE(ios(8.0), tvos(10.0));
+@property (nullable, nonatomic) PHImageManager *imageManager API_AVAILABLE(ios(8.0), tvos(10.0));
 @end
 
 

--- a/Source/ASMultiplexImageNode.mm
+++ b/Source/ASMultiplexImageNode.mm
@@ -98,10 +98,10 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 }
 
 //! @abstract Read-write redeclaration of property declared in ASMultiplexImageNode.h.
-@property (nonatomic, readwrite, copy) id loadedImageIdentifier;
+@property (nonatomic, copy) id loadedImageIdentifier;
 
 //! @abstract The image identifier that's being loaded by _loadNextImageWithCompletion:.
-@property (nonatomic, readwrite, copy) id loadingImageIdentifier;
+@property (nonatomic, copy) id loadingImageIdentifier;
 
 /**
   @abstract Returns the next image identifier that should be downloaded.

--- a/Source/ASNetworkImageNode.h
+++ b/Source/ASNetworkImageNode.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The delegate, which must conform to the <ASNetworkImageNodeDelegate> protocol.
  */
-@property (nullable, atomic, weak) id<ASNetworkImageNodeDelegate> delegate;
+@property (nullable, weak) id<ASNetworkImageNodeDelegate> delegate;
 
 /**
  * The image to display.
@@ -65,14 +65,14 @@ NS_ASSUME_NONNULL_BEGIN
  * (<defaultImage>) image while loading and the final image after the new image data was downloaded and processed.
  * If you want to use a placholder image functionality use the defaultImage property instead.
  */
-@property (nullable, atomic) UIImage *image;
+@property (nullable) UIImage *image;
 
 /**
  * A placeholder image to display while the URL is loading. This is slightly different than placeholderImage in the
  * ASDisplayNode superclass as defaultImage will *not* be displayed synchronously. If you wish to have the image
  * displayed synchronously, use @c placeholderImage.
  */
-@property (nullable, atomic) UIImage *defaultImage;
+@property (nullable) UIImage *defaultImage;
 
 /**
  * The URL of a new image to download and display.
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
  * directly set images to the image property will be cleared out and replaced by the placeholder (<defaultImage>) image
  * while loading and the final image after the new image data was downloaded and processed.
  */
-@property (nullable, atomic, copy) NSURL *URL;
+@property (nullable, copy) NSURL *URL;
 
 /**
   * An array of URLs of increasing cost to download.
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
   * @deprecated This API has been removed for now due to the increased complexity to the class that it brought.
   * Please use .URL instead.
   */
-@property (nullable, atomic, copy) NSArray <NSURL *> *URLs ASDISPLAYNODE_DEPRECATED_MSG("Please use URL instead.");
+@property (nullable, copy) NSArray <NSURL *> *URLs ASDISPLAYNODE_DEPRECATED_MSG("Please use URL instead.");
 
 /**
  * Download and display a new image.
@@ -110,14 +110,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * If <URL> is a local file, set this property to YES to take advantage of UIKit's image caching.  Defaults to YES.
  */
-@property (atomic) BOOL shouldCacheImage;
+@property BOOL shouldCacheImage;
 
 /**
  * If the downloader implements progressive image rendering and this value is YES progressive renders of the
  * image will be displayed as the image downloads. Regardless of this properties value, progress renders will
  * only occur when the node is visible. Defaults to YES.
  */
-@property (atomic) BOOL shouldRenderProgressImages;
+@property BOOL shouldRenderProgressImages;
 
 /**
  * The image quality of the current image.
@@ -129,12 +129,12 @@ NS_ASSUME_NONNULL_BEGIN
  * If the URL is unset, this is 1 if defaultImage or image is set to non-nil.
  *
  */
-@property (atomic, readonly) CGFloat currentImageQuality;
+@property (readonly) CGFloat currentImageQuality;
 
 /**
  * The currentImageQuality (value between 0 and 1) of the last image that completed displaying.
  */
-@property (atomic, readonly) CGFloat renderedImageQuality;
+@property (readonly) CGFloat renderedImageQuality;
 
 @end
 

--- a/Source/ASNetworkImageNode.h
+++ b/Source/ASNetworkImageNode.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The delegate, which must conform to the <ASNetworkImageNodeDelegate> protocol.
  */
-@property (nullable, nonatomic, weak, readwrite) id<ASNetworkImageNodeDelegate> delegate;
+@property (nullable, atomic, weak) id<ASNetworkImageNodeDelegate> delegate;
 
 /**
  * The image to display.
@@ -65,14 +65,14 @@ NS_ASSUME_NONNULL_BEGIN
  * (<defaultImage>) image while loading and the final image after the new image data was downloaded and processed.
  * If you want to use a placholder image functionality use the defaultImage property instead.
  */
-@property (nullable, nonatomic, strong) UIImage *image;
+@property (nullable, atomic) UIImage *image;
 
 /**
  * A placeholder image to display while the URL is loading. This is slightly different than placeholderImage in the
  * ASDisplayNode superclass as defaultImage will *not* be displayed synchronously. If you wish to have the image
  * displayed synchronously, use @c placeholderImage.
  */
-@property (nullable, nonatomic, strong, readwrite) UIImage *defaultImage;
+@property (nullable, atomic) UIImage *defaultImage;
 
 /**
  * The URL of a new image to download and display.
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
  * directly set images to the image property will be cleared out and replaced by the placeholder (<defaultImage>) image
  * while loading and the final image after the new image data was downloaded and processed.
  */
-@property (nullable, nonatomic, strong, readwrite) NSURL *URL;
+@property (nullable, atomic, copy) NSURL *URL;
 
 /**
   * An array of URLs of increasing cost to download.
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
   * @deprecated This API has been removed for now due to the increased complexity to the class that it brought.
   * Please use .URL instead.
   */
-@property (nullable, nonatomic, strong, readwrite) NSArray <NSURL *> *URLs ASDISPLAYNODE_DEPRECATED_MSG("Please use URL instead.");
+@property (nullable, atomic, copy) NSArray <NSURL *> *URLs ASDISPLAYNODE_DEPRECATED_MSG("Please use URL instead.");
 
 /**
  * Download and display a new image.
@@ -110,14 +110,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * If <URL> is a local file, set this property to YES to take advantage of UIKit's image caching.  Defaults to YES.
  */
-@property (nonatomic, assign, readwrite) BOOL shouldCacheImage;
+@property (atomic) BOOL shouldCacheImage;
 
 /**
  * If the downloader implements progressive image rendering and this value is YES progressive renders of the
  * image will be displayed as the image downloads. Regardless of this properties value, progress renders will
  * only occur when the node is visible. Defaults to YES.
  */
-@property (nonatomic, assign, readwrite) BOOL shouldRenderProgressImages;
+@property (atomic) BOOL shouldRenderProgressImages;
 
 /**
  * The image quality of the current image.
@@ -129,12 +129,12 @@ NS_ASSUME_NONNULL_BEGIN
  * If the URL is unset, this is 1 if defaultImage or image is set to non-nil.
  *
  */
-@property (nonatomic, assign, readonly) CGFloat currentImageQuality;
+@property (atomic, readonly) CGFloat currentImageQuality;
 
 /**
  * The currentImageQuality (value between 0 and 1) of the last image that completed displaying.
  */
-@property (nonatomic, assign, readonly) CGFloat renderedImageQuality;
+@property (atomic, readonly) CGFloat renderedImageQuality;
 
 @end
 

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -204,6 +204,8 @@
       return;
     }
     
+    URL = [URL copy];
+    
     ASDisplayNodeAssert(_imageWasSetExternally == NO, @"Setting a URL to an ASNetworkImageNode after setting an image changes its behavior from an ASImageNode to an ASNetworkImageNode. If this is what you want, set the image to nil first.");
     
     _imageWasSetExternally = NO;
@@ -312,15 +314,9 @@
 
 - (void)setShouldRenderProgressImages:(BOOL)shouldRenderProgressImages
 {
-  {
-    ASLockScopeSelf();
-    if (shouldRenderProgressImages == _shouldRenderProgressImages) {
-      return;
-    }
-    _shouldRenderProgressImages = shouldRenderProgressImages;
+  if (ASLockedSelfCompareAssign(_shouldRenderProgressImages, shouldRenderProgressImages)) {
+    [self _updateProgressImageBlockOnDownloaderIfNeeded];
   }
-
-  [self _updateProgressImageBlockOnDownloaderIfNeeded];
 }
 
 - (BOOL)shouldRenderProgressImages

--- a/Source/ASNodeController+Beta.h
+++ b/Source/ASNodeController+Beta.h
@@ -26,7 +26,7 @@
 // Until an ASNodeController can be provided in place of an ASCellNode, some apps may prefer to have
 // nodes keep their controllers alive (and a weak reference from controller to node)
 
-@property (nonatomic, assign) BOOL shouldInvertStrongReference;
+@property (nonatomic) BOOL shouldInvertStrongReference;
 
 - (void)loadNode;
 

--- a/Source/ASPagerNode.h
+++ b/Source/ASPagerNode.h
@@ -96,12 +96,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The underlying ASCollectionView object.
  */
-@property (nonatomic, readonly) ASCollectionView *view;
+@property (atomic, readonly) ASCollectionView *view;
 
 /**
- * Returns the current page index
+ * Returns the current page index. Main thread only.
  */
-@property (nonatomic, assign, readonly) NSInteger currentPageIndex;
+@property (nonatomic, readonly) NSInteger currentPageIndex;
 
 /**
  * Scroll the contents of the receiver to ensure that the page is visible
@@ -134,7 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
  * the pager node will set the property on the view controller to NO and log a warning message. In the future,
  * the pager node will just log the warning, and you'll need to configure your view controller on your own.
  */
-@property (nonatomic, assign) BOOL allowsAutomaticInsetsAdjustment;
+@property (nonatomic) BOOL allowsAutomaticInsetsAdjustment;
 
 @end
 

--- a/Source/ASPagerNode.h
+++ b/Source/ASPagerNode.h
@@ -96,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The underlying ASCollectionView object.
  */
-@property (atomic, readonly) ASCollectionView *view;
+@property (readonly) ASCollectionView *view;
 
 /**
  * Returns the current page index. Main thread only.

--- a/Source/ASRunLoopQueue.h
+++ b/Source/ASRunLoopQueue.h
@@ -48,7 +48,7 @@ AS_SUBCLASSING_RESTRICTED
 
 - (void)enqueue:(ObjectType)object;
 
-@property (atomic, readonly) BOOL isEmpty;
+@property (readonly) BOOL isEmpty;
 
 @property (nonatomic) NSUInteger batchSize;           // Default == 1.
 @property (nonatomic) BOOL ensureExclusiveMembership; // Default == YES.  Set-like behavior.
@@ -58,9 +58,9 @@ AS_SUBCLASSING_RESTRICTED
 AS_SUBCLASSING_RESTRICTED
 @interface ASCATransactionQueue : ASAbstractRunLoopQueue
 
-@property (atomic, readonly) BOOL isEmpty;
+@property (readonly) BOOL isEmpty;
 
-@property (atomic, readonly, getter=isEnabled) BOOL enabled;
+@property (readonly, getter=isEnabled) BOOL enabled;
 
 /**
  * The queue to run on main run loop before CATransaction commit.
@@ -69,7 +69,7 @@ AS_SUBCLASSING_RESTRICTED
  * to get last chance of updating/coalesce info like interface state.
  * Each node will only be called once per transaction commit to reflect interface change.
  */
-@property (class, atomic, readonly) ASCATransactionQueue *sharedQueue;
+@property (class, readonly) ASCATransactionQueue *sharedQueue;
 + (ASCATransactionQueue *)sharedQueue NS_RETURNS_RETAINED;
 
 - (void)enqueue:(id<ASCATransactionQueueObserving>)object;
@@ -78,7 +78,7 @@ AS_SUBCLASSING_RESTRICTED
 
 @interface ASDeallocQueue : NSObject
 
-@property (class, atomic, readonly) ASDeallocQueue *sharedDeallocationQueue;
+@property (class, readonly) ASDeallocQueue *sharedDeallocationQueue;
 + (ASDeallocQueue *)sharedDeallocationQueue NS_RETURNS_RETAINED;
 
 - (void)drain;

--- a/Source/ASRunLoopQueue.h
+++ b/Source/ASRunLoopQueue.h
@@ -50,8 +50,8 @@ AS_SUBCLASSING_RESTRICTED
 
 @property (atomic, readonly) BOOL isEmpty;
 
-@property (nonatomic, assign) NSUInteger batchSize;           // Default == 1.
-@property (nonatomic, assign) BOOL ensureExclusiveMembership; // Default == YES.  Set-like behavior.
+@property (nonatomic) NSUInteger batchSize;           // Default == 1.
+@property (nonatomic) BOOL ensureExclusiveMembership; // Default == YES.  Set-like behavior.
 
 @end
 

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -349,7 +349,7 @@ typedef enum {
 #endif
 }
 
-@property (nonatomic, copy) void (^queueConsumer)(id dequeuedItem, BOOL isQueueDrained);
+@property (nonatomic) void (^queueConsumer)(id dequeuedItem, BOOL isQueueDrained);
 
 @end
 

--- a/Source/ASScrollNode.h
+++ b/Source/ASScrollNode.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @abstract The node's UIScrollView.
  */
-@property (atomic, readonly) UIScrollView *view;
+@property (readonly) UIScrollView *view;
 
 /**
  * @abstract When enabled, the size calculated by the node's layout spec is used as
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  * also grows to the full contentSize).  It also works with .layoutSpecBlock().
  * NOTE: Most users of ASScrollNode will want to use this, and may be enabled by default later.
  */
-@property (atomic) BOOL automaticallyManagesContentSize;
+@property BOOL automaticallyManagesContentSize;
 
 /**
  * @abstract This property controls how the constrainedSize is interpreted when sizing the content.
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Vertical & Horizontal: the constrainedSize is interpreted as unbounded in both directions.
  * @default ASScrollDirectionVerticalDirections
  */
-@property (atomic) ASScrollDirection scrollableDirections;
+@property ASScrollDirection scrollableDirections;
 
 @end
 

--- a/Source/ASScrollNode.h
+++ b/Source/ASScrollNode.h
@@ -30,16 +30,16 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @abstract The node's UIScrollView.
  */
-@property (nonatomic, readonly, strong) UIScrollView *view;
+@property (atomic, readonly) UIScrollView *view;
 
 /**
  * @abstract When enabled, the size calculated by the node's layout spec is used as
  * the .contentSize of the scroll view, instead of the bounds size.  The bounds is instead
  * allowed to match the parent's size (whenever it is finite - otherwise, the bounds size
  * also grows to the full contentSize).  It also works with .layoutSpecBlock().
- * NOTE: Most users of ASScrollView will want to use this, and may be enabled by default later.
+ * NOTE: Most users of ASScrollNode will want to use this, and may be enabled by default later.
  */
-@property (nonatomic, assign) BOOL automaticallyManagesContentSize;
+@property (atomic) BOOL automaticallyManagesContentSize;
 
 /**
  * @abstract This property controls how the constrainedSize is interpreted when sizing the content.
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Vertical & Horizontal: the constrainedSize is interpreted as unbounded in both directions.
  * @default ASScrollDirectionVerticalDirections
  */
-@property (nonatomic, assign) ASScrollDirection scrollableDirections;
+@property (atomic) ASScrollDirection scrollableDirections;
 
 @end
 

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -36,34 +36,34 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init; // UITableViewStylePlain
 - (instancetype)initWithStyle:(UITableViewStyle)style NS_DESIGNATED_INITIALIZER;
 
-@property (strong, nonatomic, readonly) ASTableView *view;
+@property (atomic, readonly) ASTableView *view;
 
 // These properties can be set without triggering the view to be created, so it's fine to set them in -init.
-@property (weak, nonatomic) id <ASTableDelegate>   delegate;
-@property (weak, nonatomic) id <ASTableDataSource> dataSource;
+@property (nullable, weak, nonatomic) id <ASTableDelegate>   delegate;
+@property (nullable, weak, nonatomic) id <ASTableDataSource> dataSource;
 
 /**
  * The number of screens left to scroll before the delegate -tableNode:beginBatchFetchingWithContext: is called.
  *
  * Defaults to two screenfuls.
  */
-@property (nonatomic, assign) CGFloat leadingScreensForBatching;
+@property (nonatomic) CGFloat leadingScreensForBatching;
 
 /*
  * A Boolean value that determines whether the table will be flipped.
  * If the value of this property is YES, the first cell node will be at the bottom of the table (as opposed to the top by default). This is useful for chat/messaging apps. The default value is NO.
  */
-@property (nonatomic, assign) BOOL inverted;
+@property (nonatomic) BOOL inverted;
 
 /**
  * The distance that the content view is inset from the table node edges. Defaults to UIEdgeInsetsZero.
  */
-@property (nonatomic, assign) UIEdgeInsets contentInset;
+@property (nonatomic) UIEdgeInsets contentInset;
 
 /**
  * The offset of the content view's origin from the table node's origin. Defaults to CGPointZero.
  */
-@property (nonatomic, assign) CGPoint contentOffset;
+@property (nonatomic) CGPoint contentOffset;
 
 /**
  * Sets the offset from the content node’s origin to the table node’s origin.
@@ -83,28 +83,28 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * default is NO.
  */
-@property (nonatomic, assign) BOOL automaticallyAdjustsContentOffset;
+@property (nonatomic) BOOL automaticallyAdjustsContentOffset;
 
 /*
  * A Boolean value that determines whether users can select a row.
  * If the value of this property is YES (the default), users can select rows. If you set it to NO, they cannot select rows. Setting this property affects cell selection only when the table view is not in editing mode. If you want to restrict selection of cells in editing mode, use `allowsSelectionDuringEditing`.
  */
-@property (nonatomic, assign) BOOL allowsSelection;
+@property (nonatomic) BOOL allowsSelection;
 /*
  * A Boolean value that determines whether users can select cells while the table view is in editing mode.
  * If the value of this property is YES, users can select rows during editing. The default value is NO. If you want to restrict selection of cells regardless of mode, use allowsSelection.
  */
-@property (nonatomic, assign) BOOL allowsSelectionDuringEditing;
+@property (nonatomic) BOOL allowsSelectionDuringEditing;
 /*
  * A Boolean value that determines whether users can select more than one row outside of editing mode.
  * This property controls whether multiple rows can be selected simultaneously outside of editing mode. When the value of this property is YES, each row that is tapped acquires a selected appearance. Tapping the row again removes the selected appearance. If you access indexPathsForSelectedRows, you can get the index paths that identify the selected rows.
  */
-@property (nonatomic, assign) BOOL allowsMultipleSelection;
+@property (nonatomic) BOOL allowsMultipleSelection;
 /*
  * A Boolean value that controls whether users can select more than one cell simultaneously in editing mode.
  * The default value of this property is NO. If you set it to YES, check marks appear next to selected rows in editing mode. In addition, UITableView does not query for editing styles when it goes into editing mode. If you access indexPathsForSelectedRows, you can get the index paths that identify the selected rows.
  */
-@property (nonatomic, assign) BOOL allowsMultipleSelectionDuringEditing;
+@property (nonatomic) BOOL allowsMultipleSelectionDuringEditing;
 
 /**
  * Tuning parameters for a range type in full mode.

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init; // UITableViewStylePlain
 - (instancetype)initWithStyle:(UITableViewStyle)style NS_DESIGNATED_INITIALIZER;
 
-@property (atomic, readonly) ASTableView *view;
+@property (readonly) ASTableView *view;
 
 // These properties can be set without triggering the view to be created, so it's fine to set them in -init.
 @property (nullable, weak, nonatomic) id <ASTableDelegate>   delegate;
@@ -444,7 +444,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This method must be called from the main thread.
  */
-@property (nonatomic, readonly, nullable) NSIndexPath *indexPathForSelectedRow;
+@property (nullable, nonatomic, copy, readonly) NSIndexPath *indexPathForSelectedRow;
 
 @property (nonatomic, readonly, nullable) NSArray<NSIndexPath *> *indexPathsForSelectedRows;
 

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -79,7 +79,7 @@
   id<ASBatchFetchingDelegate> _batchFetchingDelegate;
 }
 
-@property (nonatomic, strong) _ASTablePendingState *pendingState;
+@property (nonatomic) _ASTablePendingState *pendingState;
 @end
 
 @implementation ASTableNode

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -36,17 +36,17 @@
 @interface _ASTablePendingState : NSObject
 @property (weak, nonatomic) id <ASTableDelegate>   delegate;
 @property (weak, nonatomic) id <ASTableDataSource> dataSource;
-@property (nonatomic, assign) ASLayoutRangeMode rangeMode;
-@property (nonatomic, assign) BOOL allowsSelection;
-@property (nonatomic, assign) BOOL allowsSelectionDuringEditing;
-@property (nonatomic, assign) BOOL allowsMultipleSelection;
-@property (nonatomic, assign) BOOL allowsMultipleSelectionDuringEditing;
-@property (nonatomic, assign) BOOL inverted;
-@property (nonatomic, assign) CGFloat leadingScreensForBatching;
-@property (nonatomic, assign) UIEdgeInsets contentInset;
-@property (nonatomic, assign) CGPoint contentOffset;
-@property (nonatomic, assign) BOOL animatesContentOffset;
-@property (nonatomic, assign) BOOL automaticallyAdjustsContentOffset;
+@property (nonatomic) ASLayoutRangeMode rangeMode;
+@property (nonatomic) BOOL allowsSelection;
+@property (nonatomic) BOOL allowsSelectionDuringEditing;
+@property (nonatomic) BOOL allowsMultipleSelection;
+@property (nonatomic) BOOL allowsMultipleSelectionDuringEditing;
+@property (nonatomic) BOOL inverted;
+@property (nonatomic) CGFloat leadingScreensForBatching;
+@property (nonatomic) UIEdgeInsets contentInset;
+@property (nonatomic) CGPoint contentOffset;
+@property (nonatomic) BOOL animatesContentOffset;
+@property (nonatomic) BOOL automaticallyAdjustsContentOffset;
 @end
 
 @implementation _ASTablePendingState

--- a/Source/ASTableView.h
+++ b/Source/ASTableView.h
@@ -65,17 +65,17 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Defaults to two screenfuls.
  */
-@property (nonatomic, assign) CGFloat leadingScreensForBatching ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode property instead.");
+@property (nonatomic) CGFloat leadingScreensForBatching ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode property instead.");
 
 /**
  * The distance that the content view is inset from the table view edges. Defaults to UIEdgeInsetsZero.
  */
-@property (nonatomic, assign) UIEdgeInsets contentInset ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode property instead");
+@property (nonatomic) UIEdgeInsets contentInset ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode property instead");
 
 /**
  * The offset of the content view's origin from the table node's origin. Defaults to CGPointZero.
  */
-@property (nonatomic, assign) CGPoint contentOffset ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode property instead.");
+@property (nonatomic) CGPoint contentOffset ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode property instead.");
 
 /**
  * YES to automatically adjust the contentOffset when cells are inserted or deleted above
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * A Boolean value that determines whether the nodes that the data source renders will be flipped.
  */
-@property (nonatomic, assign) BOOL inverted ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode property instead.");
+@property (nonatomic) BOOL inverted ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode property instead.");
 
 @property (nonatomic, readonly, nullable) NSIndexPath *indexPathForSelectedRow  ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode property instead.");
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -82,7 +82,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 @interface _ASTableViewCell : UITableViewCell
 @property (nonatomic, weak) id<_ASTableViewCellDelegate> delegate;
-@property (nonatomic, strong, readonly) ASCellNode *node;
+@property (nonatomic, readonly) ASCellNode *node;
 @property (nonatomic, strong) ASCollectionElement *element;
 @end
 
@@ -279,7 +279,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   } _asyncDataSourceFlags;
 }
 
-@property (nonatomic, strong, readwrite) ASDataController *dataController;
+@property (nonatomic, readwrite) ASDataController *dataController;
 
 @property (nonatomic, weak)   ASTableNode *tableNode;
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -83,7 +83,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 @interface _ASTableViewCell : UITableViewCell
 @property (nonatomic, weak) id<_ASTableViewCellDelegate> delegate;
 @property (nonatomic, readonly) ASCellNode *node;
-@property (nonatomic, strong) ASCollectionElement *element;
+@property (nonatomic) ASCollectionElement *element;
 @end
 
 @implementation _ASTableViewCell
@@ -279,7 +279,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   } _asyncDataSourceFlags;
 }
 
-@property (nonatomic, readwrite) ASDataController *dataController;
+@property (nonatomic) ASDataController *dataController;
 
 @property (nonatomic, weak)   ASTableNode *tableNode;
 

--- a/Source/ASTableViewInternal.h
+++ b/Source/ASTableViewInternal.h
@@ -24,9 +24,9 @@
 
 @interface ASTableView (Internal)
 
-@property (nonatomic, strong, readonly) ASDataController *dataController;
+@property (nonatomic, readonly) ASDataController *dataController;
 @property (nonatomic, weak, readwrite) ASTableNode *tableNode;
-@property (nonatomic, strong, readonly) ASRangeController *rangeController;
+@property (nonatomic, readonly) ASRangeController *rangeController;
 
 /**
  * Initializer.

--- a/Source/ASTableViewInternal.h
+++ b/Source/ASTableViewInternal.h
@@ -25,7 +25,7 @@
 @interface ASTableView (Internal)
 
 @property (nonatomic, readonly) ASDataController *dataController;
-@property (nonatomic, weak, readwrite) ASTableNode *tableNode;
+@property (nonatomic, weak) ASTableNode *tableNode;
 @property (nonatomic, readonly) ASRangeController *rangeController;
 
 /**

--- a/Source/ASTextNode+Beta.h
+++ b/Source/ASTextNode+Beta.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns YES if this node is using the experimental implementation. NO otherwise. Will not change.
  */
-@property (atomic, readonly) BOOL usingExperiment;
+@property (readonly) BOOL usingExperiment;
 
 @end
 

--- a/Source/ASTextNode+Beta.h
+++ b/Source/ASTextNode+Beta.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  This property can be useful for handling text which does not fit within the view by default. An example: like UILabel,
  ASTextNode will clip the left and right of the string "judar" if it's rendered in an italicised font.
  */
-@property (nonatomic, assign) UIEdgeInsets textContainerInset;
+@property (nonatomic) UIEdgeInsets textContainerInset;
 
 /**
  * Returns YES if this node is using the experimental implementation. NO otherwise. Will not change.

--- a/Source/ASTextNode.h
+++ b/Source/ASTextNode.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Defaults to nil, no text is shown.
  For inline image attachments, add an attribute of key NSAttachmentAttributeName, with a value of an NSTextAttachment.
  */
-@property (nullable, atomic, copy) NSAttributedString *attributedText;
+@property (nullable, copy) NSAttributedString *attributedText;
 
 #pragma mark - Truncation
 
@@ -40,37 +40,37 @@ NS_ASSUME_NONNULL_BEGIN
  @abstract The attributedText to use when the text must be truncated.
  @discussion Defaults to a localized ellipsis character.
  */
-@property (nullable, atomic, copy) NSAttributedString *truncationAttributedText;
+@property (nullable, copy) NSAttributedString *truncationAttributedText;
 
 /**
  @summary The second attributed string appended for truncation.
  @discussion This string will be highlighted on touches.
  @default nil
  */
-@property (nullable, atomic, copy) NSAttributedString *additionalTruncationMessage;
+@property (nullable, copy) NSAttributedString *additionalTruncationMessage;
 
 /**
  @abstract Determines how the text is truncated to fit within the receiver's maximum size.
  @discussion Defaults to NSLineBreakByWordWrapping.
  @note Setting a truncationMode in attributedString will override the truncation mode set here.
  */
-@property (atomic) NSLineBreakMode truncationMode;
+@property NSLineBreakMode truncationMode;
 
 /**
  @abstract If the text node is truncated. Text must have been sized first.
  */
-@property (atomic, readonly, getter=isTruncated) BOOL truncated;
+@property (readonly, getter=isTruncated) BOOL truncated;
 
 /**
  @abstract The maximum number of lines to render of the text before truncation.
  @default 0 (No limit)
  */
-@property (atomic) NSUInteger maximumNumberOfLines;
+@property NSUInteger maximumNumberOfLines;
 
 /**
  @abstract The number of lines in the text. Text must have been sized first.
  */
-@property (atomic, readonly) NSUInteger lineCount;
+@property (readonly) NSUInteger lineCount;
 
 /**
  * An array of path objects representing the regions where text should not be displayed.
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
  * the text node's bounds. You can use this property to have text wrap around images,
  * shapes or other text like a fancy magazine.
  */
-@property (nullable, atomic, copy) NSArray<UIBezierPath *> *exclusionPaths;
+@property (nullable, copy) NSArray<UIBezierPath *> *exclusionPaths;
 
 #pragma mark - Placeholders
 
@@ -91,17 +91,17 @@ NS_ASSUME_NONNULL_BEGIN
  * following the true shape of the text's wrapping.  This visually mirrors the overall
  * shape and weight of paragraphs, making the appearance of the finished text less jarring.
  */
-@property (atomic) BOOL placeholderEnabled;
+@property BOOL placeholderEnabled;
 
 /**
  @abstract The placeholder color.
  */
-@property (nullable, atomic, copy) UIColor *placeholderColor;
+@property (nullable, copy) UIColor *placeholderColor;
 
 /**
  @abstract Inset each line of the placeholder.
  */
-@property (atomic) UIEdgeInsets placeholderInsets;
+@property UIEdgeInsets placeholderInsets;
 
 #pragma mark - Shadow
 
@@ -120,7 +120,7 @@ NS_ASSUME_NONNULL_BEGIN
  UIEdgeInsetsRect(boundingRectForText, shadowPadding)
  will return a CGRect large enough to fit both the text and the appropriate shadow padding.
  */
-@property (atomic, readonly) UIEdgeInsets shadowPadding;
+@property (readonly) UIEdgeInsets shadowPadding;
 
 #pragma mark - Positioning
 
@@ -167,7 +167,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract The set of attribute names to consider links.  Defaults to NSLinkAttributeName.
  */
-@property (atomic, copy) NSArray<NSString *> *linkAttributeNames;
+@property (copy) NSArray<NSString *> *linkAttributeNames;
 
 /**
  @abstract Indicates whether the receiver has an entity at a given point.
@@ -181,12 +181,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract The style to use when highlighting text.
  */
-@property (atomic) ASTextNodeHighlightStyle highlightStyle;
+@property ASTextNodeHighlightStyle highlightStyle;
 
 /**
  @abstract The range of text highlighted by the receiver. Changes to this property are not animated by default.
  */
-@property (atomic) NSRange highlightRange;
+@property NSRange highlightRange;
 
 /**
  @abstract Set the range of text to highlight, with optional animation.
@@ -203,7 +203,7 @@ NS_ASSUME_NONNULL_BEGIN
              textNode:longPressedLinkAttribute:value:atPoint:textRange: in order for
              the long press gesture recognizer to be installed.
  */
-@property (nullable, atomic, weak) id<ASTextNodeDelegate> delegate;
+@property (nullable, weak) id<ASTextNodeDelegate> delegate;
 
 /**
  @abstract If YES and a long press is recognized, touches are cancelled. Default is NO
@@ -236,7 +236,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @see attributedText
  */
-@property (nullable, atomic, copy) NSAttributedString *attributedString ASDISPLAYNODE_DEPRECATED_MSG("Use .attributedText instead.");
+@property (nullable, copy) NSAttributedString *attributedString ASDISPLAYNODE_DEPRECATED_MSG("Use .attributedText instead.");
 
 
 /**
@@ -245,7 +245,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @see truncationAttributedText
  */
-@property (nullable, atomic, copy) NSAttributedString *truncationAttributedString ASDISPLAYNODE_DEPRECATED_MSG("Use .truncationAttributedText instead.");
+@property (nullable, copy) NSAttributedString *truncationAttributedString ASDISPLAYNODE_DEPRECATED_MSG("Use .truncationAttributedText instead.");
 
 @end
 

--- a/Source/ASTextNode.h
+++ b/Source/ASTextNode.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Defaults to nil, no text is shown.
  For inline image attachments, add an attribute of key NSAttachmentAttributeName, with a value of an NSTextAttachment.
  */
-@property (nullable, nonatomic, copy) NSAttributedString *attributedText;
+@property (nullable, atomic, copy) NSAttributedString *attributedText;
 
 #pragma mark - Truncation
 
@@ -40,37 +40,37 @@ NS_ASSUME_NONNULL_BEGIN
  @abstract The attributedText to use when the text must be truncated.
  @discussion Defaults to a localized ellipsis character.
  */
-@property (nullable, nonatomic, copy) NSAttributedString *truncationAttributedText;
+@property (nullable, atomic, copy) NSAttributedString *truncationAttributedText;
 
 /**
  @summary The second attributed string appended for truncation.
  @discussion This string will be highlighted on touches.
  @default nil
  */
-@property (nullable, nonatomic, copy) NSAttributedString *additionalTruncationMessage;
+@property (nullable, atomic, copy) NSAttributedString *additionalTruncationMessage;
 
 /**
  @abstract Determines how the text is truncated to fit within the receiver's maximum size.
  @discussion Defaults to NSLineBreakByWordWrapping.
  @note Setting a truncationMode in attributedString will override the truncation mode set here.
  */
-@property (nonatomic, assign) NSLineBreakMode truncationMode;
+@property (atomic) NSLineBreakMode truncationMode;
 
 /**
  @abstract If the text node is truncated. Text must have been sized first.
  */
-@property (nonatomic, readonly, assign, getter=isTruncated) BOOL truncated;
+@property (atomic, readonly, getter=isTruncated) BOOL truncated;
 
 /**
  @abstract The maximum number of lines to render of the text before truncation.
  @default 0 (No limit)
  */
-@property (nonatomic, assign) NSUInteger maximumNumberOfLines;
+@property (atomic) NSUInteger maximumNumberOfLines;
 
 /**
  @abstract The number of lines in the text. Text must have been sized first.
  */
-@property (nonatomic, readonly, assign) NSUInteger lineCount;
+@property (atomic, readonly) NSUInteger lineCount;
 
 /**
  * An array of path objects representing the regions where text should not be displayed.
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
  * the text node's bounds. You can use this property to have text wrap around images,
  * shapes or other text like a fancy magazine.
  */
-@property (nullable, nonatomic, strong) NSArray<UIBezierPath *> *exclusionPaths;
+@property (nullable, atomic, copy) NSArray<UIBezierPath *> *exclusionPaths;
 
 #pragma mark - Placeholders
 
@@ -91,27 +91,27 @@ NS_ASSUME_NONNULL_BEGIN
  * following the true shape of the text's wrapping.  This visually mirrors the overall
  * shape and weight of paragraphs, making the appearance of the finished text less jarring.
  */
-@property (nonatomic, assign) BOOL placeholderEnabled;
+@property (atomic) BOOL placeholderEnabled;
 
 /**
  @abstract The placeholder color.
  */
-@property (nullable, nonatomic, strong) UIColor *placeholderColor;
+@property (nullable, atomic, copy) UIColor *placeholderColor;
 
 /**
  @abstract Inset each line of the placeholder.
  */
-@property (nonatomic, assign) UIEdgeInsets placeholderInsets;
+@property (atomic) UIEdgeInsets placeholderInsets;
 
 #pragma mark - Shadow
 
 /**
  @abstract When you set these ASDisplayNode properties, they are composited into the bitmap instead of being applied by CA.
 
- @property (nonatomic, assign) CGColorRef shadowColor;
- @property (nonatomic, assign) CGFloat    shadowOpacity;
- @property (nonatomic, assign) CGSize     shadowOffset;
- @property (nonatomic, assign) CGFloat    shadowRadius;
+ @property (nonatomic) CGColorRef shadowColor;
+ @property (nonatomic) CGFloat    shadowOpacity;
+ @property (nonatomic) CGSize     shadowOffset;
+ @property (nonatomic) CGFloat    shadowRadius;
  */
 
 /**
@@ -120,7 +120,7 @@ NS_ASSUME_NONNULL_BEGIN
  UIEdgeInsetsRect(boundingRectForText, shadowPadding)
  will return a CGRect large enough to fit both the text and the appropriate shadow padding.
  */
-@property (nonatomic, readonly, assign) UIEdgeInsets shadowPadding;
+@property (atomic, readonly) UIEdgeInsets shadowPadding;
 
 #pragma mark - Positioning
 
@@ -167,7 +167,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract The set of attribute names to consider links.  Defaults to NSLinkAttributeName.
  */
-@property (nonatomic, copy) NSArray<NSString *> *linkAttributeNames;
+@property (atomic, copy) NSArray<NSString *> *linkAttributeNames;
 
 /**
  @abstract Indicates whether the receiver has an entity at a given point.
@@ -181,12 +181,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract The style to use when highlighting text.
  */
-@property (nonatomic, assign) ASTextNodeHighlightStyle highlightStyle;
+@property (atomic) ASTextNodeHighlightStyle highlightStyle;
 
 /**
  @abstract The range of text highlighted by the receiver. Changes to this property are not animated by default.
  */
-@property (nonatomic, assign) NSRange highlightRange;
+@property (atomic) NSRange highlightRange;
 
 /**
  @abstract Set the range of text to highlight, with optional animation.
@@ -203,25 +203,25 @@ NS_ASSUME_NONNULL_BEGIN
              textNode:longPressedLinkAttribute:value:atPoint:textRange: in order for
              the long press gesture recognizer to be installed.
  */
-@property (nonatomic, weak) id<ASTextNodeDelegate> delegate;
+@property (nullable, atomic, weak) id<ASTextNodeDelegate> delegate;
 
 /**
  @abstract If YES and a long press is recognized, touches are cancelled. Default is NO
  */
-@property (nonatomic, assign) BOOL longPressCancelsTouches;
+@property (nonatomic) BOOL longPressCancelsTouches;
 
 /**
  @abstract if YES will not intercept touches for non-link areas of the text. Default is NO.
  */
-@property (nonatomic, assign) BOOL passthroughNonlinkTouches;
+@property (nonatomic) BOOL passthroughNonlinkTouches;
 
 @end
 
 @interface ASTextNode (Unavailable)
 
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 @end
 
@@ -236,7 +236,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @see attributedText
  */
-@property (nullable, nonatomic, copy) NSAttributedString *attributedString ASDISPLAYNODE_DEPRECATED_MSG("Use .attributedText instead.");
+@property (nullable, atomic, copy) NSAttributedString *attributedString ASDISPLAYNODE_DEPRECATED_MSG("Use .attributedText instead.");
 
 
 /**
@@ -245,7 +245,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @see truncationAttributedText
  */
-@property (nullable, nonatomic, copy) NSAttributedString *truncationAttributedString ASDISPLAYNODE_DEPRECATED_MSG("Use .truncationAttributedText instead.");
+@property (nullable, atomic, copy) NSAttributedString *truncationAttributedString ASDISPLAYNODE_DEPRECATED_MSG("Use .truncationAttributedText instead.");
 
 @end
 

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -61,8 +61,8 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
 #pragma mark - ASTextKitRenderer
 
 @interface ASTextNodeRendererKey : NSObject
-@property (assign, nonatomic) ASTextKitAttributes attributes;
-@property (assign, nonatomic) CGSize constrainedSize;
+@property (nonatomic) ASTextKitAttributes attributes;
+@property (nonatomic) CGSize constrainedSize;
 @end
 
 @implementation ASTextNodeRendererKey {
@@ -181,6 +181,7 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
   CGSize _shadowOffset;
   CGColorRef _shadowColor;
   UIColor *_cachedShadowUIColor;
+  UIColor *_placeholderColor;
   CGFloat _shadowOpacity;
   CGFloat _shadowRadius;
   
@@ -883,6 +884,11 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
 }
 
 #pragma mark - Placeholders
+
+- (UIColor *)placeholderColor
+{
+  return ASLockedSelf(_placeholderColor);
+}
 
 - (void)setPlaceholderColor:(UIColor *)placeholderColor
 {

--- a/Source/ASTextNode2.h
+++ b/Source/ASTextNode2.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Defaults to nil, no text is shown.
  For inline image attachments, add an attribute of key NSAttachmentAttributeName, with a value of an NSTextAttachment.
  */
-@property (nullable, atomic, copy) NSAttributedString *attributedText;
+@property (nullable, copy) NSAttributedString *attributedText;
 
 #pragma mark - Truncation
 
@@ -34,37 +34,37 @@ NS_ASSUME_NONNULL_BEGIN
  @abstract The attributedText to use when the text must be truncated.
  @discussion Defaults to a localized ellipsis character.
  */
-@property (nullable, atomic, copy) NSAttributedString *truncationAttributedText;
+@property (nullable, copy) NSAttributedString *truncationAttributedText;
 
 /**
  @summary The second attributed string appended for truncation.
  @discussion This string will be highlighted on touches.
  @default nil
  */
-@property (nullable, atomic, copy) NSAttributedString *additionalTruncationMessage;
+@property (nullable, copy) NSAttributedString *additionalTruncationMessage;
 
 /**
  @abstract Determines how the text is truncated to fit within the receiver's maximum size.
  @discussion Defaults to NSLineBreakByWordWrapping.
  @note Setting a truncationMode in attributedString will override the truncation mode set here.
  */
-@property (atomic) NSLineBreakMode truncationMode;
+@property NSLineBreakMode truncationMode;
 
 /**
  @abstract If the text node is truncated. Text must have been sized first.
  */
-@property (atomic, readonly, getter=isTruncated) BOOL truncated;
+@property (readonly, getter=isTruncated) BOOL truncated;
 
 /**
  @abstract The maximum number of lines to render of the text before truncation.
  @default 0 (No limit)
  */
-@property (atomic) NSUInteger maximumNumberOfLines;
+@property NSUInteger maximumNumberOfLines;
 
 /**
  @abstract The number of lines in the text. Text must have been sized first.
  */
-@property (atomic, readonly) NSUInteger lineCount;
+@property (readonly) NSUInteger lineCount;
 
 /**
  * An array of path objects representing the regions where text should not be displayed.
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
  * the text node's bounds. You can use this property to have text wrap around images,
  * shapes or other text like a fancy magazine.
  */
-@property (nullable, atomic, copy) NSArray<UIBezierPath *> *exclusionPaths;
+@property (nullable, copy) NSArray<UIBezierPath *> *exclusionPaths;
 
 #pragma mark - Placeholders
 
@@ -85,17 +85,17 @@ NS_ASSUME_NONNULL_BEGIN
  * following the true shape of the text's wrapping.  This visually mirrors the overall
  * shape and weight of paragraphs, making the appearance of the finished text less jarring.
  */
-@property (atomic) BOOL placeholderEnabled;
+@property BOOL placeholderEnabled;
 
 /**
  @abstract The placeholder color.
  */
-@property (nullable, atomic, copy) UIColor *placeholderColor;
+@property (nullable, copy) UIColor *placeholderColor;
 
 /**
  @abstract Inset each line of the placeholder.
  */
-@property (atomic) UIEdgeInsets placeholderInsets;
+@property UIEdgeInsets placeholderInsets;
 
 #pragma mark - Shadow
 
@@ -197,7 +197,7 @@ NS_ASSUME_NONNULL_BEGIN
  textNode:longPressedLinkAttribute:value:atPoint:textRange: in order for
  the long press gesture recognizer to be installed.
  */
-@property (atomic, weak) id<ASTextNodeDelegate> delegate;
+@property (weak) id<ASTextNodeDelegate> delegate;
 
 /**
  @abstract If YES and a long press is recognized, touches are cancelled. Default is NO

--- a/Source/ASTextNode2.h
+++ b/Source/ASTextNode2.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Defaults to nil, no text is shown.
  For inline image attachments, add an attribute of key NSAttachmentAttributeName, with a value of an NSTextAttachment.
  */
-@property (nullable, nonatomic, copy) NSAttributedString *attributedText;
+@property (nullable, atomic, copy) NSAttributedString *attributedText;
 
 #pragma mark - Truncation
 
@@ -34,37 +34,37 @@ NS_ASSUME_NONNULL_BEGIN
  @abstract The attributedText to use when the text must be truncated.
  @discussion Defaults to a localized ellipsis character.
  */
-@property (nullable, nonatomic, copy) NSAttributedString *truncationAttributedText;
+@property (nullable, atomic, copy) NSAttributedString *truncationAttributedText;
 
 /**
  @summary The second attributed string appended for truncation.
  @discussion This string will be highlighted on touches.
  @default nil
  */
-@property (nullable, nonatomic, copy) NSAttributedString *additionalTruncationMessage;
+@property (nullable, atomic, copy) NSAttributedString *additionalTruncationMessage;
 
 /**
  @abstract Determines how the text is truncated to fit within the receiver's maximum size.
  @discussion Defaults to NSLineBreakByWordWrapping.
  @note Setting a truncationMode in attributedString will override the truncation mode set here.
  */
-@property (nonatomic, assign) NSLineBreakMode truncationMode;
+@property (atomic) NSLineBreakMode truncationMode;
 
 /**
  @abstract If the text node is truncated. Text must have been sized first.
  */
-@property (nonatomic, readonly, assign, getter=isTruncated) BOOL truncated;
+@property (atomic, readonly, getter=isTruncated) BOOL truncated;
 
 /**
  @abstract The maximum number of lines to render of the text before truncation.
  @default 0 (No limit)
  */
-@property (nonatomic, assign) NSUInteger maximumNumberOfLines;
+@property (atomic) NSUInteger maximumNumberOfLines;
 
 /**
  @abstract The number of lines in the text. Text must have been sized first.
  */
-@property (nonatomic, readonly, assign) NSUInteger lineCount;
+@property (atomic, readonly) NSUInteger lineCount;
 
 /**
  * An array of path objects representing the regions where text should not be displayed.
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
  * the text node's bounds. You can use this property to have text wrap around images,
  * shapes or other text like a fancy magazine.
  */
-@property (nullable, nonatomic, strong) NSArray<UIBezierPath *> *exclusionPaths;
+@property (nullable, atomic, copy) NSArray<UIBezierPath *> *exclusionPaths;
 
 #pragma mark - Placeholders
 
@@ -85,27 +85,27 @@ NS_ASSUME_NONNULL_BEGIN
  * following the true shape of the text's wrapping.  This visually mirrors the overall
  * shape and weight of paragraphs, making the appearance of the finished text less jarring.
  */
-@property (nonatomic, assign) BOOL placeholderEnabled;
+@property (atomic) BOOL placeholderEnabled;
 
 /**
  @abstract The placeholder color.
  */
-@property (nullable, nonatomic, strong) UIColor *placeholderColor;
+@property (nullable, atomic, copy) UIColor *placeholderColor;
 
 /**
  @abstract Inset each line of the placeholder.
  */
-@property (nonatomic, assign) UIEdgeInsets placeholderInsets;
+@property (atomic) UIEdgeInsets placeholderInsets;
 
 #pragma mark - Shadow
 
 /**
  @abstract When you set these ASDisplayNode properties, they are composited into the bitmap instead of being applied by CA.
  
- @property (nonatomic, assign) CGColorRef shadowColor;
- @property (nonatomic, assign) CGFloat    shadowOpacity;
- @property (nonatomic, assign) CGSize     shadowOffset;
- @property (nonatomic, assign) CGFloat    shadowRadius;
+ @property (nonatomic) CGColorRef shadowColor;
+ @property (nonatomic) CGFloat    shadowOpacity;
+ @property (nonatomic) CGSize     shadowOffset;
+ @property (nonatomic) CGFloat    shadowRadius;
  */
 
 /**
@@ -114,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
  UIEdgeInsetsRect(boundingRectForText, shadowPadding)
  will return a CGRect large enough to fit both the text and the appropriate shadow padding.
  */
-@property (nonatomic, readonly, assign) UIEdgeInsets shadowPadding;
+@property (nonatomic, readonly) UIEdgeInsets shadowPadding;
 
 #pragma mark - Positioning
 
@@ -175,12 +175,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract The style to use when highlighting text.
  */
-@property (nonatomic, assign) ASTextNodeHighlightStyle highlightStyle;
+@property (nonatomic) ASTextNodeHighlightStyle highlightStyle;
 
 /**
  @abstract The range of text highlighted by the receiver. Changes to this property are not animated by default.
  */
-@property (nonatomic, assign) NSRange highlightRange;
+@property (nonatomic) NSRange highlightRange;
 
 /**
  @abstract Set the range of text to highlight, with optional animation.
@@ -202,12 +202,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract If YES and a long press is recognized, touches are cancelled. Default is NO
  */
-@property (nonatomic, assign) BOOL longPressCancelsTouches;
+@property (nonatomic) BOOL longPressCancelsTouches;
 
 /**
  @abstract if YES will not intercept touches for non-link areas of the text. Default is NO.
  */
-@property (nonatomic, assign) BOOL passthroughNonlinkTouches;
+@property (nonatomic) BOOL passthroughNonlinkTouches;
 
 + (void)enableDebugging;
 
@@ -215,9 +215,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASTextNode2 (Unavailable)
 
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 @end
 

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -75,14 +75,18 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
   CGFloat _shadowRadius;
   
   NSAttributedString *_attributedText;
+  NSAttributedString *_truncationAttributedText;
+  NSAttributedString *_additionalTruncationMessage;
   NSAttributedString *_composedTruncationText;
   NSArray<NSNumber *> *_pointSizeScaleFactors;
+  NSLineBreakMode _truncationMode;
   
   NSString *_highlightedLinkAttributeName;
   id _highlightedLinkAttributeValue;
   ASTextNodeHighlightStyle _highlightStyle;
   NSRange _highlightRange;
   ASHighlightOverlayLayer *_activeHighlightLayer;
+  UIColor *_placeholderColor;
   
   UILongPressGestureRecognizer *_longPressGestureRecognizer;
 }
@@ -691,14 +695,16 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
 #pragma mark - Placeholders
 
+- (UIColor *)placeholderColor
+{
+  return ASLockedSelf(_placeholderColor);
+}
+
 - (void)setPlaceholderColor:(UIColor *)placeholderColor
 {
-  ASLockScopeSelf();
-  
-  _placeholderColor = placeholderColor;
-  
-  // prevent placeholders if we don't have a color
-  self.placeholderEnabled = placeholderColor != nil;
+  if (ASLockedSelfCompareAssignCopy(_placeholderColor, placeholderColor)) {
+    self.placeholderEnabled = CGColorGetAlpha(placeholderColor.CGColor) > 0;
+  }
 }
 
 - (UIImage *)placeholderImage
@@ -966,6 +972,11 @@ static NSAttributedString *DefaultTruncationAttributedString()
   }
 }
 
+- (NSAttributedString *)truncationAttributedText
+{
+  return ASLockedSelf(_truncationAttributedText);
+}
+
 - (void)setTruncationAttributedText:(NSAttributedString *)truncationAttributedText
 {
   ASLockScopeSelf();
@@ -974,12 +985,22 @@ static NSAttributedString *DefaultTruncationAttributedString()
   }
 }
 
+- (NSAttributedString *)additionalTruncationMessage
+{
+  return ASLockedSelf(_additionalTruncationMessage);
+}
+
 - (void)setAdditionalTruncationMessage:(NSAttributedString *)additionalTruncationMessage
 {
   ASLockScopeSelf();
   if (ASCompareAssignCopy(_additionalTruncationMessage, additionalTruncationMessage)) {
     [self _invalidateTruncationText];
   }
+}
+
+- (NSLineBreakMode)truncationMode
+{
+  return ASLockedSelf(_truncationMode);
 }
 
 - (void)setTruncationMode:(NSLineBreakMode)truncationMode

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -702,7 +702,8 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
 - (void)setPlaceholderColor:(UIColor *)placeholderColor
 {
-  if (ASLockedSelfCompareAssignCopy(_placeholderColor, placeholderColor)) {
+  ASLockScopeSelf();
+  if (ASCompareAssignCopy(_placeholderColor, placeholderColor)) {
     self.placeholderEnabled = CGColorGetAlpha(placeholderColor.CGColor) > 0;
   }
 }

--- a/Source/ASVideoNode.h
+++ b/Source/ASVideoNode.h
@@ -46,39 +46,40 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isPlaying;
 - (void)resetToPlaceholder;
 
-@property (nullable, nonatomic, strong, readwrite) AVAsset *asset;
+@property (nullable, atomic) AVAsset *asset;
 /**
  ** @abstract The URL with which the asset was initialized.
  ** @discussion Setting the URL will override the current asset with a newly created AVURLAsset created from the given URL, and AVAsset *asset will point to that newly created AVURLAsset.  Please don't set both assetURL and asset.
  ** @return Current URL the asset was initialized or nil if no URL was given.
  **/
-@property (nullable, nonatomic, strong, readwrite) NSURL *assetURL;
-@property (nullable, nonatomic, strong, readwrite) AVVideoComposition *videoComposition;
-@property (nullable, nonatomic, strong, readwrite) AVAudioMix *audioMix;
+@property (nullable, atomic, copy) NSURL *assetURL;
+@property (nullable, atomic) AVVideoComposition *videoComposition;
+@property (nullable, atomic) AVAudioMix *audioMix;
 
-@property (nullable, nonatomic, strong, readonly) AVPlayer *player;
-@property (nullable, nonatomic, strong, readonly) AVPlayerLayer *playerLayer;
-@property (nullable, nonatomic, strong, readonly) AVPlayerItem *currentItem;
+@property (nullable, atomic, readonly) AVPlayer *player;
+@property (nullable, atomic, readonly) AVPlayerItem *currentItem;
+
+@property (nullable, nonatomic, readonly) AVPlayerLayer *playerLayer;
 
 
 /**
  * When shouldAutoplay is set to true, a video node will play when it has both loaded and entered the "visible" interfaceState.
  * If it leaves the visible interfaceState it will pause but will resume once it has returned.
  */
-@property (nonatomic, assign, readwrite) BOOL shouldAutoplay;
-@property (nonatomic, assign, readwrite) BOOL shouldAutorepeat;
+@property (atomic) BOOL shouldAutoplay;
+@property (atomic) BOOL shouldAutorepeat;
 
-@property (nonatomic, assign, readwrite) BOOL muted;
-@property (nonatomic, assign, readwrite) BOOL shouldAggressivelyRecoverFromStall;
+@property (atomic) BOOL muted;
+@property (atomic) BOOL shouldAggressivelyRecoverFromStall;
 
-@property (nonatomic, assign, readonly) ASVideoNodePlayerState playerState;
+@property (atomic, readonly) ASVideoNodePlayerState playerState;
 //! Defaults to 1000
-@property (nonatomic, assign) int32_t periodicTimeObserverTimescale;
+@property (atomic) int32_t periodicTimeObserverTimescale;
 
 //! Defaults to AVLayerVideoGravityResizeAspect
-@property (nonatomic, copy) NSString *gravity;
+@property (null_resettable, atomic) NSString *gravity;
 
-@property (nullable, nonatomic, weak, readwrite) id<ASVideoNodeDelegate, ASNetworkImageNodeDelegate> delegate;
+@property (nullable, atomic, weak) id<ASVideoNodeDelegate, ASNetworkImageNodeDelegate> delegate;
 
 @end
 
@@ -160,7 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASVideoNode (Unavailable)
 
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 @end
 

--- a/Source/ASVideoNode.h
+++ b/Source/ASVideoNode.h
@@ -46,18 +46,24 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isPlaying;
 - (void)resetToPlaceholder;
 
-@property (nullable, atomic) AVAsset *asset;
+// TODO: copy
+@property (nullable) AVAsset *asset;
+
 /**
  ** @abstract The URL with which the asset was initialized.
  ** @discussion Setting the URL will override the current asset with a newly created AVURLAsset created from the given URL, and AVAsset *asset will point to that newly created AVURLAsset.  Please don't set both assetURL and asset.
  ** @return Current URL the asset was initialized or nil if no URL was given.
  **/
-@property (nullable, atomic, copy) NSURL *assetURL;
-@property (nullable, atomic) AVVideoComposition *videoComposition;
-@property (nullable, atomic) AVAudioMix *audioMix;
+@property (nullable, copy) NSURL *assetURL;
 
-@property (nullable, atomic, readonly) AVPlayer *player;
-@property (nullable, atomic, readonly) AVPlayerItem *currentItem;
+// TODO: copy both of these.
+@property (nullable) AVVideoComposition *videoComposition;
+@property (nullable) AVAudioMix *audioMix;
+
+@property (nullable, readonly) AVPlayer *player;
+
+// TODO: copy
+@property (nullable, readonly) AVPlayerItem *currentItem;
 
 @property (nullable, nonatomic, readonly) AVPlayerLayer *playerLayer;
 
@@ -66,20 +72,20 @@ NS_ASSUME_NONNULL_BEGIN
  * When shouldAutoplay is set to true, a video node will play when it has both loaded and entered the "visible" interfaceState.
  * If it leaves the visible interfaceState it will pause but will resume once it has returned.
  */
-@property (atomic) BOOL shouldAutoplay;
-@property (atomic) BOOL shouldAutorepeat;
+@property BOOL shouldAutoplay;
+@property BOOL shouldAutorepeat;
 
-@property (atomic) BOOL muted;
-@property (atomic) BOOL shouldAggressivelyRecoverFromStall;
+@property BOOL muted;
+@property BOOL shouldAggressivelyRecoverFromStall;
 
-@property (atomic, readonly) ASVideoNodePlayerState playerState;
+@property (readonly) ASVideoNodePlayerState playerState;
 //! Defaults to 1000
-@property (atomic) int32_t periodicTimeObserverTimescale;
+@property int32_t periodicTimeObserverTimescale;
 
 //! Defaults to AVLayerVideoGravityResizeAspect
-@property (null_resettable, atomic) NSString *gravity;
+@property (null_resettable, copy) NSString *gravity;
 
-@property (nullable, atomic, weak) id<ASVideoNodeDelegate, ASNetworkImageNodeDelegate> delegate;
+@property (nullable, weak) id<ASVideoNodeDelegate, ASNetworkImageNodeDelegate> delegate;
 
 @end
 

--- a/Source/ASVideoNode.mm
+++ b/Source/ASVideoNode.mm
@@ -618,6 +618,14 @@ static NSString * const kRate = @"rate";
 - (void)setGravity:(NSString *)gravity
 {
   ASLockScopeSelf();
+  if (!gravity) {
+    gravity = AVLayerVideoGravityResizeAspect;
+  }
+  
+  if (!ASCompareAssignObjects(_gravity, gravity)) {
+    return;
+  }
+  
   if (_playerNode.isNodeLoaded) {
     ((AVPlayerLayer *)_playerNode.layer).videoGravity = gravity;
   }

--- a/Source/ASVideoPlayerNode.h
+++ b/Source/ASVideoPlayerNode.h
@@ -49,20 +49,20 @@ NS_ASSUME_NONNULL_BEGIN
  * When shouldAutoplay is set to true, a video node will play when it has both loaded and entered the "visible" interfaceState.
  * If it leaves the visible interfaceState it will pause but will resume once it has returned.
  */
-@property (nonatomic, readwrite) BOOL shouldAutoPlay;
-@property (nonatomic, readwrite) BOOL shouldAutoRepeat;
-@property (nonatomic, readwrite) BOOL muted;
+@property (nonatomic) BOOL shouldAutoPlay;
+@property (nonatomic) BOOL shouldAutoRepeat;
+@property (nonatomic) BOOL muted;
 @property (nonatomic, readonly) ASVideoNodePlayerState playerState;
-@property (nonatomic, readwrite) BOOL shouldAggressivelyRecoverFromStall;
-@property (nullable, nonatomic, readwrite) NSURL *placeholderImageURL;
+@property (nonatomic) BOOL shouldAggressivelyRecoverFromStall;
+@property (nullable, nonatomic) NSURL *placeholderImageURL;
 
-@property (nullable, nonatomic, readwrite) AVAsset *asset;
+@property (nullable, nonatomic) AVAsset *asset;
 /**
  ** @abstract The URL with which the asset was initialized.
  ** @discussion Setting the URL will override the current asset with a newly created AVURLAsset created from the given URL, and AVAsset *asset will point to that newly created AVURLAsset.  Please don't set both assetURL and asset.
  ** @return Current URL the asset was initialized or nil if no URL was given.
  **/
-@property (nullable, nonatomic, readwrite) NSURL *assetURL;
+@property (nullable, nonatomic) NSURL *assetURL;
 
 /// You should never set any value on the backing video node. Use exclusivively the video player node to set properties
 @property (nonatomic, readonly) ASVideoNode *videoNode;

--- a/Source/ASVideoPlayerNode.h
+++ b/Source/ASVideoPlayerNode.h
@@ -40,35 +40,35 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable, nonatomic, weak) id<ASVideoPlayerNodeDelegate> delegate;
 
-@property (nonatomic, assign, readonly) CMTime duration;
+@property (nonatomic, readonly) CMTime duration;
 
-@property (nonatomic, assign) BOOL controlsDisabled;
+@property (nonatomic) BOOL controlsDisabled;
 
 #pragma mark - ASVideoNode property proxy
 /**
  * When shouldAutoplay is set to true, a video node will play when it has both loaded and entered the "visible" interfaceState.
  * If it leaves the visible interfaceState it will pause but will resume once it has returned.
  */
-@property (nonatomic, assign, readwrite) BOOL shouldAutoPlay;
-@property (nonatomic, assign, readwrite) BOOL shouldAutoRepeat;
-@property (nonatomic, assign, readwrite) BOOL muted;
-@property (nonatomic, assign, readonly) ASVideoNodePlayerState playerState;
-@property (nonatomic, assign, readwrite) BOOL shouldAggressivelyRecoverFromStall;
-@property (nullable, nonatomic, strong, readwrite) NSURL *placeholderImageURL;
+@property (nonatomic, readwrite) BOOL shouldAutoPlay;
+@property (nonatomic, readwrite) BOOL shouldAutoRepeat;
+@property (nonatomic, readwrite) BOOL muted;
+@property (nonatomic, readonly) ASVideoNodePlayerState playerState;
+@property (nonatomic, readwrite) BOOL shouldAggressivelyRecoverFromStall;
+@property (nullable, nonatomic, readwrite) NSURL *placeholderImageURL;
 
-@property (nullable, nonatomic, strong, readwrite) AVAsset *asset;
+@property (nullable, nonatomic, readwrite) AVAsset *asset;
 /**
  ** @abstract The URL with which the asset was initialized.
  ** @discussion Setting the URL will override the current asset with a newly created AVURLAsset created from the given URL, and AVAsset *asset will point to that newly created AVURLAsset.  Please don't set both assetURL and asset.
  ** @return Current URL the asset was initialized or nil if no URL was given.
  **/
-@property (nullable, nonatomic, strong, readwrite) NSURL *assetURL;
+@property (nullable, nonatomic, readwrite) NSURL *assetURL;
 
 /// You should never set any value on the backing video node. Use exclusivively the video player node to set properties
-@property (nonatomic, strong, readonly) ASVideoNode *videoNode;
+@property (nonatomic, readonly) ASVideoNode *videoNode;
 
 //! Defaults to 100
-@property (nonatomic, assign) int32_t periodicTimeObserverTimescale;
+@property (nonatomic) int32_t periodicTimeObserverTimescale;
 //! Defaults to AVLayerVideoGravityResizeAspect
 @property (nonatomic, copy) NSString *gravity;
 

--- a/Source/ASViewController.h
+++ b/Source/ASViewController.h
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_END
 /**
  * @return node Returns the ASDisplayNode which provides the backing view to the view controller.
  */
-@property (nonatomic, strong, readonly, null_unspecified) DisplayNodeType node;
+@property (nonatomic, readonly, null_unspecified) DisplayNodeType node;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 // AsyncDisplayKit 2.0 BETA: This property is still being tested, but it allows
 // blocking as a view controller becomes visible to ensure no placeholders flash onscreen.
 // Refer to examples/SynchronousConcurrency, AsyncViewController.m
-@property (nonatomic, assign) BOOL neverShowPlaceholders;
+@property (nonatomic) BOOL neverShowPlaceholders;
 
 /* Custom container UIViewController subclasses can use this property to add to the overlay
  that UIViewController calculates for the safeAreaInsets for contained view controllers.
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Default value is YES *if* node or view controller conform to ASRangeControllerUpdateRangeProtocol otherwise it is NO.
  */
-@property (nonatomic, assign) BOOL automaticallyAdjustRangeModeBasedOnViewEvents;
+@property (nonatomic) BOOL automaticallyAdjustRangeModeBasedOnViewEvents;
 
 @end
 

--- a/Source/Base/ASDisplayNode+Ancestry.h
+++ b/Source/Base/ASDisplayNode+Ancestry.h
@@ -35,12 +35,12 @@ NS_ASSUME_NONNULL_BEGIN
  * Note: If this property is read on the main thread, the enumeration will attempt to go up
  *  the layer hierarchy if it finds a break in the display node hierarchy.
  */
-@property (atomic, readonly) id<NSFastEnumeration> supernodes;
+@property (readonly) id<NSFastEnumeration> supernodes;
 
 /**
  * Same as `supernodes` but begins the enumeration with self.
  */
-@property (atomic, readonly) id<NSFastEnumeration> supernodesIncludingSelf;
+@property (readonly) id<NSFastEnumeration> supernodesIncludingSelf;
 
 /**
  * Searches the supernodes of this node for one matching the given class.
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * e.g. "(<MYTextNode: 0xFFFF>, <MYTextContainingNode: 0xFFFF>, <MYCellNode: 0xFFFF>)"
  */
-@property (atomic, copy, readonly) NSString *ancestryDescription;
+@property (copy, readonly) NSString *ancestryDescription;
 
 @end
 

--- a/Source/Debug/AsyncDisplayKit+Debug.m
+++ b/Source/Debug/AsyncDisplayKit+Debug.m
@@ -230,8 +230,8 @@ static BOOL __enableHitTestDebug = NO;
 @interface _ASRangeDebugBarView : UIView
 
 @property (nonatomic, weak) ASRangeController *rangeController;
-@property (nonatomic, assign) BOOL destroyOnLayout;
-@property (nonatomic, strong) NSString *debugString;
+@property (nonatomic) BOOL destroyOnLayout;
+@property (nonatomic) NSString *debugString;
 
 - (instancetype)initWithRangeController:(ASRangeController *)rangeController;
 

--- a/Source/Debug/AsyncDisplayKit+Tips.h
+++ b/Source/Debug/AsyncDisplayKit+Tips.h
@@ -44,7 +44,7 @@ typedef void(^ASTipDisplayBlock)(ASDisplayNode *node, NSString *message);
  * If nil, the default, the message is just logged to the console with the
  * ancestry of the node.
  */
-@property (class, nonatomic, copy, null_resettable) ASTipDisplayBlock tipDisplayBlock; 
+@property (class, nonatomic, null_resettable) ASTipDisplayBlock tipDisplayBlock;
 
 @end
 

--- a/Source/Details/ASBasicImageDownloader.mm
+++ b/Source/Details/ASBasicImageDownloader.mm
@@ -39,7 +39,7 @@ NSString * const kASBasicImageDownloaderContextCompletionBlock = @"kASBasicImage
   ASDN::RecursiveMutex __instanceLock__;
 }
 
-@property (nonatomic, strong) NSMutableArray *callbackDatas;
+@property (nonatomic) NSMutableArray *callbackDatas;
 
 @end
 
@@ -179,7 +179,7 @@ static ASDN::StaticMutex& currentRequestsLock = *new ASDN::StaticMutex;
  * NSURLSessionDownloadTask lacks a `userInfo` property, so add this association ourselves.
  */
 @interface NSURLRequest (ASBasicImageDownloader)
-@property (nonatomic, strong) ASBasicImageDownloaderContext *asyncdisplaykit_context;
+@property (nonatomic) ASBasicImageDownloaderContext *asyncdisplaykit_context;
 @end
 
 @implementation NSURLRequest (ASBasicImageDownloader)

--- a/Source/Details/ASCollectionElement.h
+++ b/Source/Details/ASCollectionElement.h
@@ -26,11 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED
 @interface ASCollectionElement : NSObject
 
-@property (nonatomic, readonly, copy, nullable) NSString *supplementaryElementKind;
-@property (nonatomic, assign) ASSizeRange constrainedSize;
-@property (nonatomic, readonly, weak) id<ASRangeManagingNode> owningNode;
-@property (nonatomic, assign) ASPrimitiveTraitCollection traitCollection;
-@property (nonatomic, readonly, nullable) id nodeModel;
+@property (nullable, nonatomic, copy, readonly) NSString *supplementaryElementKind;
+@property (nonatomic) ASSizeRange constrainedSize;
+@property (nonatomic, weak, readonly) id<ASRangeManagingNode> owningNode;
+@property (nonatomic) ASPrimitiveTraitCollection traitCollection;
+@property (nullable, nonatomic, readonly) id nodeModel;
 
 - (instancetype)initWithNodeModel:(nullable id)nodeModel
                         nodeBlock:(ASCellNodeBlock)nodeBlock
@@ -43,12 +43,12 @@ AS_SUBCLASSING_RESTRICTED
  * @return The node, running the node block if necessary. The node block will be discarded
  * after the first time it is run.
  */
-@property (strong, readonly) ASCellNode *node;
+@property (readonly) ASCellNode *node;
 
 /**
  * @return The node, if the node block has been run already.
  */
-@property (strong, readonly, nullable) ASCellNode *nodeIfAllocated;
+@property (nullable, readonly) ASCellNode *nodeIfAllocated;
 
 @end
 

--- a/Source/Details/ASCollectionElement.mm
+++ b/Source/Details/ASCollectionElement.mm
@@ -22,7 +22,7 @@
 @interface ASCollectionElement ()
 
 /// Required node block used to allocate a cell node. Nil after the first execution.
-@property (nonatomic, strong) ASCellNodeBlock nodeBlock;
+@property (nonatomic) ASCellNodeBlock nodeBlock;
 
 @end
 

--- a/Source/Details/ASCollectionInternal.h
+++ b/Source/Details/ASCollectionInternal.h
@@ -27,19 +27,19 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASCollectionView ()
 - (instancetype)_initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(nullable id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator owningNode:(nullable ASCollectionNode *)owningNode eventLog:(nullable ASEventLog *)eventLog;
 
-@property (nonatomic, weak, readwrite) ASCollectionNode *collectionNode;
-@property (nonatomic, strong, readonly) ASDataController *dataController;
-@property (nonatomic, strong, readonly) ASRangeController *rangeController;
+@property (nonatomic, weak) ASCollectionNode *collectionNode;
+@property (nonatomic, readonly) ASDataController *dataController;
+@property (nonatomic, readonly) ASRangeController *rangeController;
 
 /**
  * The change set that we're currently building, if any.
  */
-@property (nonatomic, strong, nullable, readonly) _ASHierarchyChangeSet *changeSet;
+@property (nonatomic, nullable, readonly) _ASHierarchyChangeSet *changeSet;
 
 /**
  * @see ASCollectionNode+Beta.h for full documentation.
  */
-@property (nonatomic, assign) BOOL usesSynchronousDataLoading;
+@property (nonatomic) BOOL usesSynchronousDataLoading;
 
 /**
  * Attempt to get the view-layer index path for the item with the given index path.

--- a/Source/Details/ASCollectionLayoutContext.h
+++ b/Source/Details/ASCollectionLayoutContext.h
@@ -26,13 +26,13 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED
 @interface ASCollectionLayoutContext : NSObject
 
-@property (nonatomic, assign, readonly) CGSize viewportSize;
-@property (nonatomic, assign, readonly) CGPoint initialContentOffset;
-@property (nonatomic, assign, readonly) ASScrollDirection scrollableDirections;
+@property (nonatomic, readonly) CGSize viewportSize;
+@property (nonatomic, readonly) CGPoint initialContentOffset;
+@property (nonatomic, readonly) ASScrollDirection scrollableDirections;
 @property (nonatomic, weak, readonly) ASElementMap *elements;
-@property (nonatomic, strong, readonly, nullable) id additionalInfo;
+@property (nullable, nonatomic, readonly) id additionalInfo;
 
-- (instancetype)init __unavailable;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/Source/Details/ASCollectionLayoutState.h
+++ b/Source/Details/ASCollectionLayoutState.h
@@ -37,12 +37,12 @@ AS_SUBCLASSING_RESTRICTED
 @interface ASCollectionLayoutState : NSObject
 
 /// The context used to calculate this object
-@property (nonatomic, strong, readonly) ASCollectionLayoutContext *context;
+@property (readonly) ASCollectionLayoutContext *context;
 
 /// The final content size of the collection's layout
-@property (nonatomic, assign, readonly) CGSize contentSize;
+@property (readonly) CGSize contentSize;
 
-- (instancetype)init __unavailable;
+- (instancetype)init NS_UNAVAILABLE;
 
 /**
  * Designated initializer.

--- a/Source/Details/ASCollectionLayoutState.mm
+++ b/Source/Details/ASCollectionLayoutState.mm
@@ -37,6 +37,8 @@
 
 @implementation ASCollectionLayoutState {
   ASDN::Mutex __instanceLock__;
+  CGSize _contentSize;
+  ASCollectionLayoutContext *_context;
   NSMapTable<ASCollectionElement *, UICollectionViewLayoutAttributes *> *_elementToLayoutAttributesTable;
   ASPageToLayoutAttributesTable *_pageToLayoutAttributesTable;
   ASPageToLayoutAttributesTable *_unmeasuredPageToLayoutAttributesTable;
@@ -113,6 +115,16 @@ elementToLayoutAttributesTable:[NSMapTable elementToLayoutAttributesTable]];
     _unmeasuredPageToLayoutAttributesTable = [ASCollectionLayoutState _unmeasuredLayoutAttributesTableFromTable:table contentSize:contentSize pageSize:pageSize];
   }
   return self;
+}
+
+- (ASCollectionLayoutContext *)context
+{
+  return _context;
+}
+
+- (CGSize)contentSize
+{
+  return _contentSize;
 }
 
 - (NSArray<UICollectionViewLayoutAttributes *> *)allLayoutAttributes

--- a/Source/Details/ASDataController.h
+++ b/Source/Details/ASDataController.h
@@ -168,21 +168,21 @@ extern NSString * const ASCollectionInvalidUpdateException;
  *
  * NOTE: Soon we will drop support for using ASTableView/ASCollectionView without the node, so this will be non-null.
  */
-@property (nonatomic, nullable, weak, readonly) id<ASRangeManagingNode> node;
+@property (nullable, nonatomic, weak, readonly) id<ASRangeManagingNode> node;
 
 /**
  * The map that is currently displayed. The "UIKit index space."
  *
  * This property will only be changed on the main thread.
  */
-@property (atomic, copy, readonly) ASElementMap *visibleMap;
+@property (copy, readonly) ASElementMap *visibleMap;
 
 /**
  * The latest map fetched from the data source. May be more recent than @c visibleMap.
  *
  * This property will only be changed on the main thread.
  */
-@property (atomic, copy, readonly) ASElementMap *pendingMap;
+@property (copy, readonly) ASElementMap *pendingMap;
 
 /**
  Data source for fetching data info.
@@ -227,13 +227,13 @@ extern NSString * const ASCollectionInvalidUpdateException;
 /*
  * @abstract The primitive event tracing object. You shouldn't directly use it to log event. Use the ASDataControllerLogEvent macro instead.
  */
-@property (nonatomic, strong, readonly) ASEventLog *eventLog;
+@property (nonatomic, readonly) ASEventLog *eventLog;
 #endif
 
 /**
  * @see ASCollectionNode+Beta.h for full documentation.
  */
-@property (nonatomic, assign) BOOL usesSynchronousDataLoading;
+@property (nonatomic) BOOL usesSynchronousDataLoading;
 
 /** @name Data Updating */
 

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -87,8 +87,8 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   } _dataSourceFlags;
 }
 
-@property (atomic, copy, readwrite) ASElementMap *pendingMap;
-@property (atomic, copy, readwrite) ASElementMap *visibleMap;
+@property (copy) ASElementMap *pendingMap;
+@property (copy) ASElementMap *visibleMap;
 @end
 
 @implementation ASDataController

--- a/Source/Details/ASElementMap.h
+++ b/Source/Details/ASElementMap.h
@@ -114,7 +114,7 @@ AS_SUBCLASSING_RESTRICTED
 /**
  * A very terse description e.g. { itemCounts = [ <S0: 1> <S1: 16> ] }
  */
-@property (atomic, readonly) NSString *smallDescription;
+@property (readonly) NSString *smallDescription;
 
 #pragma mark - Initialization -- Only Useful to ASDataController
 

--- a/Source/Details/ASElementMap.m
+++ b/Source/Details/ASElementMap.m
@@ -26,15 +26,15 @@
 
 @interface ASElementMap () <ASDescriptionProvider>
 
-@property (nonatomic, strong, readonly) NSArray<ASSection *> *sections;
+@property (nonatomic, readonly) NSArray<ASSection *> *sections;
 
 // Element -> IndexPath
-@property (nonatomic, strong, readonly) NSMapTable<ASCollectionElement *, NSIndexPath *> *elementToIndexPathMap;
+@property (nonatomic, readonly) NSMapTable<ASCollectionElement *, NSIndexPath *> *elementToIndexPathMap;
 
 // The items, in a 2D array
-@property (nonatomic, strong, readonly) ASCollectionElementTwoDimensionalArray *sectionsOfItems;
+@property (nonatomic, readonly) ASCollectionElementTwoDimensionalArray *sectionsOfItems;
 
-@property (nonatomic, strong, readonly) ASSupplementaryElementDictionary *supplementaryElements;
+@property (nonatomic, readonly) ASSupplementaryElementDictionary *supplementaryElements;
 
 @end
 

--- a/Source/Details/ASHighlightOverlayLayer.h
+++ b/Source/Details/ASHighlightOverlayLayer.h
@@ -41,7 +41,7 @@ AS_SUBCLASSING_RESTRICTED
  */
 - (instancetype)initWithRects:(NSArray<NSValue *> *)rects;
 
-@property (nullable, nonatomic, strong) __attribute__((NSObject)) CGColorRef highlightColor;
+@property (nullable, nonatomic) __attribute__((NSObject)) CGColorRef highlightColor;
 @property (nonatomic, weak) CALayer *targetLayer;
 
 @end
@@ -52,7 +52,7 @@ AS_SUBCLASSING_RESTRICTED
  @summary Set to YES to indicate to a sublayer that this is where highlight overlay layers (for pressed states) should
  be added so that the highlight won't be clipped by a neighboring layer.
  */
-@property (nonatomic, assign, setter=as_setAllowsHighlightDrawing:) BOOL as_allowsHighlightDrawing;
+@property (nonatomic, setter=as_setAllowsHighlightDrawing:) BOOL as_allowsHighlightDrawing;
 
 @end
 

--- a/Source/Details/ASImageProtocols.h
+++ b/Source/Details/ASImageProtocols.h
@@ -164,7 +164,7 @@ withDownloadIdentifier:(id)downloadIdentifier;
 /**
  @abstract A block which receives the cover image. Should be called when the objects cover image is ready.
  */
-@property (nonatomic, readwrite) void (^coverImageReadyCallback)(UIImage *coverImage);
+@property (nonatomic) void (^coverImageReadyCallback)(UIImage *coverImage);
 
 /**
  @abstract Returns whether the supplied data contains a supported animated image format.
@@ -210,7 +210,7 @@ withDownloadIdentifier:(id)downloadIdentifier;
 /**
  @abstract Should be called when playback is ready.
  */
-@property (nonatomic, readwrite) dispatch_block_t playbackReadyCallback;
+@property (nonatomic) dispatch_block_t playbackReadyCallback;
 
 /**
  @abstract Return the image at a given index.

--- a/Source/Details/ASIntegerMap.h
+++ b/Source/Details/ASIntegerMap.h
@@ -36,7 +36,7 @@ AS_SUBCLASSING_RESTRICTED
  *
  * Note: You cannot mutate this.
  */
-@property (class, atomic, readonly) ASIntegerMap *identityMap;
+@property (class, readonly) ASIntegerMap *identityMap;
 + (ASIntegerMap *)identityMap NS_RETURNS_RETAINED;
 
 /**
@@ -44,7 +44,7 @@ AS_SUBCLASSING_RESTRICTED
  *
  * Note: You cannot mutate this.
  */
-@property (class, atomic, readonly) ASIntegerMap *emptyMap;
+@property (class, readonly) ASIntegerMap *emptyMap;
 + (ASIntegerMap *)emptyMap NS_RETURNS_RETAINED;
 
 /**

--- a/Source/Details/ASPINRemoteImageDownloader.m
+++ b/Source/Details/ASPINRemoteImageDownloader.m
@@ -76,7 +76,7 @@
 @end
 
 @protocol ASPINDiskCache
-@property (assign) NSUInteger byteLimit;
+@property NSUInteger byteLimit;
 @end
 
 @interface ASPINRemoteImageManager : PINRemoteImageManager

--- a/Source/Details/ASPhotosFrameworkImageRequest.h
+++ b/Source/Details/ASPhotosFrameworkImageRequest.h
@@ -59,7 +59,7 @@ API_AVAILABLE(ios(8.0), tvos(10.0))
  @discussion Some properties of this object are ignored when converting this request into a URL.
  As of iOS SDK 9.0, these properties are `progressHandler` and `synchronous`.
  */
-@property (nonatomic, strong) PHImageRequestOptions *options;
+@property (nonatomic) PHImageRequestOptions *options;
 
 /**
  @return A new URL converted from this request.

--- a/Source/Details/ASRangeController.h
+++ b/Source/Details/ASRangeController.h
@@ -88,7 +88,7 @@ AS_SUBCLASSING_RESTRICTED
  * Used primarily for providing the current range of index paths and identifying when the
  * range controller should invalidate its range.
  */
-@property (nonatomic, strong) id<ASLayoutController> layoutController;
+@property (nonatomic) id<ASLayoutController> layoutController;
 
 /**
  * The underlying data source for the range controller
@@ -103,7 +103,7 @@ AS_SUBCLASSING_RESTRICTED
 /**
  * Property that indicates whether the scroll view for this range controller has ever changed its contentOffset.
  */
-@property (nonatomic, assign) BOOL contentHasBeenScrolled;
+@property (nonatomic) BOOL contentHasBeenScrolled;
 
 @end
 

--- a/Source/Details/ASTraceEvent.h
+++ b/Source/Details/ASTraceEvent.h
@@ -32,7 +32,7 @@ AS_SUBCLASSING_RESTRICTED
 
 // Will be nil unless AS_SAVE_EVENT_BACKTRACES=1 (default=0)
 @property (nonatomic, nullable, readonly) NSArray<NSString *> *backtrace;
-@property (nonatomic, strong, readonly) NSString *message;
+@property (nonatomic, readonly) NSString *message;
 @property (nonatomic, readonly) NSTimeInterval timestamp;
 
 @end

--- a/Source/Details/ASTraceEvent.m
+++ b/Source/Details/ASTraceEvent.m
@@ -21,8 +21,8 @@
 static NSString *const ASTraceEventThreadDescriptionKey = @"ASThreadTraceEventDescription";
 
 @interface ASTraceEvent ()
-@property (nonatomic, strong, readonly) NSString *objectDescription;
-@property (nonatomic, strong, readonly) NSString *threadDescription;
+@property (nonatomic, readonly) NSString *objectDescription;
+@property (nonatomic, readonly) NSString *threadDescription;
 @end
 
 @implementation ASTraceEvent

--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -176,22 +176,22 @@ ASDISPLAYNODE_EXTERN_C_END
 AS_SUBCLASSING_RESTRICTED
 @interface ASTraitCollection : NSObject
 
-@property (nonatomic, assign, readonly) UIUserInterfaceSizeClass horizontalSizeClass;
-@property (nonatomic, assign, readonly) UIUserInterfaceSizeClass verticalSizeClass;
+@property (nonatomic, readonly) UIUserInterfaceSizeClass horizontalSizeClass;
+@property (nonatomic, readonly) UIUserInterfaceSizeClass verticalSizeClass;
 
-@property (nonatomic, assign, readonly) CGFloat displayScale;
-@property (nonatomic, assign, readonly) UIDisplayGamut displayGamut;
+@property (nonatomic, readonly) CGFloat displayScale;
+@property (nonatomic, readonly) UIDisplayGamut displayGamut;
 
-@property (nonatomic, assign, readonly) UIUserInterfaceIdiom userInterfaceIdiom;
-@property (nonatomic, assign, readonly) UIForceTouchCapability forceTouchCapability;
-@property (nonatomic, assign, readonly) UITraitEnvironmentLayoutDirection layoutDirection;
+@property (nonatomic, readonly) UIUserInterfaceIdiom userInterfaceIdiom;
+@property (nonatomic, readonly) UIForceTouchCapability forceTouchCapability;
+@property (nonatomic, readonly) UITraitEnvironmentLayoutDirection layoutDirection;
 #if TARGET_OS_TV
-@property (nonatomic, assign, readonly) UIUserInterfaceStyle userInterfaceStyle;
+@property (nonatomic, readonly) UIUserInterfaceStyle userInterfaceStyle;
 #endif
 
-@property (nonatomic, assign, readonly) UIContentSizeCategory preferredContentSizeCategory;
+@property (nonatomic, readonly) UIContentSizeCategory preferredContentSizeCategory;
 
-@property (nonatomic, assign, readonly) CGSize containerSize;
+@property (nonatomic, readonly) CGSize containerSize;
 
 + (ASTraitCollection *)traitCollectionWithUITraitCollection:(UITraitCollection *)traitCollection
                                               containerSize:(CGSize)windowSize NS_RETURNS_RETAINED;

--- a/Source/Details/ASWeakSet.m
+++ b/Source/Details/ASWeakSet.m
@@ -18,7 +18,7 @@
 #import <AsyncDisplayKit/ASWeakSet.h>
 
 @interface ASWeakSet<__covariant ObjectType> ()
-@property (nonatomic, strong, readonly) NSHashTable<ObjectType> *hashTable;
+@property (nonatomic, readonly) NSHashTable<ObjectType> *hashTable;
 @end
 
 @implementation ASWeakSet

--- a/Source/Details/Transactions/_ASAsyncTransaction.h
+++ b/Source/Details/Transactions/_ASAsyncTransaction.h
@@ -76,13 +76,13 @@ extern NSInteger const ASDefaultTransactionPriority;
 /**
  A block that is called when the transaction is completed.
  */
-@property (nonatomic, readonly, copy, nullable) asyncdisplaykit_async_transaction_completion_block_t completionBlock;
+@property (nullable, nonatomic, readonly) asyncdisplaykit_async_transaction_completion_block_t completionBlock;
 
 /**
  The state of the transaction.
  @see ASAsyncTransactionState
  */
-@property (readonly, assign) ASAsyncTransactionState state;
+@property (readonly) ASAsyncTransactionState state;
 
 /**
  @summary Adds a synchronous operation to the transaction.  The execution block will be executed immediately.

--- a/Source/Details/Transactions/_ASAsyncTransaction.mm
+++ b/Source/Details/Transactions/_ASAsyncTransaction.mm
@@ -36,8 +36,8 @@ NSInteger const ASDefaultTransactionPriority = 0;
 
 @interface ASAsyncTransactionOperation : NSObject
 - (instancetype)initWithOperationCompletionBlock:(asyncdisplaykit_async_transaction_operation_completion_block_t)operationCompletionBlock;
-@property (nonatomic, copy) asyncdisplaykit_async_transaction_operation_completion_block_t operationCompletionBlock;
-@property (atomic, strong) id value; // set on bg queue by the operation block
+@property (nonatomic) asyncdisplaykit_async_transaction_operation_completion_block_t operationCompletionBlock;
+@property id value; // set on bg queue by the operation block
 @end
 
 @implementation ASAsyncTransactionOperation
@@ -330,7 +330,7 @@ ASAsyncTransactionQueue & ASAsyncTransactionQueue::instance()
 }
 
 @interface _ASAsyncTransaction ()
-@property (atomic) ASAsyncTransactionState state;
+@property ASAsyncTransactionState state;
 @end
 
 

--- a/Source/Details/Transactions/_ASAsyncTransactionContainer+Private.h
+++ b/Source/Details/Transactions/_ASAsyncTransactionContainer+Private.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class _ASAsyncTransaction;
 
 @interface CALayer (ASAsyncTransactionContainerTransactions)
-@property (nonatomic, strong, nullable, setter=asyncdisplaykit_setAsyncLayerTransactions:) NSHashTable<_ASAsyncTransaction *> *asyncdisplaykit_asyncLayerTransactions;
+@property (nonatomic, nullable, setter=asyncdisplaykit_setAsyncLayerTransactions:) NSHashTable<_ASAsyncTransaction *> *asyncdisplaykit_asyncLayerTransactions;
 
 - (void)asyncdisplaykit_asyncTransactionContainerWillBeginTransaction:(_ASAsyncTransaction *)transaction;
 - (void)asyncdisplaykit_asyncTransactionContainerDidCompleteTransaction:(_ASAsyncTransaction *)transaction;

--- a/Source/Details/Transactions/_ASAsyncTransactionContainer.h
+++ b/Source/Details/Transactions/_ASAsyncTransactionContainer.h
@@ -44,19 +44,19 @@ typedef NS_ENUM(NSUInteger, ASAsyncTransactionContainerState) {
 
  @default NO
  */
-@property (nonatomic, assign, getter=asyncdisplaykit_isAsyncTransactionContainer, setter=asyncdisplaykit_setAsyncTransactionContainer:) BOOL asyncdisplaykit_asyncTransactionContainer;
+@property (nonatomic, getter=asyncdisplaykit_isAsyncTransactionContainer, setter=asyncdisplaykit_setAsyncTransactionContainer:) BOOL asyncdisplaykit_asyncTransactionContainer;
 
 /**
  @summary The current state of the receiver; indicates if it is currently performing asynchronous operations or if all operations have finished/canceled.
  */
-@property (nonatomic, readonly, assign) ASAsyncTransactionContainerState asyncdisplaykit_asyncTransactionContainerState;
+@property (nonatomic, readonly) ASAsyncTransactionContainerState asyncdisplaykit_asyncTransactionContainerState;
 
 /**
  @summary Cancels all async transactions on the receiver.
  */
 - (void)asyncdisplaykit_cancelAsyncTransactions;
 
-@property (nonatomic, strong, nullable, setter=asyncdisplaykit_setCurrentAsyncTransaction:) _ASAsyncTransaction *asyncdisplaykit_currentAsyncTransaction;
+@property (nullable, nonatomic, setter=asyncdisplaykit_setCurrentAsyncTransaction:) _ASAsyncTransaction *asyncdisplaykit_currentAsyncTransaction;
 
 @end
 
@@ -66,13 +66,13 @@ typedef NS_ENUM(NSUInteger, ASAsyncTransactionContainerState) {
  did not already exist. This method will always return an open, uncommitted transaction.
  @desc asyncdisplaykit_isAsyncTransactionContainer does not need to be YES for this to return a transaction.
  */
-@property (nonatomic, readonly, strong, nullable) _ASAsyncTransaction *asyncdisplaykit_asyncTransaction;
+@property (nullable, nonatomic, readonly) _ASAsyncTransaction *asyncdisplaykit_asyncTransaction;
 
 /**
  @summary Goes up the superlayer chain until it finds the first layer with asyncdisplaykit_isAsyncTransactionContainer=YES (including the receiver) and returns it.
  Returns nil if no parent container is found.
  */
-@property (nonatomic, readonly, strong, nullable) CALayer *asyncdisplaykit_parentTransactionContainer;
+@property (nullable, nonatomic, readonly) CALayer *asyncdisplaykit_parentTransactionContainer;
 @end
 
 @interface UIView (ASAsyncTransactionContainer) <ASAsyncTransactionContainer>

--- a/Source/Details/UIView+ASConvenience.h
+++ b/Source/Details/UIView+ASConvenience.h
@@ -26,30 +26,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ASDisplayProperties <NSObject>
 
-@property (nonatomic, assign) CGPoint position;
-@property (nonatomic, assign) CGFloat zPosition;
-@property (nonatomic, assign) CGPoint anchorPoint;
-@property (nonatomic, assign) CGFloat cornerRadius;
-@property (nullable, nonatomic, strong) id contents;
+@property (nonatomic) CGPoint position;
+@property (nonatomic) CGFloat zPosition;
+@property (nonatomic) CGPoint anchorPoint;
+@property (nonatomic) CGFloat cornerRadius;
+@property (nullable, nonatomic) id contents;
 @property (nonatomic, copy)   NSString *contentsGravity;
-@property (nonatomic, assign) CGRect contentsRect;
-@property (nonatomic, assign) CGRect contentsCenter;
-@property (nonatomic, assign) CGFloat contentsScale;
-@property (nonatomic, assign) CGFloat rasterizationScale;
-@property (nonatomic, assign) CATransform3D transform;
-@property (nonatomic, assign) CATransform3D sublayerTransform;
-@property (nonatomic, assign) BOOL needsDisplayOnBoundsChange;
-@property (nonatomic, strong) __attribute__((NSObject)) CGColorRef shadowColor;
-@property (nonatomic, assign) CGFloat shadowOpacity;
-@property (nonatomic, assign) CGSize shadowOffset;
-@property (nonatomic, assign) CGFloat shadowRadius;
-@property (nonatomic, assign) CGFloat borderWidth;
-@property (nonatomic, assign, getter = isOpaque) BOOL opaque;
-@property (nonatomic, strong) __attribute__((NSObject)) CGColorRef borderColor;
-@property (nonatomic, strong) __attribute__((NSObject)) CGColorRef backgroundColor;
-@property (nonatomic, assign) BOOL allowsGroupOpacity;
-@property (nonatomic, assign) BOOL allowsEdgeAntialiasing;
-@property (nonatomic, assign) unsigned int edgeAntialiasingMask;
+@property (nonatomic) CGRect contentsRect;
+@property (nonatomic) CGRect contentsCenter;
+@property (nonatomic) CGFloat contentsScale;
+@property (nonatomic) CGFloat rasterizationScale;
+@property (nonatomic) CATransform3D transform;
+@property (nonatomic) CATransform3D sublayerTransform;
+@property (nonatomic) BOOL needsDisplayOnBoundsChange;
+@property (nonatomic) __attribute__((NSObject)) CGColorRef shadowColor;
+@property (nonatomic) CGFloat shadowOpacity;
+@property (nonatomic) CGSize shadowOffset;
+@property (nonatomic) CGFloat shadowRadius;
+@property (nonatomic) CGFloat borderWidth;
+@property (nonatomic, getter = isOpaque) BOOL opaque;
+@property (nonatomic) __attribute__((NSObject)) CGColorRef borderColor;
+@property (nonatomic) __attribute__((NSObject)) CGColorRef backgroundColor;
+@property (nonatomic) BOOL allowsGroupOpacity;
+@property (nonatomic) BOOL allowsEdgeAntialiasing;
+@property (nonatomic) unsigned int edgeAntialiasingMask;
 
 - (void)setNeedsDisplay;
 - (void)setNeedsLayout;
@@ -62,41 +62,41 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol ASDisplayNodeViewProperties
 
-@property (nonatomic, assign)          BOOL clipsToBounds;
+@property (nonatomic)          BOOL clipsToBounds;
 @property (nonatomic, getter=isHidden) BOOL hidden;
-@property (nonatomic, assign)          BOOL autoresizesSubviews;
-@property (nonatomic, assign)          UIViewAutoresizing autoresizingMask;
-@property (nonatomic, strong, null_resettable) UIColor *tintColor;
-@property (nonatomic, assign)          CGFloat alpha;
-@property (nonatomic, assign)          CGRect bounds;
-@property (nonatomic, assign)          CGRect frame;   // Only for use with nodes wrapping synchronous views
-@property (nonatomic, assign)          UIViewContentMode contentMode;
-@property (nonatomic, assign)          UISemanticContentAttribute semanticContentAttribute API_AVAILABLE(ios(9.0), tvos(9.0));
-@property (nonatomic, assign, getter=isUserInteractionEnabled) BOOL userInteractionEnabled;
-@property (nonatomic, assign, getter=isExclusiveTouch) BOOL exclusiveTouch;
-@property (nonatomic, assign, getter=asyncdisplaykit_isAsyncTransactionContainer, setter = asyncdisplaykit_setAsyncTransactionContainer:) BOOL asyncdisplaykit_asyncTransactionContainer;
-@property (nonatomic, assign)           UIEdgeInsets layoutMargins;
-@property (nonatomic, assign)           BOOL preservesSuperviewLayoutMargins;
-@property (nonatomic, assign)           BOOL insetsLayoutMarginsFromSafeArea;
+@property (nonatomic)          BOOL autoresizesSubviews;
+@property (nonatomic)          UIViewAutoresizing autoresizingMask;
+@property (nonatomic, null_resettable) UIColor *tintColor;
+@property (nonatomic)          CGFloat alpha;
+@property (nonatomic)          CGRect bounds;
+@property (nonatomic)          CGRect frame;   // Only for use with nodes wrapping synchronous views
+@property (nonatomic)          UIViewContentMode contentMode;
+@property (nonatomic)          UISemanticContentAttribute semanticContentAttribute API_AVAILABLE(ios(9.0), tvos(9.0));
+@property (nonatomic, getter=isUserInteractionEnabled) BOOL userInteractionEnabled;
+@property (nonatomic, getter=isExclusiveTouch) BOOL exclusiveTouch;
+@property (nonatomic, getter=asyncdisplaykit_isAsyncTransactionContainer, setter = asyncdisplaykit_setAsyncTransactionContainer:) BOOL asyncdisplaykit_asyncTransactionContainer;
+@property (nonatomic)           UIEdgeInsets layoutMargins;
+@property (nonatomic)           BOOL preservesSuperviewLayoutMargins;
+@property (nonatomic)           BOOL insetsLayoutMarginsFromSafeArea;
 
 /**
  Following properties of the UIAccessibility informal protocol are supported as well.
  We don't declare them here, so _ASPendingState does not complain about them being not implemented,
  as they are already on NSObject
 
- @property (nonatomic, assign)           BOOL isAccessibilityElement;
+ @property (nonatomic)           BOOL isAccessibilityElement;
  @property (nonatomic, copy, nullable)   NSString *accessibilityLabel;
  @property (nonatomic, copy, nullable)   NSAttributedString *accessibilityAttributedLabel API_AVAILABLE(ios(11.0),tvos(11.0));
  @property (nonatomic, copy, nullable)   NSString *accessibilityHint;
  @property (nonatomic, copy, nullable)   NSAttributedString *accessibilityAttributedHint API_AVAILABLE(ios(11.0),tvos(11.0));
  @property (nonatomic, copy, nullable)   NSString *accessibilityValue;
  @property (nonatomic, copy, nullable)   NSAttributedString *accessibilityAttributedValue API_AVAILABLE(ios(11.0),tvos(11.0));
- @property (nonatomic, assign)           UIAccessibilityTraits accessibilityTraits;
- @property (nonatomic, assign)           CGRect accessibilityFrame;
- @property (nonatomic, strong, nullable) NSString *accessibilityLanguage;
- @property (nonatomic, assign)           BOOL accessibilityElementsHidden;
- @property (nonatomic, assign)           BOOL accessibilityViewIsModal;
- @property (nonatomic, assign)           BOOL shouldGroupAccessibilityChildren;
+ @property (nonatomic)           UIAccessibilityTraits accessibilityTraits;
+ @property (nonatomic)           CGRect accessibilityFrame;
+ @property (nonatomic, nullable) NSString *accessibilityLanguage;
+ @property (nonatomic)           BOOL accessibilityElementsHidden;
+ @property (nonatomic)           BOOL accessibilityViewIsModal;
+ @property (nonatomic)           BOOL shouldGroupAccessibilityChildren;
  */
 
 // Accessibility identification support

--- a/Source/Details/_ASCollectionReusableView.h
+++ b/Source/Details/_ASCollectionReusableView.h
@@ -25,9 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED // Note: ASDynamicCastStrict is used on instances of this class based on this restriction.
 @interface _ASCollectionReusableView : UICollectionReusableView
 
-@property (nonatomic, strong, readonly, nullable) ASCellNode *node;
-@property (nonatomic, strong, nullable) ASCollectionElement *element;
-@property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
+@property (nullable, nonatomic, readonly) ASCellNode *node;
+@property (nullable, nonatomic) ASCollectionElement *element;
+@property (nullable, nonatomic) UICollectionViewLayoutAttributes *layoutAttributes;
 
 @end
 

--- a/Source/Details/_ASCollectionViewCell.h
+++ b/Source/Details/_ASCollectionViewCell.h
@@ -26,9 +26,9 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED // Note: ASDynamicCastStrict is used on instances of this class based on this restriction.
 @interface _ASCollectionViewCell : UICollectionViewCell
 
-@property (nonatomic, strong, nullable) ASCollectionElement *element;
-@property (nonatomic, strong, readonly, nullable) ASCellNode *node;
-@property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
+@property (nonatomic, nullable) ASCollectionElement *element;
+@property (nullable, nonatomic, readonly) ASCellNode *node;
+@property (nonatomic, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
 
 /**
  * Whether or not this cell is interested in cell node visibility events.

--- a/Source/Details/_ASDisplayLayer.h
+++ b/Source/Details/_ASDisplayLayer.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @default YES (note that this might change for subclasses)
  */
-@property (nonatomic, assign) BOOL displaysAsynchronously;
+@property (nonatomic) BOOL displaysAsynchronously;
 
 /**
  @summary Cancels any pending async display.
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @desc The asyncDelegate will have the opportunity to override the methods related to async display.
  */
-@property (nullable, atomic, weak) id<_ASDisplayLayerDelegate> asyncDelegate;
+@property (nullable, weak) id<_ASDisplayLayerDelegate> asyncDelegate;
 
 /**
  @summary Suspends both asynchronous and synchronous display of the receiver if YES.
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @default NO
  */
-@property (nonatomic, assign, getter=isDisplaySuspended) BOOL displaySuspended;
+@property (nonatomic, getter=isDisplaySuspended) BOOL displaySuspended;
 
 /**
  @summary Bypasses asynchronous rendering and performs a blocking display immediately on the current thread.

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -77,7 +77,7 @@ static _ASDisplayViewMethodOverrides GetASDisplayViewMethodOverrides(Class c)
 
 // Keep the node alive while its view is active.  If you create a view, add its layer to a layer hierarchy, then release
 // the view, the layer retains the view to prevent a crash.  This replicates this behaviour for the node abstraction.
-@property (nonatomic, strong, readwrite) ASDisplayNode *keepalive_node;
+@property (nonatomic) ASDisplayNode *keepalive_node;
 @end
 
 @implementation _ASDisplayView

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -65,8 +65,8 @@ static void SortAccessibilityElements(NSMutableArray *elements)
 
 @interface ASAccessibilityElement : UIAccessibilityElement<ASAccessibilityElementPositioning>
 
-@property (nonatomic, strong) ASDisplayNode *node;
-@property (nonatomic, strong) ASDisplayNode *containerNode;
+@property (nonatomic) ASDisplayNode *node;
+@property (nonatomic) ASDisplayNode *containerNode;
 
 + (ASAccessibilityElement *)accessibilityElementWithContainer:(UIView *)container node:(ASDisplayNode *)node containerNode:(ASDisplayNode *)containerNode;
 
@@ -107,9 +107,9 @@ static void SortAccessibilityElements(NSMutableArray *elements)
 
 @interface ASAccessibilityCustomAction : UIAccessibilityCustomAction<ASAccessibilityElementPositioning>
 
-@property (nonatomic, strong) UIView *container;
-@property (nonatomic, strong) ASDisplayNode *node;
-@property (nonatomic, strong) ASDisplayNode *containerNode;
+@property (nonatomic) UIView *container;
+@property (nonatomic) ASDisplayNode *node;
+@property (nonatomic) ASDisplayNode *containerNode;
 
 @end
 

--- a/Source/Layout/ASAbsoluteLayoutElement.h
+++ b/Source/Layout/ASAbsoluteLayoutElement.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @abstract The position of this object within its parent spec.
  */
-@property (nonatomic, assign) CGPoint layoutPosition;
+@property (nonatomic) CGPoint layoutPosition;
 
 @end
 

--- a/Source/Layout/ASAbsoluteLayoutSpec.h
+++ b/Source/Layout/ASAbsoluteLayoutSpec.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  How much space will the spec taken up
  */
-@property (nonatomic, assign) ASAbsoluteLayoutSpecSizing sizing;
+@property (nonatomic) ASAbsoluteLayoutSpecSizing sizing;
 
 /**
  @param sizing How much space the spec will take up

--- a/Source/Layout/ASBackgroundLayoutSpec.h
+++ b/Source/Layout/ASBackgroundLayoutSpec.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Background layoutElement for this layout spec
  */
-@property (nonatomic, strong) id<ASLayoutElement> background;
+@property (nonatomic) id<ASLayoutElement> background;
 
 /**
  * Creates and returns an ASBackgroundLayoutSpec object

--- a/Source/Layout/ASCenterLayoutSpec.h
+++ b/Source/Layout/ASCenterLayoutSpec.h
@@ -59,8 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface ASCenterLayoutSpec : ASRelativeLayoutSpec
 
-@property (nonatomic, assign) ASCenterLayoutSpecCenteringOptions centeringOptions;
-@property (nonatomic, assign) ASCenterLayoutSpecSizingOptions sizingOptions;
+@property (nonatomic) ASCenterLayoutSpecCenteringOptions centeringOptions;
+@property (nonatomic) ASCenterLayoutSpecSizingOptions sizingOptions;
 
 /**
  * Initializer.

--- a/Source/Layout/ASCornerLayoutSpec.h
+++ b/Source/Layout/ASCornerLayoutSpec.h
@@ -54,25 +54,25 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A layoutElement object that is laid out to a corner on the child.
  */
-@property (nonatomic, strong) id <ASLayoutElement> corner;
+@property (nonatomic) id <ASLayoutElement> corner;
 
 /**
  The corner position option.
  */
-@property (nonatomic, assign) ASCornerLayoutLocation cornerLocation;
+@property (nonatomic) ASCornerLayoutLocation cornerLocation;
 
 /**
  The point which offsets from the corner location. Use this property to make delta
  distance from the default corner location. Default is CGPointZero.
  */
-@property (nonatomic, assign) CGPoint offset;
+@property (nonatomic) CGPoint offset;
 
 /**
  Whether should include corner element into layout size calculation. If included,
  the layout size will be the union size of both child and corner; If not included,
  the layout size will be only child's size. Default is NO.
  */
-@property (nonatomic, assign) BOOL wrapsCorner;
+@property (nonatomic) BOOL wrapsCorner;
 
 @end
 

--- a/Source/Layout/ASInsetLayoutSpec.h
+++ b/Source/Layout/ASInsetLayoutSpec.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface ASInsetLayoutSpec : ASLayoutSpec
 
-@property (nonatomic, assign) UIEdgeInsets insets;
+@property (nonatomic) UIEdgeInsets insets;
 
 /**
  @param insets The amount of space to inset on each side.

--- a/Source/Layout/ASLayout.h
+++ b/Source/Layout/ASLayout.h
@@ -58,19 +58,19 @@ ASDISPLAYNODE_EXTERN_C_END
 /**
  * The type of ASLayoutElement that created this layout
  */
-@property (nonatomic, assign, readonly) ASLayoutElementType type;
+@property (nonatomic, readonly) ASLayoutElementType type;
 
 /**
  * Size of the current layout
  */
-@property (nonatomic, assign, readonly) CGSize size;
+@property (nonatomic, readonly) CGSize size;
 
 /**
  * Position in parent. Default to ASPointNull.
  * 
  * @discussion When being used as a sublayout, this property must not equal ASPointNull.
  */
-@property (nonatomic, assign, readonly) CGPoint position;
+@property (nonatomic, readonly) CGPoint position;
 
 /**
  * Array of ASLayouts. Each must have a valid non-null position.
@@ -87,7 +87,7 @@ ASDISPLAYNODE_EXTERN_C_END
  * @abstract Returns a valid frame for the current layout computed with the size and position.
  * @discussion Clamps the layout's origin or position to 0 if any of the calculated values are infinite.
  */
-@property (nonatomic, assign, readonly) CGRect frame;
+@property (nonatomic, readonly) CGRect frame;
 
 /**
  * Designated initializer
@@ -143,7 +143,7 @@ ASDISPLAYNODE_EXTERN_C_END
 
 @interface ASLayout (Unavailable)
 
-- (instancetype)init __unavailable;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -84,7 +84,7 @@ ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT BOOL ASLayoutIsFlattened(ASLayout *la
 /**
  * Array for explicitly retain sublayout layout elements in case they are created and references in layoutSpecThatFits: and no one else will hold a strong reference on it
  */
-@property (nonatomic, strong) NSMutableArray<id<ASLayoutElement>> *sublayoutLayoutElements;
+@property (nonatomic) NSMutableArray<id<ASLayoutElement>> *sublayoutLayoutElements;
 
 @property (nonatomic, readonly) ASRectMap *elementToRectMap;
 

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -79,14 +79,14 @@ ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT BOOL ASLayoutIsFlattened(ASLayout *la
 /*
  * Caches all sublayouts if set to YES or destroys the sublayout cache if set to NO. Defaults to NO
  */
-@property (nonatomic, assign) BOOL retainSublayoutLayoutElements;
+@property (nonatomic) BOOL retainSublayoutLayoutElements;
 
 /**
  * Array for explicitly retain sublayout layout elements in case they are created and references in layoutSpecThatFits: and no one else will hold a strong reference on it
  */
 @property (nonatomic, strong) NSMutableArray<id<ASLayoutElement>> *sublayoutLayoutElements;
 
-@property (nonatomic, strong, readonly) ASRectMap *elementToRectMap;
+@property (nonatomic, readonly) ASRectMap *elementToRectMap;
 
 @end
 

--- a/Source/Layout/ASLayoutElement.h
+++ b/Source/Layout/ASLayoutElement.h
@@ -68,12 +68,12 @@ typedef NS_ENUM(NSUInteger, ASLayoutElementType) {
 /**
  * @abstract Returns type of layoutElement
  */
-@property (nonatomic, assign, readonly) ASLayoutElementType layoutElementType;
+@property (nonatomic, readonly) ASLayoutElementType layoutElementType;
 
 /**
  * @abstract A size constraint that should apply to this ASLayoutElement.
  */
-@property (nonatomic, strong, readonly) ASLayoutElementStyle *style;
+@property (nonatomic, readonly) ASLayoutElementStyle *style;
 
 /**
  * @abstract Returns all children of an object which class conforms to the ASLayoutElement protocol
@@ -196,14 +196,14 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * The minWidth and maxWidth properties override width.
  * Defaults to ASDimensionAuto
  */
-@property (nonatomic, assign, readwrite) ASDimension width;
+@property (nonatomic, readwrite) ASDimension width;
 
 /**
  * @abstract The height property specifies the height of the content area of an ASLayoutElement
  * The minHeight and maxHeight properties override height.
  * Defaults to ASDimensionAuto
  */
-@property (nonatomic, assign, readwrite) ASDimension height;
+@property (nonatomic, readwrite) ASDimension height;
 
 /**
  * @abstract The minHeight property is used to set the minimum height of a given element. It prevents the used value
@@ -211,7 +211,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * The value of minHeight overrides both maxHeight and height.
  * Defaults to ASDimensionAuto
  */
-@property (nonatomic, assign, readwrite) ASDimension minHeight;
+@property (nonatomic, readwrite) ASDimension minHeight;
 
 /**
  * @abstract The maxHeight property is used to set the maximum height of an element. It prevents the used value of the
@@ -219,7 +219,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * The value of maxHeight overrides height, but minHeight overrides maxHeight.
  * Defaults to ASDimensionAuto
  */
-@property (nonatomic, assign, readwrite) ASDimension maxHeight;
+@property (nonatomic, readwrite) ASDimension maxHeight;
 
 /**
  * @abstract The minWidth property is used to set the minimum width of a given element. It prevents the used value of
@@ -227,7 +227,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * The value of minWidth overrides both maxWidth and width.
  * Defaults to ASDimensionAuto
  */
-@property (nonatomic, assign, readwrite) ASDimension minWidth;
+@property (nonatomic, readwrite) ASDimension minWidth;
 
 /**
  * @abstract The maxWidth property is used to set the maximum width of a given element. It prevents the used value of
@@ -235,7 +235,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * The value of maxWidth overrides width, but minWidth overrides maxWidth.
  * Defaults to ASDimensionAuto
  */
-@property (nonatomic, assign, readwrite) ASDimension maxWidth;
+@property (nonatomic, readwrite) ASDimension maxWidth;
 
 #pragma mark - ASLayoutElementStyleSizeHelpers
 
@@ -251,7 +251,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  *
  * @warning Calling the getter when the size's width or height are relative will cause an assert.
  */
-@property (nonatomic, assign) CGSize preferredSize;
+@property (nonatomic) CGSize preferredSize;
 
  /**
  * @abstract An optional property that provides a minimum size bound for a layout element. If provided, this restriction will 
@@ -262,7 +262,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * element in a full screen container, this would result in a width of 160 points on an iPhone screen. However, 
  * since 160 pts is lower than the minimum width of 200 pts, the minimum width would be used.
  */
-@property (nonatomic, assign) CGSize minSize;
+@property (nonatomic) CGSize minSize;
 - (CGSize)minSize UNAVAILABLE_ATTRIBUTE;
 
 /**
@@ -274,7 +274,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * element in a full screen container, this would result in a width of 160 points on an iPhone screen. However, 
  * since 160 pts is higher than the maximum width of 120 pts, the maximum width would be used.
  */
-@property (nonatomic, assign) CGSize maxSize;
+@property (nonatomic) CGSize maxSize;
 - (CGSize)maxSize UNAVAILABLE_ATTRIBUTE;
 
 /**
@@ -284,21 +284,21 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * will be enforced. If this optional value is not provided, the layout element’s size will default to its intrinsic content size 
  * provided calculateSizeThatFits:
  */
-@property (nonatomic, assign, readwrite) ASLayoutSize preferredLayoutSize;
+@property (nonatomic, readwrite) ASLayoutSize preferredLayoutSize;
 
 /**
  * @abstract An optional property that provides a minimum RELATIVE size bound for a layout element. If provided, this
  * restriction will always be enforced. If a parent layout element’s minimum relative size is smaller than its child’s minimum
  * relative size, the child’s minimum relative size will be enforced and its size will extend out of the layout spec’s.
  */
-@property (nonatomic, assign, readwrite) ASLayoutSize minLayoutSize;
+@property (nonatomic, readwrite) ASLayoutSize minLayoutSize;
 
 /**
  * @abstract An optional property that provides a maximum RELATIVE size bound for a layout element. If provided, this
  * restriction will always be enforced. If a parent layout element’s maximum relative size is smaller than its child’s maximum
  * relative size, the child’s maximum relative size will be enforced and its size will extend out of the layout spec’s.
  */
-@property (nonatomic, assign, readwrite) ASLayoutSize maxLayoutSize;
+@property (nonatomic, readwrite) ASLayoutSize maxLayoutSize;
 
 @end
 

--- a/Source/Layout/ASLayoutElement.h
+++ b/Source/Layout/ASLayoutElement.h
@@ -196,14 +196,14 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * The minWidth and maxWidth properties override width.
  * Defaults to ASDimensionAuto
  */
-@property (nonatomic, readwrite) ASDimension width;
+@property (nonatomic) ASDimension width;
 
 /**
  * @abstract The height property specifies the height of the content area of an ASLayoutElement
  * The minHeight and maxHeight properties override height.
  * Defaults to ASDimensionAuto
  */
-@property (nonatomic, readwrite) ASDimension height;
+@property (nonatomic) ASDimension height;
 
 /**
  * @abstract The minHeight property is used to set the minimum height of a given element. It prevents the used value
@@ -211,7 +211,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * The value of minHeight overrides both maxHeight and height.
  * Defaults to ASDimensionAuto
  */
-@property (nonatomic, readwrite) ASDimension minHeight;
+@property (nonatomic) ASDimension minHeight;
 
 /**
  * @abstract The maxHeight property is used to set the maximum height of an element. It prevents the used value of the
@@ -219,7 +219,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * The value of maxHeight overrides height, but minHeight overrides maxHeight.
  * Defaults to ASDimensionAuto
  */
-@property (nonatomic, readwrite) ASDimension maxHeight;
+@property (nonatomic) ASDimension maxHeight;
 
 /**
  * @abstract The minWidth property is used to set the minimum width of a given element. It prevents the used value of
@@ -227,7 +227,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * The value of minWidth overrides both maxWidth and width.
  * Defaults to ASDimensionAuto
  */
-@property (nonatomic, readwrite) ASDimension minWidth;
+@property (nonatomic) ASDimension minWidth;
 
 /**
  * @abstract The maxWidth property is used to set the maximum width of a given element. It prevents the used value of
@@ -235,7 +235,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * The value of maxWidth overrides width, but minWidth overrides maxWidth.
  * Defaults to ASDimensionAuto
  */
-@property (nonatomic, readwrite) ASDimension maxWidth;
+@property (nonatomic) ASDimension maxWidth;
 
 #pragma mark - ASLayoutElementStyleSizeHelpers
 
@@ -284,21 +284,21 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * will be enforced. If this optional value is not provided, the layout element’s size will default to its intrinsic content size 
  * provided calculateSizeThatFits:
  */
-@property (nonatomic, readwrite) ASLayoutSize preferredLayoutSize;
+@property (nonatomic) ASLayoutSize preferredLayoutSize;
 
 /**
  * @abstract An optional property that provides a minimum RELATIVE size bound for a layout element. If provided, this
  * restriction will always be enforced. If a parent layout element’s minimum relative size is smaller than its child’s minimum
  * relative size, the child’s minimum relative size will be enforced and its size will extend out of the layout spec’s.
  */
-@property (nonatomic, readwrite) ASLayoutSize minLayoutSize;
+@property (nonatomic) ASLayoutSize minLayoutSize;
 
 /**
  * @abstract An optional property that provides a maximum RELATIVE size bound for a layout element. If provided, this
  * restriction will always be enforced. If a parent layout element’s maximum relative size is smaller than its child’s maximum
  * relative size, the child’s maximum relative size will be enforced and its size will extend out of the layout spec’s.
  */
-@property (nonatomic, readwrite) ASLayoutSize maxLayoutSize;
+@property (nonatomic) ASLayoutSize maxLayoutSize;
 
 @end
 

--- a/Source/Layout/ASLayoutSpec+Subclasses.h
+++ b/Source/Layout/ASLayoutSpec+Subclasses.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion When being used as a sublayout, this property must not equal CGPointNull.
  */
-@property (nonatomic, assign, readwrite) CGPoint position;
+@property (nonatomic, readwrite) CGPoint position;
 
 @end
 

--- a/Source/Layout/ASLayoutSpec+Subclasses.h
+++ b/Source/Layout/ASLayoutSpec+Subclasses.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion When being used as a sublayout, this property must not equal CGPointNull.
  */
-@property (nonatomic, readwrite) CGPoint position;
+@property (nonatomic) CGPoint position;
 
 @end
 

--- a/Source/Layout/ASLayoutSpec+Subclasses.mm
+++ b/Source/Layout/ASLayoutSpec+Subclasses.mm
@@ -23,7 +23,7 @@
 #pragma mark - ASNullLayoutSpec
 
 @interface ASNullLayoutSpec : ASLayoutSpec
-- (instancetype)init __unavailable;
+- (instancetype)init NS_UNAVAILABLE;
 + (ASNullLayoutSpec *)null;
 @end
 

--- a/Source/Layout/ASLayoutSpec.h
+++ b/Source/Layout/ASLayoutSpec.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  * layout spec can be created and mutated. Once it is passed back to ASDK, the isMutable flag will be
  * set to NO and any further mutations will cause an assert.
  */
-@property (nonatomic, assign) BOOL isMutable;
+@property (nonatomic) BOOL isMutable;
 
 /**
  * First child within the children's array.
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  * setChild:atIndex: internally. For example, ASBackgroundLayoutSpec exposes a "background"
  * property that behind the scenes is calling setChild:atIndex:.
  */
-@property (nullable, strong, nonatomic) id<ASLayoutElement> child;
+@property (nullable, nonatomic) id<ASLayoutElement> child;
 
 /**
  * An array of ASLayoutElement children
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  * For good measure, in these layout specs it probably makes sense to define
  * setChild: and setChild:forIdentifier: methods to do something appropriate or to assert.
  */
-@property (nullable, strong, nonatomic) NSArray<id<ASLayoutElement>> *children;
+@property (nullable, nonatomic) NSArray<id<ASLayoutElement>> *children;
 
 @end
 
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * Init not available for ASWrapperLayoutSpec
  */
-- (instancetype)init __unavailable;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/Source/Layout/ASOverlayLayoutSpec.h
+++ b/Source/Layout/ASOverlayLayoutSpec.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Overlay layoutElement of this layout spec
  */
-@property (nonatomic, strong) id<ASLayoutElement> overlay;
+@property (nonatomic) id<ASLayoutElement> overlay;
 
 /**
  * Creates and returns an ASOverlayLayoutSpec object with a given child and an layoutElement that act as overlay.

--- a/Source/Layout/ASRatioLayoutSpec.h
+++ b/Source/Layout/ASRatioLayoutSpec.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  **/
 @interface ASRatioLayoutSpec : ASLayoutSpec
 
-@property (nonatomic, assign) CGFloat ratio;
+@property (nonatomic) CGFloat ratio;
 
 + (instancetype)ratioLayoutSpecWithRatio:(CGFloat)ratio child:(id<ASLayoutElement>)child NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT;
 

--- a/Source/Layout/ASRelativeLayoutSpec.h
+++ b/Source/Layout/ASRelativeLayoutSpec.h
@@ -59,9 +59,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASRelativeLayoutSpec : ASLayoutSpec
 
 // You may create a spec with alloc / init, then set any non-default properties; or use a convenience initialize that accepts all properties.
-@property (nonatomic, assign) ASRelativeLayoutSpecPosition horizontalPosition;
-@property (nonatomic, assign) ASRelativeLayoutSpecPosition verticalPosition;
-@property (nonatomic, assign) ASRelativeLayoutSpecSizingOption sizingOption;
+@property (nonatomic) ASRelativeLayoutSpecPosition horizontalPosition;
+@property (nonatomic) ASRelativeLayoutSpecPosition verticalPosition;
+@property (nonatomic) ASRelativeLayoutSpecSizingOption sizingOption;
 
 /*!
  * @discussion convenience constructor for a ASRelativeLayoutSpec

--- a/Source/Layout/ASStackLayoutElement.h
+++ b/Source/Layout/ASStackLayoutElement.h
@@ -30,51 +30,51 @@ NS_ASSUME_NONNULL_BEGIN
  * @abstract Additional space to place before this object in the stacking direction.
  * Used when attached to a stack layout.
  */
-@property (nonatomic, readwrite) CGFloat spacingBefore;
+@property (nonatomic) CGFloat spacingBefore;
 
 /**
  * @abstract Additional space to place after this object in the stacking direction.
  * Used when attached to a stack layout.
  */
-@property (nonatomic, readwrite) CGFloat spacingAfter;
+@property (nonatomic) CGFloat spacingAfter;
 
 /**
  * @abstract If the sum of childrens' stack dimensions is less than the minimum size, how much should this component grow?
  * This value represents the "flex grow factor" and determines how much this component should grow in relation to any
  * other flexible children.
  */
-@property (nonatomic, readwrite) CGFloat flexGrow;
+@property (nonatomic) CGFloat flexGrow;
 
 /**
  * @abstract If the sum of childrens' stack dimensions is greater than the maximum size, how much should this component shrink?
  * This value represents the "flex shrink factor" and determines how much this component should shink in relation to
  * other flexible children.
  */
-@property (nonatomic, readwrite) CGFloat flexShrink;
+@property (nonatomic) CGFloat flexShrink;
 
 /**
  * @abstract Specifies the initial size in the stack dimension for this object.
  * Defaults to ASDimensionAuto.
  * Used when attached to a stack layout.
  */
-@property (nonatomic, readwrite) ASDimension flexBasis;
+@property (nonatomic) ASDimension flexBasis;
 
 /**
  * @abstract Orientation of the object along cross axis, overriding alignItems.
  * Defaults to ASStackLayoutAlignSelfAuto.
  * Used when attached to a stack layout.
  */
-@property (nonatomic, readwrite) ASStackLayoutAlignSelf alignSelf;
+@property (nonatomic) ASStackLayoutAlignSelf alignSelf;
 
 /**
  *  @abstract Used for baseline alignment. The distance from the top of the object to its baseline.
  */
-@property (nonatomic, readwrite) CGFloat ascender;
+@property (nonatomic) CGFloat ascender;
 
 /**
  *  @abstract Used for baseline alignment. The distance from the baseline of the object to its bottom.
  */
-@property (nonatomic, readwrite) CGFloat descender;
+@property (nonatomic) CGFloat descender;
 
 @end
 

--- a/Source/Layout/ASStackLayoutSpec.h
+++ b/Source/Layout/ASStackLayoutSpec.h
@@ -47,33 +47,33 @@ NS_ASSUME_NONNULL_BEGIN
  Specifies the direction children are stacked in. If horizontalAlignment and verticalAlignment were set, 
  they will be resolved again, causing justifyContent and alignItems to be updated accordingly
  */
-@property (nonatomic, assign) ASStackLayoutDirection direction;
+@property (nonatomic) ASStackLayoutDirection direction;
 /** The amount of space between each child. */
-@property (nonatomic, assign) CGFloat spacing;
+@property (nonatomic) CGFloat spacing;
 /** 
  Specifies how children are aligned horizontally. Depends on the stack direction, setting the alignment causes either
  justifyContent or alignItems to be updated. The alignment will remain valid after future direction changes.
  Thus, it is preferred to those properties
  */
-@property (nonatomic, assign) ASHorizontalAlignment horizontalAlignment;
+@property (nonatomic) ASHorizontalAlignment horizontalAlignment;
 /** 
  Specifies how children are aligned vertically. Depends on the stack direction, setting the alignment causes either
  justifyContent or alignItems to be updated. The alignment will remain valid after future direction changes.
  Thus, it is preferred to those properties
  */
-@property (nonatomic, assign) ASVerticalAlignment verticalAlignment;
+@property (nonatomic) ASVerticalAlignment verticalAlignment;
 /** The amount of space between each child. Defaults to ASStackLayoutJustifyContentStart */
-@property (nonatomic, assign) ASStackLayoutJustifyContent justifyContent;
+@property (nonatomic) ASStackLayoutJustifyContent justifyContent;
 /** Orientation of children along cross axis. Defaults to ASStackLayoutAlignItemsStretch */
-@property (nonatomic, assign) ASStackLayoutAlignItems alignItems;
+@property (nonatomic) ASStackLayoutAlignItems alignItems;
 /** Whether children are stacked into a single or multiple lines. Defaults to single line (ASStackLayoutFlexWrapNoWrap) */
-@property (nonatomic, assign) ASStackLayoutFlexWrap flexWrap;
+@property (nonatomic) ASStackLayoutFlexWrap flexWrap;
 /** Orientation of lines along cross axis if there are multiple lines. Defaults to ASStackLayoutAlignContentStart */
-@property (nonatomic, assign) ASStackLayoutAlignContent alignContent;
+@property (nonatomic) ASStackLayoutAlignContent alignContent;
 /** If the stack spreads on multiple lines using flexWrap, the amount of space between lines. */
-@property (nonatomic, assign) CGFloat lineSpacing;
+@property (nonatomic) CGFloat lineSpacing;
 /** Whether this stack can dispatch to other threads, regardless of which thread it's running on */
-@property (nonatomic, assign, getter=isConcurrent) BOOL concurrent;
+@property (nonatomic, getter=isConcurrent) BOOL concurrent;
 
 - (instancetype)init;
 

--- a/Source/Layout/ASYogaLayoutSpec.h
+++ b/Source/Layout/ASYogaLayoutSpec.h
@@ -18,7 +18,7 @@
 #import <AsyncDisplayKit/ASLayoutSpec.h>
 
 @interface ASYogaLayoutSpec : ASLayoutSpec
-@property (nonatomic, strong, nonnull) ASDisplayNode *rootNode;
+@property (nonatomic, nonnull) ASDisplayNode *rootNode;
 @end
 
 #endif /* YOGA */

--- a/Source/Private/ASBasicImageDownloaderInternal.h
+++ b/Source/Private/ASBasicImageDownloaderInternal.h
@@ -19,7 +19,7 @@
 
 + (ASBasicImageDownloaderContext *)contextForURL:(NSURL *)URL;
 
-@property (nonatomic, strong, readonly) NSURL *URL;
+@property (nonatomic, readonly) NSURL *URL;
 @property (nonatomic, weak) NSURLSessionTask *sessionTask;
 
 - (BOOL)isCancelled;

--- a/Source/Private/ASCellNode+Internal.h
+++ b/Source/Private/ASCellNode+Internal.h
@@ -57,11 +57,11 @@ NS_ASSUME_NONNULL_BEGIN
  *   that it's always safe simply to retain it, and copy if needed. Since @c UICollectionViewLayoutAttributes
  *   is always mutable, @c copy is never "free" like it is for e.g. NSString.
  */
-@property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
+@property (nullable, nonatomic) UICollectionViewLayoutAttributes *layoutAttributes;
 
-@property (atomic, weak, nullable) ASCollectionElement *collectionElement;
+@property (weak, nullable) ASCollectionElement *collectionElement;
 
-@property (atomic, weak, nullable) id<ASRangeManagingNode> owningNode;
+@property (weak, nullable) id<ASRangeManagingNode> owningNode;
 
 @property (nonatomic, readonly) BOOL shouldUseUIKitCell;
 
@@ -75,9 +75,9 @@ typedef UICollectionReusableView * _Nonnull(^ASViewForSupplementaryBlock)(ASWrap
 
 @interface ASWrapperCellNode : ASCellNode
 
-@property (nonatomic, copy, readonly) ASSizeForItemBlock sizeForItemBlock;
-@property (nonatomic, copy, readonly) ASCellForItemBlock cellForItemBlock;
-@property (nonatomic, copy, readonly) ASViewForSupplementaryBlock viewForSupplementaryBlock;
+@property (nonatomic, readonly) ASSizeForItemBlock sizeForItemBlock;
+@property (nonatomic, readonly) ASCellForItemBlock cellForItemBlock;
+@property (nonatomic, readonly) ASViewForSupplementaryBlock viewForSupplementaryBlock;
 
 @end
 

--- a/Source/Private/ASCollectionLayout.h
+++ b/Source/Private/ASCollectionLayout.h
@@ -33,7 +33,7 @@ AS_SUBCLASSING_RESTRICTED
  */
 @property (nonatomic, weak) ASCollectionNode *collectionNode;
 
-@property (nonatomic, strong, readonly) id<ASCollectionLayoutDelegate> layoutDelegate;
+@property (nonatomic, readonly) id<ASCollectionLayoutDelegate> layoutDelegate;
 
 /**
  * Initializes with a layout delegate.

--- a/Source/Private/ASCollectionLayoutContext+Private.h
+++ b/Source/Private/ASCollectionLayoutContext+Private.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASCollectionLayoutContext (Private)
 
-@property (nonatomic, strong, readonly) Class<ASCollectionLayoutDelegate> layoutDelegateClass;
+@property (nonatomic, readonly) Class<ASCollectionLayoutDelegate> layoutDelegateClass;
 @property (nonatomic, weak, readonly) ASCollectionLayoutCache *layoutCache;
 
 - (instancetype)initWithViewportSize:(CGSize)viewportSize

--- a/Source/Private/ASCollectionView+Undeprecated.h
+++ b/Source/Private/ASCollectionView+Undeprecated.h
@@ -65,9 +65,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout;
 
-@property (nonatomic, assign) CGFloat leadingScreensForBatching;
+@property (nonatomic) CGFloat leadingScreensForBatching;
 
-@property (nonatomic, assign) BOOL inverted;
+@property (nonatomic) BOOL inverted;
 
 @property (nonatomic, readonly) ASScrollDirection scrollDirection;
 
@@ -75,9 +75,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) id<ASCollectionViewLayoutInspecting> layoutInspector;
 
-@property (nonatomic, assign) UIEdgeInsets contentInset;
+@property (nonatomic) UIEdgeInsets contentInset;
 
-@property (nonatomic, assign) CGPoint contentOffset;
+@property (nonatomic) CGPoint contentOffset;
 
 /**
  * Tuning parameters for a range type in full mode.

--- a/Source/Private/ASControlTargetAction.h
+++ b/Source/Private/ASControlTargetAction.h
@@ -25,12 +25,12 @@
 /** 
  The action to be called on the registered target.
  */
-@property (nonatomic, readwrite, assign) SEL action;
+@property (nonatomic) SEL action;
 
 /**
  Event handler target. The specified action will be called on this object.
  */
-@property (nonatomic, readwrite, weak) id target;
+@property (nonatomic, weak) id target;
 
 /**
  Indicated whether this target was created without a target, so the action should travel up in the responder chain.

--- a/Source/Private/ASDefaultPlaybackButton.h
+++ b/Source/Private/ASDefaultPlaybackButton.h
@@ -23,5 +23,5 @@ typedef NS_ENUM(NSInteger, ASDefaultPlaybackButtonType) {
 };
 
 @interface ASDefaultPlaybackButton : ASControlNode
-@property (nonatomic, assign) ASDefaultPlaybackButtonType buttonType;
+@property (nonatomic) ASDefaultPlaybackButtonType buttonType;
 @end

--- a/Source/Private/ASDisplayNode+FrameworkPrivate.h
+++ b/Source/Private/ASDisplayNode+FrameworkPrivate.h
@@ -133,7 +133,7 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyStateChange(ASHierarc
 + (Class)viewClass;
 
 // Thread safe way to access the bounds of the node
-@property (nonatomic, assign) CGRect threadSafeBounds;
+@property (nonatomic) CGRect threadSafeBounds;
 
 // Returns the bounds of the node without reaching the view or layer
 - (CGRect)_locked_threadSafeBounds;
@@ -155,7 +155,7 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyStateChange(ASHierarc
 - (void)exitHierarchyState:(ASHierarchyState)hierarchyState;
 
 // Changed before calling willEnterHierarchy / didExitHierarchy.
-@property (readonly, assign, getter = isInHierarchy) BOOL inHierarchy;
+@property (readonly, getter = isInHierarchy) BOOL inHierarchy;
 // Call willEnterHierarchy if necessary and set inHierarchy = YES if visibility notifications are enabled on all of its parents
 - (void)__enterHierarchy;
 // Call didExitHierarchy if necessary and set inHierarchy = NO if visibility notifications are enabled on all of its parents
@@ -168,7 +168,7 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyStateChange(ASHierarc
  *
  * @see ASInterfaceState
  */
-@property (nonatomic, readwrite) ASHierarchyState hierarchyState;
+@property (nonatomic) ASHierarchyState hierarchyState;
 
 /**
  * @abstract Return if the node is range managed or not
@@ -234,7 +234,7 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyStateChange(ASHierarc
  * ASNetworkImageNode and ASMultiplexImageNode set this to YES, because they load data from a database or server,
  * and are expected to support a placeholder state given that display is often blocked on slow data fetching.
  */
-@property (atomic) BOOL shouldBypassEnsureDisplay;
+@property BOOL shouldBypassEnsureDisplay;
 
 /**
  * @abstract Checks whether a node should be scheduled for display, considering its current and new interface states.
@@ -248,7 +248,7 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyStateChange(ASHierarc
  * @discussion This should be set by the owning view controller based on it's layout guides.
  * If this is not a view controllet's node the value will be calculated automatically by the parent node.
  */
-@property (nonatomic, assign) UIEdgeInsets fallbackSafeAreaInsets;
+@property (nonatomic) UIEdgeInsets fallbackSafeAreaInsets;
 
 /**
  * @abstract Indicates if this node is a view controller's root node. Defaults to NO.
@@ -258,7 +258,7 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyStateChange(ASHierarc
  * YES here only means that this node is used as an ASViewController node. It doesn't mean that this node is a root of
  * ASDisplayNode hierarchy, e.g. when its view controller is parented by another ASViewController.
  */
-@property (nonatomic, assign, getter=isViewControllerRoot) BOOL viewControllerRoot;
+@property (nonatomic, getter=isViewControllerRoot) BOOL viewControllerRoot;
 
 @end
 
@@ -319,11 +319,11 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyStateChange(ASHierarc
 @end
 
 @interface UIView (ASDisplayNodeInternal)
-@property (nullable, atomic, weak, readwrite) ASDisplayNode *asyncdisplaykit_node;
+@property (nullable, weak) ASDisplayNode *asyncdisplaykit_node;
 @end
 
 @interface CALayer (ASDisplayNodeInternal)
-@property (nullable, atomic, weak, readwrite) ASDisplayNode *asyncdisplaykit_node;
+@property (nullable, weak) ASDisplayNode *asyncdisplaykit_node;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -246,10 +246,10 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 + (void)scheduleNodeForRecursiveDisplay:(ASDisplayNode *)node;
 
 /// The _ASDisplayLayer backing the node, if any.
-@property (nullable, nonatomic, readonly, strong) _ASDisplayLayer *asyncLayer;
+@property (nullable, nonatomic, readonly) _ASDisplayLayer *asyncLayer;
 
 /// Bitmask to check which methods an object overrides.
-@property (nonatomic, assign, readonly) ASDisplayNodeMethodOverrides methodOverrides;
+@property (nonatomic, readonly) ASDisplayNodeMethodOverrides methodOverrides;
 
 /**
  * Invoked before a call to setNeedsLayout to the underlying view
@@ -308,7 +308,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 /// Alternative initialiser for backing with a custom layer class.  Supports asynchronous display with _ASDisplayLayer subclasses.
 - (instancetype)initWithLayerClass:(Class)layerClass;
 
-@property (nonatomic, assign) CGFloat contentsScaleForDisplay;
+@property (nonatomic) CGFloat contentsScaleForDisplay;
 
 - (void)applyPendingViewState;
 
@@ -324,7 +324,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
  *
  * @see ASInterfaceState
  */
-@property (nonatomic, assign) BOOL interfaceStateSuspended;
+@property (nonatomic) BOOL interfaceStateSuspended;
 
 /**
  * This method has proven helpful in a few rare scenarios, similar to a category extension on UIView,
@@ -337,7 +337,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 /**
  * Whether this node rasterizes its descendants. See -enableSubtreeRasterization.
  */
-@property (atomic, readonly) BOOL rasterizesSubtree;
+@property (readonly) BOOL rasterizesSubtree;
 
 /**
  * Called if a gesture recognizer was attached to an _ASDisplayView
@@ -351,7 +351,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 
 @interface ASDisplayNode (InternalPropertyBridge)
 
-@property (nonatomic, assign) CGFloat layerCornerRadius;
+@property (nonatomic) CGFloat layerCornerRadius;
 
 - (BOOL)_locked_insetsLayoutMarginsFromSafeArea;
 

--- a/Source/Private/ASDisplayNodeTipState.h
+++ b/Source/Private/ASDisplayNodeTipState.h
@@ -33,7 +33,7 @@ AS_SUBCLASSING_RESTRICTED
 @property (nonatomic, unsafe_unretained, readonly) ASDisplayNode *node;
 
 /// Main-thread-only.
-@property (nonatomic, strong, nullable) ASTipNode *tipNode;
+@property (nonatomic, nullable) ASTipNode *tipNode;
 
 @end
 

--- a/Source/Private/ASImageNode+AnimatedImagePrivate.h
+++ b/Source/Private/ASImageNode+AnimatedImagePrivate.h
@@ -33,7 +33,7 @@ extern NSString *const ASAnimatedImageDefaultRunLoopMode;
   NSUInteger _playedLoops;
 }
 
-@property (nonatomic, assign) CFTimeInterval lastDisplayLinkFire;
+@property (nonatomic) CFTimeInterval lastDisplayLinkFire;
 
 @end
 

--- a/Source/Private/ASLayoutTransition.h
+++ b/Source/Private/ASLayoutTransition.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @abstract Returns if the layoutElement can be used to layout in an asynchronous way on a background thread.
  */
-@property (nonatomic, assign, readonly) BOOL canLayoutAsynchronous;
+@property (nonatomic, readonly) BOOL canLayoutAsynchronous;
 
 @end
 
@@ -55,22 +55,22 @@ AS_SUBCLASSING_RESTRICTED
 /**
  * Node to apply layout transition on
  */
-@property (nonatomic, readonly, weak) ASDisplayNode *node;
+@property (nonatomic, weak, readonly) ASDisplayNode *node;
 
 /**
  * Previous layout to transition from
  */
-@property (nonatomic, readonly, assign) std::shared_ptr<ASDisplayNodeLayout> previousLayout;
+@property (nonatomic, readonly) std::shared_ptr<ASDisplayNodeLayout> previousLayout;
 
 /**
  * Pending layout to transition to
  */
-@property (nonatomic, readonly, assign) std::shared_ptr<ASDisplayNodeLayout> pendingLayout;
+@property (nonatomic, readonly) std::shared_ptr<ASDisplayNodeLayout> pendingLayout;
 
 /**
  * Returns if the layout transition needs to happen synchronously
  */
-@property (nonatomic, readonly, assign) BOOL isSynchronous;
+@property (nonatomic, readonly) BOOL isSynchronous;
 
 /**
  * Returns a newly initialized layout transition

--- a/Source/Private/ASPendingStateController.mm
+++ b/Source/Private/ASPendingStateController.mm
@@ -29,7 +29,7 @@
   } _flags;
 }
 
-@property (nonatomic, strong, readonly) ASWeakSet<ASDisplayNode *> *dirtyNodes;
+@property (nonatomic, readonly) ASWeakSet<ASDisplayNode *> *dirtyNodes;
 @end
 
 @implementation ASPendingStateController

--- a/Source/Private/ASSection.h
+++ b/Source/Private/ASSection.h
@@ -33,8 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED
 @interface ASSection : NSObject
 
-@property (assign, readonly) NSInteger sectionID;
-@property (strong, nullable, readonly) id<ASSectionContext> context;
+@property (readonly) NSInteger sectionID;
+@property (nullable, readonly) id<ASSectionContext> context;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithSectionID:(NSInteger)sectionID context:(nullable id<ASSectionContext>)context NS_DESIGNATED_INITIALIZER;

--- a/Source/Private/ASTableView+Undeprecated.h
+++ b/Source/Private/ASTableView+Undeprecated.h
@@ -31,22 +31,22 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface ASTableView (Undeprecated)
 
-@property (nonatomic, weak) id<ASTableDelegate>   asyncDelegate;
-@property (nonatomic, weak) id<ASTableDataSource> asyncDataSource;
-@property (nonatomic, assign) UIEdgeInsets contentInset;
-@property (nonatomic, assign) CGPoint contentOffset;
-@property (nonatomic, assign) BOOL automaticallyAdjustsContentOffset;
-@property (nonatomic, assign) BOOL inverted;
-@property (nonatomic, readonly, nullable) NSArray<NSIndexPath *> *indexPathsForVisibleRows;
-@property (nonatomic, readonly, nullable) NSArray<NSIndexPath *> *indexPathsForSelectedRows;
-@property (nonatomic, readonly, nullable) NSIndexPath *indexPathForSelectedRow;
+@property (nullable, nonatomic, weak) id<ASTableDelegate>   asyncDelegate;
+@property (nullable, nonatomic, weak) id<ASTableDataSource> asyncDataSource;
+@property (nonatomic) UIEdgeInsets contentInset;
+@property (nonatomic) CGPoint contentOffset;
+@property (nonatomic) BOOL automaticallyAdjustsContentOffset;
+@property (nonatomic) BOOL inverted;
+@property (nullable, nonatomic, readonly) NSArray<NSIndexPath *> *indexPathsForVisibleRows;
+@property (nullable, nonatomic, readonly) NSArray<NSIndexPath *> *indexPathsForSelectedRows;
+@property (nullable, nonatomic, readonly) NSIndexPath *indexPathForSelectedRow;
 
 /**
  * The number of screens left to scroll before the delegate -tableView:beginBatchFetchingWithContext: is called.
  *
  * Defaults to two screenfuls.
  */
-@property (nonatomic, assign) CGFloat leadingScreensForBatching;
+@property (nonatomic) CGFloat leadingScreensForBatching;
 
 /**
  * Initializer.

--- a/Source/Private/ASTip.h
+++ b/Source/Private/ASTip.h
@@ -43,12 +43,12 @@ AS_SUBCLASSING_RESTRICTED
 /**
  * The node that this tip applies to.
  */
-@property (nonatomic, strong, readonly) ASDisplayNode *node;
+@property (nonatomic, readonly) ASDisplayNode *node;
 
 /**
  * The text to show the user.
  */
-@property (nonatomic, strong, readonly) NSString *text;
+@property (nonatomic, readonly) NSString *text;
 
 @end
 

--- a/Source/Private/ASTipNode.h
+++ b/Source/Private/ASTipNode.h
@@ -38,7 +38,7 @@ AS_SUBCLASSING_RESTRICTED
 
 - (instancetype)init NS_UNAVAILABLE;
 
-@property (nonatomic, strong, readonly) ASTip *tip;
+@property (nonatomic, readonly) ASTip *tip;
 
 @end
 

--- a/Source/Private/ASTipsController.h
+++ b/Source/Private/ASTipsController.h
@@ -30,7 +30,7 @@ AS_SUBCLASSING_RESTRICTED
 /**
  * The shared tip controller instance.
  */
-@property (class, strong, readonly) ASTipsController *shared;
+@property (class, readonly) ASTipsController *shared;
 
 #pragma mark - Node Event Hooks
 

--- a/Source/Private/ASTipsController.m
+++ b/Source/Private/ASTipsController.m
@@ -29,15 +29,15 @@
 @interface ASTipsController ()
 
 /// Nil on init, updates to most recent visible window.
-@property (nonatomic, strong) UIWindow *appVisibleWindow;
+@property (nonatomic) UIWindow *appVisibleWindow;
 
 /// Nil until an application window has become visible.
-@property (nonatomic, strong) ASTipsWindow *tipWindow;
+@property (nonatomic) ASTipsWindow *tipWindow;
 
 /// Main-thread-only.
-@property (nonatomic, strong, readonly) NSMapTable<ASDisplayNode *, ASDisplayNodeTipState *> *nodeToTipStates;
+@property (nonatomic, readonly) NSMapTable<ASDisplayNode *, ASDisplayNodeTipState *> *nodeToTipStates;
 
-@property (nonatomic, strong) NSMutableArray<ASDisplayNode *> *nodesThatAppearedDuringRunLoop;
+@property (nonatomic) NSMutableArray<ASDisplayNode *> *nodesThatAppearedDuringRunLoop;
 
 @end
 

--- a/Source/Private/ASTipsWindow.m
+++ b/Source/Private/ASTipsWindow.m
@@ -24,7 +24,7 @@
 #import <AsyncDisplayKit/AsyncDisplayKit+Tips.h>
 
 @interface ASTipsWindow ()
-@property (nonatomic, strong, readonly) ASDisplayNode *node;
+@property (nonatomic, readonly) ASDisplayNode *node;
 @end
 
 @implementation ASTipsWindow

--- a/Source/Private/ASWeakMap.h
+++ b/Source/Private/ASWeakMap.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED
 @interface ASWeakMapEntry<Value> : NSObject
 
-@property (atomic, strong, readonly) Value value;
+@property (readonly) Value value;
 
 @end
 

--- a/Source/Private/ASWeakMap.m
+++ b/Source/Private/ASWeakMap.m
@@ -18,8 +18,8 @@
 #import <AsyncDisplayKit/ASWeakMap.h>
 
 @interface ASWeakMapEntry ()
-@property (nonatomic, strong, readonly) id key;
-@property (atomic, strong) id value;
+@property (nonatomic, readonly) id key;
+@property id value;
 @end
 
 @implementation ASWeakMapEntry
@@ -38,7 +38,7 @@
 
 
 @interface ASWeakMap ()
-@property (nonatomic, strong, readonly) NSMapTable<id, ASWeakMapEntry *> *hashTable;
+@property (nonatomic, readonly) NSMapTable<id, ASWeakMapEntry *> *hashTable;
 @end
 
 /**

--- a/Source/Private/Layout/ASLayoutElementStylePrivate.h
+++ b/Source/Private/Layout/ASLayoutElementStylePrivate.h
@@ -31,6 +31,6 @@
 /**
  * @abstract A size constraint that should apply to this ASLayoutElement.
  */
-@property (nonatomic, assign, readonly) ASLayoutElementSize size;
+@property (nonatomic, readonly) ASLayoutElementSize size;
 
 @end

--- a/Source/Private/TextExperiment/Component/ASTextDebugOption.h
+++ b/Source/Private/TextExperiment/Component/ASTextDebugOption.h
@@ -39,17 +39,17 @@ NS_ASSUME_NONNULL_BEGIN
  The debug option for ASText.
  */
 @interface ASTextDebugOption : NSObject <NSCopying>
-@property (nullable, nonatomic, strong) UIColor *baselineColor;      ///< baseline color
-@property (nullable, nonatomic, strong) UIColor *CTFrameBorderColor; ///< CTFrame path border color
-@property (nullable, nonatomic, strong) UIColor *CTFrameFillColor;   ///< CTFrame path fill color
-@property (nullable, nonatomic, strong) UIColor *CTLineBorderColor;  ///< CTLine bounds border color
-@property (nullable, nonatomic, strong) UIColor *CTLineFillColor;    ///< CTLine bounds fill color
-@property (nullable, nonatomic, strong) UIColor *CTLineNumberColor;  ///< CTLine line number color
-@property (nullable, nonatomic, strong) UIColor *CTRunBorderColor;   ///< CTRun bounds border color
-@property (nullable, nonatomic, strong) UIColor *CTRunFillColor;     ///< CTRun bounds fill color
-@property (nullable, nonatomic, strong) UIColor *CTRunNumberColor;   ///< CTRun number color
-@property (nullable, nonatomic, strong) UIColor *CGGlyphBorderColor; ///< CGGlyph bounds border color
-@property (nullable, nonatomic, strong) UIColor *CGGlyphFillColor;   ///< CGGlyph bounds fill color
+@property (nullable, nonatomic) UIColor *baselineColor;      ///< baseline color
+@property (nullable, nonatomic) UIColor *CTFrameBorderColor; ///< CTFrame path border color
+@property (nullable, nonatomic) UIColor *CTFrameFillColor;   ///< CTFrame path fill color
+@property (nullable, nonatomic) UIColor *CTLineBorderColor;  ///< CTLine bounds border color
+@property (nullable, nonatomic) UIColor *CTLineFillColor;    ///< CTLine bounds fill color
+@property (nullable, nonatomic) UIColor *CTLineNumberColor;  ///< CTLine line number color
+@property (nullable, nonatomic) UIColor *CTRunBorderColor;   ///< CTRun bounds border color
+@property (nullable, nonatomic) UIColor *CTRunFillColor;     ///< CTRun bounds fill color
+@property (nullable, nonatomic) UIColor *CTRunNumberColor;   ///< CTRun number color
+@property (nullable, nonatomic) UIColor *CGGlyphBorderColor; ///< CGGlyph bounds border color
+@property (nullable, nonatomic) UIColor *CGGlyphFillColor;   ///< CGGlyph bounds fill color
 
 - (BOOL)needDrawDebug; ///< `YES`: at least one debug color is visible. `NO`: all debug color is invisible/nil.
 - (void)clear; ///< Set all debug color to nil.

--- a/Source/Private/TextExperiment/Component/ASTextInput.h
+++ b/Source/Private/TextExperiment/Component/ASTextInput.h
@@ -82,11 +82,11 @@ typedef NS_ENUM(NSInteger, ASTextAffinity) {
  */
 @interface ASTextSelectionRect : UITextSelectionRect <NSCopying>
 
-@property (nonatomic, readwrite) CGRect rect;
-@property (nonatomic, readwrite) UITextWritingDirection writingDirection;
-@property (nonatomic, readwrite) BOOL containsStart;
-@property (nonatomic, readwrite) BOOL containsEnd;
-@property (nonatomic, readwrite) BOOL isVertical;
+@property (nonatomic) CGRect rect;
+@property (nonatomic) UITextWritingDirection writingDirection;
+@property (nonatomic) BOOL containsStart;
+@property (nonatomic) BOOL containsEnd;
+@property (nonatomic) BOOL isVertical;
 
 @end
 

--- a/Source/Private/TextExperiment/Component/ASTextLayout.h
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.h
@@ -126,7 +126,7 @@ extern const CGSize ASTextContainerMaxSize;
  to a specified value, lets each line of height be the same.
  */
 @interface ASTextLinePositionSimpleModifier : NSObject <ASTextLinePositionModifier>
-@property (assign) CGFloat fixedLineHeight; ///< The fixed line height (distance between two baseline).
+@property CGFloat fixedLineHeight; ///< The fixed line height (distance between two baseline).
 @end
 
 
@@ -220,9 +220,9 @@ extern const CGSize ASTextContainerMaxSize;
 ///=============================================================================
 
 ///< The text container
-@property (nonatomic, strong, readonly) ASTextContainer *container;
+@property (nonatomic, readonly) ASTextContainer *container;
 ///< The full text
-@property (nonatomic, strong, readonly) NSAttributedString *text;
+@property (nonatomic, readonly) NSAttributedString *text;
 ///< The text range in full text
 @property (nonatomic, readonly) NSRange range;
 ///< CTFrameSetter
@@ -230,17 +230,17 @@ extern const CGSize ASTextContainerMaxSize;
 ///< CTFrame
 @property (nonatomic, readonly) CTFrameRef frame;
 ///< Array of `ASTextLine`, no truncated
-@property (nonatomic, strong, readonly) NSArray<ASTextLine *> *lines;
+@property (nonatomic, readonly) NSArray<ASTextLine *> *lines;
 ///< ASTextLine with truncated token, or nil
-@property (nullable, nonatomic, strong, readonly) ASTextLine *truncatedLine;
+@property (nullable, nonatomic, readonly) ASTextLine *truncatedLine;
 ///< Array of `ASTextAttachment`
-@property (nullable, nonatomic, strong, readonly) NSArray<ASTextAttachment *> *attachments;
+@property (nullable, nonatomic, readonly) NSArray<ASTextAttachment *> *attachments;
 ///< Array of NSRange(wrapped by NSValue) in text
-@property (nullable, nonatomic, strong, readonly) NSArray<NSValue *> *attachmentRanges;
+@property (nullable, nonatomic, readonly) NSArray<NSValue *> *attachmentRanges;
 ///< Array of CGRect(wrapped by NSValue) in container
-@property (nullable, nonatomic, strong, readonly) NSArray<NSValue *> *attachmentRects;
+@property (nullable, nonatomic, readonly) NSArray<NSValue *> *attachmentRects;
 ///< Set of Attachment (UIImage/UIView/CALayer)
-@property (nullable, nonatomic, strong, readonly) NSSet *attachmentContentsSet;
+@property (nullable, nonatomic, readonly) NSSet *attachmentContentsSet;
 ///< Number of rows
 @property (nonatomic, readonly) NSUInteger rowCount;
 ///< Visible text range

--- a/Source/Private/TextExperiment/Component/ASTextLayout.m
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.m
@@ -316,36 +316,36 @@ dispatch_semaphore_signal(_lock);
 
 @interface ASTextLayout ()
 
-@property (nonatomic, readwrite) ASTextContainer *container;
-@property (nonatomic, readwrite) NSAttributedString *text;
-@property (nonatomic, readwrite) NSRange range;
+@property (nonatomic) ASTextContainer *container;
+@property (nonatomic) NSAttributedString *text;
+@property (nonatomic) NSRange range;
 
-@property (nonatomic, readwrite) CTFramesetterRef frameSetter;
-@property (nonatomic, readwrite) CTFrameRef frame;
-@property (nonatomic, readwrite) NSArray *lines;
-@property (nonatomic, readwrite) ASTextLine *truncatedLine;
-@property (nonatomic, readwrite) NSArray *attachments;
-@property (nonatomic, readwrite) NSArray *attachmentRanges;
-@property (nonatomic, readwrite) NSArray *attachmentRects;
-@property (nonatomic, readwrite) NSSet *attachmentContentsSet;
-@property (nonatomic, readwrite) NSUInteger rowCount;
-@property (nonatomic, readwrite) NSRange visibleRange;
-@property (nonatomic, readwrite) CGRect textBoundingRect;
-@property (nonatomic, readwrite) CGSize textBoundingSize;
+@property (nonatomic) CTFramesetterRef frameSetter;
+@property (nonatomic) CTFrameRef frame;
+@property (nonatomic) NSArray *lines;
+@property (nonatomic) ASTextLine *truncatedLine;
+@property (nonatomic) NSArray *attachments;
+@property (nonatomic) NSArray *attachmentRanges;
+@property (nonatomic) NSArray *attachmentRects;
+@property (nonatomic) NSSet *attachmentContentsSet;
+@property (nonatomic) NSUInteger rowCount;
+@property (nonatomic) NSRange visibleRange;
+@property (nonatomic) CGRect textBoundingRect;
+@property (nonatomic) CGSize textBoundingSize;
 
-@property (nonatomic, readwrite) BOOL containsHighlight;
-@property (nonatomic, readwrite) BOOL needDrawBlockBorder;
-@property (nonatomic, readwrite) BOOL needDrawBackgroundBorder;
-@property (nonatomic, readwrite) BOOL needDrawShadow;
-@property (nonatomic, readwrite) BOOL needDrawUnderline;
-@property (nonatomic, readwrite) BOOL needDrawText;
-@property (nonatomic, readwrite) BOOL needDrawAttachment;
-@property (nonatomic, readwrite) BOOL needDrawInnerShadow;
-@property (nonatomic, readwrite) BOOL needDrawStrikethrough;
-@property (nonatomic, readwrite) BOOL needDrawBorder;
+@property (nonatomic) BOOL containsHighlight;
+@property (nonatomic) BOOL needDrawBlockBorder;
+@property (nonatomic) BOOL needDrawBackgroundBorder;
+@property (nonatomic) BOOL needDrawShadow;
+@property (nonatomic) BOOL needDrawUnderline;
+@property (nonatomic) BOOL needDrawText;
+@property (nonatomic) BOOL needDrawAttachment;
+@property (nonatomic) BOOL needDrawInnerShadow;
+@property (nonatomic) BOOL needDrawStrikethrough;
+@property (nonatomic) BOOL needDrawBorder;
 
-@property (nonatomic, assign) NSUInteger *lineRowsIndex;
-@property (nonatomic, assign) ASRowEdge *lineRowsEdge; ///< top-left origin
+@property (nonatomic) NSUInteger *lineRowsIndex;
+@property (nonatomic) ASRowEdge *lineRowsEdge; ///< top-left origin
 
 @end
 

--- a/Source/Private/TextExperiment/Component/ASTextLine.h
+++ b/Source/Private/TextExperiment/Component/ASTextLine.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) NSUInteger index;     ///< line index
 @property (nonatomic) NSUInteger row;       ///< line row
-@property (nullable, nonatomic, strong) NSArray<NSArray<ASTextRunGlyphRange *> *> *verticalRotateRange; ///< Run rotate range
+@property (nullable, nonatomic) NSArray<NSArray<ASTextRunGlyphRange *> *> *verticalRotateRange; ///< Run rotate range
 
 @property (nonatomic, readonly) CTLineRef CTLine;   ///< CoreText line
 @property (nonatomic, readonly) NSRange range;      ///< string range

--- a/Source/Private/TextExperiment/String/ASTextAttribute.h
+++ b/Source/Private/TextExperiment/String/ASTextAttribute.h
@@ -209,11 +209,11 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
 @interface ASTextShadow : NSObject <NSCoding, NSCopying>
 + (instancetype)shadowWithColor:(nullable UIColor *)color offset:(CGSize)offset radius:(CGFloat)radius NS_RETURNS_RETAINED;
 
-@property (nullable, nonatomic, strong) UIColor *color; ///< shadow color
+@property (nullable, nonatomic) UIColor *color; ///< shadow color
 @property (nonatomic) CGSize offset;                    ///< shadow offset
 @property (nonatomic) CGFloat radius;                   ///< shadow blur radius
 @property (nonatomic) CGBlendMode blendMode;            ///< shadow blend mode
-@property (nullable, nonatomic, strong) ASTextShadow *subShadow;  ///< a sub shadow which will be added above the parent shadow
+@property (nullable, nonatomic) ASTextShadow *subShadow;  ///< a sub shadow which will be added above the parent shadow
 
 + (instancetype)shadowWithNSShadow:(NSShadow *)nsShadow NS_RETURNS_RETAINED; ///< convert NSShadow to ASTextShadow
 - (NSShadow *)nsShadow; ///< convert ASTextShadow to NSShadow
@@ -232,9 +232,9 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
 + (instancetype)decorationWithStyle:(ASTextLineStyle)style NS_RETURNS_RETAINED;
 + (instancetype)decorationWithStyle:(ASTextLineStyle)style width:(nullable NSNumber *)width color:(nullable UIColor *)color NS_RETURNS_RETAINED;
 @property (nonatomic) ASTextLineStyle style;                   ///< line style
-@property (nullable, nonatomic, strong) NSNumber *width;       ///< line width (nil means automatic width)
-@property (nullable, nonatomic, strong) UIColor *color;        ///< line color (nil means automatic color)
-@property (nullable, nonatomic, strong) ASTextShadow *shadow;  ///< line shadow
+@property (nullable, nonatomic) NSNumber *width;       ///< line width (nil means automatic width)
+@property (nullable, nonatomic) UIColor *color;        ///< line color (nil means automatic color)
+@property (nullable, nonatomic) ASTextShadow *shadow;  ///< line shadow
 @end
 
 
@@ -256,12 +256,12 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
 + (instancetype)borderWithFillColor:(nullable UIColor *)color cornerRadius:(CGFloat)cornerRadius NS_RETURNS_RETAINED;
 @property (nonatomic) ASTextLineStyle lineStyle;              ///< border line style
 @property (nonatomic) CGFloat strokeWidth;                    ///< border line width
-@property (nullable, nonatomic, strong) UIColor *strokeColor; ///< border line color
+@property (nullable, nonatomic) UIColor *strokeColor; ///< border line color
 @property (nonatomic) CGLineJoin lineJoin;                    ///< border line join
 @property (nonatomic) UIEdgeInsets insets;                    ///< border insets for text bounds
 @property (nonatomic) CGFloat cornerRadius;                   ///< border corder radius
-@property (nullable, nonatomic, strong) ASTextShadow *shadow; ///< border shadow
-@property (nullable, nonatomic, strong) UIColor *fillColor;   ///< inner fill color
+@property (nullable, nonatomic) ASTextShadow *shadow; ///< border shadow
+@property (nullable, nonatomic) UIColor *fillColor;   ///< inner fill color
 @end
 
 
@@ -277,10 +277,10 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
  */
 @interface ASTextAttachment : NSObject<NSCoding, NSCopying>
 + (instancetype)attachmentWithContent:(nullable id)content NS_RETURNS_RETAINED;
-@property (nullable, nonatomic, strong) id content;             ///< Supported type: UIImage, UIView, CALayer
+@property (nullable, nonatomic) id content;             ///< Supported type: UIImage, UIView, CALayer
 @property (nonatomic) UIViewContentMode contentMode;            ///< Content display mode.
 @property (nonatomic) UIEdgeInsets contentInsets;               ///< The insets when drawing content.
-@property (nullable, nonatomic, strong) NSDictionary *userInfo; ///< The user information dictionary.
+@property (nullable, nonatomic) NSDictionary *userInfo; ///< The user information dictionary.
 @end
 
 
@@ -340,13 +340,13 @@ typedef void(^ASTextAction)(UIView *containerView, NSAttributedString *text, NSR
  Tap action when user tap the highlight, default is nil.
  If the value is nil, ASTextView or ASLabel will ask it's delegate to handle the tap action.
  */
-@property (nullable, nonatomic, copy) ASTextAction tapAction;
+@property (nullable, nonatomic) ASTextAction tapAction;
 
 /**
  Long press action when user long press the highlight, default is nil.
  If the value is nil, ASTextView or ASLabel will ask it's delegate to handle the long press action.
  */
-@property (nullable, nonatomic, copy) ASTextAction longPressAction;
+@property (nullable, nonatomic) ASTextAction longPressAction;
 
 @end
 

--- a/Source/Private/TextExperiment/String/ASTextRunDelegate.h
+++ b/Source/Private/TextExperiment/String/ASTextRunDelegate.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Additional information about the the run delegate.
  */
-@property (nullable, nonatomic, strong) NSDictionary *userInfo;
+@property (nullable, nonatomic) NSDictionary *userInfo;
 
 /**
  The typographic ascent of glyphs in the run.

--- a/Source/Private/TextExperiment/Utility/NSAttributedString+ASText.h
+++ b/Source/Private/TextExperiment/Utility/NSAttributedString+ASText.h
@@ -73,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) UIFont *as_font;
+@property (nullable, nonatomic, readonly) UIFont *as_font;
 - (nullable UIFont *)as_fontAtIndex:(NSUInteger)index;
 
 /**
@@ -88,7 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) NSNumber *as_kern;
+@property (nullable, nonatomic, readonly) NSNumber *as_kern;
 - (nullable NSNumber *)as_kernAtIndex:(NSUInteger)index;
 
 /**
@@ -98,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) UIColor *as_color;
+@property (nullable, nonatomic, readonly) UIColor *as_color;
 - (nullable UIColor *)as_colorAtIndex:(NSUInteger)index;
 
 /**
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since UIKit:6.0
  */
-@property (nullable, nonatomic, strong, readonly) UIColor *as_backgroundColor;
+@property (nullable, nonatomic, readonly) UIColor *as_backgroundColor;
 - (nullable UIColor *)as_backgroundColorAtIndex:(NSUInteger)index;
 
 /**
@@ -121,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0
  */
-@property (nullable, nonatomic, strong, readonly) NSNumber *as_strokeWidth;
+@property (nullable, nonatomic, readonly) NSNumber *as_strokeWidth;
 - (nullable NSNumber *)as_strokeWidthAtIndex:(NSUInteger)index;
 
 /**
@@ -131,7 +131,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0
  */
-@property (nullable, nonatomic, strong, readonly) UIColor *as_strokeColor;
+@property (nullable, nonatomic, readonly) UIColor *as_strokeColor;
 - (nullable UIColor *)as_strokeColorAtIndex:(NSUInteger)index;
 
 /**
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) NSShadow *as_shadow;
+@property (nullable, nonatomic, readonly) NSShadow *as_shadow;
 - (nullable NSShadow *)as_shadowAtIndex:(NSUInteger)index;
 
 /**
@@ -161,7 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since UIKit:7.0
  */
-@property (nullable, nonatomic, strong, readonly) UIColor *as_strikethroughColor;
+@property (nullable, nonatomic, readonly) UIColor *as_strikethroughColor;
 - (nullable UIColor *)as_strikethroughColorAtIndex:(NSUInteger)index;
 
 /**
@@ -181,7 +181,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:7.0
  */
-@property (nullable, nonatomic, strong, readonly) UIColor *as_underlineColor;
+@property (nullable, nonatomic, readonly) UIColor *as_underlineColor;
 - (nullable UIColor *)as_underlineColorAtIndex:(NSUInteger)index;
 
 /**
@@ -196,7 +196,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) NSNumber *as_ligature;
+@property (nullable, nonatomic, readonly) NSNumber *as_ligature;
 - (nullable NSNumber *)as_ligatureAtIndex:(NSUInteger)index;
 
 /**
@@ -207,7 +207,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since UIKit:7.0
  */
-@property (nullable, nonatomic, strong, readonly) NSString *as_textEffect;
+@property (nullable, nonatomic, readonly) NSString *as_textEffect;
 - (nullable NSString *)as_textEffectAtIndex:(NSUInteger)index;
 
 /**
@@ -217,7 +217,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since UIKit:7.0
  */
-@property (nullable, nonatomic, strong, readonly) NSNumber *as_obliqueness;
+@property (nullable, nonatomic, readonly) NSNumber *as_obliqueness;
 - (nullable NSNumber *)as_obliquenessAtIndex:(NSUInteger)index;
 
 /**
@@ -227,7 +227,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since UIKit:7.0
  */
-@property (nullable, nonatomic, strong, readonly) NSNumber *as_expansion;
+@property (nullable, nonatomic, readonly) NSNumber *as_expansion;
 - (nullable NSNumber *)as_expansionAtIndex:(NSUInteger)index;
 
 /**
@@ -237,7 +237,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since UIKit:7.0
  */
-@property (nullable, nonatomic, strong, readonly) NSNumber *as_baselineOffset;
+@property (nullable, nonatomic, readonly) NSNumber *as_baselineOffset;
 - (nullable NSNumber *)as_baselineOffsetAtIndex:(NSUInteger)index;
 
 /**
@@ -260,7 +260,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since CoreText:7.0  ASText:7.0
  */
-@property (nullable, nonatomic, strong, readonly) NSString *as_language;
+@property (nullable, nonatomic, readonly) NSString *as_language;
 - (nullable NSString *)as_languageAtIndex:(NSUInteger)index;
 
 /**
@@ -270,7 +270,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:7.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) NSArray<NSNumber *> *as_writingDirection;
+@property (nullable, nonatomic, readonly) NSArray<NSNumber *> *as_writingDirection;
 - (nullable NSArray<NSNumber *> *)as_writingDirectionAtIndex:(NSUInteger)index;
 
 /**
@@ -281,7 +281,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) NSParagraphStyle *as_paragraphStyle;
+@property (nullable, nonatomic, readonly) NSParagraphStyle *as_paragraphStyle;
 - (nullable NSParagraphStyle *)as_paragraphStyleAtIndex:(NSUInteger)index;
 
 #pragma mark - Get paragraph attribute as property
@@ -495,7 +495,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) ASTextShadow *as_textShadow;
+@property (nullable, nonatomic, readonly) ASTextShadow *as_textShadow;
 - (nullable ASTextShadow *)as_textShadowAtIndex:(NSUInteger)index;
 
 /**
@@ -505,7 +505,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) ASTextShadow *as_textInnerShadow;
+@property (nullable, nonatomic, readonly) ASTextShadow *as_textInnerShadow;
 - (nullable ASTextShadow *)as_textInnerShadowAtIndex:(NSUInteger)index;
 
 /**
@@ -515,7 +515,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) ASTextDecoration *as_textUnderline;
+@property (nullable, nonatomic, readonly) ASTextDecoration *as_textUnderline;
 - (nullable ASTextDecoration *)as_textUnderlineAtIndex:(NSUInteger)index;
 
 /**
@@ -525,7 +525,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) ASTextDecoration *as_textStrikethrough;
+@property (nullable, nonatomic, readonly) ASTextDecoration *as_textStrikethrough;
 - (nullable ASTextDecoration *)as_textStrikethroughAtIndex:(NSUInteger)index;
 
 /**
@@ -535,7 +535,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) ASTextBorder *as_textBorder;
+@property (nullable, nonatomic, readonly) ASTextBorder *as_textBorder;
 - (nullable ASTextBorder *)as_textBorderAtIndex:(NSUInteger)index;
 
 /**
@@ -545,7 +545,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nullable, nonatomic, strong, readonly) ASTextBorder *as_textBackgroundBorder;
+@property (nullable, nonatomic, readonly) ASTextBorder *as_textBackgroundBorder;
 - (nullable ASTextBorder *)as_textBackgroundBorderAtIndex:(NSUInteger)index;
 
 /**
@@ -735,7 +735,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) UIFont *as_font;
+@property (nullable, nonatomic) UIFont *as_font;
 - (void)as_setFont:(nullable UIFont *)font range:(NSRange)range;
 
 /**
@@ -751,7 +751,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) NSNumber *as_kern;
+@property (nullable, nonatomic) NSNumber *as_kern;
 - (void)as_setKern:(nullable NSNumber *)kern range:(NSRange)range;
 
 /**
@@ -762,7 +762,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) UIColor *as_color;
+@property (nullable, nonatomic) UIColor *as_color;
 - (void)as_setColor:(nullable UIColor *)color range:(NSRange)range;
 
 /**
@@ -773,7 +773,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since UIKit:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) UIColor *as_backgroundColor;
+@property (nullable, nonatomic) UIColor *as_backgroundColor;
 - (void)as_setBackgroundColor:(nullable UIColor *)backgroundColor range:(NSRange)range;
 
 /**
@@ -787,7 +787,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) NSNumber *as_strokeWidth;
+@property (nullable, nonatomic) NSNumber *as_strokeWidth;
 - (void)as_setStrokeWidth:(nullable NSNumber *)strokeWidth range:(NSRange)range;
 
 /**
@@ -798,7 +798,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) UIColor *as_strokeColor;
+@property (nullable, nonatomic) UIColor *as_strokeColor;
 - (void)as_setStrokeColor:(nullable UIColor *)strokeColor range:(NSRange)range;
 
 /**
@@ -809,7 +809,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) NSShadow *as_shadow;
+@property (nullable, nonatomic) NSShadow *as_shadow;
 - (void)as_setShadow:(nullable NSShadow *)shadow range:(NSRange)range;
 
 /**
@@ -820,7 +820,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since UIKit:6.0
  */
-@property (nonatomic, readwrite) NSUnderlineStyle as_strikethroughStyle;
+@property (nonatomic) NSUnderlineStyle as_strikethroughStyle;
 - (void)as_setStrikethroughStyle:(NSUnderlineStyle)strikethroughStyle range:(NSRange)range;
 
 /**
@@ -831,7 +831,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since UIKit:7.0
  */
-@property (nullable, nonatomic, strong, readwrite) UIColor *as_strikethroughColor;
+@property (nullable, nonatomic) UIColor *as_strikethroughColor;
 - (void)as_setStrikethroughColor:(nullable UIColor *)strikethroughColor range:(NSRange)range NS_AVAILABLE_IOS(7_0);
 
 /**
@@ -842,7 +842,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0
  */
-@property (nonatomic, readwrite) NSUnderlineStyle as_underlineStyle;
+@property (nonatomic) NSUnderlineStyle as_underlineStyle;
 - (void)as_setUnderlineStyle:(NSUnderlineStyle)underlineStyle range:(NSRange)range;
 
 /**
@@ -853,7 +853,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:7.0
  */
-@property (nullable, nonatomic, strong, readwrite) UIColor *as_underlineColor;
+@property (nullable, nonatomic) UIColor *as_underlineColor;
 - (void)as_setUnderlineColor:(nullable UIColor *)underlineColor range:(NSRange)range;
 
 /**
@@ -869,7 +869,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:3.2  UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) NSNumber *as_ligature;
+@property (nullable, nonatomic) NSNumber *as_ligature;
 - (void)as_setLigature:(nullable NSNumber *)ligature range:(NSRange)range;
 
 /**
@@ -881,7 +881,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since UIKit:7.0
  */
-@property (nullable, nonatomic, strong, readwrite) NSString *as_textEffect;
+@property (nullable, nonatomic) NSString *as_textEffect;
 - (void)as_setTextEffect:(nullable NSString *)textEffect range:(NSRange)range NS_AVAILABLE_IOS(7_0);
 
 /**
@@ -892,7 +892,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since UIKit:7.0
  */
-@property (nullable, nonatomic, strong, readwrite) NSNumber *as_obliqueness;
+@property (nullable, nonatomic) NSNumber *as_obliqueness;
 - (void)as_setObliqueness:(nullable NSNumber *)obliqueness range:(NSRange)range NS_AVAILABLE_IOS(7_0);
 
 /**
@@ -903,7 +903,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since UIKit:7.0
  */
-@property (nullable, nonatomic, strong, readwrite) NSNumber *as_expansion;
+@property (nullable, nonatomic) NSNumber *as_expansion;
 - (void)as_setExpansion:(nullable NSNumber *)expansion range:(NSRange)range NS_AVAILABLE_IOS(7_0);
 
 /**
@@ -914,7 +914,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since UIKit:7.0
  */
-@property (nullable, nonatomic, strong, readwrite) NSNumber *as_baselineOffset;
+@property (nullable, nonatomic) NSNumber *as_baselineOffset;
 - (void)as_setBaselineOffset:(nullable NSNumber *)baselineOffset range:(NSRange)range NS_AVAILABLE_IOS(7_0);
 
 /**
@@ -926,7 +926,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:4.3  ASText:6.0
  */
-@property (nonatomic, readwrite) BOOL as_verticalGlyphForm;
+@property (nonatomic) BOOL as_verticalGlyphForm;
 - (void)as_setVerticalGlyphForm:(BOOL)verticalGlyphForm range:(NSRange)range;
 
 /**
@@ -939,7 +939,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:7.0  ASText:7.0
  */
-@property (nullable, nonatomic, strong, readwrite) NSString *as_language;
+@property (nullable, nonatomic) NSString *as_language;
 - (void)as_setLanguage:(nullable NSString *)language range:(NSRange)range NS_AVAILABLE_IOS(7_0);
 
 /**
@@ -950,7 +950,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:7.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) NSArray<NSNumber *> *as_writingDirection;
+@property (nullable, nonatomic) NSArray<NSNumber *> *as_writingDirection;
 - (void)as_setWritingDirection:(nullable NSArray<NSNumber *> *)writingDirection range:(NSRange)range;
 
 /**
@@ -962,7 +962,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) NSParagraphStyle *as_paragraphStyle;
+@property (nullable, nonatomic) NSParagraphStyle *as_paragraphStyle;
 - (void)as_setParagraphStyle:(nullable NSParagraphStyle *)paragraphStyle range:(NSRange)range;
 
 
@@ -981,7 +981,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nonatomic, readwrite) NSTextAlignment as_alignment;
+@property (nonatomic) NSTextAlignment as_alignment;
 - (void)as_setAlignment:(NSTextAlignment)alignment range:(NSRange)range;
 
 /**
@@ -993,7 +993,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nonatomic, readwrite) NSLineBreakMode as_lineBreakMode;
+@property (nonatomic) NSLineBreakMode as_lineBreakMode;
 - (void)as_setLineBreakMode:(NSLineBreakMode)lineBreakMode range:(NSRange)range;
 
 /**
@@ -1007,7 +1007,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nonatomic, readwrite) CGFloat as_lineSpacing;
+@property (nonatomic) CGFloat as_lineSpacing;
 - (void)as_setLineSpacing:(CGFloat)lineSpacing range:(NSRange)range;
 
 /**
@@ -1022,7 +1022,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nonatomic, readwrite) CGFloat as_paragraphSpacing;
+@property (nonatomic) CGFloat as_paragraphSpacing;
 - (void)as_setParagraphSpacing:(CGFloat)paragraphSpacing range:(NSRange)range;
 
 /**
@@ -1036,7 +1036,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nonatomic, readwrite) CGFloat as_paragraphSpacingBefore;
+@property (nonatomic) CGFloat as_paragraphSpacingBefore;
 - (void)as_setParagraphSpacingBefore:(CGFloat)paragraphSpacingBefore range:(NSRange)range;
 
 /**
@@ -1050,7 +1050,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nonatomic, readwrite) CGFloat as_firstLineHeadIndent;
+@property (nonatomic) CGFloat as_firstLineHeadIndent;
 - (void)as_setFirstLineHeadIndent:(CGFloat)firstLineHeadIndent range:(NSRange)range;
 
 /**
@@ -1064,7 +1064,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nonatomic, readwrite) CGFloat as_headIndent;
+@property (nonatomic) CGFloat as_headIndent;
 - (void)as_setHeadIndent:(CGFloat)headIndent range:(NSRange)range;
 
 /**
@@ -1078,7 +1078,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nonatomic, readwrite) CGFloat as_tailIndent;
+@property (nonatomic) CGFloat as_tailIndent;
 - (void)as_setTailIndent:(CGFloat)tailIndent range:(NSRange)range;
 
 /**
@@ -1092,7 +1092,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nonatomic, readwrite) CGFloat as_minimumLineHeight;
+@property (nonatomic) CGFloat as_minimumLineHeight;
 - (void)as_setMinimumLineHeight:(CGFloat)minimumLineHeight range:(NSRange)range;
 
 /**
@@ -1108,7 +1108,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nonatomic, readwrite) CGFloat as_maximumLineHeight;
+@property (nonatomic) CGFloat as_maximumLineHeight;
 - (void)as_setMaximumLineHeight:(CGFloat)maximumLineHeight range:(NSRange)range;
 
 /**
@@ -1120,7 +1120,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nonatomic, readwrite) CGFloat as_lineHeightMultiple;
+@property (nonatomic) CGFloat as_lineHeightMultiple;
 - (void)as_setLineHeightMultiple:(CGFloat)lineHeightMultiple range:(NSRange)range;
 
 /**
@@ -1134,7 +1134,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:6.0  UIKit:6.0  ASText:6.0
  */
-@property (nonatomic, readwrite) NSWritingDirection as_baseWritingDirection;
+@property (nonatomic) NSWritingDirection as_baseWritingDirection;
 - (void)as_setBaseWritingDirection:(NSWritingDirection)baseWritingDirection range:(NSRange)range;
 
 /**
@@ -1150,7 +1150,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since UIKit:6.0
  */
-@property (nonatomic, readwrite) float as_hyphenationFactor;
+@property (nonatomic) float as_hyphenationFactor;
 - (void)as_setHyphenationFactor:(float)hyphenationFactor range:(NSRange)range;
 
 /**
@@ -1163,7 +1163,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:7.0  UIKit:7.0  ASText:7.0
  */
-@property (nonatomic, readwrite) CGFloat as_defaultTabInterval;
+@property (nonatomic) CGFloat as_defaultTabInterval;
 - (void)as_setDefaultTabInterval:(CGFloat)defaultTabInterval range:(NSRange)range NS_AVAILABLE_IOS(7_0);
 
 /**
@@ -1177,7 +1177,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since CoreText:7.0  UIKit:7.0  ASText:7.0
  */
-@property (nullable, nonatomic, copy, readwrite) NSArray<NSTextTab *> *as_tabStops;
+@property (nullable, nonatomic, copy) NSArray<NSTextTab *> *as_tabStops;
 - (void)as_setTabStops:(nullable NSArray<NSTextTab *> *)tabStops range:(NSRange)range NS_AVAILABLE_IOS(7_0);
 
 #pragma mark - Set ASText attribute as property
@@ -1193,7 +1193,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) ASTextShadow *as_textShadow;
+@property (nullable, nonatomic) ASTextShadow *as_textShadow;
 - (void)as_setTextShadow:(nullable ASTextShadow *)textShadow range:(NSRange)range;
 
 /**
@@ -1204,7 +1204,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) ASTextShadow *as_textInnerShadow;
+@property (nullable, nonatomic) ASTextShadow *as_textInnerShadow;
 - (void)as_setTextInnerShadow:(nullable ASTextShadow *)textInnerShadow range:(NSRange)range;
 
 /**
@@ -1215,7 +1215,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) ASTextDecoration *as_textUnderline;
+@property (nullable, nonatomic) ASTextDecoration *as_textUnderline;
 - (void)as_setTextUnderline:(nullable ASTextDecoration *)textUnderline range:(NSRange)range;
 
 /**
@@ -1226,7 +1226,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) ASTextDecoration *as_textStrikethrough;
+@property (nullable, nonatomic) ASTextDecoration *as_textStrikethrough;
 - (void)as_setTextStrikethrough:(nullable ASTextDecoration *)textStrikethrough range:(NSRange)range;
 
 /**
@@ -1237,7 +1237,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) ASTextBorder *as_textBorder;
+@property (nullable, nonatomic) ASTextBorder *as_textBorder;
 - (void)as_setTextBorder:(nullable ASTextBorder *)textBorder range:(NSRange)range;
 
 /**
@@ -1248,7 +1248,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nullable, nonatomic, strong, readwrite) ASTextBorder *as_textBackgroundBorder;
+@property (nullable, nonatomic) ASTextBorder *as_textBackgroundBorder;
 - (void)as_setTextBackgroundBorder:(nullable ASTextBorder *)textBackgroundBorder range:(NSRange)range;
 
 /**
@@ -1259,7 +1259,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get this property returns the first character's attribute.
  @since ASText:6.0
  */
-@property (nonatomic, readwrite) CGAffineTransform as_textGlyphTransform;
+@property (nonatomic) CGAffineTransform as_textGlyphTransform;
 - (void)as_setTextGlyphTransform:(CGAffineTransform)textGlyphTransform range:(NSRange)range;
 
 

--- a/Source/Private/_ASCollectionGalleryLayoutInfo.h
+++ b/Source/Private/_ASCollectionGalleryLayoutInfo.h
@@ -15,16 +15,16 @@
 @interface _ASCollectionGalleryLayoutInfo : NSObject
 
 // Read-only properties
-@property (nonatomic, assign, readonly) CGSize itemSize;
-@property (nonatomic, assign, readonly) CGFloat minimumLineSpacing;
-@property (nonatomic, assign, readonly) CGFloat minimumInteritemSpacing;
-@property (nonatomic, assign, readonly) UIEdgeInsets sectionInset;
+@property (nonatomic, readonly) CGSize itemSize;
+@property (nonatomic, readonly) CGFloat minimumLineSpacing;
+@property (nonatomic, readonly) CGFloat minimumInteritemSpacing;
+@property (nonatomic, readonly) UIEdgeInsets sectionInset;
 
 - (instancetype)initWithItemSize:(CGSize)itemSize
               minimumLineSpacing:(CGFloat)minimumLineSpacing
          minimumInteritemSpacing:(CGFloat)minimumInteritemSpacing
                     sectionInset:(UIEdgeInsets)sectionInset NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)init __unavailable;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end

--- a/Source/Private/_ASCollectionGalleryLayoutItem.h
+++ b/Source/Private/_ASCollectionGalleryLayoutItem.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED
 @interface _ASGalleryLayoutItem : NSObject <ASLayoutElement>
 
-@property (nonatomic, assign, readonly) CGSize itemSize;
+@property (nonatomic, readonly) CGSize itemSize;
 @property (nonatomic, weak, readonly) ASCollectionElement *collectionElement;
 
 - (instancetype)initWithItemSize:(CGSize)itemSize collectionElement:(ASCollectionElement *)collectionElement;

--- a/Source/Private/_ASHierarchyChangeSet.h
+++ b/Source/Private/_ASHierarchyChangeSet.h
@@ -71,7 +71,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType);
 // FIXME: Generalize this to `changeMetadata` dict?
 @property (nonatomic, readonly) ASDataControllerAnimationOptions animationOptions;
 
-@property (nonatomic, strong, readonly) NSIndexSet *indexSet;
+@property (nonatomic, readonly) NSIndexSet *indexSet;
 
 @property (nonatomic, readonly) _ASHierarchyChangeType changeType;
 
@@ -88,7 +88,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType);
 @property (nonatomic, readonly) ASDataControllerAnimationOptions animationOptions;
 
 /// Index paths are sorted descending for changeType .Delete, ascending otherwise
-@property (nonatomic, strong, readonly) NSArray<NSIndexPath *> *indexPaths;
+@property (nonatomic, readonly) NSArray<NSIndexPath *> *indexPaths;
 
 @property (nonatomic, readonly) _ASHierarchyChangeType changeType;
 
@@ -105,16 +105,16 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType);
 @interface _ASHierarchyChangeSet : NSObject <ASDescriptionProvider, ASDebugDescriptionProvider>
 
 /// @precondition The change set must be completed.
-@property (nonatomic, strong, readonly) NSIndexSet *deletedSections;
+@property (nonatomic, readonly) NSIndexSet *deletedSections;
 
 /// @precondition The change set must be completed.
-@property (nonatomic, strong, readonly) NSIndexSet *insertedSections;
+@property (nonatomic, readonly) NSIndexSet *insertedSections;
 
 @property (nonatomic, readonly) BOOL completed;
 
 /// Whether or not changes should be animated.
 // TODO: if any update in this chagne set is non-animated, the whole update should be non-animated.
-@property (nonatomic, readwrite) BOOL animated;
+@property (nonatomic) BOOL animated;
 
 @property (nonatomic, readonly) BOOL includesReloadData;
 
@@ -158,12 +158,12 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType);
 /**
  * A table that maps old section indexes to new section indexes.
  */
-@property (nonatomic, readonly, strong) ASIntegerMap *sectionMapping;
+@property (nonatomic, readonly) ASIntegerMap *sectionMapping;
 
 /**
  * A table that maps new section indexes to old section indexes.
  */
-@property (nonatomic, readonly, strong) ASIntegerMap *reverseSectionMapping;
+@property (nonatomic, readonly) ASIntegerMap *reverseSectionMapping;
 
 /**
  * A table that provides the item mapping for the old section. If the section was deleted

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -94,26 +94,26 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 @interface _ASHierarchyChangeSet ()
 
 // array index is old section index, map goes oldItem -> newItem
-@property (nonatomic, strong, readonly) NSMutableArray<ASIntegerMap *> *itemMappings;
+@property (nonatomic, readonly) NSMutableArray<ASIntegerMap *> *itemMappings;
 
 // array index is new section index, map goes newItem -> oldItem
-@property (nonatomic, strong, readonly) NSMutableArray<ASIntegerMap *> *reverseItemMappings;
+@property (nonatomic, readonly) NSMutableArray<ASIntegerMap *> *reverseItemMappings;
 
-@property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchyItemChange *> *insertItemChanges;
-@property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchyItemChange *> *originalInsertItemChanges;
+@property (nonatomic, readonly) NSMutableArray<_ASHierarchyItemChange *> *insertItemChanges;
+@property (nonatomic, readonly) NSMutableArray<_ASHierarchyItemChange *> *originalInsertItemChanges;
 
-@property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchyItemChange *> *deleteItemChanges;
-@property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchyItemChange *> *originalDeleteItemChanges;
+@property (nonatomic, readonly) NSMutableArray<_ASHierarchyItemChange *> *deleteItemChanges;
+@property (nonatomic, readonly) NSMutableArray<_ASHierarchyItemChange *> *originalDeleteItemChanges;
 
-@property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchyItemChange *> *reloadItemChanges;
+@property (nonatomic, readonly) NSMutableArray<_ASHierarchyItemChange *> *reloadItemChanges;
 
-@property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchySectionChange *> *insertSectionChanges;
-@property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchySectionChange *> *originalInsertSectionChanges;
+@property (nonatomic, readonly) NSMutableArray<_ASHierarchySectionChange *> *insertSectionChanges;
+@property (nonatomic, readonly) NSMutableArray<_ASHierarchySectionChange *> *originalInsertSectionChanges;
 
-@property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchySectionChange *> *deleteSectionChanges;
-@property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchySectionChange *> *originalDeleteSectionChanges;
+@property (nonatomic, readonly) NSMutableArray<_ASHierarchySectionChange *> *deleteSectionChanges;
+@property (nonatomic, readonly) NSMutableArray<_ASHierarchySectionChange *> *originalDeleteSectionChanges;
 
-@property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchySectionChange *> *reloadSectionChanges;
+@property (nonatomic, readonly) NSMutableArray<_ASHierarchySectionChange *> *reloadSectionChanges;
 
 @end
 

--- a/Source/TextKit/ASTextKitComponents.h
+++ b/Source/TextKit/ASTextKitComponents.h
@@ -61,10 +61,10 @@ AS_SUBCLASSING_RESTRICTED
 - (CGSize)sizeForConstrainedWidth:(CGFloat)constrainedWidth
               forMaxNumberOfLines:(NSInteger)numberOfLines;
 
-@property (nonatomic, strong, readonly) NSTextStorage *textStorage;
-@property (nonatomic, strong, readonly) NSTextContainer *textContainer;
-@property (nonatomic, strong, readonly) NSLayoutManager *layoutManager;
-@property (nonatomic, strong, nullable) ASTextKitComponentsTextView *textView;
+@property (nonatomic, readonly) NSTextStorage *textStorage;
+@property (nonatomic, readonly) NSTextContainer *textContainer;
+@property (nonatomic, readonly) NSLayoutManager *layoutManager;
+@property (nonatomic, nullable) ASTextKitComponentsTextView *textView;
 
 @end
 

--- a/Source/TextKit/ASTextKitComponents.mm
+++ b/Source/TextKit/ASTextKitComponents.mm
@@ -24,7 +24,7 @@
   // Prevent UITextView from updating contentOffset while deallocating: https://github.com/TextureGroup/Texture/issues/860
   BOOL _deallocating;
 }
-@property (atomic, assign) CGRect threadSafeBounds;
+@property CGRect threadSafeBounds;
 @end
 
 @implementation ASTextKitComponentsTextView
@@ -73,9 +73,9 @@
 @interface ASTextKitComponents ()
 
 // read-write redeclarations
-@property (nonatomic, strong, readwrite) NSTextStorage *textStorage;
-@property (nonatomic, strong, readwrite) NSTextContainer *textContainer;
-@property (nonatomic, strong, readwrite) NSLayoutManager *layoutManager;
+@property (nonatomic) NSTextStorage *textStorage;
+@property (nonatomic) NSTextContainer *textContainer;
+@property (nonatomic) NSLayoutManager *layoutManager;
 
 @end
 

--- a/Source/TextKit/ASTextKitEntityAttribute.h
+++ b/Source/TextKit/ASTextKitEntityAttribute.h
@@ -30,7 +30,7 @@
 AS_SUBCLASSING_RESTRICTED
 @interface ASTextKitEntityAttribute : NSObject
 
-@property (nonatomic, strong, readonly) id<NSObject> entity;
+@property (nonatomic, readonly) id<NSObject> entity;
 
 - (instancetype)initWithEntity:(id<NSObject>)entity;
 

--- a/Source/TextKit/ASTextKitFontSizeAdjuster.h
+++ b/Source/TextKit/ASTextKitFontSizeAdjuster.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED
 @interface ASTextKitFontSizeAdjuster : NSObject
 
-@property (nonatomic, assign) CGSize constrainedSize;
+@property (nonatomic) CGSize constrainedSize;
 
 /**
  *  Creates a class that will return a scale factor the will make a string fit inside the constrained size.

--- a/Source/TextKit/ASTextKitFontSizeAdjuster.mm
+++ b/Source/TextKit/ASTextKitFontSizeAdjuster.mm
@@ -29,8 +29,8 @@
 #define LOG(...)
 
 @interface ASTextKitFontSizeAdjuster()
-@property (nonatomic, strong, readonly) NSLayoutManager *sizingLayoutManager;
-@property (nonatomic, strong, readonly) NSTextContainer *sizingTextContainer;
+@property (nonatomic, readonly) NSLayoutManager *sizingLayoutManager;
+@property (nonatomic, readonly) NSTextContainer *sizingTextContainer;
 @end
 
 @implementation ASTextKitFontSizeAdjuster

--- a/Source/TextKit/ASTextKitRenderer+TextChecking.h
+++ b/Source/TextKit/ASTextKitRenderer+TextChecking.h
@@ -26,7 +26,7 @@ static uint64_t const ASTextKitTextCheckingTypeTruncation =           1ULL << 34
 @class ASTextKitEntityAttribute;
 
 @interface ASTextKitTextCheckingResult : NSTextCheckingResult
-@property (nonatomic, strong, readonly) ASTextKitEntityAttribute *entityAttribute;
+@property (nonatomic, readonly) ASTextKitEntityAttribute *entityAttribute;
 @end
 
 @interface ASTextKitRenderer (TextChecking)

--- a/Source/TextKit/ASTextKitRenderer.h
+++ b/Source/TextKit/ASTextKitRenderer.h
@@ -50,19 +50,19 @@
 - (instancetype)initWithTextKitAttributes:(const ASTextKitAttributes &)textComponentAttributes
                           constrainedSize:(const CGSize)constrainedSize;
 
-@property (nonatomic, strong, readonly) ASTextKitContext *context;
+@property (nonatomic, readonly) ASTextKitContext *context;
 
-@property (nonatomic, strong, readonly) id<ASTextKitTruncating> truncater;
+@property (nonatomic, readonly) id<ASTextKitTruncating> truncater;
 
-@property (nonatomic, strong, readonly) ASTextKitFontSizeAdjuster *fontSizeAdjuster;
+@property (nonatomic, readonly) ASTextKitFontSizeAdjuster *fontSizeAdjuster;
 
-@property (nonatomic, strong, readonly) ASTextKitShadower *shadower;
+@property (nonatomic, readonly) ASTextKitShadower *shadower;
 
-@property (nonatomic, assign, readonly) ASTextKitAttributes attributes;
+@property (nonatomic, readonly) ASTextKitAttributes attributes;
 
-@property (nonatomic, assign, readonly) CGSize constrainedSize;
+@property (nonatomic, readonly) CGSize constrainedSize;
 
-@property (nonatomic, assign, readonly) CGFloat currentScaleFactor;
+@property (nonatomic, readonly) CGFloat currentScaleFactor;
 
 #pragma mark - Drawing
 /**
@@ -85,7 +85,7 @@
  The character range from the original attributedString that is displayed by the renderer given the parameters in the
  initializer.
  */
-@property (nonatomic, assign, readonly) std::vector<NSRange> visibleRanges;
+@property (nonatomic, readonly) std::vector<NSRange> visibleRanges;
 
 /**
  The number of lines shown in the string.
@@ -105,6 +105,6 @@
  Returns the first visible range or an NSRange with location of NSNotFound and size of 0 if no first visible
  range exists
  */
-@property (nonatomic, assign, readonly) NSRange firstVisibleRange;
+@property (nonatomic, readonly) NSRange firstVisibleRange;
 
 @end

--- a/Source/TextKit/ASTextKitShadower.h
+++ b/Source/TextKit/ASTextKitShadower.h
@@ -34,16 +34,16 @@ AS_SUBCLASSING_RESTRICTED
  * @discussion A positive width will move the shadow to the right.
  *             A positive height will move the shadow downwards.
  */
-@property (nonatomic, readonly, assign) CGSize shadowOffset;
+@property (nonatomic, readonly) CGSize shadowOffset;
 
 //! CGColor in which the shadow is drawn
-@property (nonatomic, readonly, strong) UIColor *shadowColor;
+@property (nonatomic, copy, readonly) UIColor *shadowColor;
 
 //! Alpha of the shadow
-@property (nonatomic, readonly, assign) CGFloat shadowOpacity;
+@property (nonatomic, readonly) CGFloat shadowOpacity;
 
 //! Radius, in pixels
-@property (nonatomic, readonly, assign) CGFloat shadowRadius;
+@property (nonatomic, readonly) CGFloat shadowRadius;
 
 /**
  * @abstract The edge insets which represent shadow padding

--- a/Source/TextKit/ASTextKitTruncating.h
+++ b/Source/TextKit/ASTextKitTruncating.h
@@ -28,13 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
  The character range from the original attributedString that is displayed by the renderer given the parameters in the
  initializer.
  */
-@property (nonatomic, assign, readonly) std::vector<NSRange> visibleRanges;
+@property (nonatomic, readonly) std::vector<NSRange> visibleRanges;
 
 /**
  Returns the first visible range or an NSRange with location of NSNotFound and size of 0 if no first visible
  range exists
  */
-@property (nonatomic, assign, readonly) NSRange firstVisibleRange;
+@property (nonatomic, readonly) NSRange firstVisibleRange;
 
 /**
  A truncater object is initialized with the full state of the text.  It is a Single Responsibility Object that is

--- a/Source/_ASTransitionContext.h
+++ b/Source/_ASTransitionContext.h
@@ -42,7 +42,7 @@
 
 @interface _ASTransitionContext : NSObject <ASContextTransitioning>
 
-@property (assign, readonly, nonatomic, getter=isAnimated) BOOL animated;
+@property (nonatomic, readonly, getter=isAnimated) BOOL animated;
 
 - (instancetype)initWithAnimation:(BOOL)animated
                    layoutDelegate:(id<_ASTransitionContextLayoutDelegate>)layoutDelegate
@@ -51,7 +51,7 @@
 @end
 
 @interface _ASAnimatedTransitionContext : NSObject
-@property (nonatomic, strong, readonly) ASDisplayNode *node;
-@property (nonatomic, assign, readonly) CGFloat alpha;
+@property (nonatomic, readonly) ASDisplayNode *node;
+@property (nonatomic, readonly) CGFloat alpha;
 + (instancetype)contextForNode:(ASDisplayNode *)node alpha:(CGFloat)alphaValue NS_RETURNS_RETAINED;
 @end

--- a/Source/_ASTransitionContext.m
+++ b/Source/_ASTransitionContext.m
@@ -95,8 +95,8 @@ NSString * const ASTransitionContextToLayoutKey = @"org.asyncdisplaykit.ASTransi
 
 
 @interface _ASAnimatedTransitionContext ()
-@property (nonatomic, strong, readwrite) ASDisplayNode *node;
-@property (nonatomic, assign, readwrite) CGFloat alpha;
+@property (nonatomic) ASDisplayNode *node;
+@property (nonatomic) CGFloat alpha;
 @end
 
 @implementation _ASAnimatedTransitionContext

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -28,8 +28,8 @@
 
 @interface ASTextCellNodeWithSetSelectedCounter : ASTextCellNode
 
-@property (nonatomic, assign) NSUInteger setSelectedCounter;
-@property (nonatomic, assign) NSUInteger applyLayoutAttributesCount;
+@property (nonatomic) NSUInteger setSelectedCounter;
+@property (nonatomic) NSUInteger applyLayoutAttributesCount;
 
 @end
 
@@ -50,8 +50,8 @@
 
 @interface ASTestSectionContext : NSObject <ASSectionContext>
 
-@property (nonatomic, assign) NSInteger sectionIndex;
-@property (nonatomic, assign) NSInteger sectionGeneration;
+@property (nonatomic) NSInteger sectionIndex;
+@property (nonatomic) NSInteger sectionGeneration;
 
 @end
 
@@ -63,8 +63,8 @@
 
 @interface ASCollectionViewTestDelegate : NSObject <ASCollectionDataSource, ASCollectionDelegate, UICollectionViewDelegateFlowLayout>
 
-@property (nonatomic, assign) NSInteger sectionGeneration;
-@property (nonatomic, copy) void(^willBeginBatchFetch)(ASBatchContext *);
+@property (nonatomic) NSInteger sectionGeneration;
+@property (nonatomic) void(^willBeginBatchFetch)(ASBatchContext *);
 
 @end
 
@@ -139,9 +139,9 @@
 
 @interface ASCollectionViewTestController: UIViewController
 
-@property (nonatomic, strong) ASCollectionViewTestDelegate *asyncDelegate;
-@property (nonatomic, strong) ASCollectionView *collectionView;
-@property (nonatomic, strong) ASCollectionNode *collectionNode;
+@property (nonatomic) ASCollectionViewTestDelegate *asyncDelegate;
+@property (nonatomic) ASCollectionView *collectionView;
+@property (nonatomic) ASCollectionNode *collectionNode;
 
 @end
 

--- a/Tests/ASCornerLayoutSpecSnapshotTests.mm
+++ b/Tests/ASCornerLayoutSpecSnapshotTests.mm
@@ -23,16 +23,16 @@ typedef NS_ENUM(NSInteger, ASCornerLayoutSpecSnapshotTestsOffsetOption) {
 
 @interface ASCornerLayoutSpecSnapshotTests : ASLayoutSpecSnapshotTestCase
 
-@property (nonatomic, strong) UIColor *boxColor;
-@property (nonatomic, strong) UIColor *baseColor;
-@property (nonatomic, strong) UIColor *cornerColor;
-@property (nonatomic, strong) UIColor *contextColor;
+@property (nonatomic, copy) UIColor *boxColor;
+@property (nonatomic, copy) UIColor *baseColor;
+@property (nonatomic, copy) UIColor *cornerColor;
+@property (nonatomic, copy) UIColor *contextColor;
 
-@property (nonatomic, assign) CGSize baseSize;
-@property (nonatomic, assign) CGSize cornerSize;
-@property (nonatomic, assign) CGSize contextSize;
+@property (nonatomic) CGSize baseSize;
+@property (nonatomic) CGSize cornerSize;
+@property (nonatomic) CGSize contextSize;
 
-@property (nonatomic, assign) ASSizeRange contextSizeRange;
+@property (nonatomic) ASSizeRange contextSizeRange;
 
 @end
 

--- a/Tests/ASDisplayLayerTests.m
+++ b/Tests/ASDisplayLayerTests.m
@@ -42,7 +42,7 @@ static UIImage *bogusImage() {
 }
 
 @interface _ASDisplayLayerTestContainerLayer : CALayer
-@property (nonatomic, assign, readonly) NSUInteger didCompleteTransactionCount;
+@property (nonatomic, readonly) NSUInteger didCompleteTransactionCount;
 @end
 
 @implementation _ASDisplayLayerTestContainerLayer
@@ -66,10 +66,10 @@ static UIImage *bogusImage() {
   BOOL _isInCancelAsyncDisplay;
   BOOL _isInDisplay;
 }
-@property (nonatomic, assign, readonly) NSUInteger displayCount;
-@property (nonatomic, assign, readonly) NSUInteger drawInContextCount;
-@property (nonatomic, assign, readonly) NSUInteger setContentsAsyncCount;
-@property (nonatomic, assign, readonly) NSUInteger setContentsSyncCount;
+@property (nonatomic, readonly) NSUInteger displayCount;
+@property (nonatomic, readonly) NSUInteger drawInContextCount;
+@property (nonatomic, readonly) NSUInteger setContentsAsyncCount;
+@property (nonatomic, readonly) NSUInteger setContentsSyncCount;
 @property (nonatomic, copy, readonly) NSString *setContentsCounts;
 - (BOOL)checkSetContentsCountsWithSyncCount:(NSUInteger)syncCount asyncCount:(NSUInteger)asyncCount;
 @end
@@ -142,16 +142,16 @@ typedef NS_ENUM(NSUInteger, _ASDisplayLayerTestDelegateClassModes) {
 
 @interface _ASDisplayLayerTestDelegate : ASDisplayNode <_ASDisplayLayerDelegate>
 
-@property (nonatomic, assign) NSUInteger didDisplayCount;
-@property (nonatomic, assign) NSUInteger drawParametersCount;
-@property (nonatomic, assign) NSUInteger willDisplayCount;
+@property (nonatomic) NSUInteger didDisplayCount;
+@property (nonatomic) NSUInteger drawParametersCount;
+@property (nonatomic) NSUInteger willDisplayCount;
 
 // for _ASDisplayLayerTestDelegateModeClassDisplay
-@property (nonatomic, assign) NSUInteger displayCount;
-@property (nonatomic, copy) UIImage *(^displayLayerBlock)(void);
+@property (nonatomic) NSUInteger displayCount;
+@property (nonatomic) UIImage *(^displayLayerBlock)(void);
 
 // for _ASDisplayLayerTestDelegateModeClassDrawInContext
-@property (nonatomic, assign) NSUInteger drawRectCount;
+@property (nonatomic) NSUInteger drawRectCount;
 
 @end
 

--- a/Tests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/Tests/ASDisplayNodeImplicitHierarchyTests.m
@@ -26,7 +26,7 @@
 /**
  Simple state identifier to allow control of current spec inside of the layoutSpecBlock
  */
-@property (strong, nonatomic) NSNumber *layoutState;
+@property (nonatomic) NSNumber *layoutState;
 
 @end
 

--- a/Tests/ASDisplayNodeTests.mm
+++ b/Tests/ASDisplayNodeTests.mm
@@ -104,8 +104,8 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 @end
 
 @interface ASTestDisplayNode : ASDisplayNode
-@property (nonatomic, copy) void (^willDeallocBlock)(__unsafe_unretained ASTestDisplayNode *node);
-@property (nonatomic, copy) CGSize(^calculateSizeBlock)(ASTestDisplayNode *node, CGSize size);
+@property (nonatomic) void (^willDeallocBlock)(__unsafe_unretained ASTestDisplayNode *node);
+@property (nonatomic) CGSize(^calculateSizeBlock)(ASTestDisplayNode *node, CGSize size);
 
 @property (nonatomic, nullable) UIGestureRecognizer *gestureRecognizer;
 @property (nonatomic, nullable) id idGestureRecognizer;
@@ -119,8 +119,8 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 @property (nonatomic) BOOL preloadStateChangedToYES;
 @property (nonatomic) BOOL preloadStateChangedToNO;
 
-@property (nonatomic, assign) NSUInteger displayWillStartCount;
-@property (nonatomic, assign) NSUInteger didDisplayCount;
+@property (nonatomic) NSUInteger displayWillStartCount;
+@property (nonatomic) NSUInteger didDisplayCount;
 
 @end
 

--- a/Tests/ASEditableTextNodeTests.m
+++ b/Tests/ASEditableTextNodeTests.m
@@ -27,8 +27,8 @@ static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
 }
 
 @interface ASEditableTextNodeTests : XCTestCase
-@property (nonatomic, readwrite, strong) ASEditableTextNode *editableTextNode;
-@property (nonatomic, readwrite, copy) NSAttributedString *attributedText;
+@property (nonatomic) ASEditableTextNode *editableTextNode;
+@property (nonatomic, copy) NSAttributedString *attributedText;
 @end
 
 @implementation ASEditableTextNodeTests

--- a/Tests/ASLayoutSpecSnapshotTestsHelper.m
+++ b/Tests/ASLayoutSpecSnapshotTestsHelper.m
@@ -23,7 +23,7 @@
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
 
 @interface ASTestNode : ASDisplayNode
-@property (strong, nonatomic, nullable) ASLayoutSpec *layoutSpecUnderTest;
+@property (nonatomic, nullable) ASLayoutSpec *layoutSpecUnderTest;
 @end
 
 @implementation ASLayoutSpecSnapshotTestCase

--- a/Tests/ASLayoutSpecTests.m
+++ b/Tests/ASLayoutSpecTests.m
@@ -30,8 +30,8 @@
  *  - primitive / ASStackLayoutDirection (extendedDirection)
  */
 @protocol ASDKExtendedLayoutElement <NSObject>
-@property (assign, nonatomic) CGFloat extendedWidth;
-@property (assign, nonatomic) ASDimension extendedDimension;
+@property (nonatomic) CGFloat extendedWidth;
+@property (nonatomic) ASDimension extendedDimension;
 @property (copy, nonatomic) NSString *extendedName;
 @end
 

--- a/Tests/ASLayoutTestNode.h
+++ b/Tests/ASLayoutTestNode.h
@@ -22,7 +22,7 @@
  *
  * Instead we create a strict mock for each node, and forward a selected set of calls to it.
  */
-@property (nonatomic, strong, readonly) id mock;
+@property (nonatomic, readonly) id mock;
 
 /**
  * The size that this node will return in calculateLayoutThatFits (if it doesn't have a layoutSpecBlock).

--- a/Tests/ASPagerNodeTests.m
+++ b/Tests/ASPagerNodeTests.m
@@ -44,8 +44,8 @@
 @end
 
 @interface ASPagerNodeTestController: UIViewController
-@property (nonatomic, strong) ASPagerNodeTestDataSource *testDataSource;
-@property (nonatomic, strong) ASPagerNode *pagerNode;
+@property (nonatomic) ASPagerNodeTestDataSource *testDataSource;
+@property (nonatomic) ASPagerNode *pagerNode;
 @end
 
 @implementation ASPagerNodeTestController
@@ -68,9 +68,9 @@
 @end
 
 @interface ASPagerNodeTests : XCTestCase
-@property (nonatomic, strong) ASPagerNode *pagerNode;
+@property (nonatomic) ASPagerNode *pagerNode;
 
-@property (nonatomic, strong) ASPagerNodeTestDataSource *testDataSource;
+@property (nonatomic) ASPagerNodeTestDataSource *testDataSource;
 @end
 
 @implementation ASPagerNodeTests

--- a/Tests/ASRunLoopQueueTests.m
+++ b/Tests/ASRunLoopQueueTests.m
@@ -18,7 +18,7 @@
 static NSTimeInterval const kRunLoopRunTime = 0.001; // Allow the RunLoop to run for one millisecond each time.
 
 @interface QueueObject : NSObject <ASCATransactionQueueObserving>
-@property (nonatomic, assign) BOOL queueObjectProcessed;
+@property (nonatomic) BOOL queueObjectProcessed;
 @end
 
 @implementation QueueObject

--- a/Tests/ASTLayoutFixture.h
+++ b/Tests/ASTLayoutFixture.h
@@ -21,14 +21,14 @@ AS_SUBCLASSING_RESTRICTED
 @interface ASTLayoutFixture : NSObject
 
 /// The correct layout. The root should be unpositioned (same as -calculatedLayout).
-@property (nonatomic, strong, nullable) ASLayout *layout;
+@property (nonatomic, nullable) ASLayout *layout;
 
 /// The layoutSpecBlocks for non-leaf nodes.
-@property (nonatomic, strong, readonly) NSMapTable<ASDisplayNode *, ASLayoutSpecBlock> *layoutSpecBlocks;
+@property (nonatomic, readonly) NSMapTable<ASDisplayNode *, ASLayoutSpecBlock> *layoutSpecBlocks;
 
-@property (nonatomic, strong, readonly) ASLayoutTestNode *rootNode;
+@property (nonatomic, readonly) ASLayoutTestNode *rootNode;
 
-@property (nonatomic, strong, readonly) NSSet<ASLayoutTestNode *> *allNodes;
+@property (nonatomic, readonly) NSSet<ASLayoutTestNode *> *allNodes;
 
 /// Get the (correct) layout for the specified node.
 - (ASLayout *)layoutForNode:(ASLayoutTestNode *)node;

--- a/Tests/ASTLayoutFixture.mm
+++ b/Tests/ASTLayoutFixture.mm
@@ -15,10 +15,10 @@
 @interface ASTLayoutFixture ()
 
 /// The size ranges against which nodes are expected to be measured.
-@property (nonatomic, strong, readonly) NSMapTable<ASDisplayNode *, NSMutableArray<NSValue *> *> *sizeRanges;
+@property (nonatomic, readonly) NSMapTable<ASDisplayNode *, NSMutableArray<NSValue *> *> *sizeRanges;
 
 /// The overridden returned sizes for nodes where you want to trigger multipass layout.
-@property (nonatomic, strong, readonly) NSMapTable<ASDisplayNode *, NSValue *> *returnedSizes;
+@property (nonatomic, readonly) NSMapTable<ASDisplayNode *, NSValue *> *returnedSizes;
 
 @end
 

--- a/Tests/ASTableViewTests.mm
+++ b/Tests/ASTableViewTests.mm
@@ -53,7 +53,7 @@
 @end
 
 @interface ASTestTableView : ASTableView
-@property (nonatomic, copy) void (^willDeallocBlock)(ASTableView *tableView);
+@property (nonatomic) void (^willDeallocBlock)(ASTableView *tableView);
 @end
 
 @implementation ASTestTableView
@@ -79,7 +79,7 @@
 @end
 
 @interface ASTableViewTestDelegate : NSObject <ASTableDataSource, ASTableDelegate>
-@property (nonatomic, copy) void (^willDeallocBlock)(ASTableViewTestDelegate *delegate);
+@property (nonatomic) void (^willDeallocBlock)(ASTableViewTestDelegate *delegate);
 @property (nonatomic) CGFloat headerHeight;
 @property (nonatomic) CGFloat footerHeight;
 @end
@@ -141,7 +141,7 @@
 @property (nonatomic) BOOL usesSectionIndex;
 @property (nonatomic) NSInteger numberOfSections;
 @property (nonatomic) NSInteger rowsPerSection;
-@property (nonatomic, nullable, copy) ASCellNodeBlock(^nodeBlockForItem)(NSIndexPath *);
+@property (nonatomic, nullable) ASCellNodeBlock(^nodeBlockForItem)(NSIndexPath *);
 @end
 
 @implementation ASTableViewFilledDataSource

--- a/Tests/ASTableViewThrashTests.m
+++ b/Tests/ASTableViewThrashTests.m
@@ -103,7 +103,7 @@ static atomic_uint ASThrashTestItemNextID;
 @end
 
 @interface ASThrashTestSection: NSObject <NSCopying, NSSecureCoding>
-@property (nonatomic, strong, readonly) NSMutableArray *items;
+@property (nonatomic, readonly) NSMutableArray *items;
 @property (nonatomic, readonly) NSInteger sectionID;
 
 - (CGFloat)headerHeight;
@@ -180,7 +180,7 @@ static atomic_uint ASThrashTestSectionNextID = 1;
 
 #if !USE_UIKIT_REFERENCE
 @interface ASThrashTestNode: ASCellNode
-@property (nonatomic, strong) ASThrashTestItem *item;
+@property (nonatomic) ASThrashTestItem *item;
 @end
 
 @implementation ASThrashTestNode
@@ -201,11 +201,11 @@ static atomic_uint ASThrashTestSectionNextID = 1;
 <ASTableDataSource, ASTableDelegate>
 #endif
 
-@property (nonatomic, strong, readonly) UIWindow *window;
-@property (nonatomic, strong, readonly) TableView *tableView;
-@property (nonatomic, strong) NSArray <ASThrashTestSection *> *data;
+@property (nonatomic, readonly) UIWindow *window;
+@property (nonatomic, readonly) TableView *tableView;
+@property (nonatomic) NSArray <ASThrashTestSection *> *data;
 // Only access on main
-@property (nonatomic, strong) ASWeakSet *allNodes;
+@property (nonatomic) ASWeakSet *allNodes;
 @end
 
 
@@ -314,20 +314,20 @@ static atomic_uint ASThrashTestSectionNextID = 1;
 static NSInteger ASThrashUpdateCurrentSerializationVersion = 1;
 
 @interface ASThrashUpdate : NSObject <NSSecureCoding>
-@property (nonatomic, strong, readonly) NSArray<ASThrashTestSection *> *oldData;
-@property (nonatomic, strong, readonly) NSMutableArray<ASThrashTestSection *> *data;
-@property (nonatomic, strong, readonly) NSMutableIndexSet *deletedSectionIndexes;
-@property (nonatomic, strong, readonly) NSMutableIndexSet *replacedSectionIndexes;
+@property (nonatomic, readonly) NSArray<ASThrashTestSection *> *oldData;
+@property (nonatomic, readonly) NSMutableArray<ASThrashTestSection *> *data;
+@property (nonatomic, readonly) NSMutableIndexSet *deletedSectionIndexes;
+@property (nonatomic, readonly) NSMutableIndexSet *replacedSectionIndexes;
 /// The sections used to replace the replaced sections.
-@property (nonatomic, strong, readonly) NSMutableArray<ASThrashTestSection *> *replacingSections;
-@property (nonatomic, strong, readonly) NSMutableIndexSet *insertedSectionIndexes;
-@property (nonatomic, strong, readonly) NSMutableArray<ASThrashTestSection *> *insertedSections;
-@property (nonatomic, strong, readonly) NSMutableArray<NSMutableIndexSet *> *deletedItemIndexes;
-@property (nonatomic, strong, readonly) NSMutableArray<NSMutableIndexSet *> *replacedItemIndexes;
+@property (nonatomic, readonly) NSMutableArray<ASThrashTestSection *> *replacingSections;
+@property (nonatomic, readonly) NSMutableIndexSet *insertedSectionIndexes;
+@property (nonatomic, readonly) NSMutableArray<ASThrashTestSection *> *insertedSections;
+@property (nonatomic, readonly) NSMutableArray<NSMutableIndexSet *> *deletedItemIndexes;
+@property (nonatomic, readonly) NSMutableArray<NSMutableIndexSet *> *replacedItemIndexes;
 /// The items used to replace the replaced items.
-@property (nonatomic, strong, readonly) NSMutableArray<NSArray <ASThrashTestItem *> *> *replacingItems;
-@property (nonatomic, strong, readonly) NSMutableArray<NSMutableIndexSet *> *insertedItemIndexes;
-@property (nonatomic, strong, readonly) NSMutableArray<NSArray <ASThrashTestItem *> *> *insertedItems;
+@property (nonatomic, readonly) NSMutableArray<NSArray <ASThrashTestItem *> *> *replacingItems;
+@property (nonatomic, readonly) NSMutableArray<NSMutableIndexSet *> *insertedItemIndexes;
+@property (nonatomic, readonly) NSMutableArray<NSArray <ASThrashTestItem *> *> *insertedItems;
 
 - (instancetype)initWithData:(NSArray<ASThrashTestSection *> *)data;
 

--- a/Tests/ASTextNodeTests.m
+++ b/Tests/ASTextNodeTests.m
@@ -31,7 +31,7 @@
 @interface ASTextNodeTestDelegate : NSObject <ASTextNodeDelegate>
 
 @property (nonatomic, copy, readonly) NSString *tappedLinkAttribute;
-@property (nonatomic, assign, readonly) id tappedLinkValue;
+@property (nonatomic, readonly) id tappedLinkValue;
 
 @end
 @interface ASTextNodeSubclass : ASTextNode
@@ -56,8 +56,8 @@
 
 @interface ASTextNodeTests : XCTestCase
 
-@property (nonatomic, readwrite, strong) ASTextNode *textNode;
-@property (nonatomic, readwrite, copy) NSAttributedString *attributedText;
+@property (nonatomic) ASTextNode *textNode;
+@property (nonatomic, copy) NSAttributedString *attributedText;
 
 @end
 

--- a/Tests/ASTextNodeWordKernerTests.mm
+++ b/Tests/ASTextNodeWordKernerTests.mm
@@ -25,9 +25,9 @@
 
 @interface ASTextNodeWordKernerTests : XCTestCase
 
-@property (nonatomic, readwrite, strong) ASTextNodeWordKerner *layoutManagerDelegate;
-@property (nonatomic, readwrite, strong) ASTextKitComponents *components;
-@property (nonatomic, readwrite, copy) NSAttributedString *attributedString;
+@property (nonatomic) ASTextNodeWordKerner *layoutManagerDelegate;
+@property (nonatomic) ASTextKitComponents *components;
+@property (nonatomic, copy) NSAttributedString *attributedString;
 
 @end
 

--- a/Tests/ASVideoNodeTests.m
+++ b/Tests/ASVideoNodeTests.m
@@ -39,11 +39,11 @@
 }
 
 
-@property (atomic, readwrite) ASInterfaceState interfaceState;
-@property (atomic, readonly) ASDisplayNode *spinner;
-@property (atomic, readwrite) ASDisplayNode *playerNode;
-@property (atomic, readwrite) AVPlayer *player;
-@property (atomic, readwrite) BOOL shouldBePlaying;
+@property ASInterfaceState interfaceState;
+@property (readonly) ASDisplayNode *spinner;
+@property ASDisplayNode *playerNode;
+@property AVPlayer *player;
+@property BOOL shouldBePlaying;
 
 - (void)setVideoPlaceholderImage:(UIImage *)image;
 - (void)prepareToPlayAsset:(AVAsset *)asset withKeys:(NSArray *)requestedKeys;

--- a/Tests/ASVideoNodeTests.m
+++ b/Tests/ASVideoNodeTests.m
@@ -39,11 +39,11 @@
 }
 
 
-@property (nonatomic, readwrite) ASInterfaceState interfaceState;
-@property (nonatomic, readonly) ASDisplayNode *spinner;
-@property (nonatomic, readwrite) ASDisplayNode *playerNode;
-@property (nonatomic, readwrite) AVPlayer *player;
-@property (nonatomic, readwrite) BOOL shouldBePlaying;
+@property (atomic, readwrite) ASInterfaceState interfaceState;
+@property (atomic, readonly) ASDisplayNode *spinner;
+@property (atomic, readwrite) ASDisplayNode *playerNode;
+@property (atomic, readwrite) AVPlayer *player;
+@property (atomic, readwrite) BOOL shouldBePlaying;
 
 - (void)setVideoPlaceholderImage:(UIImage *)image;
 - (void)prepareToPlayAsset:(AVAsset *)asset withKeys:(NSArray *)requestedKeys;

--- a/Tests/Common/OCMockObject+ASAdditions.h
+++ b/Tests/Common/OCMockObject+ASAdditions.h
@@ -31,7 +31,7 @@
 - (void)addImplementedOptionalProtocolMethods:(SEL)aSelector, ... NS_REQUIRES_NIL_TERMINATION;
 
 /// An optional block to modify description text. Only used in OCClassMockObject currently.
-@property (atomic) NSString *(^modifyDescriptionBlock)(OCMockObject *object, NSString *baseDescription);
+@property NSString *(^modifyDescriptionBlock)(OCMockObject *object, NSString *baseDescription);
 
 @end
 


### PR DESCRIPTION
**EDIT** I've proposed getting rid of explicit `atomic` further down in the comments and given my rationale.

OK folks this one won't be fun but let's bang it out.

I propose this as the property declaration style for Texture:

- `class`, if applicable
- Nullability first, if applicable.
  - Include `nullable` on `weak` properties even though it's implied. Nullability and storage class are separate concerns.
- Atomicity.
  - Even if the accessor has specific threading restrictions such as "first access must be on main," it may still be atomic.
  - Even if the object that is accessed doesn't provide an atomic or thread-safe interface (UIView), it may still be atomic.
  - Atomic may be synthesized, C11 atomics, or locked.
- Storage class.
  - Do not include default ARC storage classes – `strong` for objects, `copy` for blocks, and `assign` for primitives.
- Writeability
  - Never include `readwrite`.
- Custom getter/setter names.

So `(nullable, atomic, readonly)` is good. `(atomic, readwrite, assign)` is bad.

Other good examples:
✅ `(nullable, atomic) id`
✅ `(atomic) NSInteger`
✅ `(nonatomic, copy) NSString *`
✅ `(atomic, readonly) NSInteger`

Nonexamples:
🚫 `(atomic, nullable) id`
🚫 `id`
🚫 `(nonatomic, assign, readwrite) NSInteger`

Thoughts from folks? @garrettmoon @nguyenhuy @maicki @appleguy ?