### PR TITLE
Fix 32-bit simulator build on Xcode >= 9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Properly consider node for responder methods [Michael Schneider](https://github.com/maicki) 
 - [IGListKit] Adds missing UIScrollViewDelegate method to DataSource proxy [Sergey Pronin](https://github.com/wannabehero) 
 - Fix misleading/scary stack trace shown when an assertion occurs during node measurement [Huy Nguyen](https://github.com/nguyenhuy) [#1022](https://github.com/TextureGroup/Texture/pull/1022)
+- Fix build on 32-bit simulator in Xcode 9.3 and later, caused by `Thread-local storage is not supported on this architecture.` [Adlai Holler](https://github.com/Adlai-Holler)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/Base/ASAssert.m
+++ b/Source/Base/ASAssert.m
@@ -11,9 +11,11 @@
 //
 
 #import <AsyncDisplayKit/ASAssert.h>
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_TLS_AVAILABLE
 
 static _Thread_local int tls_mainThreadAssertionsDisabledCount;
-
 BOOL ASMainThreadAssertionsAreDisabled() {
   return tls_mainThreadAssertionsDisabledCount > 0;
 }
@@ -26,3 +28,35 @@ void ASPopMainThreadAssertionsDisabled() {
   tls_mainThreadAssertionsDisabledCount -= 1;
   ASDisplayNodeCAssert(tls_mainThreadAssertionsDisabledCount >= 0, @"Attempt to pop thread assertion-disabling without corresponding push.");
 }
+
+#else
+
+#import <dispatch/once.h>
+
+static pthread_key_t ASMainThreadAssertionsDisabledKey() {
+  static pthread_key_t k;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    pthread_key_create(&k, NULL);
+  });
+  return k;
+}
+
+BOOL ASMainThreadAssertionsAreDisabled() {
+  return (pthread_getspecific(ASMainThreadAssertionsDisabledKey()) > 0);
+}
+
+void ASPushMainThreadAssertionsDisabled() {
+  let key = ASMainThreadAssertionsDisabledKey();
+  let oldVal = pthread_getspecific(key);
+  pthread_setspecific(key, oldVal + 1);
+}
+
+void ASPopMainThreadAssertionsDisabled() {
+  let key = ASMainThreadAssertionsDisabledKey();
+  let oldVal = pthread_getspecific(key);
+  pthread_setspecific(key, oldVal - 1);
+  ASDisplayNodeCAssert(oldVal > 0, @"Attempt to pop thread assertion-disabling without corresponding push.");
+}
+
+#endif // AS_TLS_AVAILABLE

--- a/Source/Base/ASAvailability.h
+++ b/Source/Base/ASAvailability.h
@@ -19,6 +19,12 @@
 
 #pragma once
 
+#ifdef __i386__
+  #define AS_TLS_AVAILABLE 0
+#else
+  #define AS_TLS_AVAILABLE 1
+#endif
+
 #ifndef kCFCoreFoundationVersionNumber_iOS_10_0
   #define kCFCoreFoundationVersionNumber_iOS_10_0 1348.00
 #endif


### PR DESCRIPTION
Fixes part of the issue discussed in #873 #929 and #969.

We now provide fallbacks for i386.