### PR TITLE
Check variables before calling delegate method

### DIFF
--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -1051,7 +1051,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   
   // Respond to long-press when it begins, not when it ends.
   if (longPressRecognizer.state == UIGestureRecognizerStateBegan) {
-    if ([_delegate respondsToSelector:@selector(textNode:longPressedLinkAttribute:value:atPoint:textRange:)]) {
+    if ([self _pendingLinkTap] && [_delegate respondsToSelector:@selector(textNode:longPressedLinkAttribute:value:atPoint:textRange:)]) {
       CGPoint touchPoint = [_longPressGestureRecognizer locationInView:self.view];
       [_delegate textNode:self longPressedLinkAttribute:_highlightedLinkAttributeName value:_highlightedLinkAttributeValue atPoint:touchPoint textRange:_highlightRange];
     }


### PR DESCRIPTION
I found a bug in ASTextNode. If you do a long tap outside of the text area it'll crash.

I'm not sure about the fix, but I added a check for `[self _pendingLinkTap]` as for `tappedLinkAttribute` method and now it works correctly.

[Reproduce](https://github.com/TextureGroup/Texture/files/1958605/TextNodeLongPress.zip)

To reproduce a bug, please open demo project and do a long press on the right side of the text node.
