### PR TITLE
Address compiler warnings #trivial

### DIFF
--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -607,7 +607,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
       return;
     }
 
-    for (NSString *attributeName in _linkAttributeNames) {
+    for (NSString *attributeName in self->_linkAttributeNames) {
       NSRange range;
       id value = [attributedString attribute:attributeName atIndex:characterIndex longestEffectiveRange:&range inRange:clampedRange];
       NSString *name = attributeName;
@@ -619,8 +619,8 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
       // If highlighting, check with delegate first. If not implemented, assume YES.
       if (highlighting
-          && [_delegate respondsToSelector:@selector(textNode:shouldHighlightLinkAttribute:value:atPoint:)]
-          && ![_delegate textNode:self shouldHighlightLinkAttribute:name value:value atPoint:point]) {
+          && [self->_delegate respondsToSelector:@selector(textNode:shouldHighlightLinkAttribute:value:atPoint:)]
+          && ![self->_delegate textNode:self shouldHighlightLinkAttribute:name value:value atPoint:point]) {
         value = nil;
         name = nil;
       }

--- a/Source/Details/ASMainSerialQueue.mm
+++ b/Source/Details/ASMainSerialQueue.mm
@@ -52,16 +52,16 @@
 {
   dispatch_block_t mainThread = ^{
     do {
-      ASDN::MutexLocker l(_serialQueueLock);
+      ASDN::MutexLocker l(self->_serialQueueLock);
       dispatch_block_t block;
-      if (_blocks.count > 0) {
+      if (self->_blocks.count > 0) {
         block = _blocks[0];
-        [_blocks removeObjectAtIndex:0];
+        [self->_blocks removeObjectAtIndex:0];
       } else {
         break;
       }
       {
-        ASDN::MutexUnlocker u(_serialQueueLock);
+        ASDN::MutexUnlocker u(self->_serialQueueLock);
         block();
       }
     } while (true);

--- a/Source/Details/ASRecursiveUnfairLock.h
+++ b/Source/Details/ASRecursiveUnfairLock.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 OS_UNFAIR_LOCK_AVAILABILITY
 typedef struct {
-  os_unfair_lock _lock;
+  os_unfair_lock _lock OS_UNFAIR_LOCK_AVAILABILITY;
   _Atomic(pthread_t) _thread;  // Write-protected by lock
   int _count;                  // Protected by lock
 } ASRecursiveUnfairLock;

--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -61,11 +61,11 @@ typedef struct ASPrimitiveTraitCollection {
   UIUserInterfaceSizeClass verticalSizeClass;
 
   CGFloat displayScale;
-  UIDisplayGamut displayGamut;
+  UIDisplayGamut displayGamut API_AVAILABLE(ios(10.0));
 
   UIUserInterfaceIdiom userInterfaceIdiom;
   UIForceTouchCapability forceTouchCapability;
-  UITraitEnvironmentLayoutDirection layoutDirection;
+  UITraitEnvironmentLayoutDirection layoutDirection API_AVAILABLE(ios(10.0));
 #if TARGET_OS_TV
   UIUserInterfaceStyle userInterfaceStyle;
 #endif
@@ -168,11 +168,11 @@ AS_SUBCLASSING_RESTRICTED
 @property (nonatomic, readonly) UIUserInterfaceSizeClass verticalSizeClass;
 
 @property (nonatomic, readonly) CGFloat displayScale;
-@property (nonatomic, readonly) UIDisplayGamut displayGamut;
+@property (nonatomic, readonly) UIDisplayGamut displayGamut API_AVAILABLE(ios(10.0));
 
 @property (nonatomic, readonly) UIUserInterfaceIdiom userInterfaceIdiom;
 @property (nonatomic, readonly) UIForceTouchCapability forceTouchCapability;
-@property (nonatomic, readonly) UITraitEnvironmentLayoutDirection layoutDirection;
+@property (nonatomic, readonly) UITraitEnvironmentLayoutDirection layoutDirection API_AVAILABLE(ios(10.0));
 #if TARGET_OS_TV
 @property (nonatomic, readonly) UIUserInterfaceStyle userInterfaceStyle;
 #endif

--- a/Source/Private/TextExperiment/Component/ASTextLayout.m
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.m
@@ -835,7 +835,7 @@ dispatch_semaphore_signal(_lock);
           }
           int i = 0;
           if (type != kCTLineTruncationStart) { // Middle or End/Tail wants text preceding truncated content.
-            i = removedLines.count - 1;
+            i = (int)removedLines.count - 1;
             while (atLeastOneLine < truncatedWidth && i >= 0) {
               if (lastLineText.length > 0 && [lastLineText.string characterAtIndex:lastLineText.string.length - 1] == '\n') { // Explicit newlines are always "long enough".
                 [lastLineText deleteCharactersInRange:NSMakeRange(lastLineText.string.length - 1, 1)];

--- a/Source/TextKit/ASTextKitFontSizeAdjuster.mm
+++ b/Source/TextKit/ASTextKitFontSizeAdjuster.mm
@@ -183,8 +183,8 @@
     
     // check to see if we may need to shrink for any of these things
     BOOL longestWordFits = [longestWordNeedingResize length] ? NO : YES;
-    BOOL maxLinesFits = _attributes.maximumNumberOfLines > 0 ? NO : YES;
-    BOOL heightFits = isinf(_constrainedSize.height) ? YES : NO;
+    BOOL maxLinesFits = self->_attributes.maximumNumberOfLines > 0 ? NO : YES;
+    BOOL heightFits = isinf(self->_constrainedSize.height) ? YES : NO;
 
     CGSize longestWordSize = CGSizeZero;
     if (longestWordFits == NO) {
@@ -204,7 +204,7 @@
       
       if (longestWordFits == NO) {
         // we need to check the longest word to make sure it fits
-        longestWordFits = std::ceil((longestWordSize.width * adjustedScale) <= _constrainedSize.width);
+        longestWordFits = std::ceil((longestWordSize.width * adjustedScale) <= self->_constrainedSize.width);
       }
       
       // if the longest word fits, go ahead and check max line and height. If it didn't fit continue to the next scale factor
@@ -216,14 +216,14 @@
         
         // check to see if this scaled string fit in the max lines
         if (maxLinesFits == NO) {
-          maxLinesFits = ([self lineCountForString:scaledString] <= _attributes.maximumNumberOfLines);
+          maxLinesFits = ([self lineCountForString:scaledString] <= self->_attributes.maximumNumberOfLines);
         }
         
         // if max lines still doesn't fit, continue without checking that we fit in the constrained height
         if (maxLinesFits == YES && heightFits == NO) {
           // max lines fit so make sure that we fit in the constrained height.
           CGSize stringSize = [self boundingBoxForString:scaledString];
-          heightFits = (stringSize.height <= _constrainedSize.height);
+          heightFits = (stringSize.height <= self->_constrainedSize.height);
         }
       }
     }

--- a/Source/TextKit/ASTextKitRenderer.mm
+++ b/Source/TextKit/ASTextKitRenderer.mm
@@ -128,7 +128,7 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
     // apply the string scale before truncating or else we may truncate the string after we've done the work to shrink it.
     [[self context] performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
       NSMutableAttributedString *scaledString = [[NSMutableAttributedString alloc] initWithAttributedString:textStorage];
-      [ASTextKitFontSizeAdjuster adjustFontSizeForAttributeString:scaledString withScaleFactor:_currentScaleFactor];
+      [ASTextKitFontSizeAdjuster adjustFontSizeForAttributeString:scaledString withScaleFactor:self->_currentScaleFactor];
       scaledTextStorage = [[NSTextStorage alloc] initWithAttributedString:scaledString];
       
       [textStorage removeLayoutManager:layoutManager];
@@ -217,7 +217,7 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
       if (isScaled) {
         // if we are going to scale the text, swap out the non-scaled text for the scaled version.
         NSMutableAttributedString *scaledString = [[NSMutableAttributedString alloc] initWithAttributedString:textStorage];
-        [ASTextKitFontSizeAdjuster adjustFontSizeForAttributeString:scaledString withScaleFactor:_currentScaleFactor];
+        [ASTextKitFontSizeAdjuster adjustFontSizeForAttributeString:scaledString withScaleFactor:self->_currentScaleFactor];
         scaledTextStorage = [[NSTextStorage alloc] initWithAttributedString:scaledString];
         
         [textStorage removeLayoutManager:layoutManager];

--- a/Source/TextKit/ASTextKitTailTruncater.mm
+++ b/Source/TextKit/ASTextKitTailTruncater.mm
@@ -157,7 +157,7 @@
                                                               actualGlyphRange:NULL];
 
     // Check if text is truncated, and if so apply our truncation string
-    if (visibleCharacterRange.length < originalStringLength && _truncationAttributedString.length > 0) {
+    if (visibleCharacterRange.length < originalStringLength && self->_truncationAttributedString.length > 0) {
       NSInteger firstCharacterIndexToReplace = [self _calculateCharacterIndexBeforeTruncationMessage:layoutManager
                                                                                          textStorage:textStorage
                                                                                        textContainer:textContainer];
@@ -171,10 +171,10 @@
                                                        textStorage.length - firstCharacterIndexToReplace);
       // Replace the end of the visible message with the truncation string
       [textStorage replaceCharactersInRange:truncationReplacementRange
-                       withAttributedString:_truncationAttributedString];
+                       withAttributedString:self->_truncationAttributedString];
     }
 
-    _visibleRanges = { visibleCharacterRange };
+    self->_visibleRanges = { visibleCharacterRange };
   }];
 }
 


### PR DESCRIPTION
The compiler is still not smart enough to notice that noescape blocks should not warn on retaining self 👎 but that's OK. This will clean up our CI logs a lot.