### PR TITLE
Reduce copying in ASTextNode2 stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,7 @@
 - Improve locking situation in ASVideoPlayerNode [Michael Schneider](https://github.com/maicki) [#1042](https://github.com/TextureGroup/Texture/pull/1042)
 - Optimize ASDisplayNode -> ASNodeController reference by removing weak proxy and objc associated objects. [Adlai Holler](https://github.com/Adlai-Holler)
 - Remove CA transaction signpost injection because it causes more transactions and is too chatty. [Adlai Holler](https://github.com/Adlai-Holler)
-- Optimize display node accessibility by not creating attributed & non-attributed copies of hint, 
-label, and value. [Adlai Holler](https://github.com/Adlai-Holler)
+- Optimize display node accessibility by not creating attributed & non-attributed copies of hint, label, and value. [Adlai Holler](https://github.com/Adlai-Holler)
 - Optimize text stack by removing unneeded copying. [Adlai Holler](https://github.com/Adlai-Holler)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@
 - Improve locking situation in ASVideoPlayerNode [Michael Schneider](https://github.com/maicki) [#1042](https://github.com/TextureGroup/Texture/pull/1042)
 - Optimize ASDisplayNode -> ASNodeController reference by removing weak proxy and objc associated objects. [Adlai Holler](https://github.com/Adlai-Holler)
 - Remove CA transaction signpost injection because it causes more transactions and is too chatty. [Adlai Holler](https://github.com/Adlai-Holler)
-- Optimize display node accessibility by not creating attributed & non-attributed copies of hint, label, and value. [Adlai Holler](https://github.com/Adlai-Holler)
+- Optimize display node accessibility by not creating attributed & non-attributed copies of hint, 
+label, and value. [Adlai Holler](https://github.com/Adlai-Holler)
+- Optimize text stack by removing unneeded copying. [Adlai Holler](https://github.com/Adlai-Holler)
 
 
 ## 2.7

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -370,6 +370,8 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 {
   ASLockScopeSelf();
   [self _ensureTruncationText];
+
+  // Unlike layout, here we must copy the container since drawing is asynchronous.
   ASTextContainer *copiedContainer = [_textContainer copy];
   copiedContainer.size = self.bounds.size;
   [copiedContainer makeImmutable];

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -236,12 +236,17 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
   ASLockScopeSelf();
 
-  ASTextContainer *container = [_textContainer copy];
-  NSAttributedString *attributedText = self.attributedText;
-  container.size = constrainedSize;
+  ASTextContainer *container;
+  if (!CGSizeEqualToSize(container.size, constrainedSize)) {
+    container = [_textContainer copy];
+    container.size = constrainedSize;
+    [container makeImmutable];
+  } else {
+    container = _textContainer;
+  }
   [self _ensureTruncationText];
   
-  NSMutableAttributedString *mutableText = [attributedText mutableCopy];
+  NSMutableAttributedString *mutableText = [_attributedText mutableCopy];
   [self prepareAttributedString:mutableText];
   ASTextLayout *layout = [ASTextNode2 compatibleLayoutWithContainer:container text:mutableText];
   
@@ -367,7 +372,8 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   [self _ensureTruncationText];
   ASTextContainer *copiedContainer = [_textContainer copy];
   copiedContainer.size = self.bounds.size;
-  NSMutableAttributedString *mutableText = [self.attributedText mutableCopy] ?: [[NSMutableAttributedString alloc] init];
+  [copiedContainer makeImmutable];
+  NSMutableAttributedString *mutableText = [_attributedText mutableCopy] ?: [[NSMutableAttributedString alloc] init];
   
   [self prepareAttributedString:mutableText];
   

--- a/Source/Private/TextExperiment/Component/ASTextLayout.h
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.h
@@ -67,6 +67,9 @@ AS_EXTERN const CGSize ASTextContainerMaxSize;
 /// Creates a container with the specified path. @param path The path.
 + (instancetype)containerWithPath:(nullable UIBezierPath *)path NS_RETURNS_RETAINED;
 
+/// Mark this immutable, so you get free copies going forward.
+- (void)makeImmutable;
+
 /// The constrained size. (if the size is larger than ASTextContainerMaxSize, it will be clipped)
 @property CGSize size;
 

--- a/Source/Private/TextExperiment/Component/ASTextLayout.m
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.m
@@ -424,7 +424,7 @@ dispatch_semaphore_signal(_lock);
   container = [container copy];
   if (!text || !container) return nil;
   if (range.location + range.length > text.length) return nil;
-  [container setReadonly];
+  [container makeImmutable];
   maximumNumberOfRows = container.maximumNumberOfRows;
   
   // It may use larger constraint size when create CTFrame with

--- a/Source/Private/TextExperiment/Component/ASTextLayout.m
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.m
@@ -16,6 +16,8 @@
 //
 
 #import <AsyncDisplayKit/ASTextLayout.h>
+
+#import <AsyncDisplayKit/ASAssert.h>
 #import <AsyncDisplayKit/ASTextUtilities.h>
 #import <AsyncDisplayKit/ASTextAttribute.h>
 #import <AsyncDisplayKit/NSAttributedString+ASText.h>

--- a/Source/Private/TextExperiment/Component/ASTextLayout.m
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.m
@@ -130,26 +130,36 @@ static CGColorRef ASTextGetCGColor(CGColorRef color) {
   return self;
 }
 
-- (id)copyWithZone:(NSZone *)zone {
-  ASTextContainer *one = [self.class new];
+- (id)copyForced:(BOOL)forceCopy
+{
   dispatch_semaphore_wait(_lock, DISPATCH_TIME_FOREVER);
+  if (_readonly && !forceCopy) {
+    dispatch_semaphore_signal(_lock);
+    return self;
+  }
+
+  ASTextContainer *one = [self.class new];
   one->_size = _size;
   one->_insets = _insets;
   one->_path = _path;
-  one->_exclusionPaths = _exclusionPaths.copy;
+  one->_exclusionPaths = [_exclusionPaths copy];
   one->_pathFillEvenOdd = _pathFillEvenOdd;
   one->_pathLineWidth = _pathLineWidth;
   one->_verticalForm = _verticalForm;
   one->_maximumNumberOfRows = _maximumNumberOfRows;
   one->_truncationType = _truncationType;
-  one->_truncationToken = _truncationToken.copy;
+  one->_truncationToken = [_truncationToken copy];
   one->_linePositionModifier = [(NSObject *)_linePositionModifier copy];
   dispatch_semaphore_signal(_lock);
   return one;
 }
 
-- (id)mutableCopyWithZone:(nullable NSZone *)zone {
-  return [self copyWithZone:zone];
+- (id)copyWithZone:(NSZone *)zone {
+  return [self copyForced:NO];
+}
+
+- (id)mutableCopyWithZone:(NSZone *)zone {
+  return [self copyForced:YES];
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
@@ -185,18 +195,25 @@ static CGColorRef ASTextGetCGColor(CGColorRef color) {
   return self;
 }
 
+- (void)makeImmutable
+{
+  dispatch_semaphore_wait(_lock, DISPATCH_TIME_FOREVER);
+  _readonly = YES;
+  dispatch_semaphore_signal(_lock);
+}
+
 #define Getter(...) \
 dispatch_semaphore_wait(_lock, DISPATCH_TIME_FOREVER); \
 __VA_ARGS__; \
 dispatch_semaphore_signal(_lock);
 
 #define Setter(...) \
-if (_readonly) { \
-@throw [NSException exceptionWithName:NSInternalInconsistencyException \
-reason:@"Cannot change the property of the 'container' in 'ASTextLayout'." userInfo:nil]; \
-return; \
-} \
 dispatch_semaphore_wait(_lock, DISPATCH_TIME_FOREVER); \
+if (__builtin_expect(_readonly, NO)) { \
+  ASDisplayNodeFailAssert(@"Attempt to modify immutable text container."); \
+  dispatch_semaphore_signal(_lock); \
+  return; \
+} \
 __VA_ARGS__; \
 dispatch_semaphore_signal(_lock);
 
@@ -404,11 +421,10 @@ dispatch_semaphore_signal(_lock);
   if (lineRowsIndex) free(lineRowsIndex); \
   return nil; }
   
-  text = text.mutableCopy;
-  container = container.copy;
+  container = [container copy];
   if (!text || !container) return nil;
   if (range.location + range.length > text.length) return nil;
-  container->_readonly = YES;
+  [container setReadonly];
   maximumNumberOfRows = container.maximumNumberOfRows;
   
   // It may use larger constraint size when create CTFrame with


### PR DESCRIPTION
Make text rendering faster.
- Remove pointless attributed string mutable copy in ASTextLayout. No clue why this was here but it is not useful in the least.
- Provide an option to make ASTextContainers immutable and get free copying. ASTextLayout copies its container, which is often already a copy so we save that.