### PR TITLE
 Don’t handle touches on additional attributed message if passthrough is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - [ASDisplayNode] Expose default Texture-set accessibility values as properties. [Jia Wern Lim](https://github.com/jiawernlim) [#1170](https://github.com/TextureGroup/Texture/pull/1170)
 - ASTableNode init method match checks from ASCollectionNode [Michael Schneider](https://github.com/maicki) [#1171]
 - Add NSLocking conformance to ASNodeController [Michael Schneider](https://github.com/maicki)[#1179] (https://github.com/TextureGroup/Texture/pull/1179)
+- Don’t handle touches on additional attributed message if passthrough is enabled [Michael Schneider](https://github.com/maicki)[#1184] (https://github.com/TextureGroup/Texture/pull/1184)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -974,7 +974,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
 
   if (inAdditionalTruncationMessage) {
-    return YES;
+    return !_passthroughNonlinkTouches;
   } else if (range.length && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
     return YES;
   } else {

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -973,9 +973,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
 
-  if (inAdditionalTruncationMessage) {
-    return !_passthroughNonlinkTouches;
-  } else if (range.length && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
+  if (range.length && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
     return YES;
   } else {
     return NO;

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -973,7 +973,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
 
-  if (range.length && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
+  if (range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
     return YES;
   } else {
     return NO;
@@ -1009,7 +1009,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
     }
     NSRange truncationMessageRange = [self _additionalTruncationMessageRangeWithVisibleRange:visibleRange];
     [self _setHighlightRange:truncationMessageRange forAttributeName:ASTextNodeTruncationTokenAttributeName value:nil animated:YES];
-  } else if (range.length && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
+  } else if (range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
     [self _setHighlightRange:range forAttributeName:linkAttributeName value:linkAttributeValue animated:YES];
   }
 }

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -844,9 +844,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
   
-  if (inAdditionalTruncationMessage) {
-    return !_passthroughNonlinkTouches;
-  } else if (range.length && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
+  if (range.length && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
     return YES;
   } else {
     return NO;

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -194,7 +194,6 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     self.userInteractionEnabled = NO;
     self.needsDisplayOnBoundsChange = YES;
     
-    // The default truncation type is end for truncation
     _textContainer.truncationType = ASTextTruncationTypeEnd;
     
     // The common case is for a text node to be non-opaque and blended over some background.
@@ -626,28 +625,26 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     if (stringIndexForPosition != kCFNotFound) {
       CFIndex truncatedCTLineGlyphCount = CTLineGetGlyphCount(truncatedCTLine);
       
-      CTLineRef truncationTokenLine =
-      CTLineCreateWithAttributedString((CFAttributedStringRef)_truncationAttributedText);
-      CFIndex truncationTokenLineGlyphCount =
-      truncationTokenLine ? CTLineGetGlyphCount(truncationTokenLine) : 0;
+      CTLineRef truncationTokenLine = CTLineCreateWithAttributedString((CFAttributedStringRef)_truncationAttributedText);
+      CFIndex truncationTokenLineGlyphCount = truncationTokenLine ? CTLineGetGlyphCount(truncationTokenLine) : 0;
       
-      CTLineRef additionalTruncationTokenLine = 
-      CTLineCreateWithAttributedString((CFAttributedStringRef)_additionalTruncationMessage);
-      CFIndex additionalTruncationTokenLineGlyphCount =
-      additionalTruncationTokenLine ? CTLineGetGlyphCount(additionalTruncationTokenLine) : 0;   
+      CTLineRef additionalTruncationTokenLine = CTLineCreateWithAttributedString((CFAttributedStringRef)_additionalTruncationMessage);
+      CFIndex additionalTruncationTokenLineGlyphCount = additionalTruncationTokenLine ? CTLineGetGlyphCount(additionalTruncationTokenLine) : 0;   
       
       switch (_textContainer.truncationType) {
         case ASTextTruncationTypeStart: {
+          CFIndex composedTruncationTextLineGlyphCount = truncationTokenLineGlyphCount + additionalTruncationTokenLineGlyphCount;
           if (stringIndexForPosition > truncationTokenLineGlyphCount &&
-              stringIndexForPosition < (additionalTruncationTokenLineGlyphCount + truncationTokenLineGlyphCount)) {
+              stringIndexForPosition < composedTruncationTextLineGlyphCount) {
             inAdditionalTruncationMessage = YES;
           }      
           break;
         }
         case ASTextTruncationTypeMiddle: {
-          CFIndex firstTruncatedTokenIndex = (truncatedCTLineGlyphCount - (truncationTokenLineGlyphCount + additionalTruncationTokenLineGlyphCount)) / 2.0;
+          CFIndex composedTruncationTextLineGlyphCount = truncationTokenLineGlyphCount + additionalTruncationTokenLineGlyphCount;
+          CFIndex firstTruncatedTokenIndex = (truncatedCTLineGlyphCount - composedTruncationTextLineGlyphCount) / 2.0;
           if ((firstTruncatedTokenIndex + truncationTokenLineGlyphCount) < stringIndexForPosition &&
-              stringIndexForPosition < (firstTruncatedTokenIndex + truncationTokenLineGlyphCount + additionalTruncationTokenLineGlyphCount)) {
+              stringIndexForPosition < (firstTruncatedTokenIndex + composedTruncationTextLineGlyphCount)) {
             inAdditionalTruncationMessage = YES;
           }      
           break;
@@ -844,7 +841,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
   
-  if (range.length && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
+  if (range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
     return YES;
   } else {
     return NO;
@@ -885,7 +882,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     }
     NSRange truncationMessageRange = [self _additionalTruncationMessageRangeWithVisibleRange:visibleRange];
     [self _setHighlightRange:truncationMessageRange forAttributeName:ASTextNodeTruncationTokenAttributeName value:nil animated:YES];
-  } else if (range.length && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
+  } else if (range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
     [self _setHighlightRange:range forAttributeName:linkAttributeName value:linkAttributeValue animated:YES];
   }
 

--- a/examples/Kittens/Sample/AppDelegate.m
+++ b/examples/Kittens/Sample/AppDelegate.m
@@ -20,7 +20,20 @@
   self.window.backgroundColor = [UIColor whiteColor];
   self.window.rootViewController = [[UINavigationController alloc] initWithRootViewController:[[ViewController alloc] init]];
   [self.window makeKeyAndVisible];
+  
   return YES;
+}
+
+@end
+
+@implementation ASConfiguration (UserProvided)
+
++ (ASConfiguration *)textureConfiguration
+{
+  ASConfiguration *configuration = [ASConfiguration new];
+  configuration.experimentalFeatures = ASExperimentalTextNode; 
+  return configuration;
+  
 }
 
 @end

--- a/examples/Kittens/Sample/AppDelegate.m
+++ b/examples/Kittens/Sample/AppDelegate.m
@@ -20,7 +20,6 @@
   self.window.backgroundColor = [UIColor whiteColor];
   self.window.rootViewController = [[UINavigationController alloc] initWithRootViewController:[[ViewController alloc] init]];
   [self.window makeKeyAndVisible];
-  
   return YES;
 }
 
@@ -31,7 +30,7 @@
 + (ASConfiguration *)textureConfiguration
 {
   ASConfiguration *configuration = [ASConfiguration new];
-  configuration.experimentalFeatures = ASExperimentalTextNode; 
+//  configuration.experimentalFeatures = ASExperimentalTextNode; 
   return configuration;
   
 }

--- a/examples/Kittens/Sample/AppDelegate.m
+++ b/examples/Kittens/Sample/AppDelegate.m
@@ -30,7 +30,6 @@
 + (ASConfiguration *)textureConfiguration
 {
   ASConfiguration *configuration = [ASConfiguration new];
-//  configuration.experimentalFeatures = ASExperimentalTextNode; 
   return configuration;
   
 }

--- a/examples/Kittens/Sample/BlurbNode.m
+++ b/examples/Kittens/Sample/BlurbNode.m
@@ -44,19 +44,34 @@ static NSString *kLinkAttributeName = @"PlaceKittenNodeLinkAttributeName";
   _textNode.delegate = self;
   _textNode.userInteractionEnabled = YES;
   _textNode.linkAttributeNames = @[ kLinkAttributeName ];
+  _textNode.maximumNumberOfLines = 1;
 
   // generate an attributed string using the custom link attribute specified above
-  NSString *blurb = @"kittens courtesy placekitten.com \U0001F638";
+  ////NSString *blurb = @"Text link: some some some more even more text and even more text";
+//  NSString *blurb = @"Text link: some some";
+  NSString *blurb = @"Text link: some some some more even more text and even more text";  
   NSMutableAttributedString *string = [[NSMutableAttributedString alloc] initWithString:blurb];
-  [string addAttribute:NSFontAttributeName value:[UIFont fontWithName:@"HelveticaNeue-Light" size:16.0f] range:NSMakeRange(0, blurb.length)];
+  // [string addAttribute:NSFontAttributeName value:[UIFont fontWithName:@"HelveticaNeue-Light" size:16.0f] range:NSMakeRange(0, blurb.length)];
   [string addAttributes:@{
                           kLinkAttributeName: [NSURL URLWithString:@"http://placekitten.com/"],
                           NSForegroundColorAttributeName: [UIColor grayColor],
                           NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle | NSUnderlinePatternDot),
                           }
-                  range:[blurb rangeOfString:@"placekitten.com"]];
+                  range:[blurb rangeOfString:@"Text"]];
   _textNode.attributedText = string;
+  
+  NSAttributedString *truncationAttributedText = [[NSAttributedString alloc] initWithString:@" ..." attributes:@{}];
+  _textNode.truncationAttributedText = truncationAttributedText;
+  
+  NSAttributedString *additionalTruncationMessage = [[NSAttributedString alloc] initWithString:@" Read More " attributes:@{}];
+  _textNode.additionalTruncationMessage = additionalTruncationMessage;
 
+  //  _textNode.truncationMode = NSLineBreakByTruncatingHead;
+//    _textNode.truncationMode = NSLineBreakByTruncatingHead;
+//  _textNode.truncationMode = NSLineBreakByTruncatingMiddle;  
+ 
+//  _textNode.passthroughNonlinkTouches = YES;
+  
   // add it as a subnode, and we're done
   [self addSubnode:_textNode];
 
@@ -102,19 +117,46 @@ static NSString *kLinkAttributeName = @"PlaceKittenNodeLinkAttributeName";
 }
 #endif
 
-#pragma mark -
-#pragma mark ASTextNodeDelegate methods.
+#pragma mark - Touches Handling
+
+// This will only be called if passthroughNonlinkTouches = YES
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
+{
+  [super touchesBegan:touches withEvent:event];
+  
+  NSLog(@"Handle some touches");
+}
+
+#pragma mark - ASTextNodeDelegate methods.
 
 - (BOOL)textNode:(ASTextNode *)richTextNode shouldHighlightLinkAttribute:(NSString *)attribute value:(id)value atPoint:(CGPoint)point
 {
+  NSLog(@"%s", __PRETTY_FUNCTION__);
+  
   // opt into link highlighting -- tap and hold the link to try it!  must enable highlighting on a layer, see -didLoad
   return YES;
 }
 
 - (void)textNode:(ASTextNode *)richTextNode tappedLinkAttribute:(NSString *)attribute value:(NSURL *)URL atPoint:(CGPoint)point textRange:(NSRange)textRange
 {
+  NSLog(@"%s", __PRETTY_FUNCTION__);
+  
   // the node tapped a link, open it
-  [[UIApplication sharedApplication] openURL:URL];
+  // [[UIApplication sharedApplication] openURL:URL];
+}
+
+- (void)textNodeTappedTruncationToken:(ASTextNode *)textNode
+{
+  // This is called if the additional truncation text is tapped 
+  
+  NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+
+#pragma mark - ASTextNode actions
+
+- (void)touchUpInsideOfTextNode:(id)sender
+{
+  NSLog(@"%s", __PRETTY_FUNCTION__);
 }
 
 @end

--- a/examples/Kittens/Sample/BlurbNode.m
+++ b/examples/Kittens/Sample/BlurbNode.m
@@ -44,34 +44,19 @@ static NSString *kLinkAttributeName = @"PlaceKittenNodeLinkAttributeName";
   _textNode.delegate = self;
   _textNode.userInteractionEnabled = YES;
   _textNode.linkAttributeNames = @[ kLinkAttributeName ];
-  _textNode.maximumNumberOfLines = 1;
 
   // generate an attributed string using the custom link attribute specified above
-  ////NSString *blurb = @"Text link: some some some more even more text and even more text";
-//  NSString *blurb = @"Text link: some some";
-  NSString *blurb = @"Text link: some some some more even more text and even more text";  
+  NSString *blurb = @"kittens courtesy placekitten.com \U0001F638";
   NSMutableAttributedString *string = [[NSMutableAttributedString alloc] initWithString:blurb];
-  // [string addAttribute:NSFontAttributeName value:[UIFont fontWithName:@"HelveticaNeue-Light" size:16.0f] range:NSMakeRange(0, blurb.length)];
+  [string addAttribute:NSFontAttributeName value:[UIFont fontWithName:@"HelveticaNeue-Light" size:16.0f] range:NSMakeRange(0, blurb.length)];
   [string addAttributes:@{
                           kLinkAttributeName: [NSURL URLWithString:@"http://placekitten.com/"],
                           NSForegroundColorAttributeName: [UIColor grayColor],
                           NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle | NSUnderlinePatternDot),
                           }
-                  range:[blurb rangeOfString:@"Text"]];
+                  range:[blurb rangeOfString:@"placekitten.com"]];
   _textNode.attributedText = string;
-  
-  NSAttributedString *truncationAttributedText = [[NSAttributedString alloc] initWithString:@" ..." attributes:@{}];
-  _textNode.truncationAttributedText = truncationAttributedText;
-  
-  NSAttributedString *additionalTruncationMessage = [[NSAttributedString alloc] initWithString:@" Read More " attributes:@{}];
-  _textNode.additionalTruncationMessage = additionalTruncationMessage;
 
-  //  _textNode.truncationMode = NSLineBreakByTruncatingHead;
-//    _textNode.truncationMode = NSLineBreakByTruncatingHead;
-//  _textNode.truncationMode = NSLineBreakByTruncatingMiddle;  
- 
-//  _textNode.passthroughNonlinkTouches = YES;
-  
   // add it as a subnode, and we're done
   [self addSubnode:_textNode];
 
@@ -117,46 +102,19 @@ static NSString *kLinkAttributeName = @"PlaceKittenNodeLinkAttributeName";
 }
 #endif
 
-#pragma mark - Touches Handling
-
-// This will only be called if passthroughNonlinkTouches = YES
-- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
-{
-  [super touchesBegan:touches withEvent:event];
-  
-  NSLog(@"Handle some touches");
-}
-
-#pragma mark - ASTextNodeDelegate methods.
+#pragma mark -
+#pragma mark ASTextNodeDelegate methods.
 
 - (BOOL)textNode:(ASTextNode *)richTextNode shouldHighlightLinkAttribute:(NSString *)attribute value:(id)value atPoint:(CGPoint)point
 {
-  NSLog(@"%s", __PRETTY_FUNCTION__);
-  
   // opt into link highlighting -- tap and hold the link to try it!  must enable highlighting on a layer, see -didLoad
   return YES;
 }
 
 - (void)textNode:(ASTextNode *)richTextNode tappedLinkAttribute:(NSString *)attribute value:(NSURL *)URL atPoint:(CGPoint)point textRange:(NSRange)textRange
 {
-  NSLog(@"%s", __PRETTY_FUNCTION__);
-  
   // the node tapped a link, open it
-  // [[UIApplication sharedApplication] openURL:URL];
-}
-
-- (void)textNodeTappedTruncationToken:(ASTextNode *)textNode
-{
-  // This is called if the additional truncation text is tapped 
-  
-  NSLog(@"%s", __PRETTY_FUNCTION__);
-}
-
-#pragma mark - ASTextNode actions
-
-- (void)touchUpInsideOfTextNode:(id)sender
-{
-  NSLog(@"%s", __PRETTY_FUNCTION__);
+  [[UIApplication sharedApplication] openURL:URL];
 }
 
 @end


### PR DESCRIPTION
This diff will change the behavior handling tapping on the additional attributed message:
If `passthroughNonlinkTouches` is set to YES, taps on the additional attributed message will *not* call the `textNodeTappedTruncationToken:` delegate method anymore. Previously tapping on the additional attributed message always called `textNodeTappedTruncationToken:` without any dependence on `passthroughNonlinkTouches`.

Another approach could be to add a new property like: `handleAdditionalTruncationString` that if set to YES will call `textNodeTappedTruncationToken:` otherwise not. This would not depend on `passthroughNonlinkTouches`.

Furthermore this diff fixes taps within the additional attributed message within `ASTextNode2` what currently didn't really work. Before this the tap was not detected if tapped directly on the additional attributed text, it was only detected if tapped a bit outside of the additional attributed text but still within the `ASTextNode2` bounds.