### PR TITLE
Fix misleading/scary stack trace shown when an assertion occurs during node measurement

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1040,10 +1040,11 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
 
     // This method will confirm that the layout is up to date (and update if needed).
     // Importantly, it will also APPLY the layout to all of our subnodes if (unless parent is transitioning).
-    __instanceLock__.unlock();
-    [self _u_measureNodeWithBoundsIfNecessary:bounds];
-    __instanceLock__.lock();
-
+    {
+      ASDN::MutexUnlocker u(__instanceLock__);
+      [self _u_measureNodeWithBoundsIfNecessary:bounds];
+    }
+    
     [self _locked_layoutPlaceholderIfNecessary];
   }
   


### PR DESCRIPTION
- Currently, there is a pair of mutex unlock and unlock that wraps around `-_u_measureNodeWithBoundsIfNecessary:` in `__layout`. That is because this method must be called without the lock.
- When an assertion occurs within that method, the runtime bails early without reacquire the lock (so the lock is free now). However, the runtime then hits the end of the outmost mutex locker scope and tries to release the lock that it no longer holds, causing another assertion in ASThread to be shown to user (#932) (see [this video](https://cl.ly/stlh) here for more details). This makes it extremely hard to idenfity the root assertion.
- Fix by replacing the unlock/lock pair with a mutex unlocker.
