### PR TITLE
Fix crash when call needsMainThreadDeallocation on NSProxy instances #trivial

### DIFF
--- a/Source/ASMainThreadDeallocation.h
+++ b/Source/ASMainThreadDeallocation.h
@@ -50,7 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
  * class need to be deallocated on the main thread.
  * You do not access this property yourself.
  *
- * The NSProxy implementation returns NO.
+ * The NSProxy implementation returns NO because
+ * proxies almost always hold weak references.
  */
 @property (class, readonly) BOOL needsMainThreadDeallocation;
 

--- a/Source/ASMainThreadDeallocation.h
+++ b/Source/ASMainThreadDeallocation.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  * class need to be deallocated on the main thread.
  * You do not access this property yourself.
  *
- * The NSObject implementation returns NO if the class name has
+ * The NSObject implementation returns YES if the class name has
  * a prefix UI, AV, or CA. This property is also overridden to
  * return fixed values for other common classes, such as UIImage,
  * UIGestureRecognizer, and UIResponder.
@@ -43,5 +43,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface NSProxy (ASNeedsMainThreadDeallocation)
+
+/**
+ * Override this property to indicate that instances of this
+ * class need to be deallocated on the main thread.
+ * You do not access this property yourself.
+ *
+ * The NSProxy implementation returns NO.
+ */
+@property (class, readonly) BOOL needsMainThreadDeallocation;
+
+@end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ASMainThreadDeallocation.mm
+++ b/Source/ASMainThreadDeallocation.mm
@@ -199,3 +199,12 @@
 }
 
 @end
+
+@implementation NSProxy (ASNeedsMainThreadDeallocation)
+
++ (BOOL)needsMainThreadDeallocation
+{
+  return NO;
+}
+
+@end


### PR DESCRIPTION
<img width="782" alt="screen shot 2018-06-12 at 5 39 51 pm" src="https://user-images.githubusercontent.com/587874/41304308-af5637bc-6e67-11e8-857e-12f29ef9212c.png">
