### PR TITLE
Only clear ASCollectionView's data during deallocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Optimize layout process by removing `ASRectMap`.  [Adlai Holler](https://github.com/Adlai-Holler)
 - Remove necessity to use view to access rangeController in ASTableNode, ASCollectionNode. [Michael Schneider](https://github.com/maicki)
 - Remove display node's reliance on shared_ptr. [Adlai Holler](https://github.com/Adlai-Holler)
+- [ASCollectionView] Fix a crash that is caused by clearing a collection view's data while it's still being used. [Huy Nguyen](https://github.com/nguyenhuy) [#1154](https://github.com/TextureGroup/Texture/pull/1154)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -19,9 +19,9 @@
                     "exp_unfair_lock",
                     "exp_infer_layer_defaults",
                     "exp_network_image_queue",
-                    "exp_dealloc_queue_v2",
                     "exp_collection_teardown",
-                    "exp_framesetter_cache"
+                    "exp_framesetter_cache",
+                    "exp_clear_data_during_deallocation"
                 ]
     		}
 		}

--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -19,6 +19,7 @@
                     "exp_unfair_lock",
                     "exp_infer_layer_defaults",
                     "exp_network_image_queue",
+                    "exp_dealloc_queue_v2",
                     "exp_collection_teardown",
                     "exp_framesetter_cache",
                     "exp_clear_data_during_deallocation"

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -577,7 +577,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 {
   ASDisplayNodeAssertMainThread();
   
-  if (_asyncDataSource == nil && _asyncDelegate == nil && !ASActivateExperimentalFeature(ASExperimentalSkipClearData)) {
+  if (_asyncDataSource == nil && _asyncDelegate == nil && _isDeallocating && ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
     [_dataController clearData];
   }
 }

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -21,10 +21,9 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalUnfairLock = 1 << 3,                        // exp_unfair_lock
   ASExperimentalLayerDefaults = 1 << 4,                     // exp_infer_layer_defaults
   ASExperimentalNetworkImageQueue = 1 << 5,                 // exp_network_image_queue
-  ASExperimentalDeallocQueue = 1 << 6,                      // exp_dealloc_queue_v2
-  ASExperimentalCollectionTeardown = 1 << 7,                // exp_collection_teardown
-  ASExperimentalFramesetterCache = 1 << 8,                  // exp_framesetter_cache
-  ASExperimentalClearDataDuringDeallocation = 1 << 9,       // exp_clear_data_during_deallocation
+  ASExperimentalCollectionTeardown = 1 << 6,                // exp_collection_teardown
+  ASExperimentalFramesetterCache = 1 << 7,                  // exp_framesetter_cache
+  ASExperimentalClearDataDuringDeallocation = 1 << 8,       // exp_clear_data_during_deallocation
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -21,9 +21,10 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalUnfairLock = 1 << 3,                        // exp_unfair_lock
   ASExperimentalLayerDefaults = 1 << 4,                     // exp_infer_layer_defaults
   ASExperimentalNetworkImageQueue = 1 << 5,                 // exp_network_image_queue
-  ASExperimentalCollectionTeardown = 1 << 6,                // exp_collection_teardown
-  ASExperimentalFramesetterCache = 1 << 7,                  // exp_framesetter_cache
-  ASExperimentalSkipClearData = 1 << 8,                     // exp_skip_clear_data
+  ASExperimentalDeallocQueue = 1 << 6,                      // exp_dealloc_queue_v2
+  ASExperimentalCollectionTeardown = 1 << 7,                // exp_collection_teardown
+  ASExperimentalFramesetterCache = 1 << 8,                  // exp_framesetter_cache
+  ASExperimentalClearDataDuringDeallocation = 1 << 9,       // exp_clear_data_during_deallocation
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -21,6 +21,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalUnfairLock = 1 << 3,                        // exp_unfair_lock
   ASExperimentalLayerDefaults = 1 << 4,                     // exp_infer_layer_defaults
   ASExperimentalNetworkImageQueue = 1 << 5,                 // exp_network_image_queue
+  ASExperimentalDeallocQueue = 1 << 6,                      // exp_dealloc_queue_v2
   ASExperimentalCollectionTeardown = 1 << 6,                // exp_collection_teardown
   ASExperimentalFramesetterCache = 1 << 7,                  // exp_framesetter_cache
   ASExperimentalClearDataDuringDeallocation = 1 << 8,       // exp_clear_data_during_deallocation

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -21,7 +21,6 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalUnfairLock = 1 << 3,                        // exp_unfair_lock
   ASExperimentalLayerDefaults = 1 << 4,                     // exp_infer_layer_defaults
   ASExperimentalNetworkImageQueue = 1 << 5,                 // exp_network_image_queue
-  ASExperimentalDeallocQueue = 1 << 6,                      // exp_dealloc_queue_v2
   ASExperimentalCollectionTeardown = 1 << 6,                // exp_collection_teardown
   ASExperimentalFramesetterCache = 1 << 7,                  // exp_framesetter_cache
   ASExperimentalClearDataDuringDeallocation = 1 << 8,       // exp_clear_data_during_deallocation

--- a/Source/ASExperimentalFeatures.m
+++ b/Source/ASExperimentalFeatures.m
@@ -18,10 +18,9 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_unfair_lock",
                                       @"exp_infer_layer_defaults",
                                       @"exp_network_image_queue",
-                                      @"exp_dealloc_queue_v2",
                                       @"exp_collection_teardown",
                                       @"exp_framesetter_cache",
-                                      @"exp_skip_clear_data"]));
+                                      @"exp_clear_data_during_deallocation"]));
   
   if (flags == ASExperimentalFeatureAll) {
     return allNames;

--- a/Source/ASExperimentalFeatures.m
+++ b/Source/ASExperimentalFeatures.m
@@ -18,6 +18,7 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_unfair_lock",
                                       @"exp_infer_layer_defaults",
                                       @"exp_network_image_queue",
+                                      @"exp_dealloc_queue_v2",
                                       @"exp_collection_teardown",
                                       @"exp_framesetter_cache",
                                       @"exp_clear_data_during_deallocation"]));


### PR DESCRIPTION
This is a follow up on #1136. Our experiment results show that clearing data frequently is the cause of our #1 crash. @maicki and I believe that this is because silently clearing its data while the collection view is still being used, without notifying the backing UICollectionView, puts it out-of-sync and causes mayhem next time the collection view processes a batch update. If you look at the stack trace closely, you'll notice that the crash doesn't occur on the same run loop that `clearData` was called, making it extremely tricky to investigate and identify the root cause.

To fix this problem, I'm proposing to only call `clearData` if the collection view is actually being torn down. I'm also going to set up another experiment to slowly roll this out to make sure we don't reintroduce the crash, as well as to get insights on whether it's actually worth it. My gut feeling is that it's not, since the data will be autimatically cleared out soon anyway. Please let me know your thoughts.

![screen shot 2018-10-01 at 5 08 47 pm](https://user-images.githubusercontent.com/587874/46322275-c413c480-c59c-11e8-9ede-172f435e2cde.png)
