### PR TITLE
Add a debug text property to ASImageNode that allows users to show custom debug info

### DIFF
--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -250,7 +250,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
     [self setNeedsDisplay];
     
     // For debugging purposes we don't care about locking for now
-    if ([ASImageNode shouldShowImageScalingOverlay] && _debugLabelNode == nil) {
+    if ([ASImageNode shouldShowDebugOverlay] && _debugLabelNode == nil) {
       // do not use ASPerformBlockOnMainThread here, if it performs the block synchronously it will continue
       // holding the lock while calling addSubnode.
       dispatch_async(dispatch_get_main_queue(), ^{
@@ -540,19 +540,29 @@ static ASDN::StaticMutex& cacheLock = *new ASDN::StaticMutex;
 
   // Update the debug label if necessary
   if (hasDebugLabel) {
-    // For debugging purposes we don't care about locking for now
-    CGSize imageSize = image.size;
-    CGSize imageSizeInPixels = CGSizeMake(imageSize.width * image.scale, imageSize.height * image.scale);
-    CGSize boundsSizeInPixels = CGSizeMake(std::floor(self.bounds.size.width * self.contentsScale), std::floor(self.bounds.size.height * self.contentsScale));
-    CGFloat pixelCountRatio            = (imageSizeInPixels.width * imageSizeInPixels.height) / (boundsSizeInPixels.width * boundsSizeInPixels.height);
-    if (pixelCountRatio != 1.0) {
-      NSString *scaleString            = [NSString stringWithFormat:@"%.2fx", pixelCountRatio];
-      _debugLabelNode.attributedText   = [[NSAttributedString alloc] initWithString:scaleString attributes:[self debugLabelAttributes]];
-      _debugLabelNode.hidden           = NO;
-    } else {
-      _debugLabelNode.hidden           = YES;
-      _debugLabelNode.attributedText   = nil;
-    }
+      NSAttributedString *debugText = nil;
+
+      if ([ASImageNode shouldShowImageScalingOverlay]) {
+          // For debugging purposes we don't care about locking for now
+          CGSize imageSize = image.size;
+          CGSize imageSizeInPixels = CGSizeMake(imageSize.width * image.scale, imageSize.height * image.scale);
+          CGSize boundsSizeInPixels = CGSizeMake(std::floor(self.bounds.size.width * self.contentsScale), std::floor(self.bounds.size.height * self.contentsScale));
+          CGFloat pixelCountRatio            = (imageSizeInPixels.width * imageSizeInPixels.height) / (boundsSizeInPixels.width * boundsSizeInPixels.height);
+          if (pixelCountRatio != 1.0) {
+              debugText = [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%.2fx", pixelCountRatio]
+                                                          attributes:[self debugLabelAttributes]];
+          }
+      } else if ([ASImageNode shouldShowDebugOverlay]) {
+          debugText = self.debugText;
+      }
+
+      if (debugText) {
+          _debugLabelNode.hidden = NO;
+          _debugLabelNode.attributedText = debugText;
+      } else {
+          _debugLabelNode.hidden = YES;
+          _debugLabelNode.attributedText = nil;
+      }
   }
   
   // If we've got a block to perform after displaying, do it.
@@ -718,7 +728,8 @@ static ASDN::StaticMutex& cacheLock = *new ASDN::StaticMutex;
 {
   return @{
     NSFontAttributeName: [UIFont systemFontOfSize:15.0],
-    NSForegroundColorAttributeName: [UIColor redColor]
+    NSForegroundColorAttributeName: [UIColor redColor],
+    NSBackgroundColorAttributeName: [UIColor lightGrayColor]
   };
 }
 

--- a/Source/Debug/AsyncDisplayKit+Debug.h
+++ b/Source/Debug/AsyncDisplayKit+Debug.h
@@ -22,6 +22,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (class, nonatomic) BOOL shouldShowImageScalingOverlay;
 
+/**
+ * Enables an ASImageNode debug label that shows a debug text, such as image scaling, image URL or placeholder time.
+ * The debug text must be set on each image node via debugText property.
+ */
+@property (class, nonatomic) BOOL shouldShowDebugOverlay;
+
+/**
+ * The debug text for this node. Main thread only
+ */
+@property (nonatomic, copy) NSAttributedString *debugText;
+
 @end
 
 @interface ASControlNode (Debugging)

--- a/Source/Debug/AsyncDisplayKit+Debug.m
+++ b/Source/Debug/AsyncDisplayKit+Debug.m
@@ -8,21 +8,23 @@
 //
 
 #import <AsyncDisplayKit/AsyncDisplayKit+Debug.h>
+
 #import <AsyncDisplayKit/ASAbstractLayoutController.h>
+#import <AsyncDisplayKit/ASDisplayNodeExtras.h>
+#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
+#import <AsyncDisplayKit/ASEqualityHelpers.h>
 #import <AsyncDisplayKit/ASGraphicsContext.h>
 #import <AsyncDisplayKit/ASLayout.h>
-#import <AsyncDisplayKit/ASWeakSet.h>
-#import <AsyncDisplayKit/UIImage+ASConvenience.h>
-#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
-#import <AsyncDisplayKit/CoreGraphics+ASConvenience.h>
-#import <AsyncDisplayKit/ASDisplayNodeExtras.h>
-#import <AsyncDisplayKit/ASTextNode.h>
 #import <AsyncDisplayKit/ASRangeController.h>
-
+#import <AsyncDisplayKit/ASTextNode.h>
+#import <AsyncDisplayKit/ASWeakSet.h>
+#import <AsyncDisplayKit/CoreGraphics+ASConvenience.h>
+#import <AsyncDisplayKit/UIImage+ASConvenience.h>
 
 #pragma mark - ASImageNode (Debugging)
 
 static BOOL __shouldShowImageScalingOverlay = NO;
+static BOOL __shouldShowDebugOverlay = NO;
 
 @implementation ASImageNode (Debugging)
 
@@ -34,6 +36,34 @@ static BOOL __shouldShowImageScalingOverlay = NO;
 + (BOOL)shouldShowImageScalingOverlay
 {
   return __shouldShowImageScalingOverlay;
+}
+
++ (void)setShouldShowDebugOverlay:(BOOL)show
+{
+  __shouldShowDebugOverlay = show;
+}
+
++ (BOOL)shouldShowDebugOverlay
+{
+  return __shouldShowDebugOverlay || __shouldShowImageScalingOverlay;
+}
+
+- (void)setDebugText:(NSAttributedString *)debugText
+{
+    ASDisplayNodeAssertMainThread();
+    if (! ASObjectIsEqual(debugText, self.debugText)) {
+        objc_setAssociatedObject(self,
+                                 @selector(debugText),
+                                 debugText,
+                                 OBJC_ASSOCIATION_COPY_NONATOMIC);
+        [self setNeedsDisplay];
+    }
+}
+
+- (NSAttributedString *)debugText
+{
+    ASDisplayNodeAssertMainThread();
+    return objc_getAssociatedObject(self, @selector(debugText));
 }
 
 @end


### PR DESCRIPTION
Such as image loading time, or part of the image URL.