### PR TITLE
Clean up async transaction system a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
 - Make `ASPerformMainThreadDeallocation` visible in C. [Adlai Holler](https://github.com/Adlai-Holler)
-
 - Add snapshot test for astextnode2. [Max Wang](https://github.com/wsdwsd0829) [#935](https://github.com/TextureGroup/Texture/pull/935)
+- Internal housekeeping on the async transaction (rendering) system. [Adlai Holler](https://github.com/Adlai-Holler)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/Details/Transactions/_ASAsyncTransaction.h
+++ b/Source/Details/Transactions/_ASAsyncTransaction.h
@@ -26,8 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void(^asyncdisplaykit_async_transaction_completion_block_t)(_ASAsyncTransaction *completedTransaction, BOOL canceled);
 typedef id<NSObject> _Nullable(^asyncdisplaykit_async_transaction_operation_block_t)(void);
 typedef void(^asyncdisplaykit_async_transaction_operation_completion_block_t)(id _Nullable value, BOOL canceled);
-typedef void(^asyncdisplaykit_async_transaction_complete_async_operation_block_t)(id _Nullable value);
-typedef void(^asyncdisplaykit_async_transaction_async_operation_block_t)(asyncdisplaykit_async_transaction_complete_async_operation_block_t completeOperationBlock);
 
 /**
  State is initially ASAsyncTransactionStateOpen.
@@ -76,29 +74,13 @@ extern NSInteger const ASDefaultTransactionPriority;
 /**
  A block that is called when the transaction is completed.
  */
-@property (nullable, nonatomic, readonly) asyncdisplaykit_async_transaction_completion_block_t completionBlock;
+@property (nullable, readonly) asyncdisplaykit_async_transaction_completion_block_t completionBlock;
 
 /**
  The state of the transaction.
  @see ASAsyncTransactionState
  */
 @property (readonly) ASAsyncTransactionState state;
-
-/**
- @summary Adds a synchronous operation to the transaction.  The execution block will be executed immediately.
-
- @desc The block will be executed on the specified queue and is expected to complete synchronously.  The async
- transaction will wait for all operations to execute on their appropriate queues, so the blocks may still be executing
- async if they are running on a concurrent queue, even though the work for this block is synchronous.
-
- @param block The execution block that will be executed on a background queue.  This is where the expensive work goes.
- @param queue The dispatch queue on which to execute the block.
- @param completion The completion block that will be executed with the output of the execution block when all of the
- operations in the transaction are completed. Executed and released on callbackQueue.
- */
-- (void)addOperationWithBlock:(asyncdisplaykit_async_transaction_operation_block_t)block
-                        queue:(dispatch_queue_t)queue
-                   completion:(nullable asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
 
 /**
  @summary Adds a synchronous operation to the transaction.  The execution block will be executed immediately.
@@ -117,56 +99,6 @@ extern NSInteger const ASDefaultTransactionPriority;
                      priority:(NSInteger)priority
                         queue:(dispatch_queue_t)queue
                    completion:(nullable asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
-
-
-/**
- @summary Adds an async operation to the transaction.  The execution block will be executed immediately.
-
- @desc The block will be executed on the specified queue and is expected to complete asynchronously.  The block will be
- supplied with a completion block that can be executed once its async operation is completed.  This is useful for
- network downloads and other operations that have an async API.
-
- WARNING: Consumers MUST call the completeOperationBlock passed into the work block, or objects will be leaked!
-
- @param block The execution block that will be executed on a background queue.  This is where the expensive work goes.
- @param queue The dispatch queue on which to execute the block.
- @param completion The completion block that will be executed with the output of the execution block when all of the
- operations in the transaction are completed. Executed and released on callbackQueue.
- */
-- (void)addAsyncOperationWithBlock:(asyncdisplaykit_async_transaction_async_operation_block_t)block
-                             queue:(dispatch_queue_t)queue
-                        completion:(nullable asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
-
-/**
- @summary Adds an async operation to the transaction.  The execution block will be executed immediately.
- 
- @desc The block will be executed on the specified queue and is expected to complete asynchronously.  The block will be
- supplied with a completion block that can be executed once its async operation is completed.  This is useful for
- network downloads and other operations that have an async API.
- 
- WARNING: Consumers MUST call the completeOperationBlock passed into the work block, or objects will be leaked!
- 
- @param block The execution block that will be executed on a background queue.  This is where the expensive work goes.
- @param priority Execution priority; Tasks with higher priority will be executed sooner
- @param queue The dispatch queue on which to execute the block.
- @param completion The completion block that will be executed with the output of the execution block when all of the
- operations in the transaction are completed. Executed and released on callbackQueue.
- */
-- (void)addAsyncOperationWithBlock:(asyncdisplaykit_async_transaction_async_operation_block_t)block
-                          priority:(NSInteger)priority
-                             queue:(dispatch_queue_t)queue
-                        completion:(nullable asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
-
-
-
-/**
- @summary Adds a block to run on the completion of the async transaction.
-
- @param completion The completion block that will be executed with the output of the execution block when all of the
- operations in the transaction are completed. Executed and released on callbackQueue.
- */
-
-- (void)addCompletionBlock:(asyncdisplaykit_async_transaction_completion_block_t)completion;
 
 /**
  @summary Cancels all operations in the transaction.

--- a/Source/Details/Transactions/_ASAsyncTransactionContainer.h
+++ b/Source/Details/Transactions/_ASAsyncTransactionContainer.h
@@ -64,15 +64,23 @@ typedef NS_ENUM(NSUInteger, ASAsyncTransactionContainerState) {
 /**
  @summary Returns the current async transaction for this layer. A new transaction is created if one
  did not already exist. This method will always return an open, uncommitted transaction.
- @desc asyncdisplaykit_isAsyncTransactionContainer does not need to be YES for this to return a transaction.
+ @desc asyncdisplaykit_asyncTransactionContainer does not need to be YES for this to return a transaction.
+ Defaults to nil.
  */
 @property (nullable, nonatomic, readonly) _ASAsyncTransaction *asyncdisplaykit_asyncTransaction;
 
 /**
- @summary Goes up the superlayer chain until it finds the first layer with asyncdisplaykit_isAsyncTransactionContainer=YES (including the receiver) and returns it.
+ @summary Goes up the superlayer chain until it finds the first layer with asyncdisplaykit_asyncTransactionContainer=YES (including the receiver) and returns it.
  Returns nil if no parent container is found.
  */
 @property (nullable, nonatomic, readonly) CALayer *asyncdisplaykit_parentTransactionContainer;
+
+/**
+ @summary Whether or not this layer should serve as a transaction container.
+ Defaults to NO.
+ */
+@property (nonatomic, getter=asyncdisplaykit_isAsyncTransactionContainer, setter = asyncdisplaykit_setAsyncTransactionContainer:) BOOL asyncdisplaykit_asyncTransactionContainer;
+
 @end
 
 @interface UIView (ASAsyncTransactionContainer) <ASAsyncTransactionContainer>

--- a/Source/Details/Transactions/_ASAsyncTransactionContainer.m
+++ b/Source/Details/Transactions/_ASAsyncTransactionContainer.m
@@ -20,53 +20,18 @@
 
 #import <AsyncDisplayKit/_ASAsyncTransaction.h>
 #import <AsyncDisplayKit/_ASAsyncTransactionGroup.h>
-#import <objc/runtime.h>
-
-static const char *ASDisplayNodeAssociatedTransactionsKey = "ASAssociatedTransactions";
-static const char *ASDisplayNodeAssociatedCurrentTransactionKey = "ASAssociatedCurrentTransaction";
 
 @implementation CALayer (ASAsyncTransactionContainerTransactions)
-
-- (NSHashTable *)asyncdisplaykit_asyncLayerTransactions
-{
-  return objc_getAssociatedObject(self, ASDisplayNodeAssociatedTransactionsKey);
-}
-
-- (void)asyncdisplaykit_setAsyncLayerTransactions:(NSHashTable *)transactions
-{
-  objc_setAssociatedObject(self, ASDisplayNodeAssociatedTransactionsKey, transactions, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
+@dynamic asyncdisplaykit_asyncLayerTransactions;
 
 // No-ops in the base class. Mostly exposed for testing.
 - (void)asyncdisplaykit_asyncTransactionContainerWillBeginTransaction:(_ASAsyncTransaction *)transaction {}
 - (void)asyncdisplaykit_asyncTransactionContainerDidCompleteTransaction:(_ASAsyncTransaction *)transaction {}
 @end
 
-static const char *ASAsyncTransactionIsContainerKey = "ASTransactionIsContainer";
-
 @implementation CALayer (ASAsyncTransactionContainer)
-
-- (_ASAsyncTransaction *)asyncdisplaykit_currentAsyncTransaction
-{
-  return objc_getAssociatedObject(self, ASDisplayNodeAssociatedCurrentTransactionKey);
-}
-
-- (void)asyncdisplaykit_setCurrentAsyncTransaction:(_ASAsyncTransaction *)transaction
-{
-  objc_setAssociatedObject(self, ASDisplayNodeAssociatedCurrentTransactionKey, transaction, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-- (BOOL)asyncdisplaykit_isAsyncTransactionContainer
-{
-  CFBooleanRef isContainerBool = (__bridge CFBooleanRef)objc_getAssociatedObject(self, ASAsyncTransactionIsContainerKey);
-  BOOL isContainer = (isContainerBool == kCFBooleanTrue);
-  return isContainer;
-}
-
-- (void)asyncdisplaykit_setAsyncTransactionContainer:(BOOL)isContainer
-{
-  objc_setAssociatedObject(self, ASAsyncTransactionIsContainerKey, (id)(isContainer ? kCFBooleanTrue : kCFBooleanFalse), OBJC_ASSOCIATION_ASSIGN);
-}
+@dynamic asyncdisplaykit_currentAsyncTransaction;
+@dynamic asyncdisplaykit_asyncTransactionContainer;
 
 - (ASAsyncTransactionContainerState)asyncdisplaykit_asyncTransactionContainerState
 {
@@ -109,7 +74,7 @@ static const char *ASAsyncTransactionIsContainerKey = "ASTransactionIsContainer"
     self.asyncdisplaykit_currentAsyncTransaction = transaction;
     [self asyncdisplaykit_asyncTransactionContainerWillBeginTransaction:transaction];
   }
-  [[_ASAsyncTransactionGroup mainTransactionGroup] addTransactionContainer:self];
+  [_ASAsyncTransactionGroup.mainTransactionGroup addTransactionContainer:self];
   return transaction;
 }
 

--- a/Source/Details/Transactions/_ASAsyncTransactionGroup.h
+++ b/Source/Details/Transactions/_ASAsyncTransactionGroup.h
@@ -16,21 +16,29 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class _ASAsyncTransaction;
 @protocol ASAsyncTransactionContainer;
 
 /// A group of transaction containers, for which the current transactions are committed together at the end of the next runloop tick.
+AS_SUBCLASSING_RESTRICTED
 @interface _ASAsyncTransactionGroup : NSObject
+
 /// The main transaction group is scheduled to commit on every tick of the main runloop.
-+ (_ASAsyncTransactionGroup *)mainTransactionGroup;
-+ (void)commit;
+/// Access from the main thread only.
+@property (class, nonatomic, readonly) _ASAsyncTransactionGroup *mainTransactionGroup;
+
+- (void)commit;
 
 /// Add a transaction container to be committed.
-/// @see ASAsyncTransactionContainer
 - (void)addTransactionContainer:(id<ASAsyncTransactionContainer>)container;
+
+/// Use the main group.
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
- Remove unused methods.
  - `addAsyncOperation` we no longer do async rendering.
  - `addCompletion` this was implemented in a somewhat questionable way anyway.
  - `addOperation` without priority. You can just specify default priority.
- Implement CALayer category properties using CALayer dynamic properties rather than associated objects.
- Tighten up the `mainTransactionGroup` API and trivial reorg of its implementation.