### PR TITLE
[WIP] Implement ASDisplayTree to manage locking during tree-level operations

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -427,7 +427,11 @@
 		CCEDDDCF200C42A200FFCD0A /* ASConfigurationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CCEDDDCE200C42A200FFCD0A /* ASConfigurationDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CCEDDDD1200C488000FFCD0A /* ASConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = CCEDDDD0200C488000FFCD0A /* ASConfiguration.m */; };
 		CCEDDDD9200C518800FFCD0A /* ASConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCEDDDD8200C518800FFCD0A /* ASConfigurationTests.m */; };
+		CCEDEC2C20BC9F92000CB062 /* ASDisplayTree.h in Headers */ = {isa = PBXBuildFile; fileRef = CCEDEC2A20BC9F92000CB062 /* ASDisplayTree.h */; };
+		CCEDEC2D20BC9F92000CB062 /* ASDisplayTree.mm in Sources */ = {isa = PBXBuildFile; fileRef = CCEDEC2B20BC9F92000CB062 /* ASDisplayTree.mm */; };
+		CCEDEC2F20BCA7A8000CB062 /* ASDisplayTreeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCEDEC2E20BCA7A8000CB062 /* ASDisplayTreeTests.m */; };
 		CCF18FF41D2575E300DF5895 /* NSIndexSet+ASHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CCF1FF5E20C4785000AAD8FC /* ASLocking.h in Headers */ = {isa = PBXBuildFile; fileRef = CCF1FF5D20C4785000AAD8FC /* ASLocking.h */; };
 		DB55C2671C641AE4004EDCF5 /* ASContextTransitioning.h in Headers */ = {isa = PBXBuildFile; fileRef = DB55C2651C641AE4004EDCF5 /* ASContextTransitioning.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB7121BCD50849C498C886FB /* libPods-AsyncDisplayKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */; };
 		DB78412E1C6BCE1600A9E2B4 /* _ASTransitionContext.m in Sources */ = {isa = PBXBuildFile; fileRef = DB55C2601C6408D6004EDCF5 /* _ASTransitionContext.m */; };
@@ -947,6 +951,10 @@
 		CCEDDDCE200C42A200FFCD0A /* ASConfigurationDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASConfigurationDelegate.h; sourceTree = "<group>"; };
 		CCEDDDD0200C488000FFCD0A /* ASConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ASConfiguration.m; sourceTree = "<group>"; };
 		CCEDDDD8200C518800FFCD0A /* ASConfigurationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ASConfigurationTests.m; sourceTree = "<group>"; };
+		CCEDEC2A20BC9F92000CB062 /* ASDisplayTree.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASDisplayTree.h; sourceTree = "<group>"; };
+		CCEDEC2B20BC9F92000CB062 /* ASDisplayTree.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ASDisplayTree.mm; sourceTree = "<group>"; };
+		CCEDEC2E20BCA7A8000CB062 /* ASDisplayTreeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ASDisplayTreeTests.m; sourceTree = "<group>"; };
+		CCF1FF5D20C4785000AAD8FC /* ASLocking.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASLocking.h; sourceTree = "<group>"; };
 		D3779BCFF841AD3EB56537ED /* Pods-AsyncDisplayKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		D785F6601A74327E00291744 /* ASScrollNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASScrollNode.h; sourceTree = "<group>"; };
 		D785F6611A74327E00291744 /* ASScrollNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASScrollNode.mm; sourceTree = "<group>"; };
@@ -1155,6 +1163,8 @@
 				90FC784E1E4BFE1B00383C5A /* ASDisplayNode+Yoga.mm */,
 				058D09DB195D050800B7D73C /* ASDisplayNodeExtras.h */,
 				058D09DC195D050800B7D73C /* ASDisplayNodeExtras.mm */,
+				CCEDEC2A20BC9F92000CB062 /* ASDisplayTree.h */,
+				CCEDEC2B20BC9F92000CB062 /* ASDisplayTree.mm */,
 				0587F9BB1A7309ED00AFF0BA /* ASEditableTextNode.h */,
 				0587F9BC1A7309ED00AFF0BA /* ASEditableTextNode.mm */,
 				CC7AF195200D9BD500A21BDE /* ASExperimentalFeatures.h */,
@@ -1162,6 +1172,7 @@
 				058D09DD195D050800B7D73C /* ASImageNode.h */,
 				058D09DE195D050800B7D73C /* ASImageNode.mm */,
 				68355B2E1CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm */,
+				CCF1FF5D20C4785000AAD8FC /* ASLocking.h */,
 				92DD2FE11BF4B97E0074C9DD /* ASMapNode.h */,
 				92DD2FE21BF4B97E0074C9DD /* ASMapNode.mm */,
 				0516FA3E1A1563D200B4EBED /* ASMultiplexImageNode.h */,
@@ -1229,6 +1240,7 @@
 		058D09C5195D04C000B7D73C /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				CCEDEC2E20BCA7A8000CB062 /* ASDisplayTreeTests.m */,
 				DBC452DD1C5C6A6A00B16017 /* ArrayDiffingTests.m */,
 				AC026B571BD3F61800BBC17E /* ASAbsoluteLayoutSpecSnapshotTests.m */,
 				696FCB301D6E46050093471E /* ASBackgroundLayoutSpecSnapshotTests.mm */,
@@ -1828,6 +1840,7 @@
 				696F01EC1DD2AF450049FBD5 /* ASEventLog.h in Headers */,
 				690C35641E055C7B00069B91 /* ASDimensionInternal.h in Headers */,
 				3917EBD41E9C2FC400D04A01 /* _ASCollectionReusableView.h in Headers */,
+				CCEDEC2C20BC9F92000CB062 /* ASDisplayTree.h in Headers */,
 				CC18248C200D49C800875940 /* ASTextNodeCommon.h in Headers */,
 				698371DB1E4379CD00437585 /* ASNodeController+Beta.h in Headers */,
 				6907C2581DC4ECFE00374C66 /* ASObjectDescriptionHelpers.h in Headers */,
@@ -1871,6 +1884,7 @@
 				CC56013B1F06E9A700DC4FBE /* ASIntegerMap.h in Headers */,
 				B35061FA1B010EFD0018CF92 /* ASControlNode+Subclasses.h in Headers */,
 				E54E81FC1EB357BD00FFE8E1 /* ASPageTable.h in Headers */,
+				CCF1FF5E20C4785000AAD8FC /* ASLocking.h in Headers */,
 				B35061F81B010EFD0018CF92 /* ASControlNode.h in Headers */,
 				B35062171B010EFD0018CF92 /* ASDataController.h in Headers */,
 				34EFC75B1B701BAF00AD841F /* ASDimension.h in Headers */,
@@ -2257,6 +2271,7 @@
 				CCB2F34D1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m in Sources */,
 				AE6987C11DD04E1000B9E458 /* ASPagerNodeTests.m in Sources */,
 				058D0A3A195D057000B7D73C /* ASDisplayNodeTests.mm in Sources */,
+				CCEDEC2F20BCA7A8000CB062 /* ASDisplayTreeTests.m in Sources */,
 				696FCB311D6E46050093471E /* ASBackgroundLayoutSpecSnapshotTests.mm in Sources */,
 				CC583AD81EF9BDC300134156 /* OCMockObject+ASAdditions.m in Sources */,
 				69FEE53D1D95A9AF0086F066 /* ASLayoutElementStyleTests.m in Sources */,
@@ -2320,6 +2335,7 @@
 				3917EBD51E9C2FC400D04A01 /* _ASCollectionReusableView.m in Sources */,
 				CCA282D11E9EBF6C0037E8B7 /* ASTipsWindow.m in Sources */,
 				CCCCCCE41EC3EF060087FE10 /* NSParagraphStyle+ASText.m in Sources */,
+				CCEDEC2D20BC9F92000CB062 /* ASDisplayTree.mm in Sources */,
 				E52AC9BA1FEA90EB00AA4040 /* ASRectMap.mm in Sources */,
 				8BBBAB8D1CEBAF1E00107FC6 /* ASDefaultPlaybackButton.m in Sources */,
 				B30BF6541C59D889004FCD53 /* ASLayoutManager.m in Sources */,

--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -19,7 +19,8 @@
                     "exp_unfair_lock",
                     "exp_infer_layer_defaults",
                     "exp_network_image_queue",
-                    "exp_dealloc_queue_v2"
+                    "exp_dealloc_queue_v2",
+                    "exp_display_tree",
                 ]
     		}
 		}

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -25,6 +25,7 @@
 #import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 #import <AsyncDisplayKit/ASLayoutElement.h>
+#import <AsyncDisplayKit/ASLocking.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -127,7 +128,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  */
 
-@interface ASDisplayNode : NSObject <NSLocking>
+@interface ASDisplayNode : NSObject <ASLocking>
 
 /** @name Initializing a node object */
 

--- a/Source/ASDisplayTree.h
+++ b/Source/ASDisplayTree.h
@@ -1,0 +1,113 @@
+//
+//  ASDisplayTree.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai on 5/28/18.
+//  Copyright © 2018 Pinterest. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+#import <AsyncDisplayKit/ASLocking.h>
+#import <AsyncDisplayKit/ASTraitCollection.h>
+
+@class ASDisplayNode;
+
+typedef NS_OPTIONS(NSUInteger, ASTreeEnumerationOptions) {
+  ASEnumerateBreadthFirst  = 1 << 0,  // Default is depth-first.
+  ASEnumerateSkipSelf   = 1 << 1,     // Default is to include self.
+};
+
+typedef NS_ENUM(NSInteger, ASTreeInsertionLocation) {
+  ASTreeInsertBelow,      // Other node is sibling above. Index ignored.
+  ASTreeInsertReplace,    // Other node is replaced. Index ignored.
+  ASTreeInsertAbove,      // Other node is sibling below. Index ignored.
+  ASTreeInsertAtEnd,      // Other node is parent. Index ignored.
+  ASTreeInsertAtIndex     // Other node is parent.
+};
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*
+ * An entire tree of display nodes. Subtrees are not
+ * represented by these objects.
+ *
+ * When a node is added to a tree, the tree object
+ * is pushed down to it from its new parent.
+ *
+ * Trees use a recursive lock to ensure safe access
+ * from multiple threads simultaneously.
+ *
+ * Trees do not own their nodes. The root node is responsible
+ * for owning the tree.
+ */
+AS_SUBCLASSING_RESTRICTED
+@interface ASDisplayTree : NSObject <ASLocking>
+
+#pragma mark - Querying
+
+/*
+ * Copy the direct subnodes of the given node.
+ * Consider using @p enumerateSubnodesOf: @c instead.
+ */
+- (NSArray<ASDisplayNode *> *)copySubnodesOf:(ASDisplayNode *)node;
+
+/*
+ * Get the supernode for the given node. nil if we're at root.
+ */
+- (nullable ASDisplayNode *)supernodeOf:(ASDisplayNode *)node;
+
+#pragma mark - Mutating
+
+/*
+ * Insert the given node's tree into the receiver, at the given index.
+ *
+ * @param node The new node to add. It must be a root node.
+ * @param location The location option for the insert.
+ * @param otherNode The other node to position this node. See ASTreeInsertionLocation.
+ * @param index The absolute index, if ASTreeInsertAtIndex is specified. Ignored otherwise, pass NSNotFound.
+ */
+- (void)insert:(ASDisplayNode *)node
+            at:(ASTreeInsertionLocation)location
+    relativeTo:(ASDisplayNode *)otherNode
+          with:(NSInteger)index;
+
+/*
+ * Remove the given node.
+ */
+- (void)remove:(ASDisplayNode *)node;
+
+/*
+ * Note about enumerating: you must hold the lock for the tree throughout enumeration.
+ *
+ * These methods actually configure the receiver and then return `self`.
+ */
+#pragma mark - Enumerating
+
+/*
+ * Hold the lock.
+ */
+- (id<NSFastEnumeration>)l_enumeratingSubnodesOf:(ASDisplayNode *)node;
+
+/*
+ * Hold the lock.
+ */
+- (id<NSFastEnumeration>)l_enumeratingUpwardFrom:(ASDisplayNode *)startNode;
+
+/*
+ * Hold the lock.
+ */
+- (id<NSFastEnumeration>)l_enumeratingUpwardFromParentOf:(ASDisplayNode *)startNode;
+
+/*
+ * Hold the lock.
+ */
+- (id<NSFastEnumeration>)l_enumeratingDownwardFrom:(ASDisplayNode *)startNode with:(ASTreeEnumerationOptions)options;
+
+#pragma mark - Tree-wide data
+
+@property ASPrimitiveTraitCollection traitCollection;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ASDisplayTree.mm
+++ b/Source/ASDisplayTree.mm
@@ -1,0 +1,214 @@
+//
+//  ASDisplayTree.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai on 5/28/18.
+//  Copyright © 2018 Pinterest. All rights reserved.
+//
+
+#import "ASDisplayTree.h"
+
+#import <AsyncDisplayKit/ASDisplayNodeInternal.h>
+#import <AsyncDisplayKit/ASThread.h>
+
+using namespace ASDN;
+
+/*
+ * Assert we're locked. ASThread.h has some of the same logic, but it's not on
+ * by default during debugging for performance reasons. Since this component is much
+ * higher level, and also since it requires the client to lock it for enumerating,
+ * this assertion is at the default level.
+ */
+#define ASDisplayTreeAssertLocked() //ASDisplayNodeAssert(_lockedThread == pthread_self(), nil)
+#define ASDisplayTreeAssertNotLocked() //ASDisplayNodeAssert(_lockedThread != pthread_self(), nil)
+
+@interface ASDisplayTree () <NSFastEnumeration>
+@end
+
+@implementation ASDisplayTree {
+  ASDN::RecursiveMutex _lock;
+#if ASDISPLAYNODE_ASSERTIONS_ENABLED
+  pthread_key_t _lockSpecific;
+#endif
+  
+  ASPrimitiveTraitCollection _traitCollection;
+}
+
+#pragma mark - Querying
+
+- (NSUInteger)l_indexOf:(ASDisplayNode *)node
+{
+  NSParameterAssert(node);
+  ASDisplayTreeAssertLocked();
+  auto parent = [self supernodeOf:node];
+  auto index = [[self l_mutableSubnodesOf:parent] indexOfObjectIdenticalTo:node];
+  NSParameterAssert(index != NSNotFound); // Still a parameter assert b/c precondition fail.
+  return index;
+}
+
+- (NSArray<ASDisplayNode *> *)copySubnodesOf:(ASDisplayNode *)node
+{
+  NSParameterAssert(node);
+  ASLockScopeSelf();
+  auto mNodes = [self l_mutableSubnodesOf:node];
+  NSParameterAssert(mNodes != nil);
+  return [mNodes copy];
+}
+
+- (ASDisplayNode *)supernodeOf:(ASDisplayNode *)node
+{
+  NSParameterAssert(node);
+  ASLockScopeSelf();
+  return node->_supernode;
+}
+
+#pragma mark - Mutating
+
+- (void)insert:(ASDisplayNode *)node at:(ASTreeInsertionLocation)location relativeTo:(ASDisplayNode *)otherNode with:(NSInteger)indexArg
+{
+  NSParameterAssert(node);
+  NSParameterAssert(otherNode);
+  NSParameterAssert(node != otherNode);
+  
+  ASLockMany(3, self, node, otherNode);
+  
+  if (node->_supernode != nil || otherNode->_tree != self) {
+    // Let them get away with this. Possibly a race condition.
+    ASUnlockMany(3, self, node, otherNode);
+    return;
+  }
+  
+  // Save the node's old tree (so we can unlock it)
+  // and push self down the subtree.
+  auto previousTree = node->_tree;
+  node->_tree = self;
+  if (previousTree) {
+    for (ASDisplayNode *subnode in [previousTree l_enumeratingDownwardFrom:node with:ASEnumerateSkipSelf]) {
+      // Cannot lock subnode here or we risk deadlock.
+      // Since we locked the subnode's current tree, the
+      // node can't be removed from it in the middle of this method.
+      // We MAY have to use an atomic accessor – need to think through that more.
+      subnode->_tree = self;
+    }
+  }
+  
+  // Update subnodes array for the parent node (it's locked).
+  ASDisplayNode *parent;
+  auto index = [self l_resolveInsertionPointFor:location relativeTo:otherNode with:indexArg gettingParent:&parent];
+  auto array = [self l_mutableSubnodesOf:parent];
+  if (location == ASTreeInsertReplace) {
+    array[index] = node;
+    [self l_createTreeFor:otherNode];
+  } else {
+    [array insertObject:node atIndex:index];
+  }
+  
+  ASUnlockMany(3, self, node, otherNode);
+}
+
+- (void)remove:(ASDisplayNode *)node
+{
+  ASLockMany(2, self, node);
+  
+  // If the node is a root node, or if it's part of some other
+  // tree, then we have a race. Let it slide and ignore the call.
+  if (node->_supernode == nil || node->_tree != self) {
+    [self unlock];
+    [node unlock];
+    return;
+  }
+  
+  auto index = [self l_indexOf:node];
+  auto parent = [self supernodeOf:node];
+  [[self l_mutableSubnodesOf:parent] removeObjectAtIndex:index];
+  [self l_createTreeFor:node];
+  [self unlock];
+  [node unlock];
+}
+
+#pragma mark - Enumerating
+
+- (id<NSFastEnumeration>)l_enumeratingSubnodesOf:(ASDisplayNode *)node
+{
+  ASDisplayTreeAssertLocked();
+  return self;
+}
+
+- (id<NSFastEnumeration>)l_enumeratingUpwardFrom:(ASDisplayNode *)startNode
+{
+  ASDisplayTreeAssertLocked();
+  return self;
+}
+
+- (id<NSFastEnumeration>)l_enumeratingDownwardFrom:(ASDisplayNode *)startNode with:(ASTreeEnumerationOptions)options
+{
+  ASDisplayTreeAssertLocked();
+  return self;
+}
+
+- (id<NSFastEnumeration>)l_enumeratingUpwardFromParentOf:(ASDisplayNode *)startNode
+{
+  ASDisplayTreeAssertLocked();
+  return self;
+}
+
+#pragma mark - Treewide data
+
+- (ASPrimitiveTraitCollection)traitCollection
+{
+  return ASLockedSelf(_traitCollection);
+}
+
+- (void)setTraitCollection:(ASPrimitiveTraitCollection)traitCollection
+{
+  ASLockedSelf(_traitCollection = traitCollection);
+}
+
+#pragma mark - Internal
+
+- (NSMutableArray *)l_mutableSubnodesOf:(ASDisplayNode *)node
+{
+  ASDisplayTreeAssertLocked();
+  return node->_subnodes;
+}
+
+/*
+ * Convert a relative insertion point to an absolute point and a parent node.
+ */
+- (NSInteger)l_resolveInsertionPointFor:(ASTreeInsertionLocation)location relativeTo:(ASDisplayNode *)otherNode with:(NSInteger)index gettingParent:(ASDisplayNode **)parentPtr
+{
+  ASDisplayTreeAssertLocked();
+  NSParameterAssert(parentPtr);
+  switch (location) {
+    case ASTreeInsertAtIndex:
+      *parentPtr = otherNode;
+      return index;
+    case ASTreeInsertAtEnd:
+      *parentPtr = otherNode;
+      return [self l_mutableSubnodesOf:otherNode].count;
+    case ASTreeInsertAbove:
+      *parentPtr = [self supernodeOf:otherNode];
+      return [self l_indexOf:otherNode] + 1;
+    case ASTreeInsertBelow:
+    case ASTreeInsertReplace:
+      *parentPtr = [self supernodeOf:otherNode];
+      return [self l_indexOf:otherNode];
+  }
+}
+
+- (void)l_createTreeFor:(ASDisplayNode *)detachedNode
+{
+  ASDisplayTreeAssertLocked();
+}
+
+#pragma mark - NSFastEnumeration
+
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id  _Nullable __unsafe_unretained [])buffer count:(NSUInteger)len
+{
+  ASDisplayTreeAssertLocked();
+  return 0;
+}
+
+ASSynthesizeLockingMethodsWithMutex(_lock)
+
+@end

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -27,6 +27,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalLayerDefaults = 1 << 4,                     // exp_infer_layer_defaults
   ASExperimentalNetworkImageQueue = 1 << 5,                 // exp_network_image_queue
   ASExperimentalDeallocQueue = 1 << 6,                      // exp_dealloc_queue_v2
+  ASExperimentalDisplayTree = 1 << 7,                       // exp_display_tree
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.m
+++ b/Source/ASExperimentalFeatures.m
@@ -20,7 +20,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_unfair_lock",
                                       @"exp_infer_layer_defaults",
                                       @"exp_network_image_queue",
-                                      @"exp_dealloc_queue_v2"]));
+                                      @"exp_dealloc_queue_v2",
+                                      @"exp_display_tree"]));
   
   if (flags == ASExperimentalFeatureAll) {
     return allNames;

--- a/Source/ASLocking.h
+++ b/Source/ASLocking.h
@@ -1,0 +1,91 @@
+//
+//  ASLocking.h
+//  Texture
+//
+//  Copyright (c) 2018-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <Foundation/Foundation.h>
+#import <pthread/sched.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol ASLocking <NSLocking>
+
+/// Try to take lock without blocking. Returns whether the lock was taken.
+- (BOOL)tryLock;
+
+@end
+
+/**
+ * Take multiple locks "simultaneously," avoiding deadlocks
+ * caused by lock ordering.
+ *
+ * We use an explicit count argument to handle nil locks.
+ * If you pass a nil lock, obviously we ignore it.
+ *
+ * TODO: Implement a scoped version. The scope variable would be
+ * a struct containing the lock count and the locks to unlock.
+ */
+NS_INLINE void ASLockMany(unsigned count, id<ASLocking> _Nullable arg0, ...) {
+  if (count == 0) {
+    return;
+  }
+  
+  BOOL done = NO;
+  while (!done) {
+    // Don't retain/release locks. Arguments are retained by caller.
+    __unsafe_unretained id<ASLocking> ownedLocks[count];
+    va_list locks;
+    va_start(locks, arg0);
+    for (int i = 0; i < count; i++) {
+      __unsafe_unretained id<ASLocking> lock = va_arg(locks, id<ASLocking>);
+      
+      // Attempt to lock, or pass if nil.
+      BOOL locked = (lock ? [lock tryLock] : YES);
+      
+      if (!locked) {
+        // If we failed to lock, release what we have, yield, and start over.
+        for (int j = 0; j < i; j++) {
+          [ownedLocks[j] unlock];
+        }
+        sched_yield();
+        break;
+      } else if (i == count - 1) {
+        // If we suceeded and this was the last, we're done.
+        done = YES;
+      } else {
+        // Otherwise note that we have this lock and keep going.
+        ownedLocks[i] = lock;
+      }
+    }
+    va_end(locks);
+  }
+}
+
+NS_INLINE void ASUnlockMany(unsigned count, id<NSLocking> arg0, ...)
+{
+  va_list locks;
+  va_start(locks, arg0);
+  for (int i = 0; i < count; i++) {
+    __unsafe_unretained id<ASLocking> lock = va_arg(locks, id<ASLocking>);
+    [lock unlock];
+  }
+  va_end(locks);
+}
+
+@interface NSLock (ASLocking) <ASLocking>
+@end
+
+@interface NSRecursiveLock (ASLocking) <ASLocking>
+@end
+
+@interface NSConditionLock (ASLocking) <ASLocking>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ASRunLoopQueue.h
+++ b/Source/ASRunLoopQueue.h
@@ -17,6 +17,7 @@
 
 #import <Foundation/Foundation.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
+#import <AsyncDisplayKit/ASLocking.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 AS_SUBCLASSING_RESTRICTED
-@interface ASRunLoopQueue<ObjectType> : ASAbstractRunLoopQueue <NSLocking>
+@interface ASRunLoopQueue<ObjectType> : ASAbstractRunLoopQueue <ASLocking>
 
 /**
  * Create a new queue with the given run loop and handler.

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -65,6 +65,11 @@ static void runLoopSourceCallback(void *info) {
   ASDisplayNodeFailAssert(@"Abstract method.");
 }
 
+- (void)drain
+{
+  ASDisplayNodeFailAssert(@"Abstract method.");
+}
+
 @end
 
 @implementation ASDeallocQueueV1 {
@@ -541,17 +546,7 @@ typedef enum {
   return _internalQueue.count == 0;
 }
 
-#pragma mark - NSLocking
-
-- (void)lock
-{
-  _internalQueueLock.lock();
-}
-
-- (void)unlock
-{
-  _internalQueueLock.unlock();
-}
+ASSynthesizeLockingMethodsWithMutex(_internalQueueLock)
 
 @end
 

--- a/Source/Layout/ASLayoutElement.h
+++ b/Source/Layout/ASLayoutElement.h
@@ -22,6 +22,7 @@
 #import <AsyncDisplayKit/ASAbsoluteLayoutElement.h>
 #import <AsyncDisplayKit/ASTraitCollection.h>
 #import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
+#import <AsyncDisplayKit/ASLocking.h>
 
 @class ASLayout;
 @class ASLayoutSpec;
@@ -174,7 +175,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
 - (void)style:(__kindof ASLayoutElementStyle *)style propertyDidChange:(NSString *)propertyName;
 @end
 
-@interface ASLayoutElementStyle : NSObject <ASStackLayoutElement, ASAbsoluteLayoutElement, ASLayoutElementExtensibility, NSLocking>
+@interface ASLayoutElementStyle : NSObject <ASStackLayoutElement, ASAbsoluteLayoutElement, ASLayoutElementExtensibility, ASLocking>
 
 /**
  * @abstract Initializes the layoutElement style with a specified delegate

--- a/Source/Layout/ASLayoutElement.mm
+++ b/Source/Layout/ASLayoutElement.mm
@@ -176,17 +176,7 @@ do {\
   return self;
 }
 
-#pragma mark - NSLocking
-
-- (void)lock
-{
-  __instanceLock__.lock();
-}
-
-- (void)unlock
-{
-  __instanceLock__.unlock();
-}
+ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
 
 #pragma mark - ASLayoutElementStyleSize
 

--- a/Source/Layout/ASLayoutSpec.h
+++ b/Source/Layout/ASLayoutSpec.h
@@ -17,6 +17,7 @@
 
 #import <AsyncDisplayKit/ASLayoutElement.h>
 #import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
+#import <AsyncDisplayKit/ASLocking.h>
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -24,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A layout spec is an immutable object that describes a layout, loosely inspired by React.
  */
-@interface ASLayoutSpec : NSObject <ASLayoutElement, ASLayoutElementStylability, NSFastEnumeration, ASDescriptionProvider, NSLocking>
+@interface ASLayoutSpec : NSObject <ASLayoutElement, ASLayoutElementStylability, NSFastEnumeration, ASDescriptionProvider, ASLocking>
 
 /** 
  * Creation of a layout spec should only happen by a user in layoutSpecThatFits:. During that method, a

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -259,17 +259,7 @@ ASLayoutElementStyleExtensibilityForwarding
   return result;
 }
 
-#pragma mark - NSLocking
-
-- (void)lock
-{
-  __instanceLock__.lock();
-}
-
-- (void)unlock
-{
-  __instanceLock__.unlock();
-}
+ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
 
 @end
 

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -31,6 +31,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class ASDisplayTree;
 @protocol _ASDisplayLayerDelegate;
 @class _ASDisplayLayer;
 @class _ASPendingState;
@@ -121,10 +122,17 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
     unsigned isDeallocating:1;
   } _flags;
   
-@protected
+  /*
+   * In the tree experiment, these properties are
+   * guarded by the tree's lock whereas in
+   * control, they are guarded by __instanceLock__.
+   */
   ASDisplayNode * __weak _supernode;
   NSMutableArray<ASDisplayNode *> *_subnodes;
+  
+  ASDisplayTree * _tree; // nil unless root, nil until has first subnode.
 
+@protected
   // Set this to nil whenever you modify _subnodes
   NSArray<ASDisplayNode *> *_cachedSubnodes;
 

--- a/Tests/ASDisplayTreeTests.m
+++ b/Tests/ASDisplayTreeTests.m
@@ -1,0 +1,39 @@
+//
+//  ASDisplayTreeTests.m
+//  AsyncDisplayKitTests
+//
+//  Created by Adlai on 5/28/18.
+//  Copyright © 2018 Pinterest. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface ASDisplayTreeTests : ASTestCase
+
+@end
+
+@implementation ASDisplayTreeTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end


### PR DESCRIPTION
Right now when we walk up or down a tree, there's no way to guarantee that we get a consistent picture without deadlocking.

This diff creates a new class `ASDisplayTree` which owns a lock and which performs all tree-level queries and mutations. A reference to the tree is pushed down to nodes when they enter the tree.

Tree modifications currently require us to take _three_ locks simultaneously – the source tree, the destination tree, and the node's property lock.

Still need to come up with a testing scaffold and think through if there's a way to modify the tree without taking all three locks (although I think taking all three simultaneously is actually safe, since we use a deadlock-avoidant approach. 

At this stage it would be great to take input! But it's also far from landing so feel free to ignore for now.