### PR TITLE
Newline character support and truncated line sizing improvement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
+- [ASTextNode2] Newline character support and truncated line sizing improvement.  [Kevin Smith](https://github.com/wiseoldduck). [#1193](https://github.com/TextureGroup/Texture/pull/1193)
 - [ASDisplayNode.m] Make sure node is loaded before enter visible. [Max Wang](https://github.com/wsdwsd0829). [#886](https://github.com/TextureGroup/Texture/pull/886)
 - [ASTextNode2] Add improved support for all line-break modes in experimental text node. [Kevin Smith](https://github.com/wiseoldduck). [#1150](https://github.com/TextureGroup/Texture/pull/1150)
 - [ASExperimentalFeatures.m] Fix mismatch name in experimental features. [Max Wang](https://github.com/wsdwsd0829). [#1159](https://github.com/TextureGroup/Texture/pull/1159)

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -246,7 +246,10 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   NSMutableAttributedString *mutableText = [_attributedText mutableCopy];
   [self prepareAttributedString:mutableText isForIntrinsicSize:isCalculatingIntrinsicSize];
   ASTextLayout *layout = [ASTextNode2 compatibleLayoutWithContainer:_textContainer text:mutableText];
-  
+  if (layout.truncatedLine != nil && layout.truncatedLine.size.width > layout.textBoundingSize.width) {
+    return (CGSize) {MIN(constrainedSize.width, layout.truncatedLine.size.width), layout.textBoundingSize.height};
+  }
+
   return layout.textBoundingSize;
 }
 


### PR DESCRIPTION
As we use the returned size for sizeThatFits, we need to make sure we don't truncate text and then return the smaller size (leading to even more text being truncated).

If a newline character takes the text outside of the bounds, that text should be truncated.