### PR TITLE
Fix headers in markdown

### DIFF
--- a/docs/_docs/automatic-layout-basics.md
+++ b/docs/_docs/automatic-layout-basics.md
@@ -6,7 +6,7 @@ prevPage: scroll-node.html
 nextPage: automatic-layout-containers.html
 ---
 
-##Box Model Layout
+## Box Model Layout
 
 ASLayout is an automatic, asynchronous, purely Objective-C box model layout feature. It is a simplified version of CSS flex box, loosely inspired by ComponentKit’s Layout. It is designed to make your layouts extensible and reusable.
 
@@ -14,7 +14,7 @@ ASLayout is an automatic, asynchronous, purely Objective-C box model layout feat
 
 `<ASLayoutable>` instances (all ASDisplayNodes and subclasses) do not have any size or position information. Instead, Texture calls the `layoutSpecThatFits:` method with a given size constraint and the component must return a structure describing both its size, and the position and sizes of its children.
 
-##Terminology
+## Terminology
 
 The terminology is a bit confusing, so here is a brief description of all of the Texture automatic layout players:
 
@@ -30,7 +30,7 @@ Every ASLayoutSpec must act on at least one child. The ASLayoutSpec has the resp
 
 You don’t need to be aware of **`ASLayout`** except to know that it represents a computed immutable layout tree and is returned by objects conforming to the `<ASLayoutable>` protocol.
 
-##Layout for UIKit Components:
+## Layout for UIKit Components:
 - for UIViews that are added directly, you will still need to manually lay it out in `didLoad:`
 - for UIViews that are added via `[ASDisplayNode initWithViewBlock:]` or its variants, you can then include it in `layoutSpecThatFits:`
 


### PR DESCRIPTION
In order for markdown to properly render headers, there needs to be a space between the `#` and the text. I've added these where I found them missing.