### PR TITLE
Update documentation of ASNetworkImageNodeDelegate #trivial

### DIFF
--- a/Source/ASNetworkImageNode.h
+++ b/Source/ASNetworkImageNode.h
@@ -146,6 +146,15 @@ NS_ASSUME_NONNULL_BEGIN
 @optional
 
 /**
+ * Notification that the image node started to load
+ *
+ * @param imageNode The sender.
+ *
+ * @discussion Called on the main thread.
+ */
+- (void)imageNodeDidStartFetchingData:(ASNetworkImageNode *)imageNode;
+
+/**
  * Notification that the image node finished downloading an image, with additional info.
  * If implemented, this method will be called instead of `imageNode:didLoadImage:`.
  *
@@ -168,15 +177,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)imageNode:(ASNetworkImageNode *)imageNode didLoadImage:(UIImage *)image;
 
 /**
- * Notification that the image node started to load
- *
- * @param imageNode The sender.
- *
- * @discussion Called on a background queue.
- */
-- (void)imageNodeDidStartFetchingData:(ASNetworkImageNode *)imageNode;
-
-/**
  * Notification that the image node failed to download the image.
  *
  * @param imageNode The sender.
@@ -190,6 +190,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Notification that the image node finished decoding an image.
  *
  * @param imageNode The sender.
+ *
+ * @discussion Called on the main thread.
  */
 - (void)imageNodeDidFinishDecoding:(ASNetworkImageNode *)imageNode;
 

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -614,6 +614,8 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 
 - (void)_lazilyLoadImageIfNecessary
 {
+  ASDisplayNodeAssertMainThread();
+
   [self lock];
     __weak id<ASNetworkImageNodeDelegate> delegate = _delegate;
     BOOL delegateDidStartFetchingData = _delegateFlags.delegateDidStartFetchingData;


### PR DESCRIPTION
`-imageNodeDidStartFetchingData:` and `-imageNodeDidFinishDecoding:` are always called on main thread, and the documentation should reflect that.