### PR TITLE
Add a method for setting preconfigured PINRemoteImageManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Improve locking around clearContents [Michael Schneider](https://github.com/maicki)
 - Unlock before cleanup and calling out to subclass hooks for animated images. [Michael Schneider](https://github.com/maicki) [#1087](https://github.com/TextureGroup/Texture/pull/1087)
 - [ASDisplayNode] Fix interface state update for layer backed nodes when layer thrashes (interface coaleascing case).[Max Wang](https://github.com/wsdwsd0829). [#1111](https://github.com/TextureGroup/Texture/pull/1111)
+- [ASPINRemoteImageManager] Add a new API for setting a preconfigured PINRemoteImageManager. [Ernest Ma](https://github.com/ernestmama) [#1124](https://github.com/TextureGroup/Texture/pull/1124)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/Details/ASPINRemoteImageDownloader.h
+++ b/Source/Details/ASPINRemoteImageDownloader.h
@@ -41,6 +41,15 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setSharedImageManagerWithConfiguration:(nullable NSURLSessionConfiguration *)configuration;
 
 /**
+ * Sets a custom perconconfigured PINRemoteImageManager that will be used by @c ASNetworkImageNodes and @c ASMultiplexImageNodes
+ * while loading images off the network. This can be called at anytime. Once this is set, it will always be used with priority.
+ * If this is not set, it will call setSharedImageManagerWithConfiguration with nil.
+ *
+ * @param PINRemoteImageManager the preconfigured remote image manager that will be used by `sharedDownloader`
+ */
+- (void)setPreconfiguredPINRemoteImageManager:(PINRemoteImageManager *)preconfiguredPINRemoteImageManager;
+
+/**
  * The shared instance of a @c PINRemoteImageManager used by all @c ASPINRemoteImageDownloaders
  *
  * @discussion you can use this method to access the shared manager. This is useful to share a cache

--- a/Source/Details/ASPINRemoteImageDownloader.h
+++ b/Source/Details/ASPINRemoteImageDownloader.h
@@ -41,12 +41,12 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setSharedImageManagerWithConfiguration:(nullable NSURLSessionConfiguration *)configuration;
 
 /**
- * Sets a custom perconconfigured PINRemoteImageManager that will be used by @c ASNetworkImageNodes and @c ASMultiplexImageNodes
+ * Sets a custom preconfigured PINRemoteImageManager that will be used by @c ASNetworkImageNodes and @c ASMultiplexImageNodes
  * while loading images off the network. This must be specified early in the application lifecycle before
- * `sharedDownloader` is accessed. If nil is passed in as the PINRemoteImageManager, it will call
- * setSharedImageManagerWithConfiguration with nil configuration.
+ * `sharedDownloader` is accessed. If nil is passed in as the PINRemoteImageManager, it will create
+ * a default image manager with a nil session configuration.
  *
- * @param PINRemoteImageManager the preconfigured remote image manager that will be used by `sharedDownloader`
+ * @param PINRemoteImageManager The preconfigured remote image manager that will be used by `sharedDownloader`
  */
 + (void)setSharedPreconfiguredRemoteImageManager:(nullable PINRemoteImageManager *)preconfiguredPINRemoteImageManager;
 

--- a/Source/Details/ASPINRemoteImageDownloader.h
+++ b/Source/Details/ASPINRemoteImageDownloader.h
@@ -42,12 +42,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Sets a custom perconconfigured PINRemoteImageManager that will be used by @c ASNetworkImageNodes and @c ASMultiplexImageNodes
- * while loading images off the network. This can be called at anytime. Once this is set, it will always be used with priority.
- * If this is not set, it will call setSharedImageManagerWithConfiguration with nil.
+ * while loading images off the network. This must be specified early in the application lifecycle before
+ * `sharedDownloader` is accessed. If nil is passed in as the PINRemoteImageManager, it will call
+ * setSharedImageManagerWithConfiguration with nil configuration.
  *
  * @param PINRemoteImageManager the preconfigured remote image manager that will be used by `sharedDownloader`
  */
-- (void)setPreconfiguredPINRemoteImageManager:(PINRemoteImageManager *)preconfiguredPINRemoteImageManager;
++ (void)setSharedPreconfiguredRemoteImageManager:(nullable PINRemoteImageManager *)preconfiguredPINRemoteImageManager;
 
 /**
  * The shared instance of a @c PINRemoteImageManager used by all @c ASPINRemoteImageDownloaders

--- a/Source/Details/ASPINRemoteImageDownloader.m
+++ b/Source/Details/ASPINRemoteImageDownloader.m
@@ -75,6 +75,10 @@
 @end
 
 @implementation ASPINRemoteImageManager
+{
+@private
+  PINRemoteImageManager *_preconfiguredPINRemoteImageManager;
+}
 
 //Share image cache with sharedImageManager image cache.
 - (id <PINRemoteImageCaching>)defaultImageCache
@@ -155,7 +159,16 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
 
 - (PINRemoteImageManager *)sharedPINRemoteImageManager
 {
+  if (_preconfiguredPINRemoteImageManager) {
+    return _preconfiguredPINRemoteImageManager;
+  }
   return [ASPINRemoteImageDownloader sharedPINRemoteImageManagerWithConfiguration:nil];
+}
+
+- (PINRemoteImageManager *)setPreconfiguredPINRemoteImageManager:(PINRemoteImageManager *)preconfiguredPINRemoteImageManager
+{
+  _preconfiguredPINRemoteImageManager = preconfiguredPINRemoteImageManager;
+  return _preconfiguredPINRemoteImageManager;
 }
 
 - (BOOL)sharedImageManagerSupportsMemoryRemoval

--- a/Source/Details/ASPINRemoteImageDownloader.m
+++ b/Source/Details/ASPINRemoteImageDownloader.m
@@ -134,32 +134,32 @@ static dispatch_once_t onceToken;
 
 + (PINRemoteImageManager *)sharedPINRemoteImageManagerWithConfiguration:(NSURLSessionConfiguration *)configuration preconfiguredPINRemoteImageManager:(PINRemoteImageManager *)preconfiguredPINRemoteImageManager
 {
-  NSAssert(configuration != nil && preconfiguredPINRemoteImageManager != nil, @"Either configuration or preconfigured image manager can be set at a time.");
+  NSAssert(!(configuration != nil && preconfiguredPINRemoteImageManager != nil), @"Either configuration or preconfigured image manager can be set at a time.");
   dispatch_once(&onceToken, ^{
 
     if (preconfiguredPINRemoteImageManager) {
       sharedPINRemoteImageManager = preconfiguredPINRemoteImageManager;
     } else {
 #if PIN_ANIMATED_AVAILABLE
-    // Check that Carthage users have linked both PINRemoteImage & PINCache by testing for one file each
-    if (!(NSClassFromString(@"PINRemoteImageManager"))) {
-      NSException *e = [NSException
-                        exceptionWithName:@"FrameworkSetupException"
-                        reason:@"Missing the path to the PINRemoteImage framework."
-                        userInfo:nil];
-      @throw e;
-    }
-    if (!(NSClassFromString(@"PINCache"))) {
-      NSException *e = [NSException
-                        exceptionWithName:@"FrameworkSetupException"
-                        reason:@"Missing the path to the PINCache framework."
-                        userInfo:nil];
-      @throw e;
-    }
-    sharedPINRemoteImageManager = [[ASPINRemoteImageManager alloc] initWithSessionConfiguration:configuration
-                                                              alternativeRepresentationProvider:[self sharedDownloader]];
+      // Check that Carthage users have linked both PINRemoteImage & PINCache by testing for one file each
+      if (!(NSClassFromString(@"PINRemoteImageManager"))) {
+        NSException *e = [NSException
+                          exceptionWithName:@"FrameworkSetupException"
+                          reason:@"Missing the path to the PINRemoteImage framework."
+                          userInfo:nil];
+        @throw e;
+      }
+      if (!(NSClassFromString(@"PINCache"))) {
+        NSException *e = [NSException
+                          exceptionWithName:@"FrameworkSetupException"
+                          reason:@"Missing the path to the PINCache framework."
+                          userInfo:nil];
+        @throw e;
+      }
+      sharedPINRemoteImageManager = [[ASPINRemoteImageManager alloc] initWithSessionConfiguration:configuration
+                                                                alternativeRepresentationProvider:[self sharedDownloader]];
 #else
-    sharedPINRemoteImageManager = [[ASPINRemoteImageManager alloc] initWithSessionConfiguration:configuration];
+      sharedPINRemoteImageManager = [[ASPINRemoteImageManager alloc] initWithSessionConfiguration:configuration];
 #endif
     }
   });

--- a/Source/Details/ASPINRemoteImageDownloader.m
+++ b/Source/Details/ASPINRemoteImageDownloader.m
@@ -100,6 +100,8 @@
 
 
 static ASPINRemoteImageDownloader *sharedDownloader = nil;
+static PINRemoteImageManager *sharedPINRemoteImageManager = nil;
+static dispatch_once_t onceToken;
 
 @interface ASPINRemoteImageDownloader ()
 @end
@@ -119,21 +121,22 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
 + (void)setSharedImageManagerWithConfiguration:(nullable NSURLSessionConfiguration *)configuration
 {
   NSAssert(sharedDownloader == nil, @"Singleton has been created and session can no longer be configured.");
+  NSAssert1(sharedPINRemoteImageManager == nil, @"An instance of %@ has been set. Either configuration or preconfigured image manager can be set at a time and only once.", [[sharedPINRemoteImageManager class] description]);
   __unused PINRemoteImageManager *sharedManager = [self sharedPINRemoteImageManagerWithConfiguration:configuration preconfiguredPINRemoteImageManager:nil];
 }
 
 + (void)setSharedPreconfiguredImageManager:(nullable PINRemoteImageManager *)preconfiguredPINRemoteImageManager
 {
   NSAssert(sharedDownloader == nil, @"Singleton has been created and session can no longer be configured.");
+  NSAssert1(sharedPINRemoteImageManager == nil, @"An instance of %@ has been set. Either configuration or preconfigured image manager can be set at a time and only once.", [[sharedPINRemoteImageManager class] description]);
   __unused PINRemoteImageManager *sharedManager = [self sharedPINRemoteImageManagerWithConfiguration:nil preconfiguredPINRemoteImageManager:preconfiguredPINRemoteImageManager];
 }
 
 + (PINRemoteImageManager *)sharedPINRemoteImageManagerWithConfiguration:(NSURLSessionConfiguration *)configuration preconfiguredPINRemoteImageManager:(PINRemoteImageManager *)preconfiguredPINRemoteImageManager
 {
-  static PINRemoteImageManager *sharedPINRemoteImageManager;
-  static dispatch_once_t onceToken;
+  NSAssert(configuration != nil && preconfiguredPINRemoteImageManager != nil, @"Either configuration or preconfigured image manager can be set at a time.");
   dispatch_once(&onceToken, ^{
-    
+
     if (preconfiguredPINRemoteImageManager) {
       sharedPINRemoteImageManager = preconfiguredPINRemoteImageManager;
     } else {

--- a/Source/Details/ASPINRemoteImageDownloader.m
+++ b/Source/Details/ASPINRemoteImageDownloader.m
@@ -101,7 +101,6 @@
 
 static ASPINRemoteImageDownloader *sharedDownloader = nil;
 static PINRemoteImageManager *sharedPINRemoteImageManager = nil;
-static dispatch_once_t onceToken;
 
 @interface ASPINRemoteImageDownloader ()
 @end
@@ -135,6 +134,7 @@ static dispatch_once_t onceToken;
 + (PINRemoteImageManager *)sharedPINRemoteImageManagerWithConfiguration:(NSURLSessionConfiguration *)configuration preconfiguredPINRemoteImageManager:(PINRemoteImageManager *)preconfiguredPINRemoteImageManager
 {
   NSAssert(!(configuration != nil && preconfiguredPINRemoteImageManager != nil), @"Either configuration or preconfigured image manager can be set at a time.");
+  static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
 
     if (preconfiguredPINRemoteImageManager) {

--- a/Source/Details/ASPINRemoteImageDownloader.m
+++ b/Source/Details/ASPINRemoteImageDownloader.m
@@ -138,25 +138,25 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
       sharedPINRemoteImageManager = preconfiguredPINRemoteImageManager;
     } else {
 #if PIN_ANIMATED_AVAILABLE
-      // Check that Carthage users have linked both PINRemoteImage & PINCache by testing for one file each
-      if (!(NSClassFromString(@"PINRemoteImageManager"))) {
-        NSException *e = [NSException
-                          exceptionWithName:@"FrameworkSetupException"
-                          reason:@"Missing the path to the PINRemoteImage framework."
-                          userInfo:nil];
-        @throw e;
-      }
-      if (!(NSClassFromString(@"PINCache"))) {
-        NSException *e = [NSException
-                          exceptionWithName:@"FrameworkSetupException"
-                          reason:@"Missing the path to the PINCache framework."
-                          userInfo:nil];
-        @throw e;
-      }
-      sharedPINRemoteImageManager = [[ASPINRemoteImageManager alloc] initWithSessionConfiguration:configuration
-                                                                alternativeRepresentationProvider:[self sharedDownloader]];
+    // Check that Carthage users have linked both PINRemoteImage & PINCache by testing for one file each
+    if (!(NSClassFromString(@"PINRemoteImageManager"))) {
+      NSException *e = [NSException
+                        exceptionWithName:@"FrameworkSetupException"
+                        reason:@"Missing the path to the PINRemoteImage framework."
+                        userInfo:nil];
+      @throw e;
+    }
+    if (!(NSClassFromString(@"PINCache"))) {
+      NSException *e = [NSException
+                        exceptionWithName:@"FrameworkSetupException"
+                        reason:@"Missing the path to the PINCache framework."
+                        userInfo:nil];
+      @throw e;
+    }
+    sharedPINRemoteImageManager = [[ASPINRemoteImageManager alloc] initWithSessionConfiguration:configuration
+                                                              alternativeRepresentationProvider:[self sharedDownloader]];
 #else
-      sharedPINRemoteImageManager = [[ASPINRemoteImageManager alloc] initWithSessionConfiguration:configuration];
+    sharedPINRemoteImageManager = [[ASPINRemoteImageManager alloc] initWithSessionConfiguration:configuration];
 #endif
     }
   });


### PR DESCRIPTION
Add a method for setting preconfigured PINRemoteImageManager instead of using the self-created ASPINRemoteImageManager.

In this way, we can add custom configuration to the PINRemoteImageManager such as request configuration/url configuration.