### PR TITLE
Add ASExperimentalSkipClearData

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -576,6 +576,11 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 - (void)_asyncDelegateOrDataSourceDidChange
 {
   ASDisplayNodeAssertMainThread();
+  
+  if (ASActivateExperimentalFeature(ASExperimentalSkipClearData)) {
+    return;
+  }
+  
   if (_asyncDataSource == nil && _asyncDelegate == nil) {
     [_dataController clearData];
   }

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -24,6 +24,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalDeallocQueue = 1 << 6,                      // exp_dealloc_queue_v2
   ASExperimentalCollectionTeardown = 1 << 7,                // exp_collection_teardown
   ASExperimentalFramesetterCache = 1 << 8,                  // exp_framesetter_cache
+  ASExperimentalSkipClearData = 1 << 9,                     // exp_skip_clear_data
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.m
+++ b/Source/ASExperimentalFeatures.m
@@ -20,7 +20,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_network_image_queue",
                                       @"exp_dealloc_queue_v2",
                                       @"exp_collection_teardown",
-                                      @"exp_framesetter_cache"]));
+                                      @"exp_framesetter_cache"
+                                      @"exp_skip_clear_data"]));
   
   if (flags == ASExperimentalFeatureAll) {
     return allNames;


### PR DESCRIPTION
We are seeing crashes to an internal inconsistency deep within `UICollectionView`. We were able to track down the range of commits where we start seeing this crash. To verify the hunch of the root cause of this crash we will introduce a new experiment that will skip calling clear data if `dataSource` / `delegate` is cleared within `ASCollectionView`.