### PR TITLE
Properly consider node for responder methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Optimize layout flattening, particularly reducing retain/release operations. [Adlai Holler](https://github.com/Adlai-Holler)
 - Create a method to transfer strong C-arrays into immutable NSArrays, reducing retain/release traffic. [Adlai Holler](https://github.com/Adlai-Holler)
 - Remove yoga layout spec, which has been superseded by tighter Yoga integration (`ASDisplayNode+Yoga.h`)
+- Properly consider node for responder methods [Michael Schneider](https://github.com/maicki) 
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -154,6 +154,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   ASDisplayNodeCAssertNotNil(c, @"class is required");
   
   ASDisplayNodeMethodOverrides overrides = ASDisplayNodeMethodOverrideNone;
+  
+  // Handling touches
   if (ASDisplayNodeSubclassOverridesSelector(c, @selector(touchesBegan:withEvent:))) {
     overrides |= ASDisplayNodeMethodOverrideTouchesBegan;
   }
@@ -166,13 +168,32 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   if (ASDisplayNodeSubclassOverridesSelector(c, @selector(touchesEnded:withEvent:))) {
     overrides |= ASDisplayNodeMethodOverrideTouchesEnded;
   }
+  
+  // Responder chain
+  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(canBecomeFirstResponder))) {
+    overrides |= ASDisplayNodeMethodOverrideCanBecomeFirstResponder;
+  }
+  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(becomeFirstResponder))) {
+    overrides |= ASDisplayNodeMethodOverrideBecomeFirstResponder;
+  }
+  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(canResignFirstResponder))) {
+    overrides |= ASDisplayNodeMethodOverrideCanResignFirstResponder;
+  }
+  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(resignFirstResponder))) {
+    overrides |= ASDisplayNodeMethodOverrideResignFirstResponder;
+  }
+  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(isFirstResponder))) {
+    overrides |= ASDisplayNodeMethodOverrideIsFirstResponder;
+  }
+  
+  // Layout related methods
   if (ASDisplayNodeSubclassOverridesSelector(c, @selector(layoutSpecThatFits:))) {
     overrides |= ASDisplayNodeMethodOverrideLayoutSpecThatFits;
   }
   if (ASDisplayNodeSubclassOverridesSelector(c, @selector(calculateLayoutThatFits:)) ||
       ASDisplayNodeSubclassOverridesSelector(c, @selector(calculateLayoutThatFits:
-                                                                 restrictedToSize:
-                                                             relativeToParentSize:))) {
+                                                          restrictedToSize:
+                                                          relativeToParentSize:))) {
     overrides |= ASDisplayNodeMethodOverrideCalcLayoutThatFits;
   }
   if (ASDisplayNodeSubclassOverridesSelector(c, @selector(calculateSizeThatFits:))) {

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -44,14 +44,19 @@ _ASPendingState * ASDisplayNodeGetPendingState(ASDisplayNode * node);
 
 typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
 {
-  ASDisplayNodeMethodOverrideNone               = 0,
-  ASDisplayNodeMethodOverrideTouchesBegan       = 1 << 0,
-  ASDisplayNodeMethodOverrideTouchesCancelled   = 1 << 1,
-  ASDisplayNodeMethodOverrideTouchesEnded       = 1 << 2,
-  ASDisplayNodeMethodOverrideTouchesMoved       = 1 << 3,
-  ASDisplayNodeMethodOverrideLayoutSpecThatFits = 1 << 4,
-  ASDisplayNodeMethodOverrideCalcLayoutThatFits = 1 << 5,
-  ASDisplayNodeMethodOverrideCalcSizeThatFits   = 1 << 6,
+  ASDisplayNodeMethodOverrideNone                   = 0,
+  ASDisplayNodeMethodOverrideTouchesBegan           = 1 << 0,
+  ASDisplayNodeMethodOverrideTouchesCancelled       = 1 << 1,
+  ASDisplayNodeMethodOverrideTouchesEnded           = 1 << 2,
+  ASDisplayNodeMethodOverrideTouchesMoved           = 1 << 3,
+  ASDisplayNodeMethodOverrideLayoutSpecThatFits     = 1 << 4,
+  ASDisplayNodeMethodOverrideCalcLayoutThatFits     = 1 << 5,
+  ASDisplayNodeMethodOverrideCalcSizeThatFits       = 1 << 6,
+  ASDisplayNodeMethodOverrideCanBecomeFirstResponder= 1 << 7,
+  ASDisplayNodeMethodOverrideBecomeFirstResponder   = 1 << 8,
+  ASDisplayNodeMethodOverrideCanResignFirstResponder= 1 << 9,
+  ASDisplayNodeMethodOverrideResignFirstResponder   = 1 << 10,
+  ASDisplayNodeMethodOverrideIsFirstResponder       = 1 << 11,
 };
 
 typedef NS_OPTIONS(uint_least32_t, ASDisplayNodeAtomicFlags)

--- a/Tests/ASDisplayNodeTests.mm
+++ b/Tests/ASDisplayNodeTests.mm
@@ -263,6 +263,14 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 
 @end
 
+@interface ASTestResponderNodeWithOverride : ASDisplayNode
+@end
+@implementation ASTestResponderNodeWithOverride
+- (BOOL)canBecomeFirstResponder {
+  return YES;
+}
+@end
+
 @interface ASTestViewController: ASViewController<ASDisplayNode *>
 @end
 @implementation ASTestViewController
@@ -351,6 +359,21 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   // If the textNode resigns it's first responder the view should not be the first responder
   XCTAssertTrue([window firstResponder] == nil);
   XCTAssertFalse([textNode.view isFirstResponder]);
+}
+
+- (void)testResponderOverrrideCanBecomeFirstResponder
+{
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  ASTestResponderNodeWithOverride *node = [[ASTestResponderNodeWithOverride alloc] init];
+  
+  // We have to add the text node to a window otherwise the responder methods responses are undefined
+  // This will also create the backing view of the node
+  [window addSubnode:node];
+  [window makeKeyAndVisible];
+  
+  XCTAssertTrue([node canBecomeFirstResponder]);
+  XCTAssertTrue([node becomeFirstResponder]);
+  XCTAssertTrue([window firstResponder] == node.view);
 }
 
 - (void)testUnsupportedResponderSetupWillThrow


### PR DESCRIPTION
In certain cases we don't properly consider the overwritten responder methods from the `ASDisplayNode`. This PR should fix this situation and is adding a test to prevent this in the future.

Fixes #957