### PR TITLE
[IGListKit] Adds missing UIScrollViewDelegate method to DataSource proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Create a method to transfer strong C-arrays into immutable NSArrays, reducing retain/release traffic. [Adlai Holler](https://github.com/Adlai-Holler)
 - Remove yoga layout spec, which has been superseded by tighter Yoga integration (`ASDisplayNode+Yoga.h`)
 - Properly consider node for responder methods [Michael Schneider](https://github.com/maicki) 
+- [IGListKit] Adds missing UIScrollViewDelegate method to DataSource proxy [Sergey Pronin](https://github.com/wannabehero) 
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/Private/ASIGListAdapterBasedDataSource.m
+++ b/Source/Private/ASIGListAdapterBasedDataSource.m
@@ -115,6 +115,11 @@ typedef struct {
   [self.delegate scrollViewDidEndDragging:scrollView willDecelerate:decelerate];
 }
 
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
+{
+  [self.delegate scrollViewDidEndDecelerating:scrollView];
+}
+
 - (BOOL)shouldBatchFetchForCollectionNode:(ASCollectionNode *)collectionNode
 {
   NSInteger sectionCount = [self numberOfSectionsInCollectionNode:collectionNode];


### PR DESCRIPTION
The method `scrollViewDidEndDecelerating` have been declared by proxy but wasn't not implemented, thus messages weren't delivered to `IGListAdapter.scrollViewDelegate`.

This simple request addresses this issue.