### PR TITLE
Excluding origin from calculating text node size

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -239,7 +239,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   [self prepareAttributedString:mutableText];
   ASTextLayout *layout = [ASTextNode2 compatibleLayoutWithContainer:_textContainer text:mutableText];
   
-  return layout.textBoundingSize;
+  return CGSizeMake(layout.textBoundingSize.width - layout.textBoundingRect.origin.x, layout.textBoundingSize.height);
 }
 
 #pragma mark - Modifying User Text


### PR DESCRIPTION
ASTextLayout would include the origin to the width, it does not work when the text node is layout with other layoutspec like StackLayout.