### PR TITLE
fix: incorrect backing image scale after precompositing rounded corners

### DIFF
--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -323,7 +323,7 @@
       bounds.size.height *= contentsScale;
       CGFloat white = 0.0f, alpha = 0.0f;
       [backgroundColor getWhite:&white alpha:&alpha];
-      ASGraphicsBeginImageContextWithOptions(bounds.size, (alpha == 1.0f), contentsScale);
+      ASGraphicsBeginImageContextWithOptions(bounds.size, (alpha == 1.0f), (*image).scale);
       [*image drawInRect:bounds];
     } else {
       bounds = CGContextGetClipBoundingBox(context);


### PR DESCRIPTION
Try to fix https://github.com/TextureGroup/Texture/issues/1151

In __didDisplayNodeContentWithRenderingContext with cornerRoundingType set to precomposited, the image after and before processing should share the same scale. So just use the input image's scale when creating context.