### PR TITLE
Reduce usage of autorelease pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Internal housekeeping on the async transaction (rendering) system. [Adlai Holler](https://github.com/Adlai-Holler)
 - Add new protocol `ASLocking` that extends `NSLocking` with `tryLock`, and allows taking multiple locks safely. [Adlai Holler](https://github.com/Adlai-Holler)
 - Make the main thread ivar deallocation system available to other classes. Plus a little optimization. See `ASMainThreadDeallocation.h`. [Adlai Holler](https://github.com/Adlai-Holler) [#959](https://github.com/TextureGroup/Texture/pull/959)
+- Reduce usage of autorelease pools. [Adlai Holler](https://github.com/Adlai-Holler) [#968](https://github.com/TextureGroup/Texture/pull/968)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -303,7 +303,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   _proxyDataSource = [[ASCollectionViewProxy alloc] initWithTarget:nil interceptor:self];
   super.dataSource = (id<UICollectionViewDataSource>)_proxyDataSource;
   
-  _registeredSupplementaryKinds = [NSMutableSet set];
+  _registeredSupplementaryKinds = [[NSMutableSet alloc] init];
   _visibleElements = [[NSCountedSet alloc] init];
   
   _cellsForVisibilityUpdates = [NSHashTable hashTableWithOptions:NSHashTableObjectPointerPersonality];
@@ -1729,7 +1729,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     NSArray<ASCellNode *> *nodes = [_cellsForLayoutUpdates allObjects];
     [_cellsForLayoutUpdates removeAllObjects];
 
-    NSMutableArray<ASCellNode *> *nodesSizeChanged = [NSMutableArray array];
+    NSMutableArray<ASCellNode *> *nodesSizeChanged = [[NSMutableArray alloc] init];
 
     [_dataController relayoutNodes:nodes nodesSizeChanged:nodesSizeChanged];
     [self nodesDidRelayout:nodesSizeChanged];
@@ -2005,7 +2005,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 - (NSArray<NSString *> *)dataController:(ASDataController *)dataController supplementaryNodeKindsInSections:(NSIndexSet *)sections
 {
   if (_asyncDataSourceFlags.collectionNodeSupplementaryElementKindsInSection) {
-    NSMutableSet *kinds = [NSMutableSet set];
+    auto kinds = [[NSMutableSet<NSString *> alloc] init];
     GET_COLLECTIONNODE_OR_RETURN(collectionNode, @[]);
     [sections enumerateIndexesUsingBlock:^(NSUInteger section, BOOL * _Nonnull stop) {
       NSArray<NSString *> *kindsForSection = [_asyncDataSource collectionNode:collectionNode supplementaryElementKindsInSection:section];

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -767,10 +767,10 @@ ASLayoutElementStyleExtensibilityForwarding
   
   NSArray<ASDisplayNode *> *removedSubnodes = [context removedSubnodes];
   NSMutableArray<ASDisplayNode *> *insertedSubnodes = [[context insertedSubnodes] mutableCopy];
-  NSMutableArray<ASDisplayNode *> *movedSubnodes = [NSMutableArray array];
+  auto movedSubnodes = [[NSMutableArray<ASDisplayNode *> alloc] init];
   
-  NSMutableArray<_ASAnimatedTransitionContext *> *insertedSubnodeContexts = [NSMutableArray array];
-  NSMutableArray<_ASAnimatedTransitionContext *> *removedSubnodeContexts = [NSMutableArray array];
+  auto insertedSubnodeContexts = [[NSMutableArray<_ASAnimatedTransitionContext *> alloc] init];
+  auto removedSubnodeContexts = [[NSMutableArray<_ASAnimatedTransitionContext *> alloc] init];
   
   for (ASDisplayNode *subnode in [context subnodesForKey:ASTransitionContextToLayoutKey]) {
     if ([insertedSubnodes containsObject:subnode] == NO) {

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -80,7 +80,7 @@
     return;
   }
   if (_yogaChildren == nil) {
-    _yogaChildren = [NSMutableArray array];
+    _yogaChildren = [[NSMutableArray alloc] init];
   }
 
   // Clean up state in case this child had another parent.

--- a/Source/ASDisplayNodeExtras.mm
+++ b/Source/ASDisplayNodeExtras.mm
@@ -178,7 +178,7 @@ static void _ASCollectDisplayNodes(NSMutableArray *array, CALayer *layer)
 
 extern NSArray<ASDisplayNode *> *ASCollectDisplayNodes(ASDisplayNode *node)
 {
-  NSMutableArray *list = [NSMutableArray array];
+  NSMutableArray *list = [[NSMutableArray alloc] init];
   for (CALayer *sublayer in node.layer.sublayers) {
     _ASCollectDisplayNodes(list, sublayer);
   }
@@ -203,7 +203,7 @@ static void _ASDisplayNodeFindAllSubnodes(NSMutableArray *array, ASDisplayNode *
 
 extern NSArray<ASDisplayNode *> *ASDisplayNodeFindAllSubnodes(ASDisplayNode *start, BOOL (^block)(ASDisplayNode *node))
 {
-  NSMutableArray *list = [NSMutableArray array];
+  NSMutableArray *list = [[NSMutableArray alloc] init];
   _ASDisplayNodeFindAllSubnodes(list, start, block);
   return list;
 }

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -629,20 +629,20 @@
         } else {
           // First try to load the path directly, for efficiency assuming a developer who
           // doesn't want caching is trying to be as minimal as possible.
-          UIImage *nonAnimatedImage = [UIImage imageWithContentsOfFile:URL.path];
+          auto nonAnimatedImage = [[UIImage alloc] initWithContentsOfFile:URL.path];
           if (nonAnimatedImage == nil) {
             // If we couldn't find it, execute an -imageNamed:-like search so we can find resources even if the
             // extension is not provided in the path.  This allows the same path to work regardless of shouldCacheImage.
             NSString *filename = [[NSBundle mainBundle] pathForResource:URL.path.lastPathComponent ofType:nil];
             if (filename != nil) {
-              nonAnimatedImage = [UIImage imageWithContentsOfFile:filename];
+              nonAnimatedImage = [[UIImage alloc] initWithContentsOfFile:filename];
             }
           }
 
           // If the file may be an animated gif and then created an animated image.
           id<ASAnimatedImageProtocol> animatedImage = nil;
           if (_downloaderFlags.downloaderImplementsAnimatedImage) {
-            NSData *data = [NSData dataWithContentsOfURL:URL];
+            auto data = [[NSData alloc] initWithContentsOfURL:URL];
             if (data != nil) {
               animatedImage = [_downloader animatedImageWithData:data];
 

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -238,14 +238,12 @@ static void runLoopSourceCallback(void *info) {
 
 - (void)drain
 {
-  @autoreleasepool {
-    _lock.lock();
-    auto q = std::move(_queue);
-    _lock.unlock();
-    for (auto ref : q) {
-      // NOTE: Could check that retain count is 1 and retry later if not.
-      CFRelease(ref);
-    }
+  _lock.lock();
+  auto q = std::move(_queue);
+  _lock.unlock();
+  for (auto ref : q) {
+    // NOTE: Could check that retain count is 1 and retry later if not.
+    CFRelease(ref);
   }
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -758,7 +758,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
       NSArray<ASCellNode *> *nodes = [_cellsForLayoutUpdates allObjects];
       [_cellsForLayoutUpdates removeAllObjects];
 
-      NSMutableArray<ASCellNode *> *nodesSizeChanged = [NSMutableArray array];
+      auto nodesSizeChanged = [[NSMutableArray<ASCellNode *> alloc] init];
       [_dataController relayoutNodes:nodes nodesSizeChanged:nodesSizeChanged];
       if (nodesSizeChanged.count > 0) {
         [self requeryNodeHeights];

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -854,7 +854,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   ASLockScopeSelf();
   
   NSArray *rects = [[self _locked_renderer] rectsForTextRange:textRange measureOption:measureOption];
-  NSMutableArray *adjustedRects = [NSMutableArray array];
+  auto adjustedRects = [[NSMutableArray<NSValue *> alloc] init];
 
   for (NSValue *rectValue in rects) {
     CGRect rect = [rectValue CGRectValue];

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -259,7 +259,7 @@
  * Create a new set by mapping `collection` over `work`, ignoring nil.
  */
 #define ASSetByFlatMapping(collection, decl, work) ({ \
-  NSMutableSet *s = [NSMutableSet set]; \
+  NSMutableSet *s = [[NSMutableSet alloc] init]; \
   for (decl in collection) {\
     id result = work; \
     if (result != nil) { \
@@ -271,9 +271,11 @@
 
 /**
  * Create a new ObjectPointerPersonality NSHashTable by mapping `collection` over `work`, ignoring nil.
+ *
+ * capacity: 0 is taken from +hashTableWithOptions.
  */
 #define ASPointerTableByFlatMapping(collection, decl, work) ({ \
-  NSHashTable *t = [NSHashTable hashTableWithOptions:NSHashTableObjectPointerPersonality]; \
+  NSHashTable *t = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:0]; \
   for (decl in collection) {\
     id result = work; \
     if (result != nil) { \
@@ -287,7 +289,7 @@
  * Create a new array by mapping `collection` over `work`, ignoring nil.
  */
 #define ASArrayByFlatMapping(collection, decl, work) ({ \
-  NSMutableArray *a = [NSMutableArray array]; \
+  NSMutableArray *a = [[NSMutableArray alloc] init]; \
   for (decl in collection) {\
     id result = work; \
     if (result != nil) { \

--- a/Source/Details/ASBasicImageDownloader.mm
+++ b/Source/Details/ASBasicImageDownloader.mm
@@ -245,7 +245,7 @@ static const char *kContextKey = NSStringFromClass(ASBasicImageDownloaderContext
   // cause significant performance issues.
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     // associate metadata with it
-    NSMutableDictionary *callbackData = [NSMutableDictionary dictionary];
+    NSMutableDictionary *callbackData = [[NSMutableDictionary alloc] init];
     callbackData[kASBasicImageDownloaderContextCallbackQueue] = callbackQueue ? : dispatch_get_main_queue();
 
     if (downloadProgress) {

--- a/Source/Details/ASCollectionLayoutState.mm
+++ b/Source/Details/ASCollectionLayoutState.mm
@@ -159,7 +159,7 @@ elementToLayoutAttributesTable:[NSMapTable elementToLayoutAttributesTable]];
   }
 
   // Use a set here because some items may span multiple pages
-  NSMutableSet<UICollectionViewLayoutAttributes *> *result = [NSMutableSet set];
+  auto result = [NSMutableSet<UICollectionViewLayoutAttributes *> set];
   for (id pagePtr in pages) {
     ASPageCoordinate page = (ASPageCoordinate)pagePtr;
     NSArray<UICollectionViewLayoutAttributes *> *allAttrs = [_pageToLayoutAttributesTable objectForPage:page];
@@ -216,7 +216,7 @@ elementToLayoutAttributesTable:[NSMapTable elementToLayoutAttributesTable]];
       for (UICollectionViewLayoutAttributes *attrs in attrsInPage) {
         if (CGRectIntersectsRect(rect, attrs.frame)) {
           if (intersectingAttrsInPage == nil) {
-            intersectingAttrsInPage = [NSMutableArray array];
+            intersectingAttrsInPage = [[NSMutableArray alloc] init];
           }
           [intersectingAttrsInPage addObject:attrs];
         }
@@ -245,7 +245,7 @@ elementToLayoutAttributesTable:[NSMapTable elementToLayoutAttributesTable]];
                                                                  contentSize:(CGSize)contentSize
                                                                     pageSize:(CGSize)pageSize
 {
-  NSMutableArray<UICollectionViewLayoutAttributes *> *unmeasuredAttrs = [NSMutableArray array];
+  NSMutableArray<UICollectionViewLayoutAttributes *> *unmeasuredAttrs = [[NSMutableArray alloc] init];
   for (ASCollectionElement *element in table) {
     UICollectionViewLayoutAttributes *attrs = [table objectForKey:element];
     if (element.nodeIfAllocated == nil || CGSizeEqualToSize(element.nodeIfAllocated.calculatedSize, attrs.frame.size) == NO) {

--- a/Source/Details/ASCollectionLayoutState.mm
+++ b/Source/Details/ASCollectionLayoutState.mm
@@ -159,7 +159,7 @@ elementToLayoutAttributesTable:[NSMapTable elementToLayoutAttributesTable]];
   }
 
   // Use a set here because some items may span multiple pages
-  auto result = [NSMutableSet<UICollectionViewLayoutAttributes *> set];
+  auto result = [[NSMutableSet<UICollectionViewLayoutAttributes *> alloc] init];
   for (id pagePtr in pages) {
     ASPageCoordinate page = (ASPageCoordinate)pagePtr;
     NSArray<UICollectionViewLayoutAttributes *> *allAttrs = [_pageToLayoutAttributesTable objectForPage:page];

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -123,7 +123,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   _mainSerialQueue = [[ASMainSerialQueue alloc] init];
 
   _synchronized = YES;
-  _onDidFinishSynchronizingBlocks = [NSMutableSet set];
+  _onDidFinishSynchronizingBlocks = [[NSMutableSet alloc] init];
   
   const char *queueName = [[NSString stringWithFormat:@"org.AsyncDisplayKit.ASDataController.editingTransactionQueue:%p", self] cStringUsingEncoding:NSASCIIStringEncoding];
   _editingTransactionQueue = dispatch_queue_create(queueName, DISPATCH_QUEUE_SERIAL);
@@ -214,7 +214,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
     return @[];
   }
   
-  NSMutableArray<NSIndexPath *> *indexPaths = [NSMutableArray array];
+  auto indexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
   if ([kind isEqualToString:ASDataControllerRowNodeKind]) {
     std::vector<NSInteger> counts = [self itemCountsFromDataSource];
     [sections enumerateRangesUsingBlock:^(NSRange range, BOOL * _Nonnull stop) {
@@ -671,7 +671,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
       [layoutDelegateClass calculateLayoutWithContext:layoutContext];
       completion();
     } else {
-      NSMutableArray<ASCollectionElement *> *elementsToProcess = [NSMutableArray array];
+      auto elementsToProcess = [[NSMutableArray<ASCollectionElement *> alloc] init];
       for (ASCollectionElement *element in newMap) {
         ASCellNode *nodeIfAllocated = element.nodeIfAllocated;
         if (nodeIfAllocated.shouldUseUIKitCell) {

--- a/Source/Details/ASPageTable.m
+++ b/Source/Details/ASPageTable.m
@@ -121,7 +121,7 @@ extern NSPointerArray *ASPageCoordinatesForPagesThatIntersectRect(CGRect rect, C
       ASPageCoordinate page = (ASPageCoordinate)pagePtr;
       NSMutableArray<UICollectionViewLayoutAttributes *> *attrsInPage = [result objectForPage:page];
       if (attrsInPage == nil) {
-        attrsInPage = [NSMutableArray array];
+        attrsInPage = [[NSMutableArray alloc] init];
         [result setObject:attrsInPage forPage:page];
       }
       [attrsInPage addObject:attrs];

--- a/Source/Details/NSArray+Diffing.m
+++ b/Source/Details/NSArray+Diffing.m
@@ -34,7 +34,7 @@
   
   if (insertions) {
     NSArray *commonObjects = [self objectsAtIndexes:commonIndexes];
-    NSMutableIndexSet *insertionIndexes = [NSMutableIndexSet indexSet];
+    NSMutableIndexSet *insertionIndexes = [[NSMutableIndexSet alloc] init];
     for (NSInteger i = 0, j = 0; i < commonObjects.count || j < array.count;) {
       if (i < commonObjects.count && j < array.count && comparison(commonObjects[i], array[j])) {
         i++; j++;
@@ -47,7 +47,7 @@
   }
   
   if (deletions) {
-    NSMutableIndexSet *deletionIndexes = [NSMutableIndexSet indexSet];
+    NSMutableIndexSet *deletionIndexes = [[NSMutableIndexSet alloc] init];
     for (NSInteger i = 0; i < self.count; i++) {
       if (![commonIndexes containsIndex:i]) {
         [deletionIndexes addIndex:i];
@@ -90,7 +90,7 @@
     }
   }
   
-  NSMutableIndexSet *common = [NSMutableIndexSet indexSet];
+  NSMutableIndexSet *common = [[NSMutableIndexSet alloc] init];
   NSInteger i = selfCount, j = arrayCount;
   while(i > 0 && j > 0) {
     if (comparison(self[i-1], array[j-1])) {

--- a/Source/Details/NSIndexSet+ASHelpers.h
+++ b/Source/Details/NSIndexSet+ASHelpers.h
@@ -34,6 +34,4 @@
 /// Returns all the section indexes contained in the index paths array.
 + (NSIndexSet *)as_sectionsFromIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
 
-- (NSArray<NSIndexPath *> *)as_filterIndexPathsBySection:(id<NSFastEnumeration>)indexPaths;
-
 @end

--- a/Source/Details/NSIndexSet+ASHelpers.m
+++ b/Source/Details/NSIndexSet+ASHelpers.m
@@ -96,15 +96,4 @@
   return result;
 }
 
-- (NSArray<NSIndexPath *> *)as_filterIndexPathsBySection:(id<NSFastEnumeration>)indexPaths
-{
-  NSMutableArray *result = [NSMutableArray array];
-  for (NSIndexPath *indexPath in indexPaths) {
-    if ([self containsIndex:indexPath.section]) {
-      [result addObject:indexPath];
-    }
-  }
-  return result;
-}
-
 @end

--- a/Source/Details/NSIndexSet+ASHelpers.m
+++ b/Source/Details/NSIndexSet+ASHelpers.m
@@ -24,7 +24,7 @@
 
 - (NSIndexSet *)as_indexesByMapping:(NSUInteger (^)(NSUInteger))block
 {
-  NSMutableIndexSet *result = [NSMutableIndexSet indexSet];
+  NSMutableIndexSet *result = [[NSMutableIndexSet alloc] init];
   [self enumerateRangesUsingBlock:^(NSRange range, BOOL * _Nonnull stop) {
     for (NSUInteger i = range.location; i < NSMaxRange(range); i++) {
       NSUInteger newIndex = block(i);
@@ -38,7 +38,7 @@
 
 - (NSIndexSet *)as_intersectionWithIndexes:(NSIndexSet *)indexes
 {
-  NSMutableIndexSet *result = [NSMutableIndexSet indexSet];
+  NSMutableIndexSet *result = [[NSMutableIndexSet alloc] init];
   [self enumerateRangesUsingBlock:^(NSRange range, BOOL * _Nonnull stop) {
     [indexes enumerateRangesInRange:range options:kNilOptions usingBlock:^(NSRange range, BOOL * _Nonnull stop) {
       [result addIndexesInRange:range];
@@ -49,7 +49,7 @@
 
 + (NSIndexSet *)as_indexSetFromIndexPaths:(NSArray<NSIndexPath *> *)indexPaths inSection:(NSUInteger)section
 {
-  NSMutableIndexSet *result = [NSMutableIndexSet indexSet];
+  NSMutableIndexSet *result = [[NSMutableIndexSet alloc] init];
   for (NSIndexPath *indexPath in indexPaths) {
     if (indexPath.section == section) {
       [result addIndex:indexPath.item];
@@ -89,7 +89,7 @@
 
 + (NSIndexSet *)as_sectionsFromIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
 {
-  NSMutableIndexSet *result = [NSMutableIndexSet indexSet];
+  NSMutableIndexSet *result = [[NSMutableIndexSet alloc] init];
   for (NSIndexPath *indexPath in indexPaths) {
     [result addIndex:indexPath.section];
   }

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -142,8 +142,8 @@ static void CollectUIAccessibilityElementsForNode(ASDisplayNode *node, ASDisplay
 static void CollectAccessibilityElementsForContainer(ASDisplayNode *container, _ASDisplayView *view, NSMutableArray *elements) {
   UIAccessibilityElement *accessiblityElement = [ASAccessibilityElement accessibilityElementWithContainer:view node:container containerNode:container];
 
-  NSMutableArray<ASAccessibilityElement *> *labeledNodes = [NSMutableArray array];
-  NSMutableArray<ASAccessibilityCustomAction *> *actions = [NSMutableArray array];
+  NSMutableArray<ASAccessibilityElement *> *labeledNodes = [[NSMutableArray alloc] init];
+  NSMutableArray<ASAccessibilityCustomAction *> *actions = [[NSMutableArray alloc] init];
   std::queue<ASDisplayNode *> queue;
   queue.push(container);
 
@@ -268,7 +268,7 @@ static void CollectAccessibilityElementsForView(_ASDisplayView *view, NSMutableA
     return _accessibleElements;
   }
   
-  NSMutableArray *accessibleElements = [NSMutableArray array];
+  NSMutableArray *accessibleElements = [[NSMutableArray alloc] init];
   CollectAccessibilityElementsForView(self, accessibleElements);
   SortAccessibilityElements(accessibleElements);
   _accessibleElements = accessibleElements;

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -236,10 +236,10 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
     queue.push_back({sublayout, sublayout.position});
   }
   
-  NSMutableArray *flattenedSublayouts = [NSMutableArray array];
+  NSMutableArray *flattenedSublayouts = [[NSMutableArray alloc] init];
   
   while (!queue.empty()) {
-    const Context context = queue.front();
+    const Context context = std::move(queue.front());
     queue.pop_front();
     
     ASLayout *layout = context.layout;

--- a/Source/Layout/ASStackLayoutSpec.mm
+++ b/Source/Layout/ASStackLayoutSpec.mm
@@ -160,7 +160,7 @@
     self.style.descender = stackChildren.back().style.descender;
   }
   
-  NSMutableArray *sublayouts = [NSMutableArray array];
+  auto sublayouts = [[NSMutableArray<ASLayout *> alloc] init];
   for (const auto &item : positionedLayout.items) {
     [sublayouts addObject:item.layout];
   }

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -208,7 +208,7 @@
 
   if (shouldBeginRasterizing) {
     // Collect displayBlocks for all descendants.
-    NSMutableArray *displayBlocks = [NSMutableArray array];
+    NSMutableArray *displayBlocks = [[NSMutableArray alloc] init];
     [self _recursivelyRasterizeSelfAndSublayersWithIsCancelledBlock:isCancelledBlock displayBlocks:displayBlocks];
     CHECK_CANCELLED_AND_RETURN_NIL();
     

--- a/Source/Private/ASMutableElementMap.m
+++ b/Source/Private/ASMutableElementMap.m
@@ -87,7 +87,7 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
 - (void)insertEmptySectionsOfItemsAtIndexes:(NSIndexSet *)sections
 {
   [sections enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
-    [_sectionsOfItems insertObject:[NSMutableArray array] atIndex:idx];
+    [_sectionsOfItems insertObject:[[NSMutableArray alloc] init]  atIndex:idx];
   }];
 }
 
@@ -99,7 +99,7 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
   } else {
     NSMutableDictionary *supplementariesForKind = _supplementaryElements[kind];
     if (supplementariesForKind == nil) {
-      supplementariesForKind = [NSMutableDictionary dictionary];
+      supplementariesForKind = [[NSMutableDictionary alloc] init];
       _supplementaryElements[kind] = supplementariesForKind;
     }
     supplementariesForKind[indexPath] = element;
@@ -120,7 +120,7 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
     // Note: it's tempting to update the dictionary in-place but because of the likely collision between old and new index paths,
     // subtle bugs are possible. Note that this process is rare (only on section-level updates),
     // that this work is done off-main, and that the typical supplementary element use case is just 1-per-section (header).
-    NSMutableDictionary *newSupps = [NSMutableDictionary dictionary];
+    NSMutableDictionary *newSupps = [[NSMutableDictionary alloc] init];
     [supps enumerateKeysAndObjectsUsingBlock:^(NSIndexPath * _Nonnull oldIndexPath, ASCollectionElement * _Nonnull obj, BOOL * _Nonnull stop) {
       NSInteger oldSection = oldIndexPath.section;
       NSInteger newSection = [mapping integerForKey:oldSection];

--- a/Source/Private/ASTwoDimensionalArrayUtils.m
+++ b/Source/Private/ASTwoDimensionalArrayUtils.m
@@ -71,7 +71,7 @@ void ASDeleteElementsInTwoDimensionalArrayAtIndexPaths(NSMutableArray *mutableAr
 
 NSArray<NSIndexPath *> *ASIndexPathsForTwoDimensionalArray(NSArray <NSArray *>* twoDimensionalArray)
 {
-  NSMutableArray *result = [NSMutableArray array];
+  NSMutableArray *result = [[NSMutableArray alloc] init];
   NSInteger section = 0;
   NSInteger i = 0;
   for (NSArray *subarray in twoDimensionalArray) {
@@ -87,7 +87,7 @@ NSArray<NSIndexPath *> *ASIndexPathsForTwoDimensionalArray(NSArray <NSArray *>* 
 
 NSArray *ASElementsInTwoDimensionalArray(NSArray <NSArray *>* twoDimensionalArray)
 {
-  NSMutableArray *result = [NSMutableArray array];
+  NSMutableArray *result = [[NSMutableArray alloc] init];
   NSInteger i = 0;
   for (NSArray *subarray in twoDimensionalArray) {
     ASDisplayNodeCAssert([subarray isKindOfClass:[NSArray class]], @"This function expects NSArray<NSArray *> *");

--- a/Source/Private/TextExperiment/Component/ASTextLayout.m
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.m
@@ -473,7 +473,7 @@ dispatch_semaphore_signal(_lock);
   if (!cgPath) FAIL_AND_RETURN
   
   // frame setter config
-  frameAttrs = [NSMutableDictionary dictionary];
+  frameAttrs = [[NSMutableDictionary alloc] init];
   if (container.isPathFillEvenOdd == NO) {
     frameAttrs[(id)kCTFramePathFillRuleAttributeName] = @(kCTFramePathFillWindingNumber);
   }
@@ -886,7 +886,7 @@ dispatch_semaphore_signal(_lock);
 + (NSArray *)layoutWithContainers:(NSArray *)containers text:(NSAttributedString *)text range:(NSRange)range {
   if (!containers || !text) return nil;
   if (range.location + range.length > text.length) return nil;
-  NSMutableArray *layouts = [NSMutableArray array];
+  NSMutableArray *layouts = [[NSMutableArray alloc] init];
   for (NSUInteger i = 0, max = containers.count; i < max; i++) {
     ASTextContainer *container = containers[i];
     ASTextLayout *layout = [self layoutWithContainer:container text:text range:range];
@@ -1959,7 +1959,7 @@ dispatch_semaphore_signal(_lock);
   range = [self _correctedRangeWithEdge:range];
   
   BOOL isVertical = _container.verticalForm;
-  NSMutableArray *rects = [NSMutableArray array];
+  NSMutableArray *rects = [[NSMutableArray<NSValue *> alloc] init];
   if (!range) return rects;
   
   NSUInteger startLineIndex = [self lineIndexForPosition:range.start];

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -278,7 +278,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   [self _ensureCompleted];
 
   if (_itemMappings == nil) {
-    _itemMappings = [NSMutableArray array];
+    _itemMappings = [[NSMutableArray alloc] init];
     auto insertMap = [_ASHierarchyItemChange sectionToIndexSetMapFromChanges:_originalInsertItemChanges];
     auto deleteMap = [_ASHierarchyItemChange sectionToIndexSetMapFromChanges:_originalDeleteItemChanges];
     NSInteger oldSection = 0;
@@ -302,7 +302,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   [self _ensureCompleted];
 
   if (_reverseItemMappings == nil) {
-    _reverseItemMappings = [NSMutableArray array];
+    _reverseItemMappings = [[NSMutableArray alloc] init];
     for (NSInteger newSection = 0; newSection < _newItemCounts.size(); newSection++) {
       NSInteger oldSection = [self oldSectionForNewSection:newSection];
       ASIntegerMap *table;
@@ -865,7 +865,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 //  will become: {@0 : [0, 1], @2 : [5]}
 + (NSDictionary *)sectionToIndexSetMapFromChanges:(NSArray<_ASHierarchyItemChange *> *)changes
 {
-  NSMutableDictionary *sectionToIndexSetMap = [NSMutableDictionary dictionary];
+  NSMutableDictionary *sectionToIndexSetMap = [[NSMutableDictionary alloc] init];
   for (_ASHierarchyItemChange *change in changes) {
     for (NSIndexPath *indexPath in change.indexPaths) {
       NSNumber *sectionKey = @(indexPath.section);
@@ -935,10 +935,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   [allIndexPaths sortUsingSelector:sorting];
 
   // Create new changes by grouping sorted changes by animation option
-  NSMutableArray *result = [[NSMutableArray alloc] init];
+  auto result = [[NSMutableArray<_ASHierarchyItemChange *> alloc] init];
 
   ASDataControllerAnimationOptions currentOptions = 0;
-  NSMutableArray *currentIndexPaths = [NSMutableArray array];
+  auto currentIndexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
 
   for (NSIndexPath *indexPath in allIndexPaths) {
     ASDataControllerAnimationOptions options = [animationOptions[indexPath] integerValue];

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -237,7 +237,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 - (NSIndexSet *)indexesForItemChangesOfType:(_ASHierarchyChangeType)changeType inSection:(NSUInteger)section
 {
   [self _ensureCompleted];
-  NSMutableIndexSet *result = [NSMutableIndexSet indexSet];
+  auto result = [[NSMutableIndexSet alloc] init];
   for (_ASHierarchyItemChange *change in [self itemChangesOfType:changeType]) {
     [result addIndexes:[NSIndexSet as_indexSetFromIndexPaths:change.indexPaths inSection:section]];
   }
@@ -751,7 +751,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   NSMutableArray *result = [[NSMutableArray alloc] init];
   
   __block ASDataControllerAnimationOptions currentOptions = 0;
-  NSMutableIndexSet *currentIndexes = [NSMutableIndexSet indexSet];
+  auto currentIndexes = [[NSMutableIndexSet alloc] init];
 
   BOOL reverse = type == _ASHierarchyChangeTypeDelete || type == _ASHierarchyChangeTypeOriginalDelete;
   NSEnumerationOptions options = reverse ? NSEnumerationReverse : kNilOptions;
@@ -790,7 +790,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 
 + (NSMutableIndexSet *)allIndexesInSectionChanges:(NSArray<_ASHierarchySectionChange *> *)changes
 {
-  NSMutableIndexSet *indexes = [NSMutableIndexSet indexSet];
+  auto indexes = [[NSMutableIndexSet alloc] init];
   for (_ASHierarchySectionChange *change in changes) {
     [indexes addIndexes:change.indexSet];
   }

--- a/Source/_ASTransitionContext.m
+++ b/Source/_ASTransitionContext.m
@@ -33,8 +33,8 @@ NSString * const ASTransitionContextToLayoutKey = @"org.asyncdisplaykit.ASTransi
 @implementation _ASTransitionContext
 
 - (instancetype)initWithAnimation:(BOOL)animated
-                     layoutDelegate:(id<_ASTransitionContextLayoutDelegate>)layoutDelegate
-                 completionDelegate:(id<_ASTransitionContextCompletionDelegate>)completionDelegate
+                   layoutDelegate:(id<_ASTransitionContextLayoutDelegate>)layoutDelegate
+               completionDelegate:(id<_ASTransitionContextCompletionDelegate>)completionDelegate
 {
   self = [super init];
   if (self) {
@@ -69,7 +69,7 @@ NSString * const ASTransitionContextToLayoutKey = @"org.asyncdisplaykit.ASTransi
 
 - (NSArray<ASDisplayNode *> *)subnodesForKey:(NSString *)key
 {
-  NSMutableArray<ASDisplayNode *> *subnodes = [NSMutableArray array];
+  NSMutableArray<ASDisplayNode *> *subnodes = [[NSMutableArray alloc] init];
   for (ASLayout *sublayout in [self layoutForKey:key].sublayouts) {
     [subnodes addObject:(ASDisplayNode *)sublayout.layoutElement];
   }


### PR DESCRIPTION
Unfortunately, Foundation and UIKit are not going to be compiled with ARC any time soon.

So until then, calling methods like `+[NSArray array]` under ARC will not use the fast-return path and will result in `alloc -> autorelease -> retain` to get a +1 instead of just `alloc`. Plus draining the pool takes time! Why waste it?