### PR TITLE
ASTextNode2 to ignore certain text alignments while calculating intrinsic size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Remove display node's reliance on shared_ptr. [Adlai Holler](https://github.com/Adlai-Holler)
 - [ASCollectionView] Fix a crash that is caused by clearing a collection view's data while it's still being used. [Huy Nguyen](https://github.com/nguyenhuy) [#1154](https://github.com/TextureGroup/Texture/pull/1154)
 - Clean up timing of layout tree flattening/ copying of unflattened tree for Weaver. [Michael Zuccarino](https://github.com/mikezucc) [#1157](https://github.com/TextureGroup/Texture/pull/1157)
+- [ASTextNode2] Ignore certain text alignments while calculating intrinsic size [Huy Nguyen](https://github.com/nguyenhuy) [#1166](https://github.com/TextureGroup/Texture/pull/1166)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -235,7 +235,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   _textContainer.size = constrainedSize;
   [self _ensureTruncationText];
 
-  // If the constrained size has max/inf value on the text's forward direction, the text node is calculating its intrinsic size.
+  // If the constrained size has a max/inf value on the text's forward direction, the text node is calculating its intrinsic size.
   BOOL isCalculatingIntrinsicSize;
   if (_textContainer.isVerticalForm) {
     isCalculatingIntrinsicSize = (_textContainer.size.height >= ASTextContainerMaxSize.height);
@@ -338,7 +338,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
     const BOOL applyTruncationMode = (style != nil && style.lineBreakMode != _truncationMode);
     // Only "left" and "justified" alignments are supported while calculating intrinsic size.
-    // Other alignments such as "right" and "center" causes the text to be bigger than needed and thus should be ignored/overridden.
+    // Other alignments like "right", "center" and "natural" cause the size to be bigger than needed and thus should be ignored/overridden.
     const BOOL forceLeftAlignment = (style != nil
                                      && isForIntrinsicSize
                                      && style.alignment != NSTextAlignmentLeft

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -235,11 +235,16 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   _textContainer.size = constrainedSize;
   [self _ensureTruncationText];
 
-  // If constrained width is max/inf, the text node is calculating its intrinsic size.
-  const BOOL calculatingIntrinsicSize = (_textContainer.size.width >= ASTextContainerMaxSize.width);
+  // If the constrained size has max/inf value on the text's forward direction, the text node is calculating its intrinsic size.
+  BOOL isCalculatingIntrinsicSize;
+  if (_textContainer.isVerticalForm) {
+    isCalculatingIntrinsicSize = (_textContainer.size.height >= ASTextContainerMaxSize.height);
+  } else {
+    isCalculatingIntrinsicSize = (_textContainer.size.width >= ASTextContainerMaxSize.width);
+  }
 
   NSMutableAttributedString *mutableText = [_attributedText mutableCopy];
-  [self prepareAttributedString:mutableText forIntrinsicSize:calculatingIntrinsicSize];
+  [self prepareAttributedString:mutableText isForIntrinsicSize:isCalculatingIntrinsicSize];
   ASTextLayout *layout = [ASTextNode2 compatibleLayoutWithContainer:_textContainer text:mutableText];
   
   return layout.textBoundingSize;
@@ -324,7 +329,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   return _textContainer.exclusionPaths;
 }
 
-- (void)prepareAttributedString:(NSMutableAttributedString *)attributedString forIntrinsicSize:(BOOL)isForIntrinsicSize
+- (void)prepareAttributedString:(NSMutableAttributedString *)attributedString isForIntrinsicSize:(BOOL)isForIntrinsicSize
 {
   ASLockScopeSelf();
 
@@ -381,7 +386,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   [copiedContainer makeImmutable];
   NSMutableAttributedString *mutableText = [_attributedText mutableCopy] ?: [[NSMutableAttributedString alloc] init];
 
-  [self prepareAttributedString:mutableText forIntrinsicSize:NO];
+  [self prepareAttributedString:mutableText isForIntrinsicSize:NO];
   
   return @{
     @"container": copiedContainer,


### PR DESCRIPTION
ASTextNode2 uses ASTextLayout to calculate its layout and bounding rect. When the constrained width that is used for layout calculation is inf/max (e.g when the node is inside a horizontal stack), ASTextLayout doesn't ignore its right/center/natural text alignment but takes it into account. That results in an unreasonable size (and position).

Fix by detecting when the node is calculating intrinsic size and force its layout alignment to be left. Other alignments should still work when the max width is finite/reasonable.