### PR TITLE
Fixed removing node from supernode after layout transition

### DIFF
--- a/Source/Private/ASLayoutTransition.mm
+++ b/Source/Private/ASLayoutTransition.mm
@@ -137,7 +137,9 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
     // In this case we should only remove the subnode if it's still a subnode of the _node that executes a layout transition.
     // It can happen that a node already did a layout transition and added this subnode, in this case the subnode
     // would be removed from the new node instead of _node
-    [subnode _removeFromSupernodeIfEqualTo:_node];
+    if (_node.automaticallyManagesSubnodes) {
+      [subnode _removeFromSupernodeIfEqualTo:_node];
+    }
   }
 }
 


### PR DESCRIPTION
Fixed removing node from supernode after layout transition when automaticallyManagesSubnodes is disabled. In case if developer prefer to manage subnodes by himself then he wants to be sure that stack will not change automatically.