### PR TITLE
Fix for delegate method crash when nil values provided

### DIFF
--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -1053,6 +1053,17 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   if (longPressRecognizer.state == UIGestureRecognizerStateBegan) {
     if ([self _pendingLinkTap] && [_delegate respondsToSelector:@selector(textNode:longPressedLinkAttribute:value:atPoint:textRange:)]) {
       CGPoint touchPoint = [_longPressGestureRecognizer locationInView:self.view];
+      
+      // Fixes delegate method textNode:longPressedLinkAttribute:value:atPoint:textRange crash when nil values provided
+      
+      if (_highlightedLinkAttributeName == nil) {
+        _highlightedLinkAttributeName = @"";
+      }
+        
+      if (_highlightedLinkAttributeValue == nil) {
+        _highlightedLinkAttributeValue = @"";
+      }
+      
       [_delegate textNode:self longPressedLinkAttribute:_highlightedLinkAttributeName value:_highlightedLinkAttributeValue atPoint:touchPoint textRange:_highlightRange];
     }
   }


### PR DESCRIPTION
Fix for delegate method [`textNode:longPressedLinkAttribute:value:atPoint:textRange` crash](https://github.com/TextureGroup/Texture/blob/382f624d8374170d4e486cdb9e2b574182f45de1/Source/ASTextNode.mm#L1056) when nil values for `_highlightedLinkAttributeName` or `_highlightedLinkAttributeValue` provided