### PR TITLE
Fix logic cleaning data if delegate / dataSource changes and bring over logic to ASTableView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Yoga integration improvements [Michael Schneider](https://github.com/maicki)[#1187] (https://github.com/TextureGroup/Texture/pull/1187)
 - Correct linePositionModifier behavior [Michael Schneider](https://github.com/maicki)[#1192] (https://github.com/TextureGroup/Texture/pull/1192)
 - Tweak a11y label aggregation behavior to enable container label overrides [Michael Schneider](https://github.com/maicki)[#1199] (https://github.com/TextureGroup/Texture/pull/1199)
+- Fix logic cleaning data if delegate / dataSource changes and bring over logic to ASTableView [Michael Schneider](https://github.com/maicki)[#1200] (https://github.com/TextureGroup/Texture/pull/1200)
 
 ## 2.7
 - Fix pager node for interface coalescing. [Max Wang](https://github.com/wsdwsd0829) [#877](https://github.com/TextureGroup/Texture/pull/877)

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -576,10 +576,16 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 - (void)_asyncDelegateOrDataSourceDidChange
 {
   ASDisplayNodeAssertMainThread();
-  
-  if (_asyncDataSource == nil && _asyncDelegate == nil && _isDeallocating && ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
-    [_dataController clearData];
-  }
+
+  if (_asyncDataSource == nil && _asyncDelegate == nil) {
+    if (ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
+      if (_isDeallocating) {
+        [_dataController clearData];          
+      }
+    } else {
+      [_dataController clearData];
+    }
+  }  
 }
 
 - (void)setCollectionViewLayout:(nonnull UICollectionViewLayout *)collectionViewLayout

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -436,6 +436,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   
   _dataController.validationErrorSource = asyncDataSource;
   super.dataSource = (id<UITableViewDataSource>)_proxyDataSource;
+  [self _asyncDelegateOrDataSourceDidChange];
 }
 
 - (id<ASTableDelegate>)asyncDelegate
@@ -506,6 +507,16 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   }
   
   super.delegate = (id<UITableViewDelegate>)_proxyDelegate;
+  [self _asyncDelegateOrDataSourceDidChange];
+}
+
+- (void)_asyncDelegateOrDataSourceDidChange
+{
+  ASDisplayNodeAssertMainThread();
+  
+  if (_asyncDataSource == nil && _asyncDelegate == nil && _isDeallocating && ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
+    [_dataController clearData];
+  }
 }
 
 - (void)proxyTargetHasDeallocated:(ASDelegateProxy *)proxy

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -513,9 +513,15 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 - (void)_asyncDelegateOrDataSourceDidChange
 {
   ASDisplayNodeAssertMainThread();
-  
-  if (_asyncDataSource == nil && _asyncDelegate == nil && _isDeallocating && ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
-    [_dataController clearData];
+ 
+  if (_asyncDataSource == nil && _asyncDelegate == nil) {
+    if (ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
+      if (_isDeallocating) {
+        [_dataController clearData];          
+      }
+    } else {
+      [_dataController clearData];
+    }
   }
 }
 


### PR DESCRIPTION
The current approach we use to check if we should clear data if the dataSource / delegate changes via the `ASExperimentalClearDataDuringDeallocation` flag has some issue. The problem is that we are checking `_isDeallocating` and bail out if not true although we should only do that if the ASExperimentalClearDataDuringDeallocation flag is true.

We have the same change within `ASCollectionView`. We know from previous investigations (see #1155) that this currently can cause crashes. For consistency let's get this code over to `ASTableView` though with the experiments setup we have within `ASCollectionView`.