### PR TITLE
Fix compiler error in ASLocking #trivial

### DIFF
--- a/Source/ASLocking.h
+++ b/Source/ASLocking.h
@@ -107,7 +107,7 @@ NS_INLINE void ASUnlockSet(ASLockSet *lockSet) {
  */
 NS_INLINE ASLockSet ASLockSequence(NS_NOESCAPE ASLockSequenceBlock body)
 {
-  __block ASLockSet locks = (ASLockSet){0};
+  __block ASLockSet locks;
   BOOL (^addLock)(id<ASLocking>) = ^(id<ASLocking> obj) {
     
     // nil lock = ignore.

--- a/Source/ASLocking.h
+++ b/Source/ASLocking.h
@@ -107,7 +107,7 @@ NS_INLINE void ASUnlockSet(ASLockSet *lockSet) {
  */
 NS_INLINE ASLockSet ASLockSequence(NS_NOESCAPE ASLockSequenceBlock body)
 {
-  __block ASLockSet locks;
+  __block ASLockSet locks = (ASLockSet){0, {}};
   BOOL (^addLock)(id<ASLocking>) = ^(id<ASLocking> obj) {
     
     // nil lock = ignore.


### PR DESCRIPTION
Hitting this error because we're compiling with a stricter set of build rules internally.

![nslockset](https://user-images.githubusercontent.com/587874/44382307-3b980380-a4c9-11e8-8517-3517dafc5245.png)
