### PR TITLE
[texturegroup.org] Use valid link for Upgrade to 2.0 beta 1 page #trivial

### DIFF
--- a/docs/_docs/team.md
+++ b/docs/_docs/team.md
@@ -13,7 +13,7 @@ permalink: /docs/team.html
   </tr>
   <tr>
     <td><img src="https://d3vv6lp55qjaqc.cloudfront.net/items/2d1K0a372b1J3V2f071D/Michael-Avatar.jpg" width="100" /></td>
-    <td><p>Michael Schneider (<a href="https://github.com/maicki">@maicki</a>) is especially passionate about API design and recently led the re-architecture of the layout API for the <a href = "upgrading.html">2.0 release</a>. As our resident layout expert, Michael volunteers much of his own time to help developers on Texture's public <a href="/slack.html">slack channel</a>. Previous, Michael worked on <a href="https://itunes.apple.com/us/app/pocket-save-articles-videos/id309601447">Pocket</a> for iOS, Mac and Chrome and the <a href="https://itunes.apple.com/us/app/instapaper/id288545208">Instapaper</a> Mac app.</p></td> 
+    <td><p>Michael Schneider (<a href="https://github.com/maicki">@maicki</a>) is especially passionate about API design and recently led the re-architecture of the layout API for the <a href = "adoption-guide-2-0-beta1.html">2.0 release</a>. As our resident layout expert, Michael volunteers much of his own time to help developers on Texture's public <a href="/slack.html">slack channel</a>. Previous, Michael worked on <a href="https://itunes.apple.com/us/app/pocket-save-articles-videos/id309601447">Pocket</a> for iOS, Mac and Chrome and the <a href="https://itunes.apple.com/us/app/instapaper/id288545208">Instapaper</a> Mac app.</p></td> 
   </tr>
   <tr>
     <td><img src="https://avatars.githubusercontent.com/nguyenhuy" width="100" /></td>


### PR DESCRIPTION
Small thing, but noticed this path is dead. Switching link in Michael Schneider's bio from upgrading.html to adoption-guide-2-0-beta1.html (used in navigational links across texturegroup.org/docs)

Testing this doesn't quite work in preview as the path differs a bit from when its accessible through the normal resolver. I assume this will substitute the last path slug and the server maps `_docs` to `docs` https://github.com/TextureGroup/Texture/tree/master/docs/_docs