### PR TITLE
Migrate placeholder example project from 1.0 to 2.x

### DIFF
--- a/examples_extra/Placeholders/Sample/PostNode.m
+++ b/examples_extra/Placeholders/Sample/PostNode.m
@@ -72,8 +72,8 @@
 
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
-  CGSize textSize = [_textNode measure:constrainedSize];
-  CGSize shareSize = [_needyChildNode measure:constrainedSize];
+  CGSize textSize = [_textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
+  CGSize shareSize = [_needyChildNode layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
 
   return CGSizeMake(constrainedSize.width, textSize.height + 10.0 + shareSize.height);
 }

--- a/examples_extra/Placeholders/Sample/ViewController.m
+++ b/examples_extra/Placeholders/Sample/ViewController.m
@@ -61,8 +61,8 @@
   CGFloat constrainedWidth = CGRectGetWidth(bounds);
   CGSize constrainedSize = CGSizeMake(constrainedWidth - 2 * padding, CGFLOAT_MAX);
 
-  CGSize postSize = [_postNode measure:constrainedSize];
-  CGSize imageSize = [_imageNode measure:constrainedSize];
+  CGSize postSize = [_postNode layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
+  CGSize imageSize = [_imageNode layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
 
   _imageNode.frame = (CGRect){padding, padding, imageSize};
   _postNode.frame = (CGRect){padding, CGRectGetMaxY(_imageNode.frame) + 10.0, postSize};


### PR DESCRIPTION
Simply removes the usage of measure: and allows project to build. Not sure if examples warrant a changelog addition?