### PR TITLE
Always call out to delegate for experiments, whether enabled or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Adds an experiment to call ASNetworkImageNode callbacks off main. [Garrett Moon](https://github.com/garrettmoon)
 - Prevent UITextView from updating contentOffset while deallocating [Michael Schneider](https://github.com/maicki)
 - [ASCollectionNode/ASTableNode] Fix a crash occurs while remeasuring cell nodes. [Huy Nguyen](https://github.com/nguyenhuy) [#917](https://github.com/TextureGroup/Texture/pull/917)
+- Fix an issue where ASConfigurationDelegate would not call out for "control" users. If set, it now receives events whenever an experimental feature decision point occurs, whether it's enabled or not. [Adlai Holler](https://github.com/Adlai-Holler)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/ASConfigurationInternal.m
+++ b/Source/ASConfigurationInternal.m
@@ -63,10 +63,11 @@
   
   NSAssert(__builtin_popcount(requested) == 1, @"Cannot activate multiple features at once with this method.");
   
-  // If they're disabled, ignore them.
+  // We need to call out, whether it's enabled or not.
+  // A/B testing requires even "control" users to be activated.
   ASExperimentalFeatures enabled = requested & _config.experimentalFeatures;
-  ASExperimentalFeatures prevTriggered = atomic_fetch_or(&_activatedExperiments, enabled);
-  ASExperimentalFeatures newlyTriggered = enabled & ~prevTriggered;
+  ASExperimentalFeatures prevTriggered = atomic_fetch_or(&_activatedExperiments, requested);
+  ASExperimentalFeatures newlyTriggered = requested & ~prevTriggered;
   
   // Notify delegate if needed.
   if (newlyTriggered != 0) {

--- a/Tests/ASConfigurationTests.m
+++ b/Tests/ASConfigurationTests.m
@@ -33,14 +33,11 @@
   [ASConfigurationManager test_resetWithConfiguration:config];
   
   // Set an expectation for a callback, and assert we only get one.
-  XCTestExpectation *e = [self expectationWithDescription:@"Callback 1 done."];
+  XCTestExpectation *e = [self expectationWithDescription:@"Callbacks done."];
+  e.expectedFulfillmentCount = 2;
+  e.assertForOverFulfill = YES;
   onActivate = ^(ASConfigurationTests *self, ASExperimentalFeatures feature) {
-    XCTAssertEqual(feature, ASExperimentalGraphicsContexts);
     [e fulfill];
-    // Next time it's a fail.
-    self->onActivate = ^(ASConfigurationTests *self, ASExperimentalFeatures feature) {
-      XCTFail(@"Too many callbacks.");
-    };
   };
   
   // Now activate the graphics experiment and expect it works.
@@ -48,6 +45,7 @@
   // We should get a callback here
   // Now activate text node and expect it fails.
   XCTAssertFalse(ASActivateExperimentalFeature(ASExperimentalTextNode));
+  // But we should get another callback.
   [self waitForExpectationsWithTimeout:3 handler:nil];
 }
 


### PR DESCRIPTION
This makes sure that A/B testing frameworks can activate control users as well as treatment ones.