### PR TITLE
ASTextNode2 to consider both width and height when determining if it is calculating an intrinsic size

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -340,12 +340,9 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   [self _ensureTruncationText];
 
   // If the constrained size has a max/inf value on the text's forward direction, the text node is calculating its intrinsic size.
-  BOOL isCalculatingIntrinsicSize;
-  if (_textContainer.isVerticalForm) {
-    isCalculatingIntrinsicSize = (_textContainer.size.height >= ASTextContainerMaxSize.height);
-  } else {
-    isCalculatingIntrinsicSize = (_textContainer.size.width >= ASTextContainerMaxSize.width);
-  }
+  // Need to consider both width and height when determining if it is calculating instrinsic size. Even the constrained width is provided, the height can be inf
+  // it may provide a text that is longer than the width and require a wordWrapping line break mode and looking for the height to be calculated.
+  BOOL isCalculatingIntrinsicSize = (_textContainer.size.width >= ASTextContainerMaxSize.width) || (_textContainer.size.height >= ASTextContainerMaxSize.height);
 
   NSMutableAttributedString *mutableText = [_attributedText mutableCopy];
   [self prepareAttributedString:mutableText isForIntrinsicSize:isCalculatingIntrinsicSize];


### PR DESCRIPTION
It was only considering the individual constraint width/height when calculating the intrinsic size. However, this will not work when textnode is in a vertical ASStackLayoutSpec which also try to set a flexShrink. 

If it needs to calculate either height or width based on its own content where either of them is ambiguous, it needs to apply the proper line break mode and text alignment.

Related commit: https://github.com/TextureGroup/Texture/pull/1166/commits/a139d66c5d1d90ace6ef9adcaabe86d6df62bf38