### PR TITLE
Remove use of NSHashTable for interface state delegates #trivial

### DIFF
--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -24,6 +24,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 #define ASDisplayNodeLoggingEnabled 0
 
+#ifndef AS_MAX_INTERFACE_STATE_DELEGATES
+#define AS_MAX_INTERFACE_STATE_DELEGATES 4
+#endif
+
 @class ASDisplayNode;
 @protocol ASContextTransitioning;
 
@@ -258,6 +262,8 @@ AS_EXTERN NSInteger const ASDefaultDrawingPriority;
  * @abstract Adds a delegate to receive notifications on interfaceState changes.
  *
  * @warning This must be called from the main thread.
+ * There is a hard limit on the number of delegates a node can have; see
+ * AS_MAX_INTERFACE_STATE_DELEGATES above.
  *
  * @see ASInterfaceState
  */

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -452,17 +452,6 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
 
 #pragma mark - Loading
 
-#define ASDisplayNodeCallInterfaceStateDelegates(method) \
-    __instanceLock__.lock(); \
-    NSHashTable *delegates = _copiedInterfaceStateDelegates; \
-    if (!delegates) { \
-      delegates = _copiedInterfaceStateDelegates = [_interfaceStateDelegates copy]; \
-    } \
-    __instanceLock__.unlock(); \
-    for (id <ASInterfaceStateDelegate> delegate in delegates) { \
-      [delegate method]; \
-    }
-
 - (BOOL)_locked_shouldLoadViewOrLayer
 {
   ASAssertLocked(__instanceLock__);
@@ -575,7 +564,9 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   for (ASDisplayNodeDidLoadBlock block in onDidLoadBlocks) {
     block(self);
   }
-  ASDisplayNodeCallInterfaceStateDelegates(nodeDidLoad);
+  [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> del) {
+    [del nodeDidLoad];
+  }];
 }
 
 - (void)didLoad
@@ -1280,7 +1271,9 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   ASDisplayNodeAssertMainThread();
   ASAssertUnlocked(__instanceLock__);
   ASDisplayNodeAssertTrue(self.isNodeLoaded);
-  ASDisplayNodeCallInterfaceStateDelegates(nodeDidLayout);
+  [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> del) {
+    [del nodeDidLayout];
+  }];
 }
 
 #pragma mark Layout Transition
@@ -3218,12 +3211,9 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   // Subclass hook
   ASAssertUnlocked(__instanceLock__);
   ASDisplayNodeAssertMainThread();
-  __instanceLock__.lock();
-  NSHashTable *delegates = [_interfaceStateDelegates copy];
-  __instanceLock__.unlock();
-  for (id <ASInterfaceStateDelegate> delegate in delegates) {
-    [delegate interfaceStateDidChange:newState fromState:oldState];
-  }
+  [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> del) {
+    [del interfaceStateDidChange:newState fromState:oldState];
+  }];
 }
 
 - (BOOL)shouldScheduleDisplayWithNewInterfaceState:(ASInterfaceState)newInterfaceState
@@ -3236,20 +3226,25 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (void)addInterfaceStateDelegate:(id <ASInterfaceStateDelegate>)interfaceStateDelegate
 {
   ASDN::MutexLocker l(__instanceLock__);
-  // Not a fan of lazy loading, but this method won't get called very often and avoiding
-  // the overhead of creating this is probably worth it.
-  if (_interfaceStateDelegates == nil) {
-    _interfaceStateDelegates = [NSHashTable weakObjectsHashTable];
+  _hasHadInterfaceStateDelegates = YES;
+  for (int i = 0; i < MAX_INTERFACE_STATE_DELEGATES; i++) {
+    if (_interfaceStateDelegates[i] == nil) {
+      _interfaceStateDelegates[i] = interfaceStateDelegate;
+      return;
+    }
   }
-  _copiedInterfaceStateDelegates = nil;
-  [_interfaceStateDelegates addObject:interfaceStateDelegate];
+  ASDisplayNodeFailAssert(@"Exceeded interface state delegate limit: %d", MAX_INTERFACE_STATE_DELEGATES);
 }
 
 - (void)removeInterfaceStateDelegate:(id <ASInterfaceStateDelegate>)interfaceStateDelegate
 {
   ASDN::MutexLocker l(__instanceLock__);
-  _copiedInterfaceStateDelegates = nil;
-  [_interfaceStateDelegates removeObject:interfaceStateDelegate];
+  for (int i = 0; i < MAX_INTERFACE_STATE_DELEGATES; i++) {
+    if (_interfaceStateDelegates[i] == interfaceStateDelegate) {
+      _interfaceStateDelegates[i] = nil;
+      break;
+    }
+  }
 }
 
 - (BOOL)isVisible
@@ -3263,7 +3258,9 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   // subclass override
   ASDisplayNodeAssertMainThread();
   ASAssertUnlocked(__instanceLock__);
-  ASDisplayNodeCallInterfaceStateDelegates(didEnterVisibleState);
+  [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> del) {
+    [del didEnterVisibleState];
+  }];
 #if AS_ENABLE_TIPS
   [ASTipsController.shared nodeDidAppear:self];
 #endif
@@ -3274,7 +3271,9 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   // subclass override
   ASDisplayNodeAssertMainThread();
   ASAssertUnlocked(__instanceLock__);
-  ASDisplayNodeCallInterfaceStateDelegates(didExitVisibleState);
+  [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> del) {
+    [del didExitVisibleState];
+  }];
 }
 
 - (BOOL)isInDisplayState
@@ -3288,7 +3287,9 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   // subclass override
   ASDisplayNodeAssertMainThread();
   ASAssertUnlocked(__instanceLock__);
-  ASDisplayNodeCallInterfaceStateDelegates(didEnterDisplayState);
+  [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> del) {
+    [del didEnterDisplayState];
+  }];
 }
 
 - (void)didExitDisplayState
@@ -3296,7 +3297,10 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   // subclass override
   ASDisplayNodeAssertMainThread();
   ASAssertUnlocked(__instanceLock__);
-  ASDisplayNodeCallInterfaceStateDelegates(didExitDisplayState);
+
+  [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> del) {
+    [del didExitDisplayState];
+  }];
 }
 
 - (BOOL)isInPreloadState
@@ -3346,14 +3350,18 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   if (self.automaticallyManagesSubnodes) {
     [self layoutIfNeeded];
   }
-  ASDisplayNodeCallInterfaceStateDelegates(didEnterPreloadState);
+  [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> del) {
+    [del didEnterPreloadState];
+  }];
 }
 
 - (void)didExitPreloadState
 {
   ASDisplayNodeAssertMainThread();
   ASAssertUnlocked(__instanceLock__);
-  ASDisplayNodeCallInterfaceStateDelegates(didExitPreloadState);
+  [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> del) {
+    [del didExitPreloadState];
+  }];
 }
 
 - (void)clearContents
@@ -3380,7 +3388,29 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   });
 }
 
+- (void)enumerateInterfaceStateDelegates:(void (NS_NOESCAPE ^)(id<ASInterfaceStateDelegate>))block
+{
+  ASAssertUnlocked(__instanceLock__);
 
+  id dels[MAX_INTERFACE_STATE_DELEGATES];
+  int count = 0;
+  {
+    ASLockScopeSelf();
+    // Fast path for non-delegating nodes.
+    if (!_hasHadInterfaceStateDelegates) {
+      return;
+    }
+
+    for (int i = 0; i < MAX_INTERFACE_STATE_DELEGATES; i++) {
+      if ((dels[count] = _interfaceStateDelegates[i])) {
+        count++;
+      }
+    }
+  }
+  for (int i = 0; i < count; i++) {
+    block(dels[i]);
+  }
+}
 
 #pragma mark - Gesture Recognizing
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3229,19 +3229,19 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 {
   ASDN::MutexLocker l(__instanceLock__);
   _hasHadInterfaceStateDelegates = YES;
-  for (int i = 0; i < MAX_INTERFACE_STATE_DELEGATES; i++) {
+  for (int i = 0; i < AS_MAX_INTERFACE_STATE_DELEGATES; i++) {
     if (_interfaceStateDelegates[i] == nil) {
       _interfaceStateDelegates[i] = interfaceStateDelegate;
       return;
     }
   }
-  ASDisplayNodeFailAssert(@"Exceeded interface state delegate limit: %d", MAX_INTERFACE_STATE_DELEGATES);
+  ASDisplayNodeFailAssert(@"Exceeded interface state delegate limit: %d", AS_MAX_INTERFACE_STATE_DELEGATES);
 }
 
 - (void)removeInterfaceStateDelegate:(id <ASInterfaceStateDelegate>)interfaceStateDelegate
 {
   ASDN::MutexLocker l(__instanceLock__);
-  for (int i = 0; i < MAX_INTERFACE_STATE_DELEGATES; i++) {
+  for (int i = 0; i < AS_MAX_INTERFACE_STATE_DELEGATES; i++) {
     if (_interfaceStateDelegates[i] == interfaceStateDelegate) {
       _interfaceStateDelegates[i] = nil;
       break;
@@ -3393,7 +3393,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 {
   ASAssertUnlocked(__instanceLock__);
 
-  id dels[MAX_INTERFACE_STATE_DELEGATES];
+  id dels[AS_MAX_INTERFACE_STATE_DELEGATES];
   int count = 0;
   {
     ASLockScopeSelf();
@@ -3402,7 +3402,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
       return;
     }
 
-    for (int i = 0; i < MAX_INTERFACE_STATE_DELEGATES; i++) {
+    for (int i = 0; i < AS_MAX_INTERFACE_STATE_DELEGATES; i++) {
       if ((dels[count] = _interfaceStateDelegates[i])) {
         count++;
       }

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3297,7 +3297,6 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   // subclass override
   ASDisplayNodeAssertMainThread();
   ASAssertUnlocked(__instanceLock__);
-
   [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> del) {
     [del didExitDisplayState];
   }];

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1496,7 +1496,9 @@ NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp = @"AS
   if (_pendingDisplayNodes.isEmpty) {
     
     [self hierarchyDisplayDidFinish];
-    ASDisplayNodeCallInterfaceStateDelegates(hierarchyDisplayDidFinish);
+    [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> delegate) {
+      [delegate hierarchyDisplayDidFinish];
+    }];
       
     BOOL placeholderShouldPersist = [self placeholderShouldPersist];
 

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -75,7 +75,6 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
 #define TIME_DISPLAYNODE_OPS 0 // If you're using this information frequently, try: (DEBUG || PROFILE)
 
 #define NUM_CLIP_CORNER_LAYERS 4
-#define MAX_INTERFACE_STATE_DELEGATES 4
 
 @interface ASDisplayNode () <_ASTransitionContextCompletionDelegate>
 {

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -250,7 +250,7 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
 
   /// Fast path: tells whether we've ever had an interface state delegate before.
   BOOL _hasHadInterfaceStateDelegates;
-  __weak id<ASInterfaceStateDelegate> _interfaceStateDelegates[MAX_INTERFACE_STATE_DELEGATES];
+  __weak id<ASInterfaceStateDelegate> _interfaceStateDelegates[AS_MAX_INTERFACE_STATE_DELEGATES];
 }
 
 + (void)scheduleNodeForRecursiveDisplay:(ASDisplayNode *)node;


### PR DESCRIPTION
- An empty hash table takes 2 heap allocations at 288 bytes.
- 2 hash tables per node (original and copy for safe enumeration) is 576 bytes per node.
- ASDisplayNode is only 928 bytes, so these hash tables add 60% more weight.
- Most of these blocks are global blocks (no value capture, free retain/release) and some are stack blocks. No malloc blocks.