### PR TITLE
Issue ASNetworkImageNode callbacks off main thread

### DIFF
--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -25,6 +25,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalInterfaceStateCoalescing = 1 << 2,          // exp_interface_state_coalesce
   ASExperimentalUnfairLock = 1 << 3,                        // exp_unfair_lock
   ASExperimentalLayerDefaults = 1 << 4,                     // exp_infer_layer_defaults
+  ASExperimentalNetworkImageQueue = 1 << 5,                 // exp_network_image_queue
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.m
+++ b/Source/ASExperimentalFeatures.m
@@ -18,7 +18,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_text_node",
                                       @"exp_interface_state_coalesce",
                                       @"exp_unfair_lock",
-                                      @"exp_infer_layer_defaults"]));
+                                      @"exp_infer_layer_defaults",
+                                      @"exp_network_image_queue"]));
   
   if (flags == ASExperimentalFeatureAll) {
     return allNames;


### PR DESCRIPTION
It's under heavy contention on startup. This allows requests to go out even while the main thread is under heavy contention. Unfortunately results will still need to wait for the main thread to clear up.