### PR TITLE
Add move detection and support to ASLayoutTransition

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -110,7 +110,7 @@
 		509E68641B3AEDB7009B9150 /* ASCollectionViewLayoutController.m in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E1C1B373A2C007741D0 /* ASCollectionViewLayoutController.m */; };
 		509E68651B3AEDC5009B9150 /* CoreGraphics+ASConvenience.h in Headers */ = {isa = PBXBuildFile; fileRef = 205F0E1F1B376416007741D0 /* CoreGraphics+ASConvenience.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		509E68661B3AEDD7009B9150 /* CoreGraphics+ASConvenience.m in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E201B376416007741D0 /* CoreGraphics+ASConvenience.m */; };
-		636EA1A41C7FF4EC00EE152F /* NSArray+Diffing.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */; };
+		636EA1A41C7FF4EC00EE152F /* NSArray+Diffing.mm in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DA1C5BF64600B16017 /* NSArray+Diffing.mm */; };
 		636EA1A51C7FF4EF00EE152F /* ASDefaultPlayButton.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB7B0191C5962EA00662EF4 /* ASDefaultPlayButton.m */; };
 		680346941CE4052A0009FEB4 /* ASNavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 68FC85DC1CE29AB700EDD713 /* ASNavigationController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		68355B341CB579B9001D4E68 /* ASImageNode+AnimatedImage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 68355B2E1CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm */; };
@@ -968,7 +968,7 @@
 		DB55C2601C6408D6004EDCF5 /* _ASTransitionContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = _ASTransitionContext.m; path = ../_ASTransitionContext.m; sourceTree = "<group>"; };
 		DB55C2651C641AE4004EDCF5 /* ASContextTransitioning.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASContextTransitioning.h; sourceTree = "<group>"; };
 		DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+Diffing.h"; sourceTree = "<group>"; };
-		DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Diffing.m"; sourceTree = "<group>"; };
+		DBC452DA1C5BF64600B16017 /* NSArray+Diffing.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSArray+Diffing.mm"; sourceTree = "<group>"; };
 		DBC452DD1C5C6A6A00B16017 /* ArrayDiffingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ArrayDiffingTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		DBC453211C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ASDisplayNodeImplicitHierarchyTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		DBDB83921C6E879900D0098C /* ASPagerFlowLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPagerFlowLayout.h; sourceTree = "<group>"; };
@@ -1420,7 +1420,7 @@
 				205F0E1F1B376416007741D0 /* CoreGraphics+ASConvenience.h */,
 				205F0E201B376416007741D0 /* CoreGraphics+ASConvenience.m */,
 				DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */,
-				DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */,
+				DBC452DA1C5BF64600B16017 /* NSArray+Diffing.mm */,
 				CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */,
 				CC4981BB1D1C7F65004E13CC /* NSIndexSet+ASHelpers.m */,
 				058D09F5195D050800B7D73C /* NSMutableAttributedString+TextKitAdditions.h */,
@@ -2410,7 +2410,7 @@
 				B350624E1B010EFD0018CF92 /* ASDisplayNode+AsyncDisplay.mm in Sources */,
 				E5667E8E1F33872700FA6FC0 /* _ASCollectionGalleryLayoutInfo.m in Sources */,
 				25E327591C16819500A2170C /* ASPagerNode.m in Sources */,
-				636EA1A41C7FF4EC00EE152F /* NSArray+Diffing.m in Sources */,
+				636EA1A41C7FF4EC00EE152F /* NSArray+Diffing.mm in Sources */,
 				B35062501B010EFD0018CF92 /* ASDisplayNode+DebugTiming.mm in Sources */,
 				DEC146B91C37A16A004A0EE7 /* ASCollectionInternal.m in Sources */,
 				254C6B891BF94F8A003EC431 /* ASTextKitRenderer+Positioning.mm in Sources */,

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		058D0A40195D057000B7D73C /* ASTextNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A36195D057000B7D73C /* ASTextNodeTests.m */; };
 		058D0A41195D057000B7D73C /* ASTextNodeWordKernerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A37195D057000B7D73C /* ASTextNodeWordKernerTests.mm */; };
 		05EA6FE71AC0966E00E35788 /* ASSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 05EA6FE61AC0966E00E35788 /* ASSnapshotTestCase.m */; };
+		0FAFDF7520EC1C90003A51C0 /* ASLayout+IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FAFDF7320EC1C8F003A51C0 /* ASLayout+IGListKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0FAFDF7620EC1C90003A51C0 /* ASLayout+IGListKit.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0FAFDF7420EC1C90003A51C0 /* ASLayout+IGListKit.mm */; };
 		18C2ED7F1B9B7DE800F627B3 /* ASCollectionNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 18C2ED7C1B9B7DE800F627B3 /* ASCollectionNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18C2ED831B9B7DE800F627B3 /* ASCollectionNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18C2ED7D1B9B7DE800F627B3 /* ASCollectionNode.mm */; };
 		1A6C000D1FAB4E2100D05926 /* ASCornerLayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A6C000B1FAB4E2000D05926 /* ASCornerLayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -601,6 +603,8 @@
 		058D0A44195D058D00B7D73C /* ASBaseDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBaseDefines.h; sourceTree = "<group>"; };
 		05EA6FE61AC0966E00E35788 /* ASSnapshotTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASSnapshotTestCase.m; sourceTree = "<group>"; };
 		05F20AA31A15733C00DCA68A /* ASImageProtocols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASImageProtocols.h; sourceTree = "<group>"; };
+		0FAFDF7320EC1C8F003A51C0 /* ASLayout+IGListKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASLayout+IGListKit.h"; sourceTree = "<group>"; };
+		0FAFDF7420EC1C90003A51C0 /* ASLayout+IGListKit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "ASLayout+IGListKit.mm"; sourceTree = "<group>"; };
 		18C2ED7C1B9B7DE800F627B3 /* ASCollectionNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCollectionNode.h; sourceTree = "<group>"; };
 		18C2ED7D1B9B7DE800F627B3 /* ASCollectionNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCollectionNode.mm; sourceTree = "<group>"; };
 		1950C4481A3BB5C1005C8279 /* ASEqualityHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEqualityHelpers.h; sourceTree = "<group>"; };
@@ -1635,6 +1639,8 @@
 				ACF6ED0A1B17843500DA7C62 /* ASInsetLayoutSpec.mm */,
 				ACF6ED0B1B17843500DA7C62 /* ASLayout.h */,
 				ACF6ED0C1B17843500DA7C62 /* ASLayout.mm */,
+				0FAFDF7320EC1C8F003A51C0 /* ASLayout+IGListKit.h */,
+				0FAFDF7420EC1C90003A51C0 /* ASLayout+IGListKit.mm */,
 				ACF6ED111B17843500DA7C62 /* ASLayoutElement.h */,
 				E55D86311CA8A14000A0C26F /* ASLayoutElement.mm */,
 				698C8B601CAB49FC0052DC3F /* ASLayoutElementExtensibility.h */,
@@ -1850,6 +1856,7 @@
 				69E0E8A71D356C9400627613 /* ASEqualityHelpers.h in Headers */,
 				698C8B621CAB49FC0052DC3F /* ASLayoutElementExtensibility.h in Headers */,
 				69F10C871C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h in Headers */,
+				0FAFDF7520EC1C90003A51C0 /* ASLayout+IGListKit.h in Headers */,
 				B350623C1B010EFD0018CF92 /* _ASAsyncTransaction.h in Headers */,
 				68355B411CB57A6C001D4E68 /* ASImageContainerProtocolCategories.h in Headers */,
 				7630FFA81C9E267E007A7C0E /* ASVideoNode.h in Headers */,
@@ -2368,6 +2375,7 @@
 				E5B078001E69F4EB00C24B5B /* ASElementMap.m in Sources */,
 				9C8898BC1C738BA800D6B02E /* ASTextKitFontSizeAdjuster.mm in Sources */,
 				690ED59B1E36D118000627C0 /* ASImageNode+tvOS.m in Sources */,
+				0FAFDF7620EC1C90003A51C0 /* ASLayout+IGListKit.mm in Sources */,
 				CCDC9B4E200991D10063C1F8 /* ASGraphicsContext.m in Sources */,
 				CCCCCCD81EC3EF060087FE10 /* ASTextInput.m in Sources */,
 				34EFC7621B701CA400AD841F /* ASBackgroundLayoutSpec.mm in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
+- [ASLayoutTransition] Add support for preserving order after node moves during transitions. (This order defines the z-order as well.) [Kevin Smith](https://github.com/wiseoldduck)
 - [ASDisplayNode] Adds support for multiple interface state delegates. [Garrett Moon](https://github.com/garrettmoon) [#979](https://github.com/TextureGroup/Texture/pull/979)
 - [ASDataController] Add capability to renew supplementary views (update map) when size change from zero to non-zero.[Max Wang](https://github.com/wsdwsd0829) [#842](https://github.com/TextureGroup/Texture/pull/842)
 - Make `ASPerformMainThreadDeallocation` visible in C. [Adlai Holler](https://github.com/Adlai-Holler)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
-- [ASLayoutTransition] Add support for preserving order after node moves during transitions. (This order defines the z-order as well.) [Kevin Smith](https://github.com/wiseoldduck)
+- [ASLayoutTransition] Add support for preserving order after node moves during transitions. (This order defines the z-order as well.) [Kevin Smith](https://github.com/wiseoldduck) [#1006]
 - [ASDisplayNode] Adds support for multiple interface state delegates. [Garrett Moon](https://github.com/garrettmoon) [#979](https://github.com/TextureGroup/Texture/pull/979)
 - [ASDataController] Add capability to renew supplementary views (update map) when size change from zero to non-zero.[Max Wang](https://github.com/wsdwsd0829) [#842](https://github.com/TextureGroup/Texture/pull/842)
 - Make `ASPerformMainThreadDeallocation` visible in C. [Adlai Holler](https://github.com/Adlai-Holler)

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -680,7 +680,7 @@ ASLayoutElementStyleExtensibilityForwarding
       }
       
       // Apply the subnode insertion immediately to be able to animate the nodes
-      [pendingLayoutTransition applySubnodeInsertions];
+      [pendingLayoutTransition applySubnodeInsertionsAndMoves];
       
       // Kick off animating the layout transition
       {

--- a/Source/AsyncDisplayKit.h
+++ b/Source/AsyncDisplayKit.h
@@ -137,3 +137,4 @@
 
 #import <AsyncDisplayKit/IGListAdapter+AsyncDisplayKit.h>
 #import <AsyncDisplayKit/AsyncDisplayKit+IGListKitMethods.h>
+#import <AsyncDisplayKit/ASLayout+IGListKit.h>

--- a/Source/Details/NSArray+Diffing.h
+++ b/Source/Details/NSArray+Diffing.h
@@ -17,6 +17,60 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ * These changes can be used to transform `self` to `array` by applying them in (any) order, *without shifting* the
+ * other elements.  This can be done (in an NSMutableArray) by calling `setObject:atIndexedSubscript:` (or just use
+ * [subscripting] directly) for insertions from `array` into `self` (not the seemingly more apt `insertObject:atIndex`!),
+ * and using the same method for deletions from `self` (*set* a `[NSNull null]` as opposed to `removeObject:atIndex:`).
+ * After all inserts/deletes have been applied, there will be no nulls left (except possibly at the end of the array if
+ * `[array count] < [self count]`)
+
+ * Some examples:
+ * in:   ab c
+ * out:  abdc
+ * diff: ..+.
+ *
+ * in:   abcd
+ * out:     dcba
+ * dif:  ---.+++
+ *
+ * in:   abcd
+ * out:  ab d
+ * diff: ..-.
+ *
+ * in:   a bcd
+ * out:  adbc
+ * diff: .+..-
+ *
+ * If `moves` pointer is passed in, instances where one element moves to another location are detected and reported,
+ * possibly replacing pairs of delete/insert. The process for transforming an array remains the same, however now it is
+ * important to apply the moves in order and not overwrite an element that needs to be moved somewhere else.
+ *
+ * the same examples, with moves:
+ * in:   ab c
+ * out:  abdc
+ * diff: ..+.
+ *
+ * in:   abcd
+ * out:  dcba
+ * diff: 321.
+ *
+ * in:   abcd
+ * out:  ab d
+ * diff: ..-.
+ *
+ * in:   abcd
+ * out:  adbc
+ * diff: .312
+ *
+ * Other notes:
+ *
+ * No index will be both moved from and deleted.
+ * Each index 0...[self count] will be either moved from or deleted. If it is moved to the same location, we omit it.
+ * Each index 0...[array count] will be the destination of ONE move or ONE insert.
+ * Knowing these things means any two of the three (delete, move, insert) implies the third.
+ */
+
 @interface NSArray (Diffing)
 
 /**

--- a/Source/Details/NSArray+Diffing.h
+++ b/Source/Details/NSArray+Diffing.h
@@ -35,4 +35,12 @@
  */
 - (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions compareBlock:(BOOL (^)(id lhs, id rhs))comparison;
 
+/**
+ * @abstract Compares two arrays, providing the insertion, deletion, and move indexes needed to transform into the target array.
+ * @discussion This compares the equality of each object with `isEqual:`.
+ * This diffing algorithm uses a bottom-up memoized longest common subsequence solution to identify differences.
+ * It runs in O(mn) complexity.
+ * The moves are returned in ascending order of their destination index.
+ */
+- (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions moves:(NSArray<NSIndexPath *> **)moves;
 @end

--- a/Source/Details/NSArray+Diffing.mm
+++ b/Source/Details/NSArray+Diffing.mm
@@ -53,7 +53,7 @@ typedef BOOL (^compareBlock)(id _Nonnull lhs, id _Nonnull rhs);
   {
     bool operator()(id <NSObject> lhs, id <NSObject> rhs) const { return (bool) [lhs isEqual:rhs]; };
   };
-  std::unordered_multimap<id, NSUInteger, NSObjectHash, NSObjectCompare> potentialMoves;
+  std::unordered_multimap<unowned id, NSUInteger, NSObjectHash, NSObjectCompare> potentialMoves;
 
   NSAssert(comparison != nil, @"Comparison block is required");
   NSAssert(moves == nil || comparison == [NSArray defaultCompareBlock], @"move detection requires isEqual: and hash (no custom compare)");

--- a/Source/Layout/ASLayout+IGListKit.h
+++ b/Source/Layout/ASLayout+IGListKit.h
@@ -1,9 +1,13 @@
 //
-//  ASLayout+IGListKit.h
-//  AsyncDisplayKit
+//  ASLayout+IGListKit.mm
+//  Texture
 //
-//  Created by Kevin Smith on 7/1/18.
-//  Copyright © 2018 Pinterest. All rights reserved.
+//  Copyright (c) 2018-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #if AS_IG_LIST_KIT

--- a/Source/Layout/ASLayout+IGListKit.h
+++ b/Source/Layout/ASLayout+IGListKit.h
@@ -1,0 +1,15 @@
+//
+//  ASLayout+IGListKit.h
+//  AsyncDisplayKit
+//
+//  Created by Kevin Smith on 7/1/18.
+//  Copyright © 2018 Pinterest. All rights reserved.
+//
+
+#if AS_IG_LIST_KIT
+#import <AsyncDisplayKit/ASLayout.h>
+#import <IGListKit/IGListKit.h>
+@interface ASLayout(IGListKit) <IGListDiffable>
+@end
+
+#endif // AS_IG_LIST_KIT

--- a/Source/Layout/ASLayout+IGListKit.mm
+++ b/Source/Layout/ASLayout+IGListKit.mm
@@ -23,17 +23,12 @@
 
 - (id <NSObject>)diffIdentifier
 {
-  return [NSValue valueWithPointer: (__bridge void*) self->_layoutElement];
+  return self->_layoutElement;
 }
 
 - (BOOL)isEqualToDiffableObject:(id <IGListDiffable>)other
 {
-  if (other == self) return YES;
-
-  ASLayout *otherLayout = ASDynamicCast(other, ASLayout);
-  if (!otherLayout) return NO;
-
-  return (otherLayout->_layoutElement == self->_layoutElement);
+  return [self isEqual:other];
 }
 @end
 #endif // AS_IG_LIST_KIT

--- a/Source/Layout/ASLayout+IGListKit.mm
+++ b/Source/Layout/ASLayout+IGListKit.mm
@@ -1,9 +1,13 @@
 //
 //  ASLayout+IGListKit.mm
-//  AsyncDisplayKit
+//  Texture
 //
-//  Created by Kevin Smith on 7/1/18.
-//  Copyright © 2018 Pinterest. All rights reserved.
+//  Copyright (c) 2018-present, Pinterest, Inc.  All rights reserved.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 #import <AsyncDisplayKit/ASAvailability.h>
 #if AS_IG_LIST_KIT

--- a/Source/Layout/ASLayout+IGListKit.mm
+++ b/Source/Layout/ASLayout+IGListKit.mm
@@ -1,0 +1,31 @@
+//
+//  ASLayout+IGListKit.mm
+//  AsyncDisplayKit
+//
+//  Created by Kevin Smith on 7/1/18.
+//  Copyright © 2018 Pinterest. All rights reserved.
+//
+#import <AsyncDisplayKit/ASAvailability.h>
+#if AS_IG_LIST_KIT
+#import "ASLayout+IGListKit.h"
+#import <AsyncDisplayKit/ASLayout.h>
+#import <IGListKit/IGListKit.h>
+#import <AsyncDisplayKit/ASEqualityHelpers.h>
+
+@implementation ASLayout(IGListKit)
+- (nonnull id <NSObject>)diffIdentifier
+{
+  return @([self.layoutElement hash]);
+}
+
+- (BOOL)isEqualToDiffableObject:(nullable id <IGListDiffable>)other
+{
+  if (other == self) return YES;
+
+  ASLayout *otherLayout = ASDynamicCast(other, ASLayout);
+  if (!otherLayout) return NO;
+
+  return [otherLayout.layoutElement isEqual:self.layoutElement];
+}
+@end
+#endif // AS_IG_LIST_KIT

--- a/Source/Layout/ASLayout+IGListKit.mm
+++ b/Source/Layout/ASLayout+IGListKit.mm
@@ -12,24 +12,28 @@
 #import <AsyncDisplayKit/ASAvailability.h>
 #if AS_IG_LIST_KIT
 #import "ASLayout+IGListKit.h"
-#import <AsyncDisplayKit/ASLayout.h>
-#import <IGListKit/IGListKit.h>
-#import <AsyncDisplayKit/ASEqualityHelpers.h>
+
+@interface ASLayout() {
+@public
+  id<ASLayoutElement> _layoutElement;
+}
+@end
 
 @implementation ASLayout(IGListKit)
-- (nonnull id <NSObject>)diffIdentifier
+
+- (id <NSObject>)diffIdentifier
 {
-  return @([self.layoutElement hash]);
+  return [NSValue valueWithPointer: (__bridge void*) self->_layoutElement];
 }
 
-- (BOOL)isEqualToDiffableObject:(nullable id <IGListDiffable>)other
+- (BOOL)isEqualToDiffableObject:(id <IGListDiffable>)other
 {
   if (other == self) return YES;
 
   ASLayout *otherLayout = ASDynamicCast(other, ASLayout);
   if (!otherLayout) return NO;
 
-  return [otherLayout.layoutElement isEqual:self.layoutElement];
+  return (otherLayout->_layoutElement == self->_layoutElement);
 }
 @end
 #endif // AS_IG_LIST_KIT

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -283,6 +283,8 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
 
 - (BOOL)isEqual:(id)object
 {
+  if (self == object) return YES;
+
   ASLayout *layout = ASDynamicCast(object, ASLayout);
   if (layout == nil) {
     return NO;

--- a/Source/Private/ASLayoutTransition.h
+++ b/Source/Private/ASLayoutTransition.h
@@ -85,9 +85,10 @@ AS_SUBCLASSING_RESTRICTED
 - (void)commitTransition;
 
 /**
- * Insert all new subnodes that were added between the previous layout and the pending layout
+ * Insert all new subnodes that were added and move the subnodes that moved between the previous layout and
+ * the pending layout.
  */
-- (void)applySubnodeInsertions;
+- (void)applySubnodeInsertionsAndMoves;
 
 /**
  * Remove all subnodes that are removed between the previous layout and the pending layout

--- a/Source/Private/ASLayoutTransition.mm
+++ b/Source/Private/ASLayoutTransition.mm
@@ -20,7 +20,9 @@
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
 #import <AsyncDisplayKit/NSArray+Diffing.h>
 
+#import <AsyncDisplayKit/ASLayout.h>
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h> // Required for _insertSubnode... / _removeFromSupernode.
+#import <AsyncDisplayKit/ASLog.h>
 
 #import <queue>
 

--- a/Source/Private/ASLayoutTransition.mm
+++ b/Source/Private/ASLayoutTransition.mm
@@ -33,7 +33,7 @@
 
 #if AS_IG_LIST_KIT
 #import <IGListKit/IGListKit.h>
-#import <ASyncDisplayKit/ASLayout+IGListKit.h>
+#import <AsyncDisplayKit/ASLayout+IGListKit.h>
 #endif
 
 /**

--- a/Source/Private/ASLayoutTransition.mm
+++ b/Source/Private/ASLayoutTransition.mm
@@ -20,16 +20,9 @@
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
 #import <AsyncDisplayKit/NSArray+Diffing.h>
 
-#import <AsyncDisplayKit/ASLayout.h>
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h> // Required for _insertSubnode... / _removeFromSupernode.
-#import <AsyncDisplayKit/ASLog.h>
 
 #import <queue>
-#import <memory>
-#import <algorithm>
-
-#import <AsyncDisplayKit/ASThread.h>
-#import <AsyncDisplayKit/ASEqualityHelpers.h>
 
 #if AS_IG_LIST_KIT
 #import <IGListKit/IGListKit.h>
@@ -186,8 +179,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
     _insertedSubnodePositions = findNodesInLayoutAtIndexes(pendingLayout, result.inserts, &_insertedSubnodes);
     _removedSubnodePositions = findNodesInLayoutAtIndexes(previousLayout, result.deletes, &_removedSubnodes);
     for (IGListMoveIndex *move in result.moves) {
-      unowned ASDisplayNode *subnode = previousLayout.sublayouts[move.from].layoutElement;
-      _subnodeMoves.push_back(std::pair<ASDisplayNode *, NSUInteger>(subnode, move.to));
+      _subnodeMoves.push_back(std::make_pair(previousLayout.sublayouts[move.from].layoutElement, move.to));
     }
 
     // Sort by ascending order of move destinations, this will allow easy loop of `insertSubnode:AtIndex` later.
@@ -210,8 +202,8 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
                                                                            &_removedSubnodes);
     // These should arrive sorted in ascending order of move destinations.
     for (NSIndexPath *move in moves) {
-      unowned ASDisplayNode *subnode = previousLayout.sublayouts[([move indexAtPosition:0])].layoutElement;
-      _subnodeMoves.push_back(std::pair<id, NSUInteger>(subnode, [move indexAtPosition:1]));
+      _subnodeMoves.push_back(std::make_pair(previousLayout.sublayouts[([move indexAtPosition:0])].layoutElement,
+              [move indexAtPosition:1]));
     }
 #endif
   } else {

--- a/Tests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/Tests/ASDisplayNodeImplicitHierarchyTests.m
@@ -150,7 +150,11 @@
   ASDisplayNode *node1 = [[ASDisplayNode alloc] init];
   ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
   ASDisplayNode *node3 = [[ASDisplayNode alloc] init];
-  
+
+  node1.debugName = @"a";
+  node2.debugName = @"b";
+  node3.debugName = @"c";
+
   // As we will involve a stack spec we have to give the nodes an intrinsic content size
   node1.style.preferredSize = kSize;
   node2.style.preferredSize = kSize;

--- a/Tests/ArrayDiffingTests.m
+++ b/Tests/ArrayDiffingTests.m
@@ -127,7 +127,8 @@
         @[@0, @1, @2],
       ],
   ];
-  
+
+  long n = 0;
   for (NSArray *test in tests) {
     NSIndexSet *insertions, *deletions;
     [test[0] asdk_diffWithArray:test[1] insertions:&insertions deletions:&deletions];
@@ -135,17 +136,186 @@
     NSMutableIndexSet *mutableDeletions = [deletions mutableCopy];
 
     for (NSNumber *index in (NSArray *)test[2]) {
-      XCTAssert([mutableInsertions containsIndex:[index integerValue]]);
+      XCTAssert([mutableInsertions containsIndex:[index integerValue]], @"Test #%ld: insertions %@ does not contain %@",
+      n, insertions, index);
       [mutableInsertions removeIndex:[index integerValue]];
     }
     for (NSNumber *index in (NSArray *)test[3]) {
-      XCTAssert([mutableDeletions containsIndex:[index integerValue]]);
+      XCTAssert([mutableDeletions containsIndex:[index integerValue]], @"Test #%ld: deletions %@ does not contain %@",
+      n, deletions, index
+      );
       [mutableDeletions removeIndex:[index integerValue]];
     }
 
-    XCTAssert([mutableInsertions count] == 0, @"Unaccounted insertions: %@", mutableInsertions);
-    XCTAssert([mutableDeletions count] == 0, @"Unaccounted deletions: %@", mutableDeletions);
+    XCTAssert([mutableInsertions count] == 0, @"Test #%ld: Unaccounted insertions: %@", n, mutableInsertions);
+    XCTAssert([mutableDeletions count] == 0, @"Test #%ld: Unaccounted deletions: %@", n, mutableDeletions);
+    n++;
   }
 }
 
+- (void)testDiffingInsertsDeletesAndMoves
+{
+  NSArray<NSArray *> *tests = @[
+          @[
+                  @[@"a", @"b"],
+                  @[@"b", @"a"],
+                  @[],
+                  @[],
+                  @[[NSIndexPath indexPathWithIndexes:(NSUInteger[]) {1, 0} length:2],
+                          [NSIndexPath indexPathWithIndexes:(NSUInteger[]) {0, 1} length:2]
+                  ]],
+          @[
+                  @[@"bob", @"alice", @"dave"],
+                  @[@"bob", @"alice", @"dave", @"gary"],
+                  @[@3],
+                  @[],
+                  @[]],
+          @[
+                  @[@"a", @"b", @"c", @"d"],
+                  @[@"d", @"c", @"b", @"a"],
+                  @[],
+                  @[],
+                  @[[NSIndexPath indexPathWithIndexes:(NSUInteger[]){3, 0} length:2],
+                          [NSIndexPath indexPathWithIndexes:(NSUInteger[]){2, 1} length:2],
+                          [NSIndexPath indexPathWithIndexes:(NSUInteger[]){1, 2} length:2],
+                          [NSIndexPath indexPathWithIndexes:(NSUInteger[]){0, 3} length:2]
+                  ]],
+          @[
+                  @[@"bob", @"alice", @"dave"],
+                  @[@"bob", @"gary", @"dave", @"alice"],
+                  @[@1],
+                  @[],
+                  @[[NSIndexPath indexPathWithIndexes:(NSUInteger[]) {1, 3} length:2]
+                  ]],
+          @[
+                  @[@"bob", @"alice", @"dave"],
+                  @[@"bob", @"alice"],
+                  @[],
+                  @[@2],
+                  @[]],
+          @[
+                  @[@"bob", @"alice", @"dave"],
+                  @[],
+                  @[],
+                  @[@0, @1, @2],
+                  @[]],
+          @[
+                  @[@"bob", @"alice", @"dave"],
+                  @[@"gary", @"alice", @"dave", @"jack"],
+                  @[@0, @3],
+                  @[@0],
+                  @[]],
+          @[
+                  @[@"bob", @"alice", @"dave", @"judy", @"lynda", @"tony"],
+                  @[@"gary", @"bob", @"suzy", @"tony"],
+                  @[@0, @2],
+                  @[@1, @2, @3, @4],
+                  @[[NSIndexPath indexPathWithIndexes:(NSUInteger[]){0, 1} length:2],
+                          [NSIndexPath indexPathWithIndexes:(NSUInteger[]){5, 3} length:2]
+                  ]],
+          @[
+                  @[@"bob", @"alice", @"dave", @"judy"],
+                  @[@"judy", @"dave", @"alice", @"bob"],
+                  @[],
+                  @[],
+                  @[[NSIndexPath indexPathWithIndexes:(NSUInteger[]){3, 0} length:2],
+                          [NSIndexPath indexPathWithIndexes:(NSUInteger[]){2, 1} length:2],
+                          [NSIndexPath indexPathWithIndexes:(NSUInteger[]){1, 2} length:2],
+                          [NSIndexPath indexPathWithIndexes:(NSUInteger[]){0, 3} length:2]
+                  ]]
+
+  ];
+
+  long n = 0;
+  for (NSArray *test in tests) {
+    NSIndexSet *insertions, *deletions;
+    NSArray<NSIndexPath *> *moves;
+    [test[0] asdk_diffWithArray:test[1] insertions:&insertions deletions:&deletions moves:&moves];
+    NSMutableIndexSet *mutableInsertions = [insertions mutableCopy];
+    NSMutableIndexSet *mutableDeletions = [deletions mutableCopy];
+
+    for (NSNumber *index in (NSArray *) test[2]) {
+      XCTAssert([mutableInsertions containsIndex:[index integerValue]], @"Test #%ld, insertions does not contain %ld",
+              n, (long)[index integerValue]);
+      [mutableInsertions removeIndex:(NSUInteger) [index integerValue]];
+    }
+    for (NSNumber *index in (NSArray *) test[3]) {
+      XCTAssert([mutableDeletions containsIndex:[index integerValue]], @"Test #%ld, deletions does not contain %ld",
+              n, (long)[index integerValue]);
+      [mutableDeletions removeIndex:(NSUInteger) [index integerValue]];
+    }
+
+    XCTAssert([mutableInsertions count] == 0, @"Test #%ld, Unaccounted insertions: %@", n, mutableInsertions);
+    XCTAssert([mutableDeletions count] == 0, @"Test #%ld, Unaccounted deletions: %@", n, mutableDeletions);
+
+    XCTAssert([moves isEqual:test[4]], @"Test #%ld, %@ !isEqual: %@", n, moves, test[4]);
+    n++;
+  }
+}
+
+- (void)testArrayDiffingRebuildingWithRandomElements
+{
+  NSArray<NSNumber *> *original = @[];
+  NSArray<NSNumber *> *pending = @[];
+
+  NSIndexSet *insertions = nil;
+  NSIndexSet *deletions = nil;
+  NSArray<NSIndexPath *> *moves;
+
+  for (int testNumber = 0; testNumber <= 25; testNumber++) {
+    int len = arc4random_uniform(10);
+    for (int j = 0; j < len; j++) {
+      original = [original arrayByAddingObject:@(arc4random_uniform(25))];
+    }
+    len = arc4random_uniform(10);
+    for (int j = 0; j < len; j++) {
+      pending = [pending arrayByAddingObject:@(arc4random_uniform(25))];
+    }
+    // Some sequences that presented issues in the past:
+    if (testNumber == 0) {
+      original = [@[@20, @11, @14, @2, @14, @5, @4, @18, @0] mutableCopy];
+      pending = @[@9, @18, @18, @19, @20, @18, @22, @10, @3];
+    }
+    if (testNumber == 1) {
+      original = [@[@5, @9, @21, @11, @5, @9, @8] mutableCopy];
+      pending = @[@2, @12, @17, @19, @9, @1, @8, @5, @21];
+    }
+    if (testNumber == 2) {
+      original = [@[@14, @14, @12, @8, @20, @4, @0, @10] mutableCopy];
+      pending = @[@14];
+    }
+
+    [original asdk_diffWithArray:pending insertions:&insertions deletions:&deletions moves:&moves];
+
+    NSMutableArray *deletionsList = [NSMutableArray new];
+    [deletions enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
+      [deletionsList addObject:@(idx)];
+    }];
+    NSMutableArray *insertionsList = [NSMutableArray new];
+    [insertions enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
+      [insertionsList addObject:@(idx)];
+    }];
+    NSMutableArray *movesList = [moves mutableCopy];
+
+    NSUInteger i = 0;
+    NSUInteger j = 0;
+    NSMutableArray<NSNumber *> *test = [NSMutableArray new];
+    for (NSUInteger count = 0; count < [pending count]; count++) {
+      if (i < [insertionsList count] && [insertionsList[i] unsignedIntegerValue] == count) {
+        [test addObject:pending[[insertionsList[i] unsignedIntegerValue]]];
+        i++;
+      } else if (j < [movesList count] && [movesList[j] indexAtPosition:1] == count) {
+        [test addObject:original[[movesList[j] indexAtPosition:0]]];
+        j++;
+      } else {
+        [test addObject:original[count]];
+      }
+    }
+
+    XCTAssert([test isEqualToArray:pending], @"Did not mutate to expected new array: %@, insertions: %@, moves: %@, deletions: %@",
+            [test componentsJoinedByString:@","], insertionsList, movesList, deletionsList);
+    original = @[];
+    pending = @[];
+  }
+}
 @end

--- a/Tests/ArrayDiffingTests.m
+++ b/Tests/ArrayDiffingTests.m
@@ -273,15 +273,15 @@
     }
     // Some sequences that presented issues in the past:
     if (testNumber == 0) {
-      original = [@[@20, @11, @14, @2, @14, @5, @4, @18, @0] mutableCopy];
+      original = @[@20, @11, @14, @2, @14, @5, @4, @18, @0];
       pending = @[@9, @18, @18, @19, @20, @18, @22, @10, @3];
     }
     if (testNumber == 1) {
-      original = [@[@5, @9, @21, @11, @5, @9, @8] mutableCopy];
+      original = @[@5, @9, @21, @11, @5, @9, @8];
       pending = @[@2, @12, @17, @19, @9, @1, @8, @5, @21];
     }
     if (testNumber == 2) {
-      original = [@[@14, @14, @12, @8, @20, @4, @0, @10] mutableCopy];
+      original = @[@14, @14, @12, @8, @20, @4, @0, @10];
       pending = @[@14];
     }
 
@@ -295,7 +295,6 @@
     [insertions enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
       [insertionsList addObject:@(idx)];
     }];
-    NSMutableArray *movesList = [moves mutableCopy];
 
     NSUInteger i = 0;
     NSUInteger j = 0;
@@ -304,16 +303,17 @@
       if (i < [insertionsList count] && [insertionsList[i] unsignedIntegerValue] == count) {
         [test addObject:pending[[insertionsList[i] unsignedIntegerValue]]];
         i++;
-      } else if (j < [movesList count] && [movesList[j] indexAtPosition:1] == count) {
-        [test addObject:original[[movesList[j] indexAtPosition:0]]];
+      } else if (j < [moves count] && [moves[j] indexAtPosition:1] == count) {
+        [test addObject:original[[moves[j] indexAtPosition:0]]];
         j++;
       } else {
         [test addObject:original[count]];
       }
     }
 
-    XCTAssert([test isEqualToArray:pending], @"Did not mutate to expected new array: %@, insertions: %@, moves: %@, deletions: %@",
-            [test componentsJoinedByString:@","], insertionsList, movesList, deletionsList);
+    XCTAssert([test isEqualToArray:pending], @"Did not mutate to expected new array:\n [%@] -> [%@], actual: [%@]\ninsertions: %@\nmoves: %@\ndeletions: %@",
+            [original componentsJoinedByString:@","], [pending componentsJoinedByString:@","], [test componentsJoinedByString:@","],
+            insertions, moves, deletions);
     original = @[];
     pending = @[];
   }


### PR DESCRIPTION
...and NSArray+Diffing.
Add some tests.

See https://github.com/TextureGroup/Texture/pull/816 for more details on the existing shortcomings. This PR should allow z-order to be correct after nodes move during a transition.