### PR TITLE
[ASTextNode] Fix a deadlock that could occur when enabling experimental ASTextNode2 via ASConfiguration

### DIFF
--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -1324,8 +1324,9 @@ static NSAttributedString *DefaultTruncationAttributedString()
   // We are descended from ASTextNode. We need to change the superclass for the
   // ASTextNode subclass to ASTextNode2.
   // Walk up the class hierarchy until we find ASTextNode.
+  // Note: This may be called on multiple threads simultaneously.
   Class s;
-  for (Class c = self; c != [ASTextNode class]; c = s) {
+  for (Class c = self; c != Nil && c != [ASTextNode class]; c = s) {
     s = class_getSuperclass(c);
     if (s == [ASTextNode class]) {
 #pragma clang diagnostic push


### PR DESCRIPTION
Because multiple threads can enter this allocWithZone: method around the same time, it is possible for one of them to setSuperclass first, and then the second thread would get stuck in an infinite loop.

When climbing the inheritance hierarchy, ASTextNode2 would be encountered by this second thread, and it would continue until reaching c == Nil. Since there was no case to catch this, an infinite loop would result.

Then the main thread can be deadlocked if a method like waitUntilAllUpdatesAreProcessed is called on ASCollectionView.