### PR TITLE
Remove CATransaction signposts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Reduced binary size by disabling exception support (which we don't use.) [Adlai Holler](https://github.com/Adlai-Holler)
 - Create and set delegate for clip corner layers within ASDisplayNode [Michael Schneider](https://github.com/maicki) [#1029](https://github.com/TextureGroup/Texture/pull/1029)
 - Improve locking situation in ASVideoPlayerNode [Michael Schneider](https://github.com/maicki) [#1042](https://github.com/TextureGroup/Texture/pull/1042)
+- Remove CA transaction signpost injection because it causes more transactions and is too chatty. [Adlai Holler](https://github.com/Adlai-Holler)
 
 
 ## 2.7


### PR DESCRIPTION
### Motivation

The CA transaction signposts are implemented by registering observers each turn of the run loop. Unfortunately this wakes the run loop up which means more transactions than necessary. Too many signposts to make sense of.

ASCATransactionQueue was added after this, and if we ever want transaction signposts again we should build on top of that.

### Changes
- Remove all CA transaction signpost injection code.