### PR TITLE
Request std=c++11 dialect again, and add warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - `ASDisplayNode, ASLayoutSpec, and ASLayoutElementStyle` now conform to `NSLocking`. They act as recursive locks. Useful locking macros have been added as `ASThread.h`. Subclasses / client code can lock these objects but should be careful as usual when dealing with locks. [Adlai Holler](https://github.com/Adlai-Holler)
 - Introduces `ASRecursiveUnfairLock` as an experiment to improve locking performance. [Adlai Holler](https://github.com/Adlai-Holler)
 - Adds an experiment to shorten init time. [Adlai Holler](https://github.com/Adlai-Holler)
+- Adds a check that Texture is compiled with stdc++11 as specified by the podfile. gnu++11 can cause subtle issues that are currently being investigated. [Adlai Holler](https://github.com/Adlai-Holler)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -23,6 +23,9 @@
 // wrap constants, only C functions. See StackOverflow for more details:
 // http://stackoverflow.com/questions/1041866/in-c-source-what-is-the-effect-of-extern-c
 #ifdef __cplusplus
+# ifndef __STRICT_ANSI__
+  #error "Texture must be compiled with std=c++11. gnu++ is not supported."
+# endif
 # define ASDISPLAYNODE_EXTERN_C_BEGIN extern "C" {
 # define ASDISPLAYNODE_EXTERN_C_END   }
 #else

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -24,7 +24,7 @@
 // http://stackoverflow.com/questions/1041866/in-c-source-what-is-the-effect-of-extern-c
 #ifdef __cplusplus
 # ifndef __STRICT_ANSI__
-  #error "Texture must be compiled with std=c++11. gnu++ is not supported."
+  #warning "Texture must be compiled with std=c++11. gnu++ is not supported and may cause issues."
 # endif
 # define ASDISPLAYNODE_EXTERN_C_BEGIN extern "C" {
 # define ASDISPLAYNODE_EXTERN_C_END   }

--- a/Texture.podspec
+++ b/Texture.podspec
@@ -63,4 +63,9 @@ Pod::Spec.new do |spec|
 
   spec.social_media_url = 'https://twitter.com/TextureiOS'
   spec.library = 'c++'
+  spec.pod_target_xcconfig = {
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
+    'CLANG_CXX_LIBRARY' => 'libc++'
+   }
+   
 end


### PR DESCRIPTION
Using `std=gnu++11` causes subtle issues that I don't fully understand yet.

This adds a warning if you compile Texture using that C++ standard.