### PR TITLE
Fix the bug I introduced in #1030 #trivial

### DIFF
--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -172,7 +172,10 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
 {
   if (_retainSublayoutElements.load()) {
     for (ASLayout *sublayout in _sublayouts) {
-      CFRelease((__bridge CFTypeRef)sublayout);
+      // We retained this, so there's no risk of it deallocating on us.
+      if (let cfElement = (__bridge CFTypeRef)sublayout->_layoutElement) {
+        CFRelease(cfElement);
+      }
     }
   }
 }
@@ -186,7 +189,8 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
   }
   
   for (ASLayout *sublayout in _sublayouts) {
-    CFRetain((__bridge CFTypeRef)sublayout->_layoutElement);
+    // CFBridgingRetain atomically casts and retains. We need the atomicity.
+    CFBridgingRetain(sublayout->_layoutElement);
   }
 }
 


### PR DESCRIPTION
- Major bug in the release: I was releasing the layout itself, not the layout element.
- Improvement in the retain: Previously I bridge-casted then retained (= `[[[o retain] autorelease] retain]`), now I use a bridging retain (= `[o retain]`).

Thanks Michael for recognizing that the CI simulator loop was caused by this. I don't know why it resulted in a simulator loop but at least it's fixed.