### PR TITLE
Update license check in Dangerfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -53,7 +53,6 @@ def check_file_header(files_to_check, license)
       unless data.include? license_header
         warn ("Please ensure license is correct for #{filename}:\n```\n#{license_header}\n```")
       end
-    
     end
   end
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -51,7 +51,7 @@ def check_file_header(files_to_check, license)
       
       license_header = full_license(license, filename)
       unless data.include? license_header
-        warn ("Please ensure license is correct for #{filename}: \n```\n" + license_header + "```")
+        warn ("Please ensure license is correct for #{filename}:\n```\n#{license_header}\n```")
       end
     
     end


### PR DESCRIPTION
Follow-up on #1077, we no longer need to enforce different licenses for modified vs new files.