### PR TITLE
[ASDisplayNode] Improve thread-safety of didExitHierarchy #trivial

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3016,7 +3016,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
     return;
   }
 #endif
-  if (ASInterfaceStateIncludesVisible(_pendingInterfaceState)) {
+  if (ASInterfaceStateIncludesVisible(self.pendingInterfaceState)) {
     void(^exitVisibleInterfaceState)(void) = ^{
       // This block intentionally retains self.
       __instanceLock__.lock();


### PR DESCRIPTION
Since `didExitHierarchy` is called without the node's instance lock being held, the lock must be acquired before accessing `pendingInterfaceState`.