### PR TITLE
Don't setNeedsDisplay on text node 2 measure #trivial

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -246,8 +246,6 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   [self prepareAttributedString:mutableText];
   ASTextLayout *layout = [ASTextNode2 compatibleLayoutWithContainer:container text:mutableText];
   
-  [self setNeedsDisplay];
-  
   return layout.textBoundingSize;
 }
 


### PR DESCRIPTION
- This call was copied from TextNode1.
- Git blame there not helpful.
- Not causing problems right now.
- Doesn't belong.
- We have `needsDisplayOnBoundsChange=YES` in `init`.