### PR TITLE
[ASTextNode2] Upgrade lock safety by protecting all ivars (including rarely-changed ones).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
+- [ASTextNode2] Upgrade lock safety by protecting all ivars (including rarely-changed ones).
 - User FLT_EPSILON in ASCeilPixelValue and ASFloorPixelValue to help with floating point precision errors when computing layouts for 3x devices. [Ricky Cancro](https://github.com/rcancro) [#838](https://github.com/TextureGroup/Texture/pull/864)
 - Disable interface colescing and match to pre-colescing interface update behavior [Max Wang](https://github.com/wsdwsd0829) [#862](https://github.com/TextureGroup/Texture/pull/862) 
 - [ASDisplayNode] Add safeAreaInsets, layoutMargins and related properties to ASDisplayNode, with full support for older OS versions [Yevgen Pogribnyi](https://github.com/ypogribnyi) [#685](https://github.com/TextureGroup/Texture/pull/685)

--- a/Source/ASTextNode2.h
+++ b/Source/ASTextNode2.h
@@ -197,7 +197,7 @@ NS_ASSUME_NONNULL_BEGIN
  textNode:longPressedLinkAttribute:value:atPoint:textRange: in order for
  the long press gesture recognizer to be installed.
  */
-@property (nonatomic, weak) id<ASTextNodeDelegate> delegate;
+@property (atomic, weak) id<ASTextNodeDelegate> delegate;
 
 /**
  @abstract If YES and a long press is recognized, touches are cancelled. Default is NO

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -129,8 +129,10 @@ ASDISPLAYNODE_INLINE void _ASUnlockScopeCleanup(id<NSLocking> __strong *lockPtr)
  */
 #if CHECK_LOCKING_SAFETY
 #define ASDisplayNodeAssertLockUnownedByCurrentThread(lock) ASDisplayNodeAssertFalse(lock.ownedByCurrentThread())
+#define ASDisplayNodeAssertLockOwnedByCurrentThread(lock) ASDisplayNodeAssert(lock.ownedByCurrentThread())
 #else
 #define ASDisplayNodeAssertLockUnownedByCurrentThread(lock)
+#define ASDisplayNodeAssertLockOwnedByCurrentThread(lock)
 #endif
 
 namespace ASDN {


### PR DESCRIPTION
Although I don't know of any specific crashes caused by this, I think we should
lock all properties by default. There are also some indications of premature
optimization in keeping lock scope small, where it is actually important to
have transactional integrity, and also where the ASDisplayNode base class is
otherwise going to repeatedly re-lock the object anyway.

I think this will remain pretty efficient, especially with os_unfair_lock enabled.