### PR TITLE
Create an experiment to remove extra collection teardown step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Reduce usage of autorelease pools. [Adlai Holler](https://github.com/Adlai-Holler) [#968](https://github.com/TextureGroup/Texture/pull/968)
 - Clean up unused/unneeded header macros. [Adlai Holler](https://github.com/Adlai-Holler)
 - Clean up C-function `extern` decorators. [Adlai Holler](https://github.com/Adlai-Holler)
+- Add an experiment to reduce work involved in collection teardown. [Adlai Holler](https://github.com/Adlai-Holler)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -19,7 +19,8 @@
                     "exp_unfair_lock",
                     "exp_infer_layer_defaults",
                     "exp_network_image_queue",
-                    "exp_dealloc_queue_v2"
+                    "exp_dealloc_queue_v2",
+                    "exp_collection_teardown",
                 ]
     		}
 		}

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -324,8 +324,10 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   
   // Sometimes the UIKit classes can call back to their delegate even during deallocation, due to animation completion blocks etc.
   _isDeallocating = YES;
-  [self setAsyncDelegate:nil];
-  [self setAsyncDataSource:nil];
+  if (!ASActivateExperimentalFeature(ASExperimentalCollectionTeardown)) {
+    [self setAsyncDelegate:nil];
+    [self setAsyncDataSource:nil];
+  }
 
   // Data controller & range controller may own a ton of nodes, let's deallocate those off-main.
   ASPerformBackgroundDeallocation(&_dataController);

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -26,6 +26,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalLayerDefaults = 1 << 4,                     // exp_infer_layer_defaults
   ASExperimentalNetworkImageQueue = 1 << 5,                 // exp_network_image_queue
   ASExperimentalDeallocQueue = 1 << 6,                      // exp_dealloc_queue_v2
+  ASExperimentalCollectionTeardown = 1 << 7,                // exp_collection_teardown
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.m
+++ b/Source/ASExperimentalFeatures.m
@@ -20,7 +20,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_unfair_lock",
                                       @"exp_infer_layer_defaults",
                                       @"exp_network_image_queue",
-                                      @"exp_dealloc_queue_v2"]));
+                                      @"exp_dealloc_queue_v2",
+                                      @"exp_collection_teardown"]));
   
   if (flags == ASExperimentalFeatureAll) {
     return allNames;

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -24,6 +24,7 @@
 #import <AsyncDisplayKit/ASBatchFetching.h>
 #import <AsyncDisplayKit/ASCellNode+Internal.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>
+#import <AsyncDisplayKit/ASConfigurationInternal.h>
 #import <AsyncDisplayKit/ASDelegateProxy.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
@@ -371,8 +372,10 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   
   // Sometimes the UIKit classes can call back to their delegate even during deallocation.
   _isDeallocating = YES;
-  [self setAsyncDelegate:nil];
-  [self setAsyncDataSource:nil];
+  if (!ASActivateExperimentalFeature(ASExperimentalCollectionTeardown)) {
+    [self setAsyncDelegate:nil];
+    [self setAsyncDataSource:nil];
+  }
 
   // Data controller & range controller may own a ton of nodes, let's deallocate those off-main
   ASPerformBackgroundDeallocation(&_dataController);

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -930,6 +930,8 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   ASDisplayNodeAssertMainThread();
   if (_initialReloadDataHasBeenCalled) {
     [self waitUntilAllUpdatesAreProcessed];
+    auto vis = self.visibleMap;
+    auto pending = self.pendingMap;
     self.visibleMap = self.pendingMap = [[ASElementMap alloc] init];
   }
 }

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -930,8 +930,6 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   ASDisplayNodeAssertMainThread();
   if (_initialReloadDataHasBeenCalled) {
     [self waitUntilAllUpdatesAreProcessed];
-    auto vis = self.visibleMap;
-    auto pending = self.pendingMap;
     self.visibleMap = self.pendingMap = [[ASElementMap alloc] init];
   }
 }

--- a/Source/Details/ASDelegateProxy.h
+++ b/Source/Details/ASDelegateProxy.h
@@ -34,7 +34,7 @@
 
 @interface ASDelegateProxy : NSProxy
 
-- (instancetype)initWithTarget:(id <NSObject>)target interceptor:(id <ASDelegateProxyInterceptor>)interceptor;
+- (instancetype)initWithTarget:(id)target interceptor:(id <ASDelegateProxyInterceptor>)interceptor;
 
 // This method must be overridden by a subclass.
 - (BOOL)interceptsSelector:(SEL)selector;

--- a/Source/Details/ASDelegateProxy.m
+++ b/Source/Details/ASDelegateProxy.m
@@ -141,16 +141,11 @@
 
 @implementation ASDelegateProxy {
   id <ASDelegateProxyInterceptor> __weak _interceptor;
-  id <NSObject> __weak _target;
+  id __weak _target;
 }
 
-- (instancetype)initWithTarget:(id <NSObject>)target interceptor:(id <ASDelegateProxyInterceptor>)interceptor
+- (instancetype)initWithTarget:(id)target interceptor:(id <ASDelegateProxyInterceptor>)interceptor
 {
-  // -[NSProxy init] is undefined
-  if (!self) {
-    return nil;
-  }
-  
   ASDisplayNodeAssert(interceptor, @"interceptor must not be nil");
   
   _target = target ? : [NSNull null];
@@ -161,8 +156,9 @@
 
 - (BOOL)conformsToProtocol:(Protocol *)aProtocol
 {
-  if (_target) {
-    return [_target conformsToProtocol:aProtocol];
+  id target = _target;
+  if (target) {
+    return [target conformsToProtocol:aProtocol];
   } else {
     return [super conformsToProtocol:aProtocol];
   }
@@ -183,8 +179,9 @@
   if ([self interceptsSelector:aSelector]) {
     return _interceptor;
   } else {
-    if (_target) {
-      return [_target respondsToSelector:aSelector] ? _target : nil;
+    id target = _target;
+    if (target) {
+      return [target respondsToSelector:aSelector] ? target : nil;
     } else {
       // The _interceptor needs to be nilled out in this scenario. For that a strong reference needs to be created
       // to be able to nil out the _interceptor but still let it know that the proxy target has deallocated


### PR DESCRIPTION
Currently we have an issue where the background deallocation of most cell nodes is not happening, because of the following stack:

```
thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 8.1
  * frame #0: 0x000000010ac960ff PinterestDevelopment`::-[ASDisplayNode dealloc](self=0x00007fc71d959a00, _cmd="dealloc") at ASDisplayNode.mm:415
    frame #1: 0x000000010bd1c6aa PinterestDevelopment`-[PIPinCloseupGalleryCellV1 dealloc](self=0x00007fc71d959a00, _cmd="dealloc") at PIPinCloseupGalleryCell.m:189
    frame #2: 0x0000000118268a6e libobjc.A.dylib`objc_object::sidetable_release(bool) + 202
    frame #3: 0x000000010ac0b1f8 PinterestDevelopment`::-[ASCollectionElement .cxx_destruct](self=0x00006080003be300, _cmd=".cxx_destruct") at ASCollectionElement.mm:29
    frame #4: 0x0000000118252920 libobjc.A.dylib`object_cxxDestructFromClass(objc_object*, objc_class*) + 127
    frame #5: 0x000000011825e502 libobjc.A.dylib`objc_destructInstance + 124
    frame #6: 0x000000011825e539 libobjc.A.dylib`object_dispose + 22
    frame #7: 0x0000000118268a6e libobjc.A.dylib`objc_object::sidetable_release(bool) + 202
    frame #8: 0x000000011054a239 Foundation`empty + 58
    frame #9: 0x0000000110481f39 Foundation`-[NSConcreteMapTable dealloc] + 50
    frame #10: 0x0000000118268a6e libobjc.A.dylib`objc_object::sidetable_release(bool) + 202
    frame #11: 0x000000010aebbf98 PinterestDevelopment`-[ASElementMap .cxx_destruct](self=0x0000608000851310, _cmd=".cxx_destruct") at ASElementMap.m:41
    frame #12: 0x0000000118252920 libobjc.A.dylib`object_cxxDestructFromClass(objc_object*, objc_class*) + 127
    frame #13: 0x000000011825e502 libobjc.A.dylib`objc_destructInstance + 124
    frame #14: 0x000000011825e539 libobjc.A.dylib`object_dispose + 22
    frame #15: 0x0000000118268a6e libobjc.A.dylib`objc_object::sidetable_release(bool) + 202
    frame #16: 0x000000010ac611c7 PinterestDevelopment`::-[ASDataController setVisibleMap:](self=0x0000608000128fc0, _cmd="setVisibleMap:", visibleMap=0x000060400084e7f0) at ASDataController.mm:92
    frame #17: 0x000000010ac60ebe PinterestDevelopment`::-[ASDataController clearData](self=0x0000608000128fc0, _cmd="clearData") at ASDataController.mm:933
    frame #18: 0x000000010ac2f61c PinterestDevelopment`::-[ASCollectionView _asyncDelegateOrDataSourceDidChange](self=0x00007fc71c955c00, _cmd="_asyncDelegateOrDataSourceDidChange") at ASCollectionView.mm:579
    frame #19: 0x000000010ac2f3c0 PinterestDevelopment`::-[ASCollectionView setAsyncDelegate:](self=0x00007fc71c955c00, _cmd="setAsyncDelegate:", asyncDelegate=0x0000000000000000) at ASCollectionView.mm:572
    frame #20: 0x000000010ac2ac55 PinterestDevelopment`::-[ASCollectionView dealloc](self=0x00007fc71c955c00, _cmd="dealloc") at ASCollectionView.mm:327
```

This subtle issue was introduced in #797. 

Having dug through the history, the `[setAsyncDataSource:nil]` in `dealloc` was migrated from a prior `super.delegate = nil` which was there because at the time UICollectionView's delegate was `assign` and so there were crashes when the collection view would outlive the delegate, and try to call out to a dangling pointer. Since iOS 9, collection view delegate is `weak` and so this should no longer be a problem. 

I've removed these `set:nil` calls from the dealloc methods, behind a new experiment called `exp_collection_teardown`. As always, the default behavior is unaffected.

I'd like for this to work as-is, so that it becomes easier to reason about collection view teardown and it gets us back our background deallocation. If we find issues, we'll work through them.

As a small ridealong, I removed repeated access to weak variables in the delegate proxies. Should be a little faster and more reliable.