### PR TITLE
Revert unreleased layout debug method name change from #1030 #trivial

### DIFF
--- a/Source/Layout/ASLayout.h
+++ b/Source/Layout/ASLayout.h
@@ -149,9 +149,9 @@ AS_EXTERN ASLayout *ASCalculateLayout(id<ASLayoutElement>layoutElement, const AS
 
 /**
  * Set to YES to tell all ASLayout instances to retain their sublayout elements. Defaults to NO.
- * See `-retainSublayoutElements` to control this per-instance.
+ * See `-retainSublayoutLayoutElements` to control this per-instance.
  */
-@property (class) BOOL shouldRetainSublayoutElements;
+@property (class) BOOL shouldRetainSublayoutLayoutElements;
 
 /**
  * Recrusively output the description of the layout tree.

--- a/Source/Layout/ASLayout.h
+++ b/Source/Layout/ASLayout.h
@@ -150,6 +150,8 @@ AS_EXTERN ASLayout *ASCalculateLayout(id<ASLayoutElement>layoutElement, const AS
 /**
  * Set to YES to tell all ASLayout instances to retain their sublayout elements. Defaults to NO.
  * See `-retainSublayoutLayoutElements` to control this per-instance.
+ *
+ * Note: Weaver relies on this API.
  */
 @property (class) BOOL shouldRetainSublayoutLayoutElements;
 

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -63,9 +63,6 @@ ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT BOOL ASLayoutIsDisplayNodeType(ASLayo
   std::atomic_bool _retainSublayoutElements;
 }
 
-/// Call this to keep sublayout elements alive. Multiple calls have no effect.
-- (void)retainSublayoutLayoutElements;
-
 @property (nonatomic, readonly) ASRectMap *elementToRectMap;
 
 @end
@@ -182,7 +179,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
 
 #pragma mark - Sublayout Elements Caching
 
-- (void)retainSublayoutLayoutElements
+- (void)retainSublayoutElements
 {
   if (_retainSublayoutElements.exchange(true)) {
     return;

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -64,7 +64,7 @@ ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT BOOL ASLayoutIsDisplayNodeType(ASLayo
 }
 
 /// Call this to keep sublayout elements alive. Multiple calls have no effect.
-- (void)retainSublayoutElements;
+- (void)retainSublayoutLayoutElements;
 
 @property (nonatomic, readonly) ASRectMap *elementToRectMap;
 
@@ -182,7 +182,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
 
 #pragma mark - Sublayout Elements Caching
 
-- (void)retainSublayoutElements
+- (void)retainSublayoutLayoutElements
 {
   if (_retainSublayoutElements.exchange(true)) {
     return;


### PR DESCRIPTION
The CI unit tests were fixed in #1038, this should fix the examples build.