### PR TITLE
Update text layout cache checking #trivial

### DIFF
--- a/Source/Private/TextExperiment/Component/ASTextLayout.m
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.m
@@ -665,8 +665,8 @@ dispatch_semaphore_signal(_lock);
     size.height += rect.origin.y;
     if (size.width < 0) size.width = 0;
     if (size.height < 0) size.height = 0;
-    size.width = ceil(size.width);
-    size.height = ceil(size.height);
+    size.width = ASCeilPixelValue(size.width);
+    size.height = ASCeilPixelValue(size.height);
     textBoundingSize = size;
   }
   


### PR DESCRIPTION
Fixes the bug in #553 .

The solution in that diff was actually landed incidentally in #918 which fixes the correctness of the check, but degrades layout performance and memory by recomputing layouts more often.

This diff changes the check to have both the correctness fix and improved performance. I tested the diff against the sample code that @wsdwsd0829 gave and it fixes that case.

It also modifies ASTextLayout to use pixel-ceiling rather than point-ceiling.