### PR TITLE
Remove direct ivar access on non-self object to fix mocking case #trivial

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -877,9 +877,9 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   _automaticallyRelayoutOnLayoutMarginsChanges = flag;
 }
 
-- (void)setNodeController:(ASNodeController *)controller
+- (void)__setNodeController:(ASNodeController *)controller
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  // See docs for why we don't lock.
   if (controller.shouldInvertStrongReference) {
     _strongNodeController = controller;
     _weakNodeController = nil;

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -47,6 +47,7 @@
 #import <AsyncDisplayKit/ASLayoutSpecPrivate.h>
 #import <AsyncDisplayKit/ASLog.h>
 #import <AsyncDisplayKit/ASMainThreadDeallocation.h>
+#import <AsyncDisplayKit/ASNodeController+Beta.h>
 #import <AsyncDisplayKit/ASRunLoopQueue.h>
 #import <AsyncDisplayKit/ASSignpost.h>
 #import <AsyncDisplayKit/ASTraitCollection.h>
@@ -874,6 +875,18 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
 {
   ASDN::MutexLocker l(__instanceLock__);
   _automaticallyRelayoutOnLayoutMarginsChanges = flag;
+}
+
+- (void)setNodeController:(ASNodeController *)controller
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  if (controller.shouldInvertStrongReference) {
+    _strongNodeController = controller;
+    _weakNodeController = nil;
+  } else {
+    _weakNodeController = controller;
+    _strongNodeController = nil;
+  }
 }
 
 #pragma mark - UIResponder

--- a/Source/ASNodeController+Beta.mm
+++ b/Source/ASNodeController+Beta.mm
@@ -53,7 +53,7 @@
     _weakNode = nil;
   }
 
-  node.nodeController = self;
+  [node __setNodeController:self];
   [node addInterfaceStateDelegate:self];
 }
 

--- a/Source/ASNodeController+Beta.mm
+++ b/Source/ASNodeController+Beta.mm
@@ -46,17 +46,14 @@
   if (_shouldInvertStrongReference) {
     // The node should own the controller; weak reference from controller to node.
     _weakNode = node;
-    node->_strongNodeController = self;
-    node->_weakNodeController = nil;
     _strongNode = nil;
   } else {
     // The controller should own the node; weak reference from node to controller.
     _strongNode = node;
-    node->_weakNodeController = self;
-    node->_strongNodeController = nil;
     _weakNode = nil;
   }
 
+  node.nodeController = self;
   [node addInterfaceStateDelegate:self];
 }
 

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -93,8 +93,6 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
   ASInterfaceState _pendingInterfaceState;
   UIView *_view;
   CALayer *_layer;
-  ASNodeController *_strongNodeController;
-  __weak ASNodeController *_weakNodeController;
 
   std::atomic<ASDisplayNodeAtomicFlags> _atomicFlags;
 
@@ -137,6 +135,9 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
 @protected
   ASDisplayNode * __weak _supernode;
   NSMutableArray<ASDisplayNode *> *_subnodes;
+
+  ASNodeController *_strongNodeController;
+  __weak ASNodeController *_weakNodeController;
 
   // Set this to nil whenever you modify _subnodes
   NSArray<ASDisplayNode *> *_cachedSubnodes;
@@ -275,6 +276,8 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
  * Invoked after a call to setNeedsDisplay to the underlying view
  */
 - (void)__setNeedsDisplay;
+
+- (void)setNodeController:(ASNodeController *)controller;
 
 /**
  * Called whenever the node needs to layout its subnodes and, if it's already loaded, its subviews. Executes the layout pass for the node

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -280,8 +280,12 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
 /**
  * Setup the node -> controller reference. Strong or weak is based on
  * the "shouldInvertStrongReference" property of the controller.
+ *
+ * Note: To prevent lock-ordering deadlocks, this method does not take the node's lock.
+ * In practice, changing the node controller of a node multiple times is not
+ * supported behavior.
  */
-- (void)setNodeController:(ASNodeController *)controller;
+- (void)__setNodeController:(ASNodeController *)controller;
 
 /**
  * Called whenever the node needs to layout its subnodes and, if it's already loaded, its subviews. Executes the layout pass for the node

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -277,6 +277,10 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
  */
 - (void)__setNeedsDisplay;
 
+/**
+ * Setup the node -> controller reference. Strong or weak is based on
+ * the "shouldInvertStrongReference" property of the controller.
+ */
 - (void)setNodeController:(ASNodeController *)controller;
 
 /**


### PR DESCRIPTION
After #1061, if your unit tests use mock nodes you may get a crash because we access ivars on the mock display node. It is unsafe to access ivars on mock objects.

This diff makes it so that we send the node a message. If it's a mock, the mocking system will forward the message to the real instance.