### PR TITLE
Add missing instance variables in ASTextNode and warnings cleanup #trivial

### DIFF
--- a/Source/ASDisplayNodeExtras.h
+++ b/Source/ASDisplayNodeExtras.h
@@ -216,6 +216,6 @@ AS_EXTERN void ASDisplayNodeDisableHierarchyNotifications(ASDisplayNode *node);
 AS_EXTERN void ASDisplayNodeEnableHierarchyNotifications(ASDisplayNode *node);
 
 // Not to be called directly.
-AS_EXTERN void _ASSetDebugNames(Class owningClass, NSString *names, ASDisplayNode *object, ...);
+AS_EXTERN void _ASSetDebugNames(Class owningClass, NSString *names, ASDisplayNode * _Nullable object, ...);
 
 NS_ASSUME_NONNULL_END

--- a/Source/ASRunLoopQueue.h
+++ b/Source/ASRunLoopQueue.h
@@ -82,8 +82,6 @@ AS_SUBCLASSING_RESTRICTED
 @property (class, readonly) ASDeallocQueue *sharedDeallocationQueue;
 + (ASDeallocQueue *)sharedDeallocationQueue NS_RETURNS_RETAINED;
 
-- (void)drain;
-
 - (void)releaseObjectInBackground:(id __strong _Nullable * _Nonnull)objectPtr;
 
 @end

--- a/Source/ASRunLoopQueue.h
+++ b/Source/ASRunLoopQueue.h
@@ -82,6 +82,8 @@ AS_SUBCLASSING_RESTRICTED
 @property (class, readonly) ASDeallocQueue *sharedDeallocationQueue;
 + (ASDeallocQueue *)sharedDeallocationQueue NS_RETURNS_RETAINED;
 
+- (void)drain;
+
 - (void)releaseObjectInBackground:(id __strong _Nullable * _Nonnull)objectPtr;
 
 @end

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -65,6 +65,11 @@ static void runLoopSourceCallback(void *info) {
   ASDisplayNodeFailAssert(@"Abstract method.");
 }
 
+- (void)drain
+{
+  ASDisplayNodeFailAssert(@"Abstract method.");
+}
+
 @end
 
 @implementation ASDeallocQueueV1 {

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -191,7 +191,12 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
 
   NSAttributedString *_attributedText;
   NSAttributedString *_truncationAttributedText;
+  NSAttributedString *_additionalTruncationMessage;
   NSAttributedString *_composedTruncationText;
+  NSArray<NSNumber *> *_pointSizeScaleFactors;
+  NSLineBreakMode _truncationMode;
+  
+  NSUInteger _maximumNumberOfLines;
 
   NSString *_highlightedLinkAttributeName;
   id _highlightedLinkAttributeValue;
@@ -1175,6 +1180,11 @@ static NSAttributedString *DefaultTruncationAttributedString()
   }
 }
 
+- (NSAttributedString *)additionalTruncationMessage
+{
+  return ASLockedSelf(_additionalTruncationMessage);
+}
+
 - (void)setTruncationMode:(NSLineBreakMode)truncationMode
 {
   if (ASLockedSelfCompareAssign(_truncationMode, truncationMode)) {
@@ -1182,16 +1192,26 @@ static NSAttributedString *DefaultTruncationAttributedString()
   }
 }
 
+- (NSLineBreakMode)truncationMode
+{
+  return ASLockedSelf(_truncationMode);
+}
+
 - (BOOL)isTruncated
 {
   return ASLockedSelf([[self _locked_renderer] isTruncated]);
 }
 
-- (void)setPointSizeScaleFactors:(NSArray *)pointSizeScaleFactors
+- (void)setPointSizeScaleFactors:(NSArray<NSNumber *> *)pointSizeScaleFactors
 {
   if (ASLockedSelfCompareAssignCopy(_pointSizeScaleFactors, pointSizeScaleFactors)) {
     [self setNeedsDisplay];
   }
+}
+
+- (NSArray<NSNumber *> *)pointSizeScaleFactors
+{
+  return ASLockedSelf(_pointSizeScaleFactors);
 }
 
 - (void)setMaximumNumberOfLines:(NSUInteger)maximumNumberOfLines
@@ -1199,6 +1219,11 @@ static NSAttributedString *DefaultTruncationAttributedString()
   if (ASLockedSelfCompareAssign(_maximumNumberOfLines, maximumNumberOfLines)) {
     [self setNeedsDisplay];
   }
+}
+
+- (NSUInteger)maximumNumberOfLines
+{
+   return ASLockedSelf(_maximumNumberOfLines);
 }
 
 - (NSUInteger)lineCount

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -950,7 +950,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   }
 }
 
-- (NSArray *)pointSizeScaleFactors
+- (NSArray<NSNumber *> *)pointSizeScaleFactors
 {
   return ASLockedSelf(_pointSizeScaleFactors);
 }


### PR DESCRIPTION
Small cleanup to get our warnings down to zero again and add getters to satisfy the atomicity of defined properties.