### PR TITLE
[ASNetworkImageNode] Fix ASNetworkImageNode downloadImageWithCompletion URL nil crash

### DIFF
--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -561,7 +561,12 @@
     // it and try again.
     {
       ASLockScopeSelf();
-      url = _URL;
+      if (_URL) {
+        url = _URL;
+      } else {
+        [self _locked_cancelDownloadAndClearImageWithResumePossibility:NO];
+        return;
+      }
     }
 
 


### PR DESCRIPTION
![2018-07-11 12 53 43](https://user-images.githubusercontent.com/19504988/42549883-7928a432-8509-11e8-8248-54c5c590a322.png)
When i forcefully injected nil to _URL property before calling downloadImageWithURL method then i faced same crash like an upper screenshot
I guess that _URL became to nil before reobtain the lock on downloadImageWithCompletion method. 
