### PR TITLE
Remove unused/unneeded header macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add new protocol `ASLocking` that extends `NSLocking` with `tryLock`, and allows taking multiple locks safely. [Adlai Holler](https://github.com/Adlai-Holler)
 - Make the main thread ivar deallocation system available to other classes. Plus a little optimization. See `ASMainThreadDeallocation.h`. [Adlai Holler](https://github.com/Adlai-Holler) [#959](https://github.com/TextureGroup/Texture/pull/959)
 - Reduce usage of autorelease pools. [Adlai Holler](https://github.com/Adlai-Holler) [#968](https://github.com/TextureGroup/Texture/pull/968)
+- Clean up unused/unneeded header macros. [Adlai Holler](https://github.com/Adlai-Holler)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -49,38 +49,6 @@
 # endif
 #endif
 
-#ifndef ASDISPLAYNODE_HIDDEN
-# if ASDISPLAYNODE_GNUC (4,0)
-#  define ASDISPLAYNODE_HIDDEN __attribute__ ((visibility ("hidden")))
-# else
-#  define ASDISPLAYNODE_HIDDEN /* no hidden */
-# endif
-#endif
-
-#ifndef ASDISPLAYNODE_PURE
-# if ASDISPLAYNODE_GNUC (3, 0)
-#  define ASDISPLAYNODE_PURE __attribute__ ((pure))
-# else
-#  define ASDISPLAYNODE_PURE /* no pure */
-# endif
-#endif
-
-#ifndef ASDISPLAYNODE_CONST
-# if ASDISPLAYNODE_GNUC (3, 0)
-#  define ASDISPLAYNODE_CONST __attribute__ ((const))
-# else
-#  define ASDISPLAYNODE_CONST /* no const */
-# endif
-#endif
-
-#ifndef ASDISPLAYNODE_WARN_UNUSED
-# if ASDISPLAYNODE_GNUC (3, 4)
-#  define ASDISPLAYNODE_WARN_UNUSED __attribute__ ((warn_unused_result))
-# else
-#  define ASDISPLAYNODE_WARN_UNUSED /* no warn_unused */
-# endif
-#endif
-
 #ifndef ASDISPLAYNODE_WARN_DEPRECATED
 # define ASDISPLAYNODE_WARN_DEPRECATED 1
 #endif
@@ -101,12 +69,6 @@
 # endif
 #endif
 
-#if defined (__cplusplus) && defined (__GNUC__)
-# define ASDISPLAYNODE_NOTHROW __attribute__ ((nothrow))
-#else
-# define ASDISPLAYNODE_NOTHROW
-#endif
-
 #ifndef AS_ENABLE_TIPS
 #define AS_ENABLE_TIPS 0
 #endif
@@ -122,22 +84,12 @@
 # define AS_SAVE_EVENT_BACKTRACES 0
 #endif
 
-#define ARRAY_COUNT(x) sizeof(x) / sizeof(x[0])
-
 #ifndef __has_feature      // Optional.
 #define __has_feature(x) 0 // Compatibility with non-clang compilers.
 #endif
 
 #ifndef __has_attribute      // Optional.
 #define __has_attribute(x) 0 // Compatibility with non-clang compilers.
-#endif
-
-#ifndef NS_CONSUMED
-#if __has_feature(attribute_ns_consumed)
-#define NS_CONSUMED __attribute__((ns_consumed))
-#else
-#define NS_CONSUMED
-#endif
 #endif
 
 #ifndef NS_RETURNS_RETAINED
@@ -155,22 +107,6 @@
 #define CF_RETURNS_RETAINED
 #endif
 #endif
-
-#ifndef ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER
-#define ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER() \
-  do { \
-    NSAssert2(NO, @"%@ is not the designated initializer for instances of %@.", NSStringFromSelector(_cmd), NSStringFromClass([self class])); \
-    return nil; \
-  } while (0)
-#endif // ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER
-
-// It's hard to pass quoted strings via xcodebuild preprocessor define arguments, so we'll convert
-// the preprocessor values to strings here.
-//
-// It takes two steps to do this in gcc as per
-// http://gcc.gnu.org/onlinedocs/cpp/Stringification.html
-#define ASDISPLAYNODE_TO_STRING(str) #str
-#define ASDISPLAYNODE_TO_UNICODE_STRING(str) @ASDISPLAYNODE_TO_STRING(str)
 
 #ifndef ASDISPLAYNODE_REQUIRES_SUPER
 #if __has_attribute(objc_requires_super)

--- a/Source/Details/ASPhotosFrameworkImageRequest.h
+++ b/Source/Details/ASPhotosFrameworkImageRequest.h
@@ -66,6 +66,9 @@ API_AVAILABLE(ios(8.0), tvos(10.0))
  */
 @property (nonatomic, readonly) NSURL *url;
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Details/ASPhotosFrameworkImageRequest.m
+++ b/Source/Details/ASPhotosFrameworkImageRequest.m
@@ -45,13 +45,6 @@ static NSString *const _ASPhotosURLQueryKeyCropHeight = @"crop_h";
 
 @implementation ASPhotosFrameworkImageRequest
 
-- (instancetype)init
-{
-  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
-  self = [self initWithAssetIdentifier:@""];
-  return nil;
-}
-
 - (instancetype)initWithAssetIdentifier:(NSString *)assetIdentifier
 {
   self = [super init];

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -160,7 +160,7 @@ namespace ASDN {
   public:
 #if !TIME_LOCKER
 
-    Locker (T &l) ASDISPLAYNODE_NOTHROW : _l (l) {
+    Locker (T &l) noexcept : _l (l) {
       _l.lock ();
     }
 
@@ -174,7 +174,7 @@ namespace ASDN {
 
 #else
 
-    Locker (T &l, const char *name = NULL) ASDISPLAYNODE_NOTHROW : _l (l), _name(name) {
+    Locker (T &l, const char *name = NULL) noexcept : _l (l), _name(name) {
       _ti = CACurrentMediaTime();
       _l.lock ();
     }
@@ -204,7 +204,7 @@ namespace ASDN {
   public:
 #if !TIME_LOCKER
     
-    SharedLocker (std::shared_ptr<T> const& l) ASDISPLAYNODE_NOTHROW : _l (l) {
+    SharedLocker (std::shared_ptr<T> const& l) noexcept : _l (l) {
       ASDisplayNodeCAssertTrue(_l != nullptr);
       _l->lock ();
     }
@@ -219,7 +219,7 @@ namespace ASDN {
     
 #else
     
-    SharedLocker (std::shared_ptr<T> const& l, const char *name = NULL) ASDISPLAYNODE_NOTHROW : _l (l), _name(name) {
+    SharedLocker (std::shared_ptr<T> const& l, const char *name = NULL) noexcept : _l (l), _name(name) {
       _ti = CACurrentMediaTime();
       _l->lock ();
     }
@@ -241,7 +241,7 @@ namespace ASDN {
   {
     T &_l;
   public:
-    Unlocker (T &l) ASDISPLAYNODE_NOTHROW : _l (l) { _l.unlock (); }
+    Unlocker (T &l) noexcept : _l (l) { _l.unlock (); }
     ~Unlocker () {_l.lock ();}
     Unlocker(Unlocker<T>&) = delete;
     Unlocker &operator=(Unlocker<T>&) = delete;

--- a/Source/Private/_ASCoreAnimationExtras.mm
+++ b/Source/Private/_ASCoreAnimationExtras.mm
@@ -98,9 +98,9 @@ static const struct _UIContentModeStringLUTEntry UIContentModeDescriptionLUT[] =
 
 NSString *ASDisplayNodeNSStringFromUIContentMode(UIViewContentMode contentMode)
 {
-  for (int i=0; i< ARRAY_COUNT(UIContentModeDescriptionLUT); i++) {
-    if (UIContentModeDescriptionLUT[i].contentMode == contentMode) {
-      return UIContentModeDescriptionLUT[i].string;
+  for (auto &e : UIContentModeDescriptionLUT) {
+    if (e.contentMode == contentMode) {
+      return e.string;
     }
   }
   return [NSString stringWithFormat:@"%d", (int)contentMode];
@@ -108,9 +108,9 @@ NSString *ASDisplayNodeNSStringFromUIContentMode(UIViewContentMode contentMode)
 
 UIViewContentMode ASDisplayNodeUIContentModeFromNSString(NSString *string)
 {
-  for (int i=0; i < ARRAY_COUNT(UIContentModeDescriptionLUT); i++) {
-    if (ASObjectIsEqual(UIContentModeDescriptionLUT[i].string, string)) {
-      return UIContentModeDescriptionLUT[i].contentMode;
+  for (auto &e : UIContentModeDescriptionLUT) {
+    if (ASObjectIsEqual(e.string, string)) {
+      return e.contentMode;
     }
   }
   return UIViewContentModeScaleToFill;
@@ -118,9 +118,9 @@ UIViewContentMode ASDisplayNodeUIContentModeFromNSString(NSString *string)
 
 NSString *const ASDisplayNodeCAContentsGravityFromUIContentMode(UIViewContentMode contentMode)
 {
-  for (int i=0; i < ARRAY_COUNT(UIContentModeCAGravityLUT); i++) {
-    if (UIContentModeCAGravityLUT[i].contentMode == contentMode) {
-      return UIContentModeCAGravityLUT[i].string;
+  for (auto &e : UIContentModeCAGravityLUT) {
+    if (e.contentMode == contentMode) {
+      return e.string;
     }
   }
   ASDisplayNodeCAssert(contentMode == UIViewContentModeRedraw, @"Encountered an unknown contentMode %zd. Is this a new version of iOS?", contentMode);
@@ -140,9 +140,9 @@ UIViewContentMode ASDisplayNodeUIContentModeFromCAContentsGravity(NSString *cons
     return cachedModes[foundCacheIndex];
   }
   
-  for (int i = 0; i < ARRAY_COUNT(UIContentModeCAGravityLUT); i++) {
-    if (ASObjectIsEqual(UIContentModeCAGravityLUT[i].string, contentsGravity)) {
-      UIViewContentMode foundContentMode = UIContentModeCAGravityLUT[i].contentMode;
+  for (auto &e : UIContentModeCAGravityLUT) {
+    if (ASObjectIsEqual(e.string, contentsGravity)) {
+      UIViewContentMode foundContentMode = e.contentMode;
       
       if (currentCacheIndex < ContentModeCacheSize) {
         // Cache the input value.  This is almost always a different pointer than in our LUT and will frequently


### PR DESCRIPTION
- `AS_ARRAY_COUNT` is replaced by C++ array iteration.
- `hidden/pure/const` aren't used.
- `ASDISPLAYNODE_WARN_UNUSED` is unused in favor of `AS_WARN_UNUSED_RESULT`
- `ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER` is unnecessary since we can mark the initializer unavailable.
- `ASDISPLAYNODE_NOTHROW` is superseded by the `noexcept` decorator from C++14