### PR TITLE
Don't copy container during ASTextNode2 measure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Renamed `accessibleElements` to `accessibilityElements` and removed the re-definition of the property in ASDisplayView. [Jia Wern Lim](https://github.com/jiawernlim)
 - Remove double scaling of lineHeightMultiple & paragraphSpacing attributes in ASTextKitFontSizeAdjuster. [Eric Jensen](https://github.com/ejensen)
 - Add a delegate callback for when the framework has initialized. [Adlai Holler](https://github.com/Adlai-Holler)
+- Improve TextNode2 by skipping an unneeded copy during measurement. [Adlai Holler](https://github.com/Adlai-Holler)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -232,19 +232,12 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
   ASLockScopeSelf();
 
-  ASTextContainer *container;
-  if (!CGSizeEqualToSize(container.size, constrainedSize)) {
-    container = [_textContainer copy];
-    container.size = constrainedSize;
-    [container makeImmutable];
-  } else {
-    container = _textContainer;
-  }
+  _textContainer.size = constrainedSize;
   [self _ensureTruncationText];
   
   NSMutableAttributedString *mutableText = [_attributedText mutableCopy];
   [self prepareAttributedString:mutableText];
-  ASTextLayout *layout = [ASTextNode2 compatibleLayoutWithContainer:container text:mutableText];
+  ASTextLayout *layout = [ASTextNode2 compatibleLayoutWithContainer:_textContainer text:mutableText];
   
   [self setNeedsDisplay];
   


### PR DESCRIPTION
- My previous change #1065 intended for us to _sometimes_ copy our mutable text container during layout.
- It had a bug where we _always_ copy the text container.
- It turns out we _never_ need to copy it, because we hold our lock while we use the container. We never mutate or retain the layout during measurement.

Copying text containers is surprisingly expensive hence I think this is worthwhile.