### PR TITLE
Add support for acquiring multiple locks at once

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -428,6 +428,7 @@
 		CCEDDDD1200C488000FFCD0A /* ASConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = CCEDDDD0200C488000FFCD0A /* ASConfiguration.m */; };
 		CCEDDDD9200C518800FFCD0A /* ASConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCEDDDD8200C518800FFCD0A /* ASConfigurationTests.m */; };
 		CCF18FF41D2575E300DF5895 /* NSIndexSet+ASHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CCF1FF5E20C4785000AAD8FC /* ASLocking.h in Headers */ = {isa = PBXBuildFile; fileRef = CCF1FF5D20C4785000AAD8FC /* ASLocking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB55C2671C641AE4004EDCF5 /* ASContextTransitioning.h in Headers */ = {isa = PBXBuildFile; fileRef = DB55C2651C641AE4004EDCF5 /* ASContextTransitioning.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB7121BCD50849C498C886FB /* libPods-AsyncDisplayKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */; };
 		DB78412E1C6BCE1600A9E2B4 /* _ASTransitionContext.m in Sources */ = {isa = PBXBuildFile; fileRef = DB55C2601C6408D6004EDCF5 /* _ASTransitionContext.m */; };
@@ -947,6 +948,7 @@
 		CCEDDDCE200C42A200FFCD0A /* ASConfigurationDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASConfigurationDelegate.h; sourceTree = "<group>"; };
 		CCEDDDD0200C488000FFCD0A /* ASConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ASConfiguration.m; sourceTree = "<group>"; };
 		CCEDDDD8200C518800FFCD0A /* ASConfigurationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ASConfigurationTests.m; sourceTree = "<group>"; };
+		CCF1FF5D20C4785000AAD8FC /* ASLocking.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASLocking.h; sourceTree = "<group>"; };
 		D3779BCFF841AD3EB56537ED /* Pods-AsyncDisplayKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		D785F6601A74327E00291744 /* ASScrollNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASScrollNode.h; sourceTree = "<group>"; };
 		D785F6611A74327E00291744 /* ASScrollNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASScrollNode.mm; sourceTree = "<group>"; };
@@ -1162,6 +1164,7 @@
 				058D09DD195D050800B7D73C /* ASImageNode.h */,
 				058D09DE195D050800B7D73C /* ASImageNode.mm */,
 				68355B2E1CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm */,
+				CCF1FF5D20C4785000AAD8FC /* ASLocking.h */,
 				92DD2FE11BF4B97E0074C9DD /* ASMapNode.h */,
 				92DD2FE21BF4B97E0074C9DD /* ASMapNode.mm */,
 				0516FA3E1A1563D200B4EBED /* ASMultiplexImageNode.h */,
@@ -1871,6 +1874,7 @@
 				CC56013B1F06E9A700DC4FBE /* ASIntegerMap.h in Headers */,
 				B35061FA1B010EFD0018CF92 /* ASControlNode+Subclasses.h in Headers */,
 				E54E81FC1EB357BD00FFE8E1 /* ASPageTable.h in Headers */,
+				CCF1FF5E20C4785000AAD8FC /* ASLocking.h in Headers */,
 				B35061F81B010EFD0018CF92 /* ASControlNode.h in Headers */,
 				B35062171B010EFD0018CF92 /* ASDataController.h in Headers */,
 				34EFC75B1B701BAF00AD841F /* ASDimension.h in Headers */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Make `ASPerformMainThreadDeallocation` visible in C. [Adlai Holler](https://github.com/Adlai-Holler)
 - Add snapshot test for astextnode2. [Max Wang](https://github.com/wsdwsd0829) [#935](https://github.com/TextureGroup/Texture/pull/935)
 - Internal housekeeping on the async transaction (rendering) system. [Adlai Holler](https://github.com/Adlai-Holler)
+- Add new protocol `ASLocking` that extends `NSLocking` with `tryLock`, and allows taking multiple locks safely. [Adlai Holler](https://github.com/Adlai-Holler)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -25,6 +25,7 @@
 #import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 #import <AsyncDisplayKit/ASLayoutElement.h>
+#import <AsyncDisplayKit/ASLocking.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -127,7 +128,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  */
 
-@interface ASDisplayNode : NSObject <NSLocking>
+@interface ASDisplayNode : NSObject <ASLocking>
 
 /** @name Initializing a node object */
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -373,15 +373,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   return self;
 }
 
-- (void)lock
-{
-  __instanceLock__.lock();
-}
-
-- (void)unlock
-{
-  __instanceLock__.unlock();
-}
+ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
 
 - (void)setViewBlock:(ASDisplayNodeViewBlock)viewBlock
 {

--- a/Source/ASLocking.h
+++ b/Source/ASLocking.h
@@ -1,0 +1,95 @@
+//
+//  ASLocking.h
+//  Texture
+//
+//  Copyright (c) 2018-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <Foundation/Foundation.h>
+#import <pthread/sched.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol ASLocking <NSLocking>
+
+/// Try to take lock without blocking. Returns whether the lock was taken.
+- (BOOL)tryLock;
+
+@end
+
+/**
+ * Take multiple locks "simultaneously," avoiding deadlocks
+ * caused by lock ordering.
+ *
+ * We use an explicit count argument to handle nil locks.
+ * If you pass a nil lock, obviously we ignore it.
+ *
+ * TODO: Implement a scoped version. The scope variable would be
+ * a struct containing the lock count and the locks to unlock.
+ */
+NS_INLINE void ASLockMany(unsigned count, id<ASLocking> _Nullable arg0, ...) {
+  if (count == 0) {
+    return;
+  }
+  
+  BOOL done = NO;
+  while (!done) {
+    // Don't retain/release locks. Arguments are retained by caller.
+    __unsafe_unretained id<ASLocking> ownedLocks[count];
+    va_list locks;
+    va_start(locks, arg0);
+    for (int i = 0; i < count; i++) {
+      __unsafe_unretained id<ASLocking> lock = va_arg(locks, id<ASLocking>);
+      
+      // Attempt to lock, or pass if nil.
+      BOOL locked = (lock ? [lock tryLock] : YES);
+      
+      if (!locked) {
+        // If we failed to lock, release what we have, yield, and start over.
+        for (int j = 0; j < i; j++) {
+          [ownedLocks[j] unlock];
+        }
+        sched_yield();
+        break;
+      } else if (i == count - 1) {
+        // If we suceeded and this was the last, we're done.
+        done = YES;
+      } else {
+        // Otherwise note that we have this lock and keep going.
+        ownedLocks[i] = lock;
+      }
+    }
+    va_end(locks);
+  }
+}
+
+NS_INLINE void ASUnlockMany(unsigned count, id<NSLocking> arg0, ...)
+{
+  va_list locks;
+  va_start(locks, arg0);
+  for (int i = 0; i < count; i++) {
+    __unsafe_unretained id<ASLocking> lock = va_arg(locks, id<ASLocking>);
+    [lock unlock];
+  }
+  va_end(locks);
+}
+
+/**
+ * These Foundation classes already implement -tryLock.
+ */
+
+@interface NSLock (ASLocking) <ASLocking>
+@end
+
+@interface NSRecursiveLock (ASLocking) <ASLocking>
+@end
+
+@interface NSConditionLock (ASLocking) <ASLocking>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ASRunLoopQueue.h
+++ b/Source/ASRunLoopQueue.h
@@ -17,6 +17,7 @@
 
 #import <Foundation/Foundation.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
+#import <AsyncDisplayKit/ASLocking.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 AS_SUBCLASSING_RESTRICTED
-@interface ASRunLoopQueue<ObjectType> : ASAbstractRunLoopQueue <NSLocking>
+@interface ASRunLoopQueue<ObjectType> : ASAbstractRunLoopQueue <ASLocking>
 
 /**
  * Create a new queue with the given run loop and handler.

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -541,17 +541,7 @@ typedef enum {
   return _internalQueue.count == 0;
 }
 
-#pragma mark - NSLocking
-
-- (void)lock
-{
-  _internalQueueLock.lock();
-}
-
-- (void)unlock
-{
-  _internalQueueLock.unlock();
-}
+ASSynthesizeLockingMethodsWithMutex(_internalQueueLock)
 
 @end
 

--- a/Source/AsyncDisplayKit.h
+++ b/Source/AsyncDisplayKit.h
@@ -110,6 +110,7 @@
 #import <AsyncDisplayKit/ASHashing.h>
 #import <AsyncDisplayKit/ASHighlightOverlayLayer.h>
 #import <AsyncDisplayKit/ASImageContainerProtocolCategories.h>
+#import <AsyncDisplayKit/ASLocking.h>
 #import <AsyncDisplayKit/ASLog.h>
 #import <AsyncDisplayKit/ASMutableAttributedStringBuilder.h>
 #import <AsyncDisplayKit/ASRunLoopQueue.h>

--- a/Source/Layout/ASLayoutElement.h
+++ b/Source/Layout/ASLayoutElement.h
@@ -22,6 +22,7 @@
 #import <AsyncDisplayKit/ASAbsoluteLayoutElement.h>
 #import <AsyncDisplayKit/ASTraitCollection.h>
 #import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
+#import <AsyncDisplayKit/ASLocking.h>
 
 @class ASLayout;
 @class ASLayoutSpec;
@@ -174,7 +175,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
 - (void)style:(__kindof ASLayoutElementStyle *)style propertyDidChange:(NSString *)propertyName;
 @end
 
-@interface ASLayoutElementStyle : NSObject <ASStackLayoutElement, ASAbsoluteLayoutElement, ASLayoutElementExtensibility, NSLocking>
+@interface ASLayoutElementStyle : NSObject <ASStackLayoutElement, ASAbsoluteLayoutElement, ASLayoutElementExtensibility, ASLocking>
 
 /**
  * @abstract Initializes the layoutElement style with a specified delegate

--- a/Source/Layout/ASLayoutElement.mm
+++ b/Source/Layout/ASLayoutElement.mm
@@ -176,17 +176,7 @@ do {\
   return self;
 }
 
-#pragma mark - NSLocking
-
-- (void)lock
-{
-  __instanceLock__.lock();
-}
-
-- (void)unlock
-{
-  __instanceLock__.unlock();
-}
+ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
 
 #pragma mark - ASLayoutElementStyleSize
 

--- a/Source/Layout/ASLayoutSpec.h
+++ b/Source/Layout/ASLayoutSpec.h
@@ -17,6 +17,7 @@
 
 #import <AsyncDisplayKit/ASLayoutElement.h>
 #import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
+#import <AsyncDisplayKit/ASLocking.h>
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -24,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A layout spec is an immutable object that describes a layout, loosely inspired by React.
  */
-@interface ASLayoutSpec : NSObject <ASLayoutElement, ASLayoutElementStylability, NSFastEnumeration, ASDescriptionProvider, NSLocking>
+@interface ASLayoutSpec : NSObject <ASLayoutElement, ASLayoutElementStylability, NSFastEnumeration, ASDescriptionProvider, ASLocking>
 
 /** 
  * Creation of a layout spec should only happen by a user in layoutSpecThatFits:. During that method, a

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -259,17 +259,7 @@ ASLayoutElementStyleExtensibilityForwarding
   return result;
 }
 
-#pragma mark - NSLocking
-
-- (void)lock
-{
-  __instanceLock__.lock();
-}
-
-- (void)unlock
-{
-  __instanceLock__.unlock();
-}
+ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
 
 @end
 


### PR DESCRIPTION
- New protocol `ASLocking` which extends `NSLocking` and adds the `-tryLock` method.
- New macros `ASSynthesizeLockingMethodsWithMutex` and `ASSynthesizeLockingMethodsWithObject` to remove locking method boilerplate.
- Make all lockables conform to `ASLocking`.
- Add `ASDN::Mutex::tryLock()`.
- Add `ASLockSequence` which repeatedly tries to lock different locks in sequence.

No functional changes.

This is a precursor to #956 .