### PR TITLE
Fix mismatch in UIAccessibilityAction selector method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Clean up timing of layout tree flattening/ copying of unflattened tree for Weaver. [Michael Zuccarino](https://github.com/mikezucc) [#1157](https://github.com/TextureGroup/Texture/pull/1157)
 - Fix crash setting attributed text on multiple threads [Michael Schneider](https://github.com/maicki)
 - [ASTextNode2] Ignore certain text alignments while calculating intrinsic size [Huy Nguyen](https://github.com/nguyenhuy) [#1166](https://github.com/TextureGroup/Texture/pull/1166)
+- Fix mismatch in UIAccessibilityAction selector method [Michael Schneider](https://github.com/maicki) [#1169](https://github.com/TextureGroup/Texture/pull/1169)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/ASDisplayNode+Beta.h
+++ b/Source/ASDisplayNode+Beta.h
@@ -99,8 +99,11 @@ typedef struct {
 /**
  * @abstract Invoked when a user performs a custom action on an accessible node. Nodes that are children of accessibility containers, have
  * an accessibity label and have an interactive UIAccessibilityTrait will automatically receive custom-action handling.
+ *
+ * @return Return a boolean value that determine whether to propagate through the responder chain.
+ * To halt propagation, return YES; otherwise, return NO.
  */
-- (void)performAccessibilityCustomAction:(UIAccessibilityCustomAction *)action;
+- (BOOL)performAccessibilityCustomAction:(UIAccessibilityCustomAction *)action;
 
 /**
  * @abstract Currently used by ASNetworkImageNode and ASMultiplexImageNode to allow their placeholders to stay if they are loading an image from the network.


### PR DESCRIPTION
A UIAccessibilityCustomAction can be initialized with a target and a selector. The selector is expecting methods with the following signature:

```
- (BOOL)performAccessibilityCustomAction;
- (BOOL)performAccessibilityCustomAction:(UIAccessibilityCustomAction *)action;
```

Within Texture we use a different signature:
```
- (void)performAccessibilityCustomAction:(UIAccessibilityCustomAction *)action;
```

This diff will update the Texture API to adapt the correct API for a UIAccessibilityCustomAction:

- (BOOL)performAccessibilityCustomAction:(UIAccessibilityCustomAction *)action;