### PR TITLE
Add experiment to skip creating UIViews altogether for constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Use `NS_RETURNS_RETAINED` macro to make our methods a tiny bit faster. [Adlai Holler](https://github.com/Adlai-Holler) [#843](https://github.com/TextureGroup/Texture/pull/843/)
 - `ASDisplayNode, ASLayoutSpec, and ASLayoutElementStyle` now conform to `NSLocking`. They act as recursive locks. Useful locking macros have been added as `ASThread.h`. Subclasses / client code can lock these objects but should be careful as usual when dealing with locks. [Adlai Holler](https://github.com/Adlai-Holler)
 - Introduces `ASRecursiveUnfairLock` as an experiment to improve locking performance. [Adlai Holler](https://github.com/Adlai-Holler)
+- Adds an experiment to shorten init time. [Adlai Holler](https://github.com/Adlai-Holler)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -24,6 +24,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalTextNode = 1 << 1,                          // exp_text_node
   ASExperimentalInterfaceStateCoalescing = 1 << 2,          // exp_interface_state_coalesce
   ASExperimentalUnfairLock = 1 << 3,                        // exp_unfair_lock
+  ASExperimentalLayerDefaults = 1 << 4,                     // exp_infer_layer_defaults
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.m
+++ b/Source/ASExperimentalFeatures.m
@@ -16,7 +16,9 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
 {
   NSArray *allNames = ASCreateOnce((@[@"exp_graphics_contexts",
                                       @"exp_text_node",
-                                      @"exp_interface_state_coalesce"]));
+                                      @"exp_interface_state_coalesce",
+                                      @"exp_unfair_lock",
+                                      @"exp_infer_layer_defaults"]));
   
   if (flags == ASExperimentalFeatureAll) {
     return allNames;

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -29,7 +29,7 @@
 #import <AsyncDisplayKit/ASConfigurationInternal.h>
 #import <AsyncDisplayKit/ASRecursiveUnfairLock.h>
 
-ASDISPLAYNODE_INLINE BOOL ASDisplayNodeThreadIsMain()
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT BOOL ASDisplayNodeThreadIsMain()
 {
   return 0 != pthread_main_np();
 }

--- a/Source/Private/ASInternalHelpers.m
+++ b/Source/Private/ASInternalHelpers.m
@@ -30,11 +30,17 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
 
 void ASInitializeFrameworkMainThread(void)
 {
-  ASDisplayNodeThreadIsMain();
+  ASDisplayNodeAssertMainThread();
   // Ensure these values are cached on the main thread before needed in the background.
-  CALayer *layer = [[[UIView alloc] init] layer];
-  defaultAllowsGroupOpacity = layer.allowsGroupOpacity;
-  defaultAllowsEdgeAntialiasing = layer.allowsEdgeAntialiasing;
+  if (ASActivateExperimentalFeature(ASExperimentalLayerDefaults)) {
+    defaultAllowsGroupOpacity = YES; // Always linked against iOS >= 7.
+    NSNumber *infoDictValue = [NSBundle.mainBundle objectForInfoDictionaryKey:@"UIViewEdgeAntialiasing"];
+    defaultAllowsEdgeAntialiasing = infoDictValue ? infoDictValue.boolValue : NO;
+  } else {
+    CALayer *layer = [[[UIView alloc] init] layer];
+    defaultAllowsGroupOpacity = layer.allowsGroupOpacity;
+    defaultAllowsEdgeAntialiasing = layer.allowsEdgeAntialiasing;
+  }
 }
 
 BOOL ASDefaultAllowsGroupOpacity(void)

--- a/Source/Private/ASInternalHelpers.m
+++ b/Source/Private/ASInternalHelpers.m
@@ -33,9 +33,15 @@ void ASInitializeFrameworkMainThread(void)
   ASDisplayNodeAssertMainThread();
   // Ensure these values are cached on the main thread before needed in the background.
   if (ASActivateExperimentalFeature(ASExperimentalLayerDefaults)) {
-    defaultAllowsGroupOpacity = YES; // Always linked against iOS >= 7.
-    NSNumber *infoDictValue = [NSBundle.mainBundle objectForInfoDictionaryKey:@"UIViewEdgeAntialiasing"];
-    defaultAllowsEdgeAntialiasing = infoDictValue ? infoDictValue.boolValue : NO;
+    NSBundle *mainBundle = NSBundle.mainBundle;
+    
+    // If unspecified, group opacity is YES since we always link against >= iOS 7
+    NSNumber *infoDictGroupOpacity = [mainBundle objectForInfoDictionaryKey:@"UIViewGroupOpacity"];
+    defaultAllowsGroupOpacity = infoDictGroupOpacity ? infoDictGroupOpacity.boolValue : YES;
+    
+    // If unspecified, edge antialiasing is NO.
+    NSNumber *infoDictAntialiasing = [mainBundle objectForInfoDictionaryKey:@"UIViewEdgeAntialiasing"];
+    defaultAllowsEdgeAntialiasing = infoDictAntialiasing ? infoDictAntialiasing.boolValue : NO;
   } else {
     CALayer *layer = [[[UIView alloc] init] layer];
     defaultAllowsGroupOpacity = layer.allowsGroupOpacity;


### PR DESCRIPTION
This also fixes a missing `exp_unfair_lock` constant 😅 .

This can avoid some pretty serious pre-main time.

The diff is hard to read, so here's what it does:
- Create static `NSNumber *`'s for the two BOOLs. If you're not in the experiment, these will be set during `ASInitializeFrameworkMainThread`. If you are in the experiment, the initializer function does nothing.
- In the two accessor functions e.g. `BOOL ASDefaultAllowsGroupOpacity()` we have a dispatch_once that checks the static to see if it was set in the initialize function, and if not it selects the default based on UIKit documentation (by reading Info.plist).
- There was some thread-unsafety before which is maintained. Namely, the statics were not thread-affined and they still aren't but the dispatch_once has a memory barrier which should make us safer even than before.