### PR TITLE
Remove necessity to use view to access rangeController in ASTableNode, ASCollectionNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [ASPINRemoteImageManager] Add a new API for setting a preconfigured PINRemoteImageManager. [Ernest Ma](https://github.com/ernestmama) [#1124](https://github.com/TextureGroup/Texture/pull/1124)
 - Small optimization to the layout spec & yoga layout systems by eliminating array copies. [Adlai Holler](https://github.com/Adlai-Holler)
 - Optimize layout process by removing `ASRectMap`.  [Adlai Holler](https://github.com/Adlai-Holler)
+- Remove necessity to use view to access rangeController in ASTableNode, ASCollectionNode. [Michael Schneider](https://github.com/maicki)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -31,8 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) ASTableView *view;
 
 // These properties can be set without triggering the view to be created, so it's fine to set them in -init.
-@property (nullable, weak, nonatomic) id <ASTableDelegate>   delegate;
-@property (nullable, weak, nonatomic) id <ASTableDataSource> dataSource;
+@property (nonatomic, weak) id <ASTableDelegate>   delegate;
+@property (nonatomic, weak) id <ASTableDataSource> dataSource;
 
 /**
  * The number of screens left to scroll before the delegate -tableNode:beginBatchFetchingWithContext: is called.

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -369,6 +369,17 @@
   XCTAssertTrue(ASRangeTuningParametersEqualToRangeTuningParameters(preloadParams, [collectionView tuningParametersForRangeType:ASLayoutRangeTypePreload]));
 }
 
+// Informations to test: https://github.com/TextureGroup/Texture/issues/1094
+- (void)testThatCollectionNodeCanHandleNilRangeController
+{
+  UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+  ASCollectionNode *collectionNode = [[ASCollectionNode alloc] initWithCollectionViewLayout:layout];
+  [collectionNode recursivelySetInterfaceState:ASInterfaceStateDisplay];
+  [collectionNode setHierarchyState:ASHierarchyStateRangeManaged];
+  [collectionNode recursivelySetInterfaceState:ASInterfaceStateNone];
+  ASCATransactionQueueWait(nil);
+}
+
 /**
  * This may seem silly, but we had issues where the runtime sometimes wouldn't correctly report
  * conformances declared on categories.


### PR DESCRIPTION
While setting the interface state of a node in certain circumstances we hit the path that first grabs the instance lock and calls `-[ASCollectionNode clearContents]` while the view is not loaded. Within `clearContents` we need access to the rangeController from the view by calling self.view.rangeController what will trigger creating the view and the assert linked in the issue will be thrown as `didLoad` should not be called with the instance locked held.

For now I removed the need to use the view to access the `rangeController` what should fix the situation described above and linked here: #1094

Further todos should be that we improve the locking impelementation around this area. Currently `-[ASDisplayNode clearContents]` is accessing instance variables and therefore should be prefixed with `locked_`, but `-[ASCollectionNode clearContents]` is accessing the rangeController by calling self instead of using the instance variable. The follow up issue is here: #1104