### PR TITLE
[ASTextNode2] Simplify allocWithZone: + initialize implementation #trivial

### DIFF
--- a/Tests/ASDisplayLayerTests.m
+++ b/Tests/ASDisplayLayerTests.m
@@ -217,7 +217,7 @@ static _ASDisplayLayerTestDelegateClassModes _class_modes;
 }
 
 // DANGER: Don't use the delegate as the parameters in real code; this is not thread-safe and just for accounting in unit tests!
-+ (UIImage *)displayWithParameters:(_ASDisplayLayerTestDelegate *)delegate isCancelled:(asdisplaynode_iscancelled_block_t)sentinelBlock
++ (UIImage *)displayWithParameters:(_ASDisplayLayerTestDelegate *)delegate isCancelled:(NS_NOESCAPE asdisplaynode_iscancelled_block_t)sentinelBlock
 {
   UIImage *contents = bogusImage();
   if (delegate->_displayLayerBlock != NULL) {
@@ -228,7 +228,7 @@ static _ASDisplayLayerTestDelegateClassModes _class_modes;
 }
 
 // DANGER: Don't use the delegate as the parameters in real code; this is not thread-safe and just for accounting in unit tests!
-+ (void)drawRect:(CGRect)bounds withParameters:(_ASDisplayLayerTestDelegate *)delegate isCancelled:(asdisplaynode_iscancelled_block_t)sentinelBlock isRasterizing:(BOOL)isRasterizing
++ (void)drawRect:(CGRect)bounds withParameters:(_ASDisplayLayerTestDelegate *)delegate isCancelled:(NS_NOESCAPE asdisplaynode_iscancelled_block_t)sentinelBlock isRasterizing:(BOOL)isRasterizing
 {
   __atomic_add_fetch(&delegate->_drawRectCount, 1, __ATOMIC_SEQ_CST);
 }


### PR DESCRIPTION
### Motivation

Some code paths in our app use `class_createInstance` directly on subclasses of ASTextNode and so bypass `allocWithZone:`. In order to get the correct class hierarchy, the change must be made somewhere else.

### Changes

- Move the class change for subclasses from `allocWithZone:` to `initialize`.

We get the added benefit of improving performance.