### PR TITLE
Fix macro definition for AS_KDEBUG_ENABLE producing warning #trivial

### DIFF
--- a/Source/Base/ASSignpost.h
+++ b/Source/Base/ASSignpost.h
@@ -48,7 +48,11 @@ static inline ASSignpostColor ASSignpostGetColor(ASSignpostName name, ASSignpost
   }
 }
 
-#define AS_KDEBUG_ENABLE defined(PROFILE) && __has_include(<sys/kdebug_signpost.h>)
+#if defined(PROFILE) && __has_include(<sys/kdebug_signpost.h>)
+  #define AS_KDEBUG_ENABLE 1
+#else
+  #define AS_KDEBUG_ENABLE 0
+#endif
 
 #if AS_KDEBUG_ENABLE
 


### PR DESCRIPTION
AS_KDEBUG_ENABLE macro definition was producing warning: “Macro expansion producing ‘defined’ as undefined behavior”

This prevents building in Xcode 9.3 

Refer to issue: https://github.com/TextureGroup/Texture/issues/872
