### PR TITLE
Introduce let / var macros and some further cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - Add an experimental deallocation queue implementation that's more efficient. [Adlai Holler](https://github.com/Adlai-Holler)
 - Standardize property declaration style. [Adlai Holler](https://github.com/Adlai-Holler)
 - [ASTableView] Fix an issue that causes table view to use one of a cell's invalid layouts instead of generating a new one. [Huy Nguyen](https://github.com/nguyenhuy) [#942](https://github.com/TextureGroup/Texture/pull/942)
+- Introduce let / var macros and some further cleanup. [Michael Schneider](https://github.com/maicki) [#1012](https://github.com/TextureGroup/Texture/pull/1012)
 
 ## 2.6
 - [Xcode 9] Updated to require Xcode 9 (to fix warnings) [Garrett Moon](https://github.com/garrettmoon)

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -1545,7 +1545,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
   // If the data source implements canMoveItem, let them decide.
   if (_asyncDataSourceFlags.collectionNodeCanMoveItem) {
-    if (auto cellNode = [self nodeForItemAtIndexPath:indexPath]) {
+    if (let cellNode = [self nodeForItemAtIndexPath:indexPath]) {
       GET_COLLECTIONNODE_OR_RETURN(collectionNode, NO);
       return [_asyncDataSource collectionNode:collectionNode canMoveItemWithNode:cellNode];
     }
@@ -1561,7 +1561,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   
   // Inform the data source first, in case they call nodeForItemAtIndexPath:.
   // We want to make sure we return them the node for the item they have in mind.
-  if (auto collectionNode = self.collectionNode) {
+  if (let collectionNode = self.collectionNode) {
     [_asyncDataSource collectionNode:collectionNode moveItemAtIndexPath:sourceIndexPath toIndexPath:destinationIndexPath];
   }
   
@@ -1996,7 +1996,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 - (NSArray<NSString *> *)dataController:(ASDataController *)dataController supplementaryNodeKindsInSections:(NSIndexSet *)sections
 {
   if (_asyncDataSourceFlags.collectionNodeSupplementaryElementKindsInSection) {
-    auto kinds = [[NSMutableSet<NSString *> alloc] init];
+    let kinds = [[NSMutableSet<NSString *> alloc] init];
     GET_COLLECTIONNODE_OR_RETURN(collectionNode, @[]);
     [sections enumerateIndexesUsingBlock:^(NSUInteger section, BOOL * _Nonnull stop) {
       NSArray<NSString *> *kindsForSection = [_asyncDataSource collectionNode:collectionNode supplementaryElementKindsInSection:section];
@@ -2214,7 +2214,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     return;
   }
 
-  auto uikitIndexPaths = ASArrayByFlatMapping(nodes, ASCellNode *node, [self indexPathForNode:node]);
+  let uikitIndexPaths = ASArrayByFlatMapping(nodes, ASCellNode *node, [self indexPathForNode:node]);
   
   [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:uikitIndexPaths batched:NO];
   

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -646,8 +646,8 @@ ASLayoutElementStyleExtensibilityForwarding
         ASDN::MutexLocker l(__instanceLock__);
         
         // Update calculated layout
-        auto previousLayout = _calculatedDisplayNodeLayout;
-        auto pendingLayout = std::make_shared<ASDisplayNodeLayout>(newLayout,
+        let previousLayout = _calculatedDisplayNodeLayout;
+        let pendingLayout = std::make_shared<ASDisplayNodeLayout>(newLayout,
                                                                    constrainedSize,
                                                                    constrainedSize.max,
                                                                    newLayoutVersion);
@@ -767,10 +767,10 @@ ASLayoutElementStyleExtensibilityForwarding
   
   NSArray<ASDisplayNode *> *removedSubnodes = [context removedSubnodes];
   NSMutableArray<ASDisplayNode *> *insertedSubnodes = [[context insertedSubnodes] mutableCopy];
-  auto movedSubnodes = [[NSMutableArray<ASDisplayNode *> alloc] init];
+  let movedSubnodes = [[NSMutableArray<ASDisplayNode *> alloc] init];
   
-  auto insertedSubnodeContexts = [[NSMutableArray<_ASAnimatedTransitionContext *> alloc] init];
-  auto removedSubnodeContexts = [[NSMutableArray<_ASAnimatedTransitionContext *> alloc] init];
+  let insertedSubnodeContexts = [[NSMutableArray<_ASAnimatedTransitionContext *> alloc] init];
+  let removedSubnodeContexts = [[NSMutableArray<_ASAnimatedTransitionContext *> alloc] init];
   
   for (ASDisplayNode *subnode in [context subnodesForKey:ASTransitionContextToLayoutKey]) {
     if ([insertedSubnodes containsObject:subnode] == NO) {
@@ -905,9 +905,9 @@ ASLayoutElementStyleExtensibilityForwarding
   NSArray *subnodes = [self subnodes];
   NSArray *sublayouts = _calculatedDisplayNodeLayout->layout.sublayouts;
 
-  auto currentSubnodes = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality
+  let currentSubnodes = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality
                                                      capacity:subnodes.count];
-  auto layoutSubnodes  = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality
+  let layoutSubnodes  = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality
                                                      capacity:sublayouts.count];;
   for (ASDisplayNode *subnode in subnodes) {
     [currentSubnodes addObject:subnode];

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3674,7 +3674,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (NSString *)debugDescription
 {
   ASPushMainThreadAssertionsDisabled();
-  auto result = ASObjectDescriptionMake(self, [self propertiesForDebugDescription]);
+  let result = ASObjectDescriptionMake(self, [self propertiesForDebugDescription]);
   ASPopMainThreadAssertionsDisabled();
   return result;
 }
@@ -3746,7 +3746,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 {
   ASPushMainThreadAssertionsDisabled();
   ASDN::MutexLocker l(__instanceLock__);
-  auto props = [NSMutableArray<NSDictionary *> array];
+  let props = [[NSMutableArray<NSDictionary *> alloc] init];
 
   [props addObject:@{ @"layoutVersion": @(_layoutVersion.load()) }];
   [props addObject:@{ @"bounds": [NSValue valueWithCGRect:self.bounds] }];

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -225,7 +225,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
-  auto image = ASLockedSelf(_image);
+  let image = ASLockedSelf(_image);
 
   if (image == nil) {
     return [super calculateSizeThatFits:constrainedSize];

--- a/Source/ASMainThreadDeallocation.mm
+++ b/Source/ASMainThreadDeallocation.mm
@@ -146,7 +146,7 @@
 
 + (BOOL)needsMainThreadDeallocation
 {
-  auto name = class_getName(self);
+  let name = class_getName(self);
   if (0 == strncmp(name, "AV", 2) || 0 == strncmp(name, "UI", 2) || 0 == strncmp(name, "CA", 2)) {
     return YES;
   }

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -351,7 +351,7 @@
         // Call out to the delegate.
         if (_delegateFlags.delegateDidLoadImageWithInfo) {
           ASUnlockScope(self);
-          auto info = [[ASNetworkImageLoadInfo alloc] initWithURL:url sourceType:ASNetworkImageSourceSynchronousCache downloadIdentifier:nil userInfo:nil];
+          let info = [[ASNetworkImageLoadInfo alloc] initWithURL:url sourceType:ASNetworkImageSourceSynchronousCache downloadIdentifier:nil userInfo:nil];
           [_delegate imageNode:self didLoadImage:result info:info];
         } else if (_delegateFlags.delegateDidLoadImage) {
           ASUnlockScope(self);
@@ -629,7 +629,7 @@
         } else {
           // First try to load the path directly, for efficiency assuming a developer who
           // doesn't want caching is trying to be as minimal as possible.
-          auto nonAnimatedImage = [[UIImage alloc] initWithContentsOfFile:URL.path];
+          var nonAnimatedImage = [[UIImage alloc] initWithContentsOfFile:URL.path];
           if (nonAnimatedImage == nil) {
             // If we couldn't find it, execute an -imageNamed:-like search so we can find resources even if the
             // extension is not provided in the path.  This allows the same path to work regardless of shouldCacheImage.
@@ -642,7 +642,7 @@
           // If the file may be an animated gif and then created an animated image.
           id<ASAnimatedImageProtocol> animatedImage = nil;
           if (_downloaderFlags.downloaderImplementsAnimatedImage) {
-            auto data = [[NSData alloc] initWithContentsOfURL:URL];
+            let data = [[NSData alloc] initWithContentsOfURL:URL];
             if (data != nil) {
               animatedImage = [_downloader animatedImageWithData:data];
 
@@ -665,7 +665,7 @@
 
         if (_delegateFlags.delegateDidLoadImageWithInfo) {
           ASUnlockScope(self);
-          auto info = [[ASNetworkImageLoadInfo alloc] initWithURL:URL sourceType:ASNetworkImageSourceFileURL downloadIdentifier:nil userInfo:nil];
+          let info = [[ASNetworkImageLoadInfo alloc] initWithURL:URL sourceType:ASNetworkImageSourceFileURL downloadIdentifier:nil userInfo:nil];
           [delegate imageNode:self didLoadImage:self.image info:info];
         } else if (_delegateFlags.delegateDidLoadImage) {
           ASUnlockScope(self);
@@ -674,7 +674,7 @@
       });
     } else {
       __weak __typeof__(self) weakSelf = self;
-      auto finished = ^(id <ASImageContainerProtocol>imageContainer, NSError *error, id downloadIdentifier, ASNetworkImageSourceType imageSource, id userInfo) {
+      let finished = ^(id <ASImageContainerProtocol>imageContainer, NSError *error, id downloadIdentifier, ASNetworkImageSourceType imageSource, id userInfo) {
         ASPerformBlockOnBackgroundThread(^{
           __typeof__(self) strongSelf = weakSelf;
           if (strongSelf == nil) {
@@ -720,7 +720,7 @@
           if (newImage) {
             if (_delegateFlags.delegateDidLoadImageWithInfo) {
               calloutBlock = ^(ASNetworkImageNode *strongSelf) {
-                auto info = [[ASNetworkImageLoadInfo alloc] initWithURL:URL sourceType:imageSource downloadIdentifier:downloadIdentifier userInfo:userInfo];
+                let info = [[ASNetworkImageLoadInfo alloc] initWithURL:URL sourceType:imageSource downloadIdentifier:downloadIdentifier userInfo:userInfo];
                 [delegate imageNode:strongSelf didLoadImage:newImage info:info];
               };
             } else if (_delegateFlags.delegateDidLoadImage) {
@@ -736,7 +736,7 @@
           
           if (calloutBlock) {
             ASPerformBlockOnMainThread(^{
-              if (auto strongSelf = weakSelf) {
+              if (let strongSelf = weakSelf) {
                 calloutBlock(strongSelf);
               }
             });

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -220,13 +220,13 @@ static void runLoopSourceCallback(void *info) {
   NSParameterAssert(objectPtr != NULL);
   
   // Cast to CFType so we can manipulate retain count manually.
-  auto cfPtr = (CFTypeRef *)(void *)objectPtr;
+  let cfPtr = (CFTypeRef *)(void *)objectPtr;
   if (!cfPtr || !*cfPtr) {
     return;
   }
   
   _lock.lock();
-  auto isFirstEntry = _queue.empty();
+  let isFirstEntry = _queue.empty();
   // Push the pointer into our queue and clear their pointer.
   // This "steals" the +1 from ARC and nils their pointer so they can't
   // access or release the object.
@@ -244,9 +244,9 @@ static void runLoopSourceCallback(void *info) {
 - (void)drain
 {
   _lock.lock();
-  auto q = std::move(_queue);
+  let q = std::move(_queue);
   _lock.unlock();
-  for (auto ref : q) {
+  for (let ref : q) {
     // NOTE: Could check that retain count is 1 and retry later if not.
     CFRelease(ref);
   }
@@ -488,11 +488,11 @@ typedef enum {
   }
 
   // itemsToProcess will be empty if _queueConsumer == nil so no need to check again.
-  auto count = itemsToProcess.size();
+  let count = itemsToProcess.size();
   if (count > 0) {
     as_activity_scope_verbose(as_activity_create("Process run loop queue batch", _rootActivity, OS_ACTIVITY_FLAG_DEFAULT));
-    auto itemsEnd = itemsToProcess.cend();
-    for (auto iterator = itemsToProcess.begin(); iterator < itemsEnd; iterator++) {
+    let itemsEnd = itemsToProcess.cend();
+    for (var iterator = itemsToProcess.begin(); iterator < itemsEnd; iterator++) {
       __unsafe_unretained id value = *iterator;
       _queueConsumer(value, isQueueDrained && iterator == itemsEnd - 1);
       as_log_verbose(ASDisplayLog(), "processed %@", value);
@@ -711,11 +711,11 @@ static int const kASASCATransactionQueuePostOrder = 3000000;
   }
 
   // itemsToProcess will be empty if _queueConsumer == nil so no need to check again.
-  auto count = itemsToProcess.size();
+  let count = itemsToProcess.size();
   if (count > 0) {
     as_activity_scope_verbose(as_activity_create("Process run loop queue batch", _rootActivity, OS_ACTIVITY_FLAG_DEFAULT));
-    auto itemsEnd = itemsToProcess.cend();
-    for (auto iterator = itemsToProcess.begin(); iterator < itemsEnd; iterator++) {
+    let itemsEnd = itemsToProcess.cend();
+    for (var iterator = itemsToProcess.begin(); iterator < itemsEnd; iterator++) {
       __unsafe_unretained id value = *iterator;
       [value prepareForCATransactionCommit];
       as_log_verbose(ASDisplayLog(), "processed %@", value);

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -676,7 +676,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (NSArray<ASCellNode *> *)visibleNodes
 {
-  auto elements = [self visibleElementsForRangeController:_rangeController];
+  let elements = [self visibleElementsForRangeController:_rangeController];
   return ASArrayByFlatMapping(elements, ASCollectionElement *e, e.node);
 }
 
@@ -762,7 +762,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
       NSArray<ASCellNode *> *nodes = [_cellsForLayoutUpdates allObjects];
       [_cellsForLayoutUpdates removeAllObjects];
 
-      auto nodesSizeChanged = [[NSMutableArray<ASCellNode *> alloc] init];
+      let nodesSizeChanged = [[NSMutableArray<ASCellNode *> alloc] init];
       [_dataController relayoutNodes:nodes nodesSizeChanged:nodesSizeChanged];
       if (nodesSizeChanged.count > 0) {
         [self requeryNodeHeights];

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -859,7 +859,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   ASLockScopeSelf();
   
   NSArray *rects = [[self _locked_renderer] rectsForTextRange:textRange measureOption:measureOption];
-  auto adjustedRects = [[NSMutableArray<NSValue *> alloc] init];
+  let adjustedRects = [[NSMutableArray<NSValue *> alloc] init];
 
   for (NSValue *rectValue in rects) {
     CGRect rect = [rectValue CGRectValue];
@@ -1308,7 +1308,7 @@ static NSAttributedString *DefaultTruncationAttributedString()
     NSDictionary *originalStringAttributes = [originalString attributesAtIndex:originalStringLength-1 effectiveRange:NULL];
     [truncationString enumerateAttributesInRange:NSMakeRange(0, truncationString.length) options:0 usingBlock:
      ^(NSDictionary *attributes, NSRange range, BOOL *stop) {
-       NSMutableDictionary *futureTruncationAttributes = [NSMutableDictionary dictionaryWithDictionary:originalStringAttributes];
+       NSMutableDictionary *futureTruncationAttributes = [[NSMutableDictionary alloc] initWithDictionary:originalStringAttributes];
        [futureTruncationAttributes addEntriesFromDictionary:attributes];
        [truncationMutableString setAttributes:futureTruncationAttributes range:range];
      }];

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -1308,7 +1308,7 @@ static NSAttributedString *DefaultTruncationAttributedString()
     NSDictionary *originalStringAttributes = [originalString attributesAtIndex:originalStringLength-1 effectiveRange:NULL];
     [truncationString enumerateAttributesInRange:NSMakeRange(0, truncationString.length) options:0 usingBlock:
      ^(NSDictionary *attributes, NSRange range, BOOL *stop) {
-       NSMutableDictionary *futureTruncationAttributes = [[NSMutableDictionary alloc] initWithDictionary:originalStringAttributes];
+       NSMutableDictionary *futureTruncationAttributes = [originalStringAttributes mutableCopy];
        [futureTruncationAttributes addEntriesFromDictionary:attributes];
        [truncationMutableString setAttributes:futureTruncationAttributes range:range];
      }];

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -408,7 +408,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
   CGRect containerBounds = (CGRect){ .size = container.size };
   {
-    for (auto &t : cacheValue->_layouts) {
+    for (let &t : cacheValue->_layouts) {
       CGSize constrainedSize = std::get<0>(t);
       ASTextLayout *layout = std::get<1>(t);
 
@@ -1135,7 +1135,7 @@ static NSAttributedString *DefaultTruncationAttributedString()
     NSDictionary *originalStringAttributes = [originalString attributesAtIndex:originalStringLength-1 effectiveRange:NULL];
     [truncationString enumerateAttributesInRange:NSMakeRange(0, truncationString.length) options:0 usingBlock:
      ^(NSDictionary *attributes, NSRange range, BOOL *stop) {
-       NSMutableDictionary *futureTruncationAttributes = [NSMutableDictionary dictionaryWithDictionary:originalStringAttributes];
+       NSMutableDictionary *futureTruncationAttributes = [[NSMutableDictionary alloc] initWithDictionary:originalStringAttributes];
        [futureTruncationAttributes addEntriesFromDictionary:attributes];
        [truncationMutableString setAttributes:futureTruncationAttributes range:range];
      }];

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -1135,7 +1135,7 @@ static NSAttributedString *DefaultTruncationAttributedString()
     NSDictionary *originalStringAttributes = [originalString attributesAtIndex:originalStringLength-1 effectiveRange:NULL];
     [truncationString enumerateAttributesInRange:NSMakeRange(0, truncationString.length) options:0 usingBlock:
      ^(NSDictionary *attributes, NSRange range, BOOL *stop) {
-       NSMutableDictionary *futureTruncationAttributes = [[NSMutableDictionary alloc] initWithDictionary:originalStringAttributes];
+       NSMutableDictionary *futureTruncationAttributes = [originalStringAttributes mutableCopy];
        [futureTruncationAttributes addEntriesFromDictionary:attributes];
        [truncationMutableString setAttributes:futureTruncationAttributes range:range];
      }];

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -20,6 +20,14 @@
 #define AS_EXTERN FOUNDATION_EXTERN
 #define unowned __unsafe_unretained
 
+#if defined(__cplusplus)
+# define var auto
+# define let auto const
+#else
+# define var __auto_type
+# define let const __auto_type
+#endif
+
 #ifdef __GNUC__
 # define ASDISPLAYNODE_GNUC(major, minor) \
 (__GNUC__ > (major) || (__GNUC__ == (major) && __GNUC_MINOR__ >= (minor)))

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -22,7 +22,7 @@
 
 #if defined(__cplusplus)
 # define var auto
-# define let auto const
+# define let const auto
 #else
 # define var __auto_type
 # define let const __auto_type

--- a/Source/Details/ASBasicImageDownloader.mm
+++ b/Source/Details/ASBasicImageDownloader.mm
@@ -245,7 +245,7 @@ static const char *kContextKey = NSStringFromClass(ASBasicImageDownloaderContext
   // cause significant performance issues.
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     // associate metadata with it
-    NSMutableDictionary *callbackData = [[NSMutableDictionary alloc] init];
+    let callbackData = [[NSMutableDictionary alloc] init];
     callbackData[kASBasicImageDownloaderContextCallbackQueue] = callbackQueue ? : dispatch_get_main_queue();
 
     if (downloadProgress) {
@@ -256,7 +256,7 @@ static const char *kContextKey = NSStringFromClass(ASBasicImageDownloaderContext
       callbackData[kASBasicImageDownloaderContextCompletionBlock] = [completion copy];
     }
 
-    [context addCallbackData:[NSDictionary dictionaryWithDictionary:callbackData]];
+    [context addCallbackData:[[NSDictionary alloc] initWithDictionary:callbackData]];
 
     // Create new task if necessary
     NSURLSessionDownloadTask *task = (NSURLSessionDownloadTask *)[context createSessionTaskIfNecessaryWithBlock:^(){return [_session downloadTaskWithURL:URL];}];

--- a/Source/Details/ASCollectionLayoutState.mm
+++ b/Source/Details/ASCollectionLayoutState.mm
@@ -159,7 +159,7 @@ elementToLayoutAttributesTable:[NSMapTable elementToLayoutAttributesTable]];
   }
 
   // Use a set here because some items may span multiple pages
-  auto result = [[NSMutableSet<UICollectionViewLayoutAttributes *> alloc] init];
+  let result = [[NSMutableSet<UICollectionViewLayoutAttributes *> alloc] init];
   for (id pagePtr in pages) {
     ASPageCoordinate page = (ASPageCoordinate)pagePtr;
     NSArray<UICollectionViewLayoutAttributes *> *allAttrs = [_pageToLayoutAttributesTable objectForPage:page];

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -214,7 +214,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
     return @[];
   }
   
-  auto indexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
+  let indexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
   if ([kind isEqualToString:ASDataControllerRowNodeKind]) {
     std::vector<NSInteger> counts = [self itemCountsFromDataSource];
     [sections enumerateRangesUsingBlock:^(NSRange range, BOOL * _Nonnull stop) {
@@ -671,7 +671,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
       [layoutDelegateClass calculateLayoutWithContext:layoutContext];
       completion();
     } else {
-      auto elementsToProcess = [[NSMutableArray<ASCollectionElement *> alloc] init];
+      let elementsToProcess = [[NSMutableArray<ASCollectionElement *> alloc] init];
       for (ASCollectionElement *element in newMap) {
         ASCellNode *nodeIfAllocated = element.nodeIfAllocated;
         if (nodeIfAllocated.shouldUseUIKitCell) {
@@ -827,10 +827,10 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   }
   
   id<ASDataControllerSource> dataSource = self.dataSource;
-  auto visibleMap = self.visibleMap;
-  auto pendingMap = self.pendingMap;
+  let visibleMap = self.visibleMap;
+  let pendingMap = self.pendingMap;
   for (ASCellNode *node in nodes) {
-    auto element = node.collectionElement;
+    let element = node.collectionElement;
     NSIndexPath *indexPathInPendingMap = [pendingMap indexPathForElement:element];
     // Ensure the element is present in both maps or skip it. If it's not in the visible map,
     // then we can't check the presented size. If it's not in the pending map, we can't get the constrained size.

--- a/Source/Details/ASIntegerMap.mm
+++ b/Source/Details/ASIntegerMap.mm
@@ -102,7 +102,7 @@
     return NSNotFound;
   }
 
-  auto result = _map.find(key);
+  let result = _map.find(key);
   return result != _map.end() ? result->second : NSNotFound;
 }
 
@@ -122,8 +122,8 @@
     return self;
   }
 
-  auto result = [[ASIntegerMap alloc] init];
-  for (auto it = _map.begin(); it != _map.end(); it++) {
+  let result = [[ASIntegerMap alloc] init];
+  for (var it = _map.begin(); it != _map.end(); it++) {
     result->_map[it->second] = it->first;
   }
   return result;
@@ -137,7 +137,7 @@
     return self;
   }
 
-  auto newMap = [[ASIntegerMap allocWithZone:zone] init];
+  let newMap = [[ASIntegerMap allocWithZone:zone] init];
   newMap->_map = _map;
   return newMap;
 }
@@ -155,7 +155,7 @@
   } else {
     // { 1->2 3->4 5->6 }
     NSMutableString *str = [NSMutableString string];
-    for (auto it = _map.begin(); it != _map.end(); it++) {
+    for (var it = _map.begin(); it != _map.end(); it++) {
       [str appendFormat:@" %zd->%zd", it->first, it->second];
     }
     // Remove leading space
@@ -179,7 +179,7 @@
     return YES;
   }
 
-  if (auto otherMap = ASDynamicCast(object, ASIntegerMap)) {
+  if (let otherMap = ASDynamicCast(object, ASIntegerMap)) {
     return otherMap->_map == _map;
   }
   return NO;

--- a/Source/Details/ASIntegerMap.mm
+++ b/Source/Details/ASIntegerMap.mm
@@ -123,8 +123,9 @@
   }
 
   let result = [[ASIntegerMap alloc] init];
-  for (var it = _map.begin(); it != _map.end(); it++) {
-    result->_map[it->second] = it->first;
+  
+  for (let &e : _map) {
+    result->_map[e.second] = e.first;
   }
   return result;
 }
@@ -155,8 +156,8 @@
   } else {
     // { 1->2 3->4 5->6 }
     NSMutableString *str = [NSMutableString string];
-    for (var it = _map.begin(); it != _map.end(); it++) {
-      [str appendFormat:@" %zd->%zd", it->first, it->second];
+    for (let &e : _map) {
+      [str appendFormat:@" %zd->%zd", e.first, e.second];
     }
     // Remove leading space
     if (str.length > 0) {

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -225,7 +225,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
 
   // TODO: Consider if we need to use this codepath, or can rely on something more similar to the data & display ranges
   // Example: ... = [_layoutController indexPathsForScrolling:scrollDirection rangeType:ASLayoutRangeTypeVisible];
-  auto visibleElements = [_dataSource visibleElementsForRangeController:self];
+  var visibleElements = [_dataSource visibleElementsForRangeController:self];
   NSHashTable *newVisibleNodes = [NSHashTable hashTableWithOptions:NSHashTableObjectPointerPersonality];
 
   ASSignpostStart(ASSignpostRangeControllerUpdate);

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -283,7 +283,7 @@ namespace ASDN {
           return os_unfair_lock_trylock(&_unfair);
         }
       } else {
-        auto result = pthread_mutex_trylock(&_m);
+        let result = pthread_mutex_trylock(&_m);
         if (result == 0) {
           return true;
         } else if (result == EBUSY) {

--- a/Source/Layout/ASDimension.mm
+++ b/Source/Layout/ASDimension.mm
@@ -97,8 +97,8 @@ struct _Range {
 
 ASSizeRange ASSizeRangeIntersect(ASSizeRange sizeRange, ASSizeRange otherSizeRange)
 {
-  auto w = _Range({sizeRange.min.width, sizeRange.max.width}).intersect({otherSizeRange.min.width, otherSizeRange.max.width});
-  auto h = _Range({sizeRange.min.height, sizeRange.max.height}).intersect({otherSizeRange.min.height, otherSizeRange.max.height});
+  let w = _Range({sizeRange.min.width, sizeRange.max.width}).intersect({otherSizeRange.min.width, otherSizeRange.max.width});
+  let h = _Range({sizeRange.min.height, sizeRange.max.height}).intersect({otherSizeRange.min.height, otherSizeRange.max.height});
   return {{w.min, h.min}, {w.max, h.max}};
 }
 

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -251,10 +251,10 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
     if (ASLayoutIsDisplayNodeType(layout)) {
       if (sublayoutsCount > 0 || CGPointEqualToPoint(ASCeilPointValues(absolutePosition), layout.position) == NO) {
         // Only create a new layout if the existing one can't be reused, which means it has either some sublayouts or an invalid absolute position.
-        auto newLayout = [ASLayout layoutWithLayoutElement:layout->_layoutElement
-                                                      size:layout.size
-                                                  position:absolutePosition
-                                                sublayouts:@[]];
+        let newLayout = [ASLayout layoutWithLayoutElement:layout->_layoutElement
+                                                     size:layout.size
+                                                 position:absolutePosition
+                                               sublayouts:@[]];
         flattenedSublayouts.push_back(newLayout);
       } else {
         flattenedSublayouts.push_back(layout);
@@ -348,11 +348,11 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
   NSMutableArray *result = [NSMutableArray array];
   [result addObject:@{ @"size" : [NSValue valueWithCGSize:self.size] }];
 
-  if (auto layoutElement = self.layoutElement) {
+  if (let layoutElement = self.layoutElement) {
     [result addObject:@{ @"layoutElement" : layoutElement }];
   }
 
-  auto pos = self.position;
+  let pos = self.position;
   if (!ASPointIsNull(pos)) {
     [result addObject:@{ @"position" : [NSValue valueWithCGPoint:pos] }];
   }

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -166,10 +166,10 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (NSMutableArray<NSDictionary *> *)propertiesForDescription
 {
-  auto result = [NSMutableArray<NSDictionary *> array];
+  let result = [NSMutableArray<NSDictionary *> array];
   if (NSArray *children = self.children) {
     // Use tiny descriptions because these trees can get nested very deep.
-    auto tinyDescriptions = ASArrayByFlatMapping(children, id object, ASObjectDescriptionMakeTiny(object));
+    let tinyDescriptions = ASArrayByFlatMapping(children, id object, ASObjectDescriptionMakeTiny(object));
     [result addObject:@{ @"children": tinyDescriptions }];
   }
   return result;

--- a/Source/Layout/ASRatioLayoutSpec.mm
+++ b/Source/Layout/ASRatioLayoutSpec.mm
@@ -83,7 +83,7 @@
   }
 
   // Choose the size closest to the desired ratio.
-  const auto &bestSize = std::max_element(sizeOptions.begin(), sizeOptions.end(), [&](const CGSize &a, const CGSize &b){
+  let &bestSize = std::max_element(sizeOptions.begin(), sizeOptions.end(), [&](const CGSize &a, const CGSize &b){
     return std::fabs((a.height / a.width) - _ratio) > std::fabs((b.height / b.width) - _ratio);
   });
 

--- a/Source/Layout/ASStackLayoutSpec.mm
+++ b/Source/Layout/ASStackLayoutSpec.mm
@@ -160,7 +160,7 @@
     self.style.descender = stackChildren.back().style.descender;
   }
   
-  auto sublayouts = [[NSMutableArray<ASLayout *> alloc] init];
+  const auto sublayouts = [[NSMutableArray<ASLayout *> alloc] init];
   for (const auto &item : positionedLayout.items) {
     [sublayouts addObject:item.layout];
   }

--- a/Source/Private/ASCollectionLayoutCache.mm
+++ b/Source/Private/ASCollectionLayoutCache.mm
@@ -62,7 +62,7 @@
   }
 
   ASDN::MutexLocker l(__instanceLock__);
-  auto innerMap = [_map objectForKey:elements];
+  var innerMap = [_map objectForKey:elements];
   if (innerMap == nil) {
     innerMap = [NSMapTable strongToStrongObjectsMapTable];
     [_map setObject:innerMap forKey:elements];

--- a/Source/Private/ASMutableElementMap.m
+++ b/Source/Private/ASMutableElementMap.m
@@ -142,7 +142,7 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
 
 + (ASMutableSupplementaryElementDictionary *)deepMutableCopyOfElementsDictionary:(ASSupplementaryElementDictionary *)originalDict
 {
-  NSMutableDictionary *deepCopy = [NSMutableDictionary dictionaryWithCapacity:originalDict.count];
+  NSMutableDictionary *deepCopy = [[NSMutableDictionary alloc] initWithCapacity:originalDict.count];
   [originalDict enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSDictionary<NSIndexPath *,ASCollectionElement *> * _Nonnull obj, BOOL * _Nonnull stop) {
     deepCopy[key] = [obj mutableCopy];
   }];

--- a/Source/Private/ASRectMap.mm
+++ b/Source/Private/ASRectMap.mm
@@ -26,7 +26,7 @@
 
 - (CGRect)rectForKey:(id)key
 {
-  auto result = _map.find((__bridge void *)key);
+  let result = _map.find((__bridge void *)key);
   if (result != _map.end()) {
     // result->first is the key; result->second is the value, a CGRect.
     return result->second;
@@ -62,7 +62,7 @@
 
   // { ptr1->rect1 ptr2->rect2 ptr3->rect3 }
   NSMutableString *str = [NSMutableString string];
-  for (auto it = _map.begin(); it != _map.end(); it++) {
+  for (var it = _map.begin(); it != _map.end(); it++) {
     [str appendFormat:@" %@->%@", it->first, NSStringFromCGRect(it->second)];
   }
   [result addObject:@{ @"ASRectMap": str }];

--- a/Source/Private/ASRectMap.mm
+++ b/Source/Private/ASRectMap.mm
@@ -62,8 +62,8 @@
 
   // { ptr1->rect1 ptr2->rect2 ptr3->rect3 }
   NSMutableString *str = [NSMutableString string];
-  for (var it = _map.begin(); it != _map.end(); it++) {
-    [str appendFormat:@" %@->%@", it->first, NSStringFromCGRect(it->second)];
+  for (let &e : _map) {
+    [str appendFormat:@" %@->%@", e.first, NSStringFromCGRect(e.second)];
   }
   [result addObject:@{ @"ASRectMap": str }];
 

--- a/Source/Private/_ASCoreAnimationExtras.mm
+++ b/Source/Private/_ASCoreAnimationExtras.mm
@@ -98,7 +98,7 @@ static const struct _UIContentModeStringLUTEntry UIContentModeDescriptionLUT[] =
 
 NSString *ASDisplayNodeNSStringFromUIContentMode(UIViewContentMode contentMode)
 {
-  for (auto &e : UIContentModeDescriptionLUT) {
+  for (let &e : UIContentModeDescriptionLUT) {
     if (e.contentMode == contentMode) {
       return e.string;
     }
@@ -108,7 +108,7 @@ NSString *ASDisplayNodeNSStringFromUIContentMode(UIViewContentMode contentMode)
 
 UIViewContentMode ASDisplayNodeUIContentModeFromNSString(NSString *string)
 {
-  for (auto &e : UIContentModeDescriptionLUT) {
+  for (let &e : UIContentModeDescriptionLUT) {
     if (ASObjectIsEqual(e.string, string)) {
       return e.contentMode;
     }
@@ -118,7 +118,7 @@ UIViewContentMode ASDisplayNodeUIContentModeFromNSString(NSString *string)
 
 NSString *const ASDisplayNodeCAContentsGravityFromUIContentMode(UIViewContentMode contentMode)
 {
-  for (auto &e : UIContentModeCAGravityLUT) {
+  for (let &e : UIContentModeCAGravityLUT) {
     if (e.contentMode == contentMode) {
       return e.string;
     }
@@ -140,7 +140,7 @@ UIViewContentMode ASDisplayNodeUIContentModeFromCAContentsGravity(NSString *cons
     return cachedModes[foundCacheIndex];
   }
   
-  for (auto &e : UIContentModeCAGravityLUT) {
+  for (let &e : UIContentModeCAGravityLUT) {
     if (ASObjectIsEqual(e.string, contentsGravity)) {
       UIViewContentMode foundContentMode = e.contentMode;
       

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -238,7 +238,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 - (NSIndexSet *)indexesForItemChangesOfType:(_ASHierarchyChangeType)changeType inSection:(NSUInteger)section
 {
   [self _ensureCompleted];
-  auto result = [[NSMutableIndexSet alloc] init];
+  let result = [[NSMutableIndexSet alloc] init];
   for (_ASHierarchyItemChange *change in [self itemChangesOfType:changeType]) {
     [result addIndexes:[NSIndexSet as_indexSetFromIndexPaths:change.indexPaths inSection:section]];
   }
@@ -280,10 +280,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 
   if (_itemMappings == nil) {
     _itemMappings = [[NSMutableArray alloc] init];
-    auto insertMap = [_ASHierarchyItemChange sectionToIndexSetMapFromChanges:_originalInsertItemChanges];
-    auto deleteMap = [_ASHierarchyItemChange sectionToIndexSetMapFromChanges:_originalDeleteItemChanges];
+    let insertMap = [_ASHierarchyItemChange sectionToIndexSetMapFromChanges:_originalInsertItemChanges];
+    let deleteMap = [_ASHierarchyItemChange sectionToIndexSetMapFromChanges:_originalDeleteItemChanges];
     NSInteger oldSection = 0;
-    for (auto oldCount : _oldItemCounts) {
+    for (let oldCount : _oldItemCounts) {
       NSInteger newSection = [self newSectionForOldSection:oldSection];
       ASIntegerMap *table;
       if (newSection == NSNotFound) {
@@ -498,7 +498,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
     for (_ASHierarchyItemChange *change in _reloadItemChanges) {
       NSAssert(change.changeType == _ASHierarchyChangeTypeReload, @"It must be a reload change to be in here");
 
-      auto newIndexPaths = ASArrayByFlatMapping(change.indexPaths, NSIndexPath *indexPath, [self newIndexPathForOldIndexPath:indexPath]);
+      let newIndexPaths = ASArrayByFlatMapping(change.indexPaths, NSIndexPath *indexPath, [self newIndexPathForOldIndexPath:indexPath]);
       
       // All reload changes are translated into deletes and inserts
       // We delete the items that needs reload together with other deleted items, at their original index
@@ -752,7 +752,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   NSMutableArray *result = [[NSMutableArray alloc] init];
   
   __block ASDataControllerAnimationOptions currentOptions = 0;
-  auto currentIndexes = [[NSMutableIndexSet alloc] init];
+  let currentIndexes = [[NSMutableIndexSet alloc] init];
 
   BOOL reverse = type == _ASHierarchyChangeTypeDelete || type == _ASHierarchyChangeTypeOriginalDelete;
   NSEnumerationOptions options = reverse ? NSEnumerationReverse : kNilOptions;
@@ -791,7 +791,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 
 + (NSMutableIndexSet *)allIndexesInSectionChanges:(NSArray<_ASHierarchySectionChange *> *)changes
 {
-  auto indexes = [[NSMutableIndexSet alloc] init];
+  let indexes = [[NSMutableIndexSet alloc] init];
   for (_ASHierarchySectionChange *change in changes) {
     [indexes addIndexes:change.indexSet];
   }
@@ -918,7 +918,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   ASDisplayNodeAssert(ASHierarchyChangeTypeIsFinal(type), @"Attempt to sort and coalesce item changes of intermediary type %@. Why?", NSStringFromASHierarchyChangeType(type));
     
   // Lookup table [NSIndexPath: AnimationOptions]
-  NSMutableDictionary *animationOptions = [NSMutableDictionary new];
+  NSMutableDictionary *animationOptions = [[NSMutableDictionary alloc] init];
   
   // All changed index paths, sorted
   NSMutableArray *allIndexPaths = [[NSMutableArray alloc] init];
@@ -936,10 +936,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   [allIndexPaths sortUsingSelector:sorting];
 
   // Create new changes by grouping sorted changes by animation option
-  auto result = [[NSMutableArray<_ASHierarchyItemChange *> alloc] init];
+  let result = [[NSMutableArray<_ASHierarchyItemChange *> alloc] init];
 
   ASDataControllerAnimationOptions currentOptions = 0;
-  auto currentIndexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
+  let currentIndexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
 
   for (NSIndexPath *indexPath in allIndexPaths) {
     ASDataControllerAnimationOptions options = [animationOptions[indexPath] integerValue];

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -918,10 +918,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   ASDisplayNodeAssert(ASHierarchyChangeTypeIsFinal(type), @"Attempt to sort and coalesce item changes of intermediary type %@. Why?", NSStringFromASHierarchyChangeType(type));
     
   // Lookup table [NSIndexPath: AnimationOptions]
-  NSMutableDictionary *animationOptions = [[NSMutableDictionary alloc] init];
+  let animationOptions = [[NSMutableDictionary<NSIndexPath *, NSNumber *> alloc] init];
   
   // All changed index paths, sorted
-  NSMutableArray *allIndexPaths = [[NSMutableArray alloc] init];
+  let allIndexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
   
   for (_ASHierarchyItemChange *change in changes) {
     for (NSIndexPath *indexPath in change.indexPaths) {

--- a/Tests/ASCollectionModernDataSourceTests.m
+++ b/Tests/ASCollectionModernDataSourceTests.m
@@ -308,8 +308,7 @@
     [self expectDataSourceCountMethods];
     
     // Combine reloads + inserts and expect them to load content for all of them, in ascending order.
-    NSMutableDictionary<NSIndexPath *, id> *insertsPlusReloads = [NSMutableDictionary dictionary];
-    [insertsPlusReloads addEntriesFromDictionary:insertedItems];
+    NSMutableDictionary<NSIndexPath *, id> *insertsPlusReloads = [[NSMutableDictionary alloc] initWithDictionary:insertedItems];
 
     // Go through reloaded sections and add all their items into `insertsPlusReloads`
     [reloadedSectionIndexes enumerateIndexesUsingBlock:^(NSUInteger section, BOOL * _Nonnull stop) {

--- a/Tests/ASLayoutEngineTests.mm
+++ b/Tests/ASLayoutEngineTests.mm
@@ -298,7 +298,7 @@
       // are common to both fixture2 and fixture4 are available from the cache.
     } else {
       // Incorrect behavior: nodeC will get measured against its new bounds on main.
-      auto cPendingSize = [fixture2 layoutForNode:nodeC].size;
+      let cPendingSize = [fixture2 layoutForNode:nodeC].size;
       OCMExpect([nodeC.mock calculateLayoutThatFits:ASSizeRangeMake(cPendingSize)]).onMainThread();
     }
     [window layoutIfNeeded];
@@ -368,16 +368,16 @@
 
 - (void)verifyFixture:(ASTLayoutFixture *)fixture
 {
-  auto expected = fixture.layout;
+  let expected = fixture.layout;
 
   // Ensure expected == frames
-  auto frames = [fixture.rootNode currentLayoutBasedOnFrames];
+  let frames = [fixture.rootNode currentLayoutBasedOnFrames];
   if (![expected isEqual:frames]) {
     XCTFail(@"\n*** Layout verification failed – frames don't match expected. ***\nGot:\n%@\nExpected:\n%@", [frames recursiveDescription], [expected recursiveDescription]);
   }
 
   // Ensure expected == calculatedLayout
-  auto calculated = fixture.rootNode.calculatedLayout;
+  let calculated = fixture.rootNode.calculatedLayout;
   if (![expected isEqual:calculated]) {
     XCTFail(@"\n*** Layout verification failed – calculated layout doesn't match expected. ***\nGot:\n%@\nExpected:\n%@", [calculated recursiveDescription], [expected recursiveDescription]);
   }
@@ -406,22 +406,22 @@
  */
 - (ASTLayoutFixture *)createFixture1
 {
-  auto fixture = [[ASTLayoutFixture alloc] init];
+  let fixture = [[ASTLayoutFixture alloc] init];
 
   // nodeB
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeB];
-  auto layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
+  let layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
 
   // nodeC
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeC];
-  auto layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{2,1} position:{4,0} sublayouts:nil];
+  let layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{2,1} position:{4,0} sublayouts:nil];
 
   // nodeD
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeD];
-  auto layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{1,1} position:{9,0} sublayouts:nil];
+  let layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{1,1} position:{9,0} sublayouts:nil];
 
   [fixture addSizeRange:{{10, 1}, {10, 1}} forNode:nodeA];
-  auto layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutD ]];
+  let layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutD ]];
   fixture.layout = layoutA;
 
   [fixture.layoutSpecBlocks setObject:fixture1and3and5NodeALayoutSpecBlock forKey:nodeA];
@@ -441,22 +441,22 @@
  */
 - (ASTLayoutFixture *)createFixture2
 {
-  auto fixture = [[ASTLayoutFixture alloc] init];
+  let fixture = [[ASTLayoutFixture alloc] init];
 
   // nodeB
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeB];
-  auto layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
+  let layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
 
   // nodeC
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeC];
-  auto layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{4,1} position:{3,0} sublayouts:nil];
+  let layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{4,1} position:{3,0} sublayouts:nil];
 
   // nodeE
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeE];
-  auto layoutE = [ASLayout layoutWithLayoutElement:nodeE size:{1,1} position:{9,0} sublayouts:nil];
+  let layoutE = [ASLayout layoutWithLayoutElement:nodeE size:{1,1} position:{9,0} sublayouts:nil];
 
   [fixture addSizeRange:{{10, 1}, {10, 1}} forNode:nodeA];
-  auto layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutE ]];
+  let layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutE ]];
   fixture.layout = layoutA;
 
   ASLayoutSpecBlock specBlockA = ^ASLayoutSpec * _Nonnull(__kindof ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
@@ -477,24 +477,24 @@
  */
 - (ASTLayoutFixture *)createFixture3
 {
-  auto fixture = [[ASTLayoutFixture alloc] init];
+  let fixture = [[ASTLayoutFixture alloc] init];
 
   // nodeB wants 8,1 but it will settle for 7,1
   [fixture setReturnedSize:{8,1} forNode:nodeB];
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeB];
   [fixture addSizeRange:{{7, 0}, {7, 1}} forNode:nodeB];
-  auto layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{7,1} position:{0,0} sublayouts:nil];
+  let layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{7,1} position:{0,0} sublayouts:nil];
 
   // nodeC
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeC];
-  auto layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{2,1} position:{7,0} sublayouts:nil];
+  let layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{2,1} position:{7,0} sublayouts:nil];
 
   // nodeD
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeD];
-  auto layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{1,1} position:{9,0} sublayouts:nil];
+  let layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{1,1} position:{9,0} sublayouts:nil];
 
   [fixture addSizeRange:{{10, 1}, {10, 1}} forNode:nodeA];
-  auto layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutD ]];
+  let layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutD ]];
   fixture.layout = layoutA;
 
   [fixture.layoutSpecBlocks setObject:fixture1and3and5NodeALayoutSpecBlock forKey:nodeA];
@@ -520,22 +520,22 @@
  */
 - (ASTLayoutFixture *)createFixture4
 {
-  auto fixture = [[ASTLayoutFixture alloc] init];
+  let fixture = [[ASTLayoutFixture alloc] init];
 
   // nodeB
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeB];
-  auto layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
+  let layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
 
   // nodeD
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeD];
-  auto layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{2,1} position:{4,0} sublayouts:nil];
+  let layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{2,1} position:{4,0} sublayouts:nil];
 
   // nodeE
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeE];
-  auto layoutE = [ASLayout layoutWithLayoutElement:nodeE size:{1,1} position:{9,0} sublayouts:nil];
+  let layoutE = [ASLayout layoutWithLayoutElement:nodeE size:{1,1} position:{9,0} sublayouts:nil];
 
   [fixture addSizeRange:{{10, 1}, {10, 1}} forNode:nodeA];
-  auto layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutD, layoutE ]];
+  let layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutD, layoutE ]];
   fixture.layout = layoutA;
 
   ASLayoutSpecBlock specBlockA = ^ASLayoutSpec * _Nonnull(__kindof ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
@@ -552,22 +552,22 @@
  */
 - (ASTLayoutFixture *)createFixture5
 {
-  auto fixture = [[ASTLayoutFixture alloc] init];
+  let fixture = [[ASTLayoutFixture alloc] init];
 
   // nodeB
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeB];
-  auto layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
+  let layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
 
   // nodeC
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeC];
-  auto layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{2,1} position:{4,0} sublayouts:nil];
+  let layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{2,1} position:{4,0} sublayouts:nil];
 
   // nodeD
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeD];
-  auto layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{1,1} position:{9,0} sublayouts:nil];
+  let layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{1,1} position:{9,0} sublayouts:nil];
 
   [fixture addSizeRange:{{15, 1}, {15, 1}} forNode:nodeA];
-  auto layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{15,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutD ]];
+  let layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{15,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutD ]];
   fixture.layout = layoutA;
 
   [fixture.layoutSpecBlocks setObject:fixture1and3and5NodeALayoutSpecBlock forKey:nodeA];

--- a/Tests/ASLayoutTestNode.mm
+++ b/Tests/ASLayoutTestNode.mm
@@ -39,7 +39,7 @@
 
 - (ASLayout *)_currentLayoutBasedOnFramesForRootNode:(BOOL)isRootNode
 {
-  auto sublayouts = [NSMutableArray<ASLayout *> array];
+  let sublayouts = [[NSMutableArray<ASLayout *> alloc] init];
   for (ASLayoutTestNode *subnode in self.subnodes) {
     [sublayouts addObject:[subnode _currentLayoutBasedOnFramesForRootNode:NO]];
   }
@@ -64,7 +64,7 @@
     return [super calculateLayoutThatFits:constrainedSize];
   } else {
     // Interestingly, the infra will auto-clamp sizes from calculateSizeThatFits, but not from calculateLayoutThatFits.
-    auto size = ASSizeRangeClamp(constrainedSize, self.testSize);
+    let size = ASSizeRangeClamp(constrainedSize, self.testSize);
     return [ASLayout layoutWithLayoutElement:self size:size];
   }
 }

--- a/Tests/ASPerformanceTestContext.m
+++ b/Tests/ASPerformanceTestContext.m
@@ -24,7 +24,7 @@
 {
   self = [super init];
   if (self != nil) {
-    _userInfo = [NSMutableDictionary dictionary];
+    _userInfo = [[NSMutableDictionary alloc] init];
   }
   return self;
 }

--- a/Tests/ASPerformanceTestContext.m
+++ b/Tests/ASPerformanceTestContext.m
@@ -2,8 +2,17 @@
 //  ASPerformanceTestContext.m
 //  Texture
 //
-//  Created by Adlai Holler on 8/28/16.
-//  Copyright © 2016 Facebook. All rights reserved.
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the /ASDK-Licenses directory of this source tree. An additional
+//  grant of patent rights can be found in the PATENTS file in the same directory.
+//
+//  Modifications to this file made after 4/13/2017 are: Copyright (c) through the present,
+//  Pinterest, Inc.  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <Foundation/Foundation.h>

--- a/Tests/ASTLayoutFixture.mm
+++ b/Tests/ASTLayoutFixture.mm
@@ -37,9 +37,9 @@
 
 - (void)addSizeRange:(ASSizeRange)sizeRange forNode:(ASLayoutTestNode *)node
 {
-  auto ranges = [_sizeRanges objectForKey:node];
+  var ranges = [_sizeRanges objectForKey:node];
   if (ranges == nil) {
-    ranges = [NSMutableArray array];
+    ranges = [[NSMutableArray alloc] init];
     [_sizeRanges setObject:ranges forKey:node];
   }
   [ranges addObject:[NSValue valueWithBytes:&sizeRange objCType:@encode(ASSizeRange)]];
@@ -52,7 +52,7 @@
 
 - (ASSizeRange)firstSizeRangeForNode:(ASLayoutTestNode *)node
 {
-  auto val = [_sizeRanges objectForKey:node].firstObject;
+  let val = [_sizeRanges objectForKey:node].firstObject;
   ASSizeRange r;
   [val getValue:&r];
   return r;
@@ -104,7 +104,7 @@
 
 - (NSSet<ASLayoutTestNode *> *)allNodes
 {
-  auto allLayouts = [NSMutableArray array];
+  let allLayouts = [NSMutableArray array];
   [ASTLayoutFixture collectAllLayoutsFromLayout:self.layout array:allLayouts];
   return [NSSet setWithArray:[allLayouts valueForKey:@"layoutElement"]];
 }
@@ -113,7 +113,7 @@
 {
   // Update layoutSpecBlock for parent nodes, set automatic subnode management
   for (ASDisplayNode *node in _layoutSpecBlocks) {
-    auto block = [_layoutSpecBlocks objectForKey:node];
+    let block = [_layoutSpecBlocks objectForKey:node];
     if (node.layoutSpecBlock != block) {
       node.automaticallyManagesSubnodes = YES;
       node.layoutSpecBlock = block;
@@ -128,9 +128,9 @@
 /// to the layout size if needed, then call -setNeedsLayout
 - (void)setTestSizesOfLeafNodesInLayout:(ASLayout *)layout
 {
-  auto node = (ASLayoutTestNode *)layout.layoutElement;
+  let node = (ASLayoutTestNode *)layout.layoutElement;
   if (layout.sublayouts.count == 0) {
-    auto override = [self.returnedSizes objectForKey:node];
+    let override = [self.returnedSizes objectForKey:node];
     node.testSize = override ? override.CGSizeValue : layout.size;
   } else {
     node.testSize = CGSizeZero;


### PR DESCRIPTION
Following up from #968 were we discussed to introduce some standard in terms of defining and initializing objects with type inference. Currently we use `auto` in some places if we are in C++ land, but cannot use it if we not compile for C++. In this places we can use `__auto_type` though.

This diff introduces a `let` and `var` macro and is defined as:
```
#if defined(__cplusplus)
# define var auto
# define let auto const
#else
# define var __auto_type
# define let const __auto_type
#endif
```

Besides introducing some default, this diff should also give us a way for us to discuss and maybe come to a good solution going forward.