### PR TITLE
Add experiment flag to skip layoutIfNeeded in enterPreloadState for ASM nodes #trivial

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3377,7 +3377,8 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   // - If it doesn't have a calculated or pending layout that fits its current bounds, a measurement pass will occur
   // (see -__layout and -_u_measureNodeWithBoundsIfNecessary:). This scenario is uncommon,
   // and running a measurement pass here is a fine trade-off because preloading any time after this point would be late.
-  if (self.automaticallyManagesSubnodes) {
+  
+  if (self.automaticallyManagesSubnodes && !ASActivateExperimentalFeature(ASExperimentalDidEnterPreloadSkipASMLayout)) {
     [self layoutIfNeeded];
   }
   [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> del) {

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -24,6 +24,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalCollectionTeardown = 1 << 6,                // exp_collection_teardown
   ASExperimentalFramesetterCache = 1 << 7,                  // exp_framesetter_cache
   ASExperimentalClearDataDuringDeallocation = 1 << 8,       // exp_clear_data_during_deallocation
+  ASExperimentalDidEnterPreloadSkipASMLayout = 1 << 9,      // exp_did_enter_preload_skip_asm_layout
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -20,7 +20,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_network_image_queue",
                                       @"exp_collection_teardown",
                                       @"exp_framesetter_cache",
-                                      @"exp_clear_data_during_deallocation"]));
+                                      @"exp_clear_data_during_deallocation",
+                                      @"exp_did_enter_preload_skip_asm_layout"]));
   
   if (flags == ASExperimentalFeatureAll) {
     return allNames;

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -13,15 +13,16 @@
 #import "ASConfigurationInternal.h"
 
 static ASExperimentalFeatures features[] = {
-    ASExperimentalGraphicsContexts,
-    ASExperimentalTextNode,
-    ASExperimentalInterfaceStateCoalescing,
-    ASExperimentalUnfairLock,
-    ASExperimentalLayerDefaults,
-    ASExperimentalNetworkImageQueue,
-    ASExperimentalCollectionTeardown,
-    ASExperimentalFramesetterCache,
-    ASExperimentalClearDataDuringDeallocation
+  ASExperimentalGraphicsContexts,
+  ASExperimentalTextNode,
+  ASExperimentalInterfaceStateCoalescing,
+  ASExperimentalUnfairLock,
+  ASExperimentalLayerDefaults,
+  ASExperimentalNetworkImageQueue,
+  ASExperimentalCollectionTeardown,
+  ASExperimentalFramesetterCache,
+  ASExperimentalClearDataDuringDeallocation,
+  ASExperimentalDidEnterPreloadSkipASMLayout
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -34,16 +35,17 @@ static ASExperimentalFeatures features[] = {
 
 + (NSArray *)names {
   return @[
-           @"exp_graphics_contexts",
-           @"exp_text_node",
-           @"exp_interface_state_coalesce",
-           @"exp_unfair_lock",
-           @"exp_infer_layer_defaults",
-           @"exp_network_image_queue",
-           @"exp_collection_teardown",
-           @"exp_framesetter_cache",
-           @"exp_clear_data_during_deallocation"
-           ];
+    @"exp_graphics_contexts",
+    @"exp_text_node",
+    @"exp_interface_state_coalesce",
+    @"exp_unfair_lock",
+    @"exp_infer_layer_defaults",
+    @"exp_network_image_queue",
+    @"exp_collection_teardown",
+    @"exp_framesetter_cache",
+    @"exp_clear_data_during_deallocation",
+    @"exp_did_enter_preload_skip_asm_layout",
+  ];
 }
 
 - (ASExperimentalFeatures)allFeatures {


### PR DESCRIPTION
Performing a layout pass within `didEnterPreloadState` can have a meaningful performance impact, enough that we should measure it as an ASConfiguration experimental feature.