### PR TITLE
Address warnings in Xcode >= 9.3 about using %zd for NSInteger #trivial

### DIFF
--- a/Source/ASConfiguration.m
+++ b/Source/ASConfiguration.m
@@ -15,19 +15,16 @@
 
 /// Not too performance-sensitive here.
 
-/// Get this from C++, without the extra exception handling.
-#define autotype __auto_type
-
 @implementation ASConfiguration
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
   if (self = [super init]) {
     if (dictionary != nil) {
-      autotype featureStrings = ASDynamicCast(dictionary[@"experimental_features"], NSArray);
-      autotype version = ASDynamicCast(dictionary[@"version"], NSNumber).integerValue;
+      let featureStrings = ASDynamicCast(dictionary[@"experimental_features"], NSArray);
+      let version = ASDynamicCast(dictionary[@"version"], NSNumber).integerValue;
       if (version != ASConfigurationSchemaCurrentVersion) {
-        NSLog(@"Texture warning: configuration schema is old version (%zd vs %zd)", version, ASConfigurationSchemaCurrentVersion);
+        NSLog(@"Texture warning: configuration schema is old version (%ld vs %ld)", (long)version, (long)ASConfigurationSchemaCurrentVersion);
       }
       self.experimentalFeatures = ASExperimentalFeaturesFromArray(featureStrings);
     } else {

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -2225,7 +2225,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
     NSUInteger subnodesCount = _subnodes.count;
   __instanceLock__.unlock();
   if (subnodeIndex > subnodesCount || subnodeIndex < 0) {
-    ASDisplayNodeFailAssert(@"Cannot insert a subnode at index %zd. Count is %zd", subnodeIndex, subnodesCount);
+    ASDisplayNodeFailAssert(@"Cannot insert a subnode at index %ld. Count is %ld", (long)subnodeIndex, (long)subnodesCount);
     return;
   }
   
@@ -2540,7 +2540,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
     ASDN::MutexLocker l(__instanceLock__);
     
     if (idx > _subnodes.count || idx < 0) {
-      ASDisplayNodeFailAssert(@"Cannot insert a subnode at index %zd. Count is %zd", idx, _subnodes.count);
+      ASDisplayNodeFailAssert(@"Cannot insert a subnode at index %ld. Count is %ld", (long)idx, (long)_subnodes.count);
       return;
     }
     

--- a/Source/Details/ASElementMap.m
+++ b/Source/Details/ASElementMap.m
@@ -244,7 +244,7 @@
   NSInteger sectionCount = _sectionsOfItems.count;
   if (section >= sectionCount || section < 0) {
     if (assert) {
-      ASDisplayNodeFailAssert(@"Invalid section index %zd when there are only %zd sections!", section, sectionCount);
+      ASDisplayNodeFailAssert(@"Invalid section index %ld when there are only %ld sections!", (long)section, (long)sectionCount);
     }
     return NO;
   } else {
@@ -272,7 +272,7 @@
   NSInteger item = indexPath.item;
   if (item >= itemCount || item < 0) {
     if (assert) {
-      ASDisplayNodeFailAssert(@"Invalid item index %zd in section %zd which only has %zd items!", item, section, itemCount);
+      ASDisplayNodeFailAssert(@"Invalid item index %ld in section %ld which only has %ld items!", (long)item, (long)section, (long)itemCount);
     }
     return NO;
   }

--- a/Source/Details/ASIntegerMap.mm
+++ b/Source/Details/ASIntegerMap.mm
@@ -157,7 +157,7 @@
     // { 1->2 3->4 5->6 }
     NSMutableString *str = [NSMutableString string];
     for (let &e : _map) {
-      [str appendFormat:@" %zd->%zd", e.first, e.second];
+      [str appendFormat:@" %ld->%ld", (long)e.first, (long)e.second];
     }
     // Remove leading space
     if (str.length > 0) {

--- a/Source/Private/ASTwoDimensionalArrayUtils.m
+++ b/Source/Private/ASTwoDimensionalArrayUtils.m
@@ -55,14 +55,14 @@ void ASDeleteElementsInTwoDimensionalArrayAtIndexPaths(NSMutableArray *mutableAr
   for (NSIndexPath *indexPath in indexPaths) {
     NSInteger section = indexPath.section;
     if (section >= mutableArray.count) {
-      ASDisplayNodeCFailAssert(@"Invalid section index %zd – only %zd sections", section, mutableArray.count);
+      ASDisplayNodeCFailAssert(@"Invalid section index %ld – only %ld sections", (long)section, (long)mutableArray.count);
       continue;
     }
 
     NSMutableArray *subarray = mutableArray[section];
     NSInteger item = indexPath.item;
     if (item >= subarray.count) {
-      ASDisplayNodeCFailAssert(@"Invalid item index %zd – only %zd items in section %zd", item, subarray.count, section);
+      ASDisplayNodeCFailAssert(@"Invalid item index %ld – only %ld items in section %ld", (long)item, (long)subarray.count, (long)section);
       continue;
     }
     [subarray removeObjectAtIndex:item];

--- a/Source/Private/TextExperiment/Component/ASTextLine.m
+++ b/Source/Private/TextExperiment/Component/ASTextLine.m
@@ -153,7 +153,7 @@
 - (NSString *)description {
   NSMutableString *desc = @"".mutableCopy;
   NSRange range = self.range;
-  [desc appendFormat:@"<ASTextLine: %p> row:%zd range:%tu,%tu",self, self.row, range.location, range.length];
+  [desc appendFormat:@"<ASTextLine: %p> row:%ld range:%tu,%tu", self, (long)self.row, range.location, range.length];
   [desc appendFormat:@" position:%@",NSStringFromCGPoint(self.position)];
   [desc appendFormat:@" bounds:%@",NSStringFromCGRect(self.bounds)];
   return desc;

--- a/Source/Private/_ASCoreAnimationExtras.mm
+++ b/Source/Private/_ASCoreAnimationExtras.mm
@@ -123,7 +123,7 @@ NSString *const ASDisplayNodeCAContentsGravityFromUIContentMode(UIViewContentMod
       return e.string;
     }
   }
-  ASDisplayNodeCAssert(contentMode == UIViewContentModeRedraw, @"Encountered an unknown contentMode %zd. Is this a new version of iOS?", contentMode);
+  ASDisplayNodeCAssert(contentMode == UIViewContentModeRedraw, @"Encountered an unknown contentMode %ld. Is this a new version of iOS?", (long)contentMode);
   // Redraw is ok to return nil.
   return nil;
 }

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -536,7 +536,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   NSInteger deletedSectionCount = _deletedSections.count;
   // Assert that the new section count is correct.
   if (newSectionCount != oldSectionCount + insertedSectionCount - deletedSectionCount) {
-    ASFailUpdateValidation(@"Invalid number of sections. The number of sections after the update (%zd) must be equal to the number of sections before the update (%zd) plus or minus the number of sections inserted or deleted (%tu inserted, %tu deleted)", newSectionCount, oldSectionCount, insertedSectionCount, deletedSectionCount);
+    ASFailUpdateValidation(@"Invalid number of sections. The number of sections after the update (%ld) must be equal to the number of sections before the update (%ld) plus or minus the number of sections inserted or deleted (%ld inserted, %ld deleted)", (long)newSectionCount, (long)oldSectionCount, (long)insertedSectionCount, (long)deletedSectionCount);
     return;
   }
   
@@ -548,7 +548,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
     invalidSectionDelete = [_deletedSections indexGreaterThanIndex:oldSectionCount - 1];
   }
   if (invalidSectionDelete != NSNotFound) {
-    ASFailUpdateValidation(@"Attempt to delete section %zd but there are only %zd sections before the update.", invalidSectionDelete, oldSectionCount);
+    ASFailUpdateValidation(@"Attempt to delete section %ld but there are only %ld sections before the update.", (long)invalidSectionDelete, (long)oldSectionCount);
     return;
   }
   
@@ -558,14 +558,14 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
       NSInteger section = indexPath.section;
       NSInteger item = indexPath.item;
       if (section >= oldSectionCount) {
-        ASFailUpdateValidation(@"Attempt to delete item %zd from section %zd, but there are only %zd sections before the update.", item, section, oldSectionCount);
+        ASFailUpdateValidation(@"Attempt to delete item %ld from section %ld, but there are only %ld sections before the update.", (long)item, (long)section, (long)oldSectionCount);
         return;
       }
       
       // Assert that item delete happened to a valid item.
       NSInteger oldItemCount = _oldItemCounts[section];
       if (item >= oldItemCount) {
-        ASFailUpdateValidation(@"Attempt to delete item %zd from section %zd, which only contains %zd items before the update.", item, section, oldItemCount);
+        ASFailUpdateValidation(@"Attempt to delete item %ld from section %ld, which only contains %ld items before the update.", (long)item, (long)section, (long)oldItemCount);
         return;
       }
     }
@@ -577,14 +577,14 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
       NSInteger item = indexPath.item;
       // Assert that item insert happened in a valid section.
       if (section >= newSectionCount) {
-        ASFailUpdateValidation(@"Attempt to insert item %zd into section %zd, but there are only %zd sections after the update.", item, section, newSectionCount);
+        ASFailUpdateValidation(@"Attempt to insert item %ld into section %ld, but there are only %ld sections after the update.", (long)item, (long)section, (long)newSectionCount);
         return;
       }
       
       // Assert that item delete happened to a valid item.
       NSInteger newItemCount = _newItemCounts[section];
       if (item >= newItemCount) {
-        ASFailUpdateValidation(@"Attempt to insert item %zd into section %zd, which only contains %zd items after the update.", item, section, newItemCount);
+        ASFailUpdateValidation(@"Attempt to insert item %ld into section %ld, which only contains %ld items after the update.", (long)item, (long)section, (long)newItemCount);
         return;
       }
     }
@@ -598,7 +598,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
     invalidSectionInsert = [_insertedSections indexGreaterThanIndex:newSectionCount - 1];
   }
   if (invalidSectionInsert != NSNotFound) {
-    ASFailUpdateValidation(@"Attempt to insert section %zd but there are only %zd sections after the update.", invalidSectionInsert, newSectionCount);
+    ASFailUpdateValidation(@"Attempt to insert section %ld but there are only %ld sections after the update.", (long)invalidSectionInsert, (long)newSectionCount);
     return;
   }
   
@@ -631,7 +631,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
     NSInteger insertedItemCount = originalInsertedItems.count;
     NSInteger deletedItemCount = originalDeletedItems.count;
     if (newItemCount != oldItemCount + insertedItemCount - deletedItemCount) {
-      ASFailUpdateValidation(@"Invalid number of items in section %zd. The number of items after the update (%zd) must be equal to the number of items before the update (%zd) plus or minus the number of items inserted or deleted (%zd inserted, %zd deleted).", oldSection, newItemCount, oldItemCount, insertedItemCount, deletedItemCount);
+      ASFailUpdateValidation(@"Invalid number of items in section %ld. The number of items after the update (%ld) must be equal to the number of items before the update (%ld) plus or minus the number of items inserted or deleted (%ld inserted, %ld deleted).", (long)oldSection, (long)newItemCount, (long)oldItemCount, (long)insertedItemCount, (long)deletedItemCount);
       return;
     }
   }


### PR DESCRIPTION
Oh `%zd`, you were the solution to all our problems. The perfect specifier for `NSInteger` a.k.a `ssize_t`.

But the lords of Clang have struck you down. So let's throw in the towel and cast to `long`. For now, using `%tu` for `NSUInteger` doesn't generate warnings so let's leave it be. Easy enough to change later.