### PR TITLE
Launch network background queue

### DIFF
--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -18,7 +18,6 @@
                     "exp_interface_state_coalesce",
                     "exp_unfair_lock",
                     "exp_infer_layer_defaults",
-                    "exp_network_image_queue",
                     "exp_dealloc_queue_v2"
                 ]
     		}

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -25,8 +25,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalInterfaceStateCoalescing = 1 << 2,          // exp_interface_state_coalesce
   ASExperimentalUnfairLock = 1 << 3,                        // exp_unfair_lock
   ASExperimentalLayerDefaults = 1 << 4,                     // exp_infer_layer_defaults
-  ASExperimentalNetworkImageQueue = 1 << 5,                 // exp_network_image_queue
-  ASExperimentalDeallocQueue = 1 << 6,                      // exp_dealloc_queue_v2
+  ASExperimentalDeallocQueue = 1 << 5,                      // exp_dealloc_queue_v2
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -124,20 +124,6 @@
   [self _cancelImageDownloadWithResumePossibility:NO];
 }
 
-- (dispatch_queue_t)callbackQueue
-{
-    static dispatch_once_t onceToken;
-    static dispatch_queue_t callbackQueue;
-    dispatch_once(&onceToken, ^{
-        if (ASActivateExperimentalFeature(ASExperimentalNetworkImageQueue)) {
-            callbackQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-        } else {
-            callbackQueue = dispatch_get_main_queue();
-        }
-    });
-    return callbackQueue;
-}
-
 #pragma mark - Public methods -- must lock
 
 /// Setter for public image property. It has the side effect of setting an internal _imageWasSetExternally that prevents setting an image internally. Setting an image internally should happen with the _setImage: method
@@ -469,7 +455,7 @@
   // Unbind from the previous download.
   if (oldDownloadIDForProgressBlock != nil) {
     as_log_verbose(ASImageLoadingLog(), "Disabled progress images for %@ id: %@", self, oldDownloadIDForProgressBlock);
-    [_downloader setProgressImageBlock:nil callbackQueue:[self callbackQueue] withDownloadIdentifier:oldDownloadIDForProgressBlock];
+    [_downloader setProgressImageBlock:nil callbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) withDownloadIdentifier:oldDownloadIDForProgressBlock];
   }
 
   // Bind to the current download.
@@ -478,7 +464,7 @@
     as_log_verbose(ASImageLoadingLog(), "Enabled progress images for %@ id: %@", self, newDownloadIDForProgressBlock);
     [_downloader setProgressImageBlock:^(UIImage * _Nonnull progressImage, CGFloat progress, id  _Nullable downloadIdentifier) {
       [weakSelf handleProgressImage:progressImage progress:progress downloadIdentifier:downloadIdentifier];
-    } callbackQueue:[self callbackQueue] withDownloadIdentifier:newDownloadIDForProgressBlock];
+    } callbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) withDownloadIdentifier:newDownloadIDForProgressBlock];
   }
 
   // Update state local state with lock held.
@@ -498,7 +484,7 @@
     // In this case another thread changed the _downloadIdentifierForProgressBlock before we finished registering
     // the new progress block for newDownloadIDForProgressBlock ID. Let's clear it now and reattempt to register
     if (newDownloadIDForProgressBlock) {
-      [_downloader setProgressImageBlock:nil callbackQueue:[self callbackQueue] withDownloadIdentifier:newDownloadIDForProgressBlock];
+      [_downloader setProgressImageBlock:nil callbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) withDownloadIdentifier:newDownloadIDForProgressBlock];
     }
     [self _updateProgressImageBlockOnDownloaderIfNeeded];
   }
@@ -570,7 +556,7 @@
 
 
     downloadIdentifier = [_downloader downloadImageWithURL:url
-                                             callbackQueue:[self callbackQueue]
+                                             callbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
                                           downloadProgress:NULL
                                                 completion:^(id <ASImageContainerProtocol> _Nullable imageContainer, NSError * _Nullable error, id  _Nullable downloadIdentifier, id _Nullable userInfo) {
                                                   if (finished != NULL) {
@@ -771,7 +757,7 @@
           }
         };
         [_cache cachedImageWithURL:URL
-                     callbackQueue:[self callbackQueue]
+                     callbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
                         completion:completion];
       } else {
         [self _downloadImageWithCompletion:^(id<ASImageContainerProtocol> imageContainer, NSError *error, id downloadIdentifier, id userInfo) {


### PR DESCRIPTION
It improves image download and rendering time by about 2% on our surfaces when the main thread is under heavy load.