### PR TITLE
Update Jekyll to 3.6.3

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gem 'github-pages'
 gem 'rouge', '~>1.7'
-gem 'jekyll', '~>3.2.0'
+gem 'jekyll', '~>3.6.3'


### PR DESCRIPTION
Seeing a warning from GitHub that suggests to update Jekyll because of this vulnerability:

> Jekyll through 3.6.2, 3.7.x through 3.7.3, and 3.8.x through 3.8.3 allows attackers to access arbitrary files by specifying a symlink in the "include" key in the "_config.yml" file.

[CVE-2018-17567](https://nvd.nist.gov/vuln/detail/CVE-2018-17567)