### PR TITLE
Correct linePositionModifier behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Add NSLocking conformance to ASNodeController [Michael Schneider](https://github.com/maicki)[#1179] (https://github.com/TextureGroup/Texture/pull/1179)
 - Don’t handle touches on additional attributed message if passthrough is enabled [Michael Schneider](https://github.com/maicki)[#1184] (https://github.com/TextureGroup/Texture/pull/1184)
 - Yoga integration improvements [Michael Schneider](https://github.com/maicki)[#1187] (https://github.com/TextureGroup/Texture/pull/1187)
+- Correct linePositionModifier behavior [Michael Schneider](https://github.com/maicki)[#1192] (https://github.com/TextureGroup/Texture/pull/1192)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/ASTextNode.h
+++ b/Source/ASTextNode.h
@@ -218,6 +218,15 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /**
+ * @abstract Text node unsupported properties
+ */
+@interface ASTextNode (Unsupported)
+
+@property (nullable, nonatomic) id textContainerLinePositionModifier;
+
+@end
+
+/**
  * @abstract Text node deprecated properties
  */
 @interface ASTextNode (Deprecated)

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -1389,6 +1389,21 @@ static NSAttributedString *DefaultTruncationAttributedString()
 
 @end
 
+@implementation ASTextNode (Unsupported)
+
+- (void)setTextContainerLinePositionModifier:(id)textContainerLinePositionModifier
+{
+  AS_TEXT_ALERT_UNIMPLEMENTED_FEATURE();
+}
+
+- (id)textContainerLinePositionModifier
+{
+  AS_TEXT_ALERT_UNIMPLEMENTED_FEATURE();
+  return nil;
+}
+
+@end
+
 @implementation ASTextNode (Deprecated)
 
 - (void)setAttributedString:(NSAttributedString *)attributedString

--- a/Source/ASTextNode2.h
+++ b/Source/ASTextNode2.h
@@ -9,6 +9,8 @@
 #import <AsyncDisplayKit/ASControlNode.h>
 #import <AsyncDisplayKit/ASTextNodeCommon.h>
 
+@protocol ASTextLinePositionModifier;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -206,6 +208,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL passthroughNonlinkTouches;
 
 + (void)enableDebugging;
+
+#pragma mark - Layout and Sizing
+
+@property (nullable, nonatomic) id<ASTextLinePositionModifier> textContainerLinePositionModifier;
 
 @end
 

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -318,6 +318,17 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   return _textContainer.insets;
 }
 
+- (void)setTextContainerLinePositionModifier:(id<ASTextLinePositionModifier>)modifier
+{
+  ASLockedSelfCompareAssignObjects(_textContainer.linePositionModifier, modifier);
+}
+
+- (id<ASTextLinePositionModifier>)textContainerLinePositionModifier
+{
+  ASLockScopeSelf();
+  return _textContainer.linePositionModifier;
+}
+
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
   ASDisplayNodeAssert(constrainedSize.width >= 0, @"Constrained width for text (%f) is too  narrow", constrainedSize.width);

--- a/Source/Private/TextExperiment/Component/ASTextLayout.m
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.m
@@ -102,6 +102,13 @@ static CGColorRef ASTextGetCGColor(CGColorRef color) {
   id<ASTextLinePositionModifier> _linePositionModifier;
 }
 
+- (NSString *)description
+{
+  return [NSString
+          stringWithFormat:@"immutable: %@, insets: %@, size: %@", self->_readonly ? @"YES" : @"NO",
+                           NSStringFromUIEdgeInsets(self->_insets), NSStringFromCGSize(self->_size)];
+}
+
 + (instancetype)containerWithSize:(CGSize)size NS_RETURNS_RETAINED {
   return [self containerWithSize:size insets:UIEdgeInsetsZero];
 }
@@ -373,6 +380,14 @@ dispatch_semaphore_signal(_lock);
   return self;
 }
 
+- (NSString *)description
+{
+  return [NSString stringWithFormat:@"lines: %ld, visibleRange:%@, textBoundingRect:%@",
+                                    [self.lines count],
+                                    NSStringFromRange(self.visibleRange),
+                                    NSStringFromCGRect(self.textBoundingRect)];
+}
+
 + (ASTextLayout *)layoutWithContainerSize:(CGSize)size text:(NSAttributedString *)text {
   ASTextContainer *container = [ASTextContainer containerWithSize:size];
   return [self layoutWithContainer:container text:text];
@@ -599,15 +614,24 @@ dispatch_semaphore_signal(_lock);
     position.y = cgPathBox.size.height + cgPathBox.origin.y - ctLineOrigin.y;
     
     ASTextLine *line = [ASTextLine lineWithCTLine:ctLine position:position vertical:isVerticalForm];
+    
+    [lines addObject:line];
+  }
+  
+  // Give user a chance to modify the line's position.
+  [container.linePositionModifier modifyLines:lines fromText:text inContainer:container];
+  
+  NSUInteger i = 0;
+  for (ASTextLine *line in lines) {
+    CGPoint position = line.position;
     CGRect rect = line.bounds;
-
     if (constraintSizeIsExtended) {
       if (isVerticalForm) {
         if (rect.origin.x + rect.size.width >
             constraintRectBeforeExtended.origin.x +
                 constraintRectBeforeExtended.size.width) {
           measuringBeyondConstraints = YES;
-        };
+        }
       } else {
         if (rect.origin.y + rect.size.height >
             constraintRectBeforeExtended.origin.y +
@@ -640,11 +664,11 @@ dispatch_semaphore_signal(_lock);
     
     line.index = lineCurrentIdx;
     line.row = rowIdx;
-    [lines addObject:line];
+
     rowCount = rowIdx + 1;
     lineCurrentIdx ++;
 
-    if (i == 0) {
+    if (i++ == 0) {
       textBoundingRect = rect;
     } else if (!measuringBeyondConstraints) {
       if (maximumNumberOfRows == 0 || rowIdx < maximumNumberOfRows) {
@@ -676,17 +700,6 @@ dispatch_semaphore_signal(_lock);
           ASTextLine *line = lines.lastObject;
           [lines removeLastObject];
           [removedLines addObject:line];
-        }
-      }
-
-      // Give user a chance to modify the line's position.
-      if (container.linePositionModifier) {
-        [container.linePositionModifier modifyLines:lines fromText:text inContainer:container];
-        textBoundingRect = CGRectZero;
-        for (NSUInteger i = 0, max = lines.count; i < max; i++) {
-          ASTextLine *line = lines[i];
-          if (i == 0) textBoundingRect = line.bounds;
-          else textBoundingRect = CGRectUnion(textBoundingRect, line.bounds);
         }
       }
 


### PR DESCRIPTION
iOS will adjust line spacing if it pulls in out-of-font glyphs (ie emojis).
The cap-to-font-height option will override this adjustment, keeping line spacing (baseline-to-baseline) consistent but possibly crowding the emoji (or other out-of-font glyphs).

Implementing required ASTextNode2 to expose the linePositionModifier delegate used by ASTextLayout.