### PR TITLE
Turn off exceptions to reduce binary size (-600KB for arm64)

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -2738,7 +2738,11 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = Source/AsyncDisplayKit.modulemap;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_CFLAGS = "-Wundef";
+				OTHER_CFLAGS = (
+					"-Wundef",
+					"-fno-exceptions",
+					"-fno-objc-arc-exceptions",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AsyncDisplayKit;
 				SKIP_INSTALL = YES;
@@ -2767,7 +2771,11 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = Source/AsyncDisplayKit.modulemap;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_CFLAGS = "-Wundef";
+				OTHER_CFLAGS = (
+					"-Wundef",
+					"-fno-exceptions",
+					"-fno-objc-arc-exceptions",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AsyncDisplayKit;
 				SKIP_INSTALL = YES;
@@ -2881,7 +2889,11 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = Source/AsyncDisplayKit.modulemap;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_CFLAGS = "-Wundef";
+				OTHER_CFLAGS = (
+					"-Wundef",
+					"-fno-exceptions",
+					"-fno-objc-arc-exceptions",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AsyncDisplayKit;
 				SKIP_INSTALL = YES;

--- a/BUCK
+++ b/BUCK
@@ -4,6 +4,8 @@
 COMMON_PREPROCESSOR_FLAGS = [
   '-fobjc-arc',
   '-DDEBUG=1',
+  '-fno-exceptions',
+  '-fno-objc-arc-exceptions'
 ]
 
 COMMON_LANG_PREPROCESSOR_FLAGS = {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Enable locking assertions (and add some more) to improve and enforce locking safety within the framework [Huy Nguyen](https://github.com/nguyenhuy) [#1024](https://github.com/TextureGroup/Texture/pull/1024)
 - Split MapKit, Photos, and AssetsLibrary dependent code into separate subspecs to improve binary size and start time when they're not needed. The default subspec includes all three for backwards compatibility, but this **will change in 3.0**. When using non-Cocoapods build environments, define `AS_USE_PHOTOS, AS_USE_MAPKIT, AS_USE_ASSETS_LIBRARY` to 1 respectively to signal their use. [Adlai Holler](https://github.com/Adlai-Holler)
 - Optimization: Removed an NSMutableArray in flattened layouts. [Adlai Holler](https://github.com/Adlai-Holler)
+- Reduced binary size by disabling exception support (which we don't use.) [Adlai Holler](https://github.com/Adlai-Holler)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/ASDisplayNodeExtras.h
+++ b/Source/ASDisplayNodeExtras.h
@@ -30,7 +30,7 @@
   #define ASSetDebugName(node, format, ...) node.debugName = [NSString stringWithFormat:format, __VA_ARGS__]
   #define ASSetDebugNames(...) _ASSetDebugNames(self.class, @"" # __VA_ARGS__, __VA_ARGS__, nil)
 #else
-  #define ASSetDebugName(node, name)
+  #define ASSetDebugName(node, format, ...)
   #define ASSetDebugNames(...)
 #endif
 

--- a/Texture.podspec
+++ b/Texture.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |spec|
 
   # Subspecs
   spec.subspec 'Core' do |core|
+    core.compiler_flags = '-fno-exceptions -fno-objc-arc-exceptions'
     core.public_header_files = [
       'Source/*.h',
       'Source/Details/**/*.h',


### PR DESCRIPTION
We don't currently use exceptions so we don't need the extra binary to support them.

`-fno-exceptions` removes unwind tables and makes C++ STL put "abort" wherever there would be an exception.
`-fno-objc-arc-exceptions` removes code that ARC adds to prevent leaks in the case of exceptions https://clang.llvm.org/docs/AutomaticReferenceCounting.html#exceptions

**How big is the win?**
- In terms of total o-file size, the framework goes from **33.3MB to 31.5MB** for ARM64 release builds.
- In terms of executable size, the CatDealsCollectionView ARM64 release binary goes from **12.3MB to 11.7MB**.

So modulo any Apple fiddling with your binary, the 64-bit one should shrink by about 600KB.