### PR TITLE
Fix typos and minor code cleanups #trivial

### DIFF
--- a/Source/ASEditableTextNode.h
+++ b/Source/ASEditableTextNode.h
@@ -198,7 +198,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)editableTextNodeDidFinishEditing:(ASEditableTextNode *)editableTextNode;
 
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ASEditableTextNode.h
+++ b/Source/ASEditableTextNode.h
@@ -192,7 +192,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)editableTextNodeDidUpdateText:(ASEditableTextNode *)editableTextNode;
 
 /**
-  @abstract Indicates to the delegate that teh text node has finished editing.
+  @abstract Indicates to the delegate that the text node has finished editing.
   @param editableTextNode An editable text node.
   @discussion The invocation of this method coincides with the keyboard animating to become hidden.
  */

--- a/Source/Details/ASPINRemoteImageDownloader.h
+++ b/Source/Details/ASPINRemoteImageDownloader.h
@@ -26,7 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
  * This is the default downloader used by network backed image nodes if PINRemoteImage and PINCache are
  * available. It uses PINRemoteImage's features to provide caching and progressive image downloads.
  */
-@property (class, readonly) ASPINRemoteImageDownloader *sharedDownloader;
 + (ASPINRemoteImageDownloader *)sharedDownloader NS_RETURNS_RETAINED;
 
 

--- a/Source/Details/ASPINRemoteImageDownloader.m
+++ b/Source/Details/ASPINRemoteImageDownloader.m
@@ -37,11 +37,9 @@
 #if PIN_ANIMATED_AVAILABLE
 
 @interface ASPINRemoteImageDownloader () <PINRemoteImageManagerAlternateRepresentationProvider>
-
 @end
 
 @interface PINCachedAnimatedImage (ASPINRemoteImageDownloader) <ASAnimatedImageProtocol>
-
 @end
 
 @implementation PINCachedAnimatedImage (ASPINRemoteImageDownloader)
@@ -97,7 +95,6 @@
 }
 
 @end
-
 
 static ASPINRemoteImageDownloader *sharedDownloader = nil;
 

--- a/Source/Private/ASDisplayNode+FrameworkPrivate.h
+++ b/Source/Private/ASDisplayNode+FrameworkPrivate.h
@@ -301,7 +301,7 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyStateChange(ASHierarc
 - (void)_layoutTransitionMeasurementDidFinish;
 
 /**
- * Informs the node that hte pending layout transition did complete
+ * Informs the node that the pending layout transition did complete
  */
 - (void)_completePendingLayoutTransition;
 


### PR DESCRIPTION
- Fix typos in `ASEditableTextNode.h` and `ASDisplayNode+FrameworkPrivate.h`.
- Remove unnecessary declaration for `ASPINRemoteImageDownloader`'s `sharedDownloader` class property.
- Remove unnecessary empty lines in `ASPINRemoteImageDownloader.m` and `ASEditableTextNode.h`.