### PR TITLE
[ASImageNode+AnimatedImage] Fix early return when animatedImage is nil in setAnimatedImage #trivial

### DIFF
--- a/Source/ASImageNode+AnimatedImage.mm
+++ b/Source/ASImageNode+AnimatedImage.mm
@@ -50,7 +50,7 @@ NSString *const ASAnimatedImageDefaultRunLoopMode = NSRunLoopCommonModes;
 
 - (void)_locked_setAnimatedImage:(id <ASAnimatedImageProtocol>)animatedImage
 {
-  if (ASObjectIsEqual(_animatedImage, animatedImage) && animatedImage.playbackReady) {
+  if (ASObjectIsEqual(_animatedImage, animatedImage) && (animatedImage == nil || animatedImage.playbackReady)) {
     return;
   }
   

--- a/Tests/ASNetworkImageNodeTests.m
+++ b/Tests/ASNetworkImageNodeTests.m
@@ -81,10 +81,29 @@
   UIImage *image = [[UIImage alloc] init];
   ASNetworkImageNode *networkImageNode = [[ASNetworkImageNode alloc] init];
   networkImageNode.image = image;
+  [networkImageNode enterHierarchyState:ASHierarchyStateRangeManaged];  // Ensures didExitPreloadState is called
+  XCTAssertEqualObjects(image, networkImageNode.image);
   [networkImageNode enterInterfaceState:ASInterfaceStatePreload];
   XCTAssertEqualObjects(image, networkImageNode.image);
   [networkImageNode exitInterfaceState:ASInterfaceStatePreload];
   XCTAssertEqualObjects(image, networkImageNode.image);
+  [networkImageNode exitHierarchyState:ASHierarchyStateRangeManaged];
+  XCTAssertEqualObjects(image, networkImageNode.image);
+}
+
+- (void)testThatSettingADefaultImageWillStayForEnteringAndExitingPreloadState
+{
+  UIImage *image = [[UIImage alloc] init];
+  ASNetworkImageNode *networkImageNode = [[ASNetworkImageNode alloc] init];
+  networkImageNode.defaultImage = image;
+  [networkImageNode enterHierarchyState:ASHierarchyStateRangeManaged];  // Ensures didExitPreloadState is called
+  XCTAssertEqualObjects(image, networkImageNode.defaultImage);
+  [networkImageNode enterInterfaceState:ASInterfaceStatePreload];
+  XCTAssertEqualObjects(image, networkImageNode.defaultImage);
+  [networkImageNode exitInterfaceState:ASInterfaceStatePreload];
+  XCTAssertEqualObjects(image, networkImageNode.defaultImage);
+  [networkImageNode exitHierarchyState:ASHierarchyStateRangeManaged];
+  XCTAssertEqualObjects(image, networkImageNode.defaultImage);
 }
 
 @end


### PR DESCRIPTION
Hey guys,

I recently tried to update to `master` and ran into an issue where the `defaultImage`s I set in my `ASNetworkImageNode` are replaced by `nil` when they leave the preload range.
It turns out, #896 does not take into account the case where the `animatedImage` might be `nil`. Hence the call to `_locked_setAnimatedImage` no longer performs an early return like it used to, because `animatedImage.playbackReady` is `NO`.
This PR fixes this and gives me back my `defaultImage`s, even after they've gone out of the preload range and back. :-D

This time I haven't set up a sample project like I usually do, but I made up for it by adding a new test, yay! This test shows that the `defaultImage` is currently incorrectly set to `nil` when the `ASNetworkImageNode` leaves the preload range.
I've also slightly improved the (very similar) existing test for the `image` property, because `didExitPreloadState` wasn't actually called (see the diff and the related comment).

Please tell me how this looks and if I can improve anything!

Cheers,

Flo