### PR TITLE
Tweak a11y label aggregation behavior to enable container label overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - Don’t handle touches on additional attributed message if passthrough is enabled [Michael Schneider](https://github.com/maicki)[#1184] (https://github.com/TextureGroup/Texture/pull/1184)
 - Yoga integration improvements [Michael Schneider](https://github.com/maicki)[#1187] (https://github.com/TextureGroup/Texture/pull/1187)
 - Correct linePositionModifier behavior [Michael Schneider](https://github.com/maicki)[#1192] (https://github.com/TextureGroup/Texture/pull/1192)
+- Tweak a11y label aggregation behavior to enable container label overrides [Michael Schneider](https://github.com/maicki)[#1199] (https://github.com/TextureGroup/Texture/pull/1199)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -139,7 +139,14 @@ static void CollectAccessibilityElementsForContainer(ASDisplayNode *container, _
   std::queue<ASDisplayNode *> queue;
   queue.push(container);
 
-  ASDisplayNode *node;
+  // If the container does not have an accessibility label set, or if the label is meant for custom
+  // actions only, then aggregate its subnodes' labels. Otherwise, treat the label as an overriden
+  // value and do not perform the aggregation.
+  BOOL shouldAggregateSubnodeLabels =
+      (container.accessibilityLabel.length == 0) ||
+      (container.accessibilityTraits & InteractiveAccessibilityTraitsMask());
+
+  ASDisplayNode *node = nil;
   while (!queue.empty()) {
     node = queue.front();
     queue.pop();
@@ -156,7 +163,7 @@ static void CollectAccessibilityElementsForContainer(ASDisplayNode *container, _
         action.containerNode = node.supernode;
         action.container = node.supernode.view;
         [actions addObject:action];
-      } else {
+      } else if (node == container || shouldAggregateSubnodeLabels) {
         // Even though not surfaced to UIKit, create a non-interactive element for purposes of building sorted aggregated label.
         ASAccessibilityElement *nonInteractiveElement = [ASAccessibilityElement accessibilityElementWithContainer:view node:node containerNode:container];
         [labeledNodes addObject:nonInteractiveElement];


### PR DESCRIPTION
Modified the ASDisplayNode accessibility label to only aggregate its sub-nodes' labels when it doesn't have any explicit accessibility label set on itself. If an existing label is already present, it is instead treated as an override to the container's a11y label. Added relevant tests.