### PR TITLE
Set up CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+# iOS CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/ios-migrating-from-1-2/ for more details
+#
+version: 2
+jobs:
+  build:
+
+    # Limit to Testing branch
+    branches:
+      only:
+        - AHCircleCI
+
+    # Specify the Xcode version to use
+    macos:
+      xcode: "10.1.0"
+
+    steps:
+      - checkout
+
+      # Download cocoapods spec repo from cache
+      - run:
+          name: Fetch cocoapods spec repo from cache
+          command: |
+            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+            
+      # (For debugging) print simulator list
+      - run: xcrun simctl list
+      
+      - run: 
+          name: Run build script
+          command: ./build-new.sh all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,6 @@
-# iOS CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/ios-migrating-from-1-2/ for more details
-#
 version: 2
 jobs:
-  build:
-
+  setup_pods_and_sim:
     # Limit to Testing branch
     branches:
       only:
@@ -26,7 +21,68 @@ jobs:
             
       # (For debugging) print simulator list
       - run: xcrun simctl list
-      
+
+  tests:
+    requires:
+      - setup_pods_and_sim
+    steps:
       - run: 
           name: Run build script
-          command: ./build-new.sh all
+          command: ./build-new.sh tests
+
+  examples-pt1:
+    requires:
+      - setup_pods_and_sim
+    steps:
+      - run: 
+          name: Run build script
+          command: ./build-new.sh examples-pt1
+
+  examples-pt2:
+    requires:
+      - setup_pods_and_sim
+    steps:
+      - run: 
+          name: Run build script
+          command: ./build-new.sh examples-pt2
+
+  examples-pt3:
+    requires:
+      - setup_pods_and_sim
+    steps:
+      - run: 
+          name: Run build script
+          command: ./build-new.sh examples-pt3
+
+  examples-extra:
+    requires:
+      - setup_pods_and_sim
+    steps:
+      - run: 
+          name: Run build script
+          command: ./build-new.sh examples-extra
+
+  life-without-cocoapods:
+    requires:
+      - setup_pods_and_sim
+    steps:
+      - run: 
+          name: Run build script
+          command: ./build-new.sh life-without-cocoapods
+
+  cocoapods-lint:
+    requires:
+      - setup_pods_and_sim
+    steps:
+      - run: 
+          name: Run build script
+          command: ./build-new.sh cocoapods-lint
+
+  carthage:
+    requires:
+      - setup_pods_and_sim
+    steps:
+      - run: 
+          name: Run build script
+          command: ./build-new.sh carthage
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,10 @@
 version: 2
 jobs:
-  setup_pods_and_sim:
+  build:
     macos:
       xcode: "10.1.0"
 
+    parallelism: 2
     steps:
       - checkout
 
@@ -16,96 +17,34 @@ jobs:
       # (For debugging) print simulator list
       - run: xcrun simctl list
 
-  tests:
-    macos:
-      xcode: "10.1.0"
-    requires:
-      - setup_pods_and_sim
-    steps:
       - run: 
           name: Run build script
           command: ./build-new.sh tests
 
-  examples-pt1:
-    macos:
-      xcode: "10.1.0"
-    requires:
-      - setup_pods_and_sim
-    steps:
-      - run: 
+      - run:
           name: Run build script
           command: ./build-new.sh examples-pt1
 
-  examples-pt2:
-    macos:
-      xcode: "10.1.0"
-    requires:
-      - setup_pods_and_sim
-    steps:
-      - run: 
+      - run:
           name: Run build script
           command: ./build-new.sh examples-pt2
 
-  examples-pt3:
-    macos:
-      xcode: "10.1.0"
-    requires:
-      - setup_pods_and_sim
-    steps:
-      - run: 
+      - run:
           name: Run build script
           command: ./build-new.sh examples-pt3
 
-  examples-extra:
-    macos:
-      xcode: "10.1.0"
-    requires:
-      - setup_pods_and_sim
-    steps:
-      - run: 
+      - run:
           name: Run build script
           command: ./build-new.sh examples-extra
 
-  life-without-cocoapods:
-    macos:
-      xcode: "10.1.0"
-    requires:
-      - setup_pods_and_sim
-    steps:
-      - run: 
+      - run:
           name: Run build script
           command: ./build-new.sh life-without-cocoapods
 
-  cocoapods-lint:
-    macos:
-      xcode: "10.1.0"
-    requires:
-      - setup_pods_and_sim
-    steps:
-      - run: 
+      - run:
           name: Run build script
           command: ./build-new.sh cocoapods-lint
 
-  carthage:
-    macos:
-      xcode: "10.1.0"
-    requires:
-      - setup_pods_and_sim
-    steps:
-      - run: 
+      - run:
           name: Run build script
           command: ./build-new.sh carthage
-
-workflows:
-  version: 2
-  github_pr_check:
-    jobs:
-      - setup_pods_and_sim
-      - tests
-      - examples-pt1
-      - examples-pt2
-      - examples-pt3
-      - examples-extra
-      - life-without-cocoapods
-      - cocoapods-lint
-      - carthage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,6 @@
 version: 2
 jobs:
   setup_pods_and_sim:
-    # Limit to Testing branch
-    branches:
-      only:
-        - AHCircleCI
-
-    # Specify the Xcode version to use
     macos:
       xcode: "10.1.0"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
       - run: xcrun simctl list
 
   tests:
+    macos:
+      xcode: "10.1.0"
     requires:
       - setup_pods_and_sim
     steps:
@@ -31,6 +33,8 @@ jobs:
           command: ./build-new.sh tests
 
   examples-pt1:
+    macos:
+      xcode: "10.1.0"
     requires:
       - setup_pods_and_sim
     steps:
@@ -39,6 +43,8 @@ jobs:
           command: ./build-new.sh examples-pt1
 
   examples-pt2:
+    macos:
+      xcode: "10.1.0"
     requires:
       - setup_pods_and_sim
     steps:
@@ -47,6 +53,8 @@ jobs:
           command: ./build-new.sh examples-pt2
 
   examples-pt3:
+    macos:
+      xcode: "10.1.0"
     requires:
       - setup_pods_and_sim
     steps:
@@ -55,6 +63,8 @@ jobs:
           command: ./build-new.sh examples-pt3
 
   examples-extra:
+    macos:
+      xcode: "10.1.0"
     requires:
       - setup_pods_and_sim
     steps:
@@ -63,6 +73,8 @@ jobs:
           command: ./build-new.sh examples-extra
 
   life-without-cocoapods:
+    macos:
+      xcode: "10.1.0"
     requires:
       - setup_pods_and_sim
     steps:
@@ -71,6 +83,8 @@ jobs:
           command: ./build-new.sh life-without-cocoapods
 
   cocoapods-lint:
+    macos:
+      xcode: "10.1.0"
     requires:
       - setup_pods_and_sim
     steps:
@@ -79,6 +93,8 @@ jobs:
           command: ./build-new.sh cocoapods-lint
 
   carthage:
+    macos:
+      xcode: "10.1.0"
     requires:
       - setup_pods_and_sim
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,3 +102,16 @@ jobs:
           name: Run build script
           command: ./build-new.sh carthage
 
+workflows:
+  version: 2
+  github_pr_check:
+    jobs:
+      - setup_pods_and_sim
+      - tests
+      - examples-pt1
+      - examples-pt2
+      - examples-pt3
+      - examples-extra
+      - life-without-cocoapods
+      - cocoapods-lint
+      - carthage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,8 @@ commands:
         parameters:
             mode: {type: string}
         steps:
-            - {attach_workspace: {at: ~/project}}
+            # - {attach_workspace: {at: ~/project}}
+            - {run: {name: 'Fetch cocoapods spec repo from cache', command: "curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf\n"}}
             - {run: xcrun simctl list}
             - {run: './build-new.sh << parameters.mode >>'}
 jobs:
@@ -17,9 +18,9 @@ jobs:
         executor: texture_exec
         steps:
             - checkout
-            - {attach_workspace: {at: ~/project}}
-            - {run: {name: 'Fetch cocoapods spec repo from cache', command: "curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf\n"}}
-            - {persist_to_workspace: {root: ., paths: .}}
+            # - {attach_workspace: {at: ~/project}}
+            # - {run: {name: 'Fetch cocoapods spec repo from cache', command: "curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf\n"}}
+            # - {persist_to_workspace: {root: ., paths: .}}
     tests:
         executor: texture_exec
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ commands:
             mode: {type: string}
         steps:
             # - {attach_workspace: {at: ~/project}}
+            - checkout
             - {run: {name: 'Fetch cocoapods spec repo from cache', command: "curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf\n"}}
             - {run: xcrun simctl list}
             - {run: './build-new.sh << parameters.mode >>'}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ workflows:
     version: 2.1
     github_pr_check:
         jobs:
-            - setup_pods_and_sim
+            - fetch_deps
             - {tests: {requires: [fetch_deps]}}
             - {examples-pt1: {requires: [tests]}}
             - {examples-pt2: {requires: [tests]}}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
         parameters:
             mode: {type: string}
         steps:
-            - {attach_to_workspace: {at: ~/project}}
+            - {attach_workspace: {at: ~/project}}
             - {run: xcrun simctl list}
             - {run: './build-new.sh << parameters.mode >>'}
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,6 @@ jobs:
         executor: texture_exec
         steps:
             - {buildsh: {mode: examples-pt3}}
-    examples-extra:
-        executor: texture_exec
-        steps:
-            - {buildsh: {mode: examples-extra}}
     life-without-cocoapods:
         executor: texture_exec
         steps:
@@ -63,7 +59,6 @@ workflows:
             - {examples-pt1: {requires: [tests]}}
             - {examples-pt2: {requires: [tests]}}
             - {examples-pt3: {requires: [tests]}}
-            - {examples-extra: {requires: [tests]}}
             - {life-without-cocoapods: {requires: [tests]}}
             - {carthage: {requires: [tests]}}
             - {cocoapods-lint: {requires: [tests], filters: {branches: {only: master}}}}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ commands:
             - {run: xcrun simctl list}
             - {run: './build-new.sh << parameters.mode >>'}
 jobs:
-    setup_pods_and_sim:
+    fetch_deps:
+        executor: texture_exec
         steps:
             - checkout
             - {attach_workspace: {at: ~/project}}
@@ -56,7 +57,7 @@ workflows:
     github_pr_check:
         jobs:
             - setup_pods_and_sim
-            - {tests: {requires: [setup_pods_and_sim]}}
+            - {tests: {requires: [fetch_deps]}}
             - {examples-pt1: {requires: [tests]}}
             - {examples-pt2: {requires: [tests]}}
             - {examples-pt3: {requires: [tests]}}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ executors:
     texture_exec:
         macos:
             xcode: 10.1.0
-        working_directory: ~/project
+        # working_directory: ~/project
 commands:
     buildsh:
         parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ workflows:
         jobs:
             - fetch_deps
             - {tests: {requires: [fetch_deps]}}
-            - {framework: {requires: tests]}}
+            - {framework: {requires: [tests]}}
             - {examples-pt1: {requires: [tests]}}
             - {examples-pt2: {requires: [tests]}}
             - {examples-pt3: {requires: [tests]}}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,50 +1,66 @@
-version: 2
+version: 2.1
+executors:
+    texture_exec:
+        macos:
+            xcode: 10.1.0
+        working_directory: ~/project
+commands:
+    buildsh:
+        parameters:
+            mode: {type: string}
+        steps:
+            - {attach_to_workspace: {at: ~/project}}
+            - {run: xcrun simctl list}
+            - {run: './build-new.sh << parameters.mode >>'}
 jobs:
-  build:
-    macos:
-      xcode: "10.1.0"
-
-    parallelism: 2
-    steps:
-      - checkout
-
-      # Download cocoapods spec repo from cache
-      - run:
-          name: Fetch cocoapods spec repo from cache
-          command: |
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
-            
-      # (For debugging) print simulator list
-      - run: xcrun simctl list
-
-      - run: 
-          name: Run build script
-          command: ./build-new.sh tests
-
-      - run:
-          name: Run build script
-          command: ./build-new.sh examples-pt1
-
-      - run:
-          name: Run build script
-          command: ./build-new.sh examples-pt2
-
-      - run:
-          name: Run build script
-          command: ./build-new.sh examples-pt3
-
-      - run:
-          name: Run build script
-          command: ./build-new.sh examples-extra
-
-      - run:
-          name: Run build script
-          command: ./build-new.sh life-without-cocoapods
-
-      - run:
-          name: Run build script
-          command: ./build-new.sh cocoapods-lint
-
-      - run:
-          name: Run build script
-          command: ./build-new.sh carthage
+    setup_pods_and_sim:
+        steps:
+            - checkout
+            - {attach_workspace: {at: ~/project}}
+            - {run: {name: 'Fetch cocoapods spec repo from cache', command: "curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf\n"}}
+            - {persist_to_workspace: {root: ., paths: .}}
+    tests:
+        executor: texture_exec
+        steps:
+            - {buildsh: {mode: tests}}
+    examples-pt1:
+        executor: texture_exec
+        steps:
+            - {buildsh: {mode: examples-pt1}}
+    examples-pt2:
+        executor: texture_exec
+        steps:
+            - {buildsh: {mode: examples-pt2}}
+    examples-pt3:
+        executor: texture_exec
+        steps:
+            - {buildsh: {mode: examples-pt3}}
+    examples-extra:
+        executor: texture_exec
+        steps:
+            - {buildsh: {mode: examples-extra}}
+    life-without-cocoapods:
+        executor: texture_exec
+        steps:
+            - {buildsh: {mode: life-without-cocoapods}}
+    cocoapods-lint:
+        executor: texture_exec
+        steps:
+            - {buildsh: {mode: cocoapods-lint}}
+    carthage:
+        executor: texture_exec
+        steps:
+            - {buildsh: {mode: carthage}}
+workflows:
+    version: 2.1
+    github_pr_check:
+        jobs:
+            - setup_pods_and_sim
+            - {tests: {requires: [setup_pods_and_sim]}}
+            - {examples-pt1: {requires: [tests]}}
+            - {examples-pt2: {requires: [tests]}}
+            - {examples-pt3: {requires: [tests]}}
+            - {examples-extra: {requires: [tests]}}
+            - {life-without-cocoapods: {requires: [tests]}}
+            - {carthage: {requires: [tests]}}
+            - {cocoapods-lint: {requires: [tests], filters: {branches: {only: master}}}}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
         executor: texture_exec
         steps:
             - {buildsh: {mode: tests}}
-    tests:
+    framework:
         executor: texture_exec
         steps:
             - {buildsh: {mode: framework}}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,10 @@ jobs:
         executor: texture_exec
         steps:
             - {buildsh: {mode: tests}}
+    tests:
+        executor: texture_exec
+        steps:
+            - {buildsh: {mode: framework}}
     examples-pt1:
         executor: texture_exec
         steps:
@@ -56,6 +60,7 @@ workflows:
         jobs:
             - fetch_deps
             - {tests: {requires: [fetch_deps]}}
+            - {framework: {requires: tests]}}
             - {examples-pt1: {requires: [tests]}}
             - {examples-pt2: {requires: [tests]}}
             - {examples-pt3: {requires: [tests]}}

--- a/Podfile
+++ b/Podfile
@@ -4,8 +4,11 @@ platform :ios, '9.0'
 
 target :'AsyncDisplayKitTests' do
   pod 'OCMock', '=3.4.1' # 3.4.2 currently has issues.
-  pod 'FBSnapshotTestCase/Core', '~> 2.1'
-  pod 'JGMethodSwizzler', :git => 'https://github.com/JonasGessner/JGMethodSwizzler', :branch => 'master'
+
+  # TODO Move to Uber iOSSnapshotTestCase
+  pod 'FBSnapshotTestCase/Core', :git => 'https://github.com/facebookarchive/ios-snapshot-test-case.git', :tag => '2.1.4'
+  
+  pod 'JGMethodSwizzler', :git => 'https://github.com/JonasGessner/JGMethodSwizzler.git', :branch => 'master'
 
   # Only for buck build
   pod 'PINRemoteImage', '3.0.0-beta.13'

--- a/build-new.sh
+++ b/build-new.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+
+PLATFORM="platform=iOS Simulator,OS=10.3.1,name=iPhone 7"
+SDK="iphonesimulator12.1"
+
+
+# It is pitch black.
+set -e
+function trap_handler {
+    echo -e "\n\nOh no! You walked directly into the slavering fangs of a lurking grue!"
+    echo "**** You have died ****"
+    exit 255
+}
+trap trap_handler INT TERM EXIT
+
+# Build example
+function build_example {
+    example="$1"
+    
+    if [ -f "${example}/Podfile" ]; then
+        echo "Using CocoaPods"
+        if [ -f "${example}/Podfile.lock" ]; then
+            rm "$example/Podfile.lock"
+        fi
+        rm -rf "$example/Pods"
+        pod install --project-directory=$example --no-repo-update
+
+        set -o pipefail && xcodebuild \
+            -workspace "${example}/Sample.xcworkspace" \
+            -scheme Sample \
+            -sdk "$SDK" \
+            -destination "$PLATFORM"  \
+            build | xcpretty $FORMATTER
+    elif [ -f "${example}/Cartfile" ]; then
+        echo "Using Carthage"
+        local_repo=`pwd`
+        current_branch=`git rev-parse --abbrev-ref HEAD`
+        cd $example
+
+        echo "git \"file://${local_repo}\" \"${current_branch}\"" > "Cartfile"
+        carthage update --platform iOS
+
+        set -o pipefail && xcodebuild \
+            -project "Sample.xcodeproj" \
+            -scheme Sample \
+            -sdk "$SDK" \
+            -destination "$PLATFORM" \
+            build | xcpretty $FORMATTER
+
+        cd ../..
+    fi
+}
+
+MODE="$1"
+
+if type xcpretty-travis-formatter &> /dev/null; then
+    FORMATTER="-f $(xcpretty-travis-formatter)"
+  else
+    FORMATTER="-s"
+fi
+
+if [ "$MODE" = "tests" -o "$MODE" = "all" ]; then
+    echo "Building & testing AsyncDisplayKit."
+    pod install
+    set -o pipefail && xcodebuild \
+        -workspace AsyncDisplayKit.xcworkspace \
+        -scheme AsyncDisplayKit \
+        -sdk "$SDK" \
+        -destination "$PLATFORM" \
+        build-for-testing test | xcpretty $FORMATTER
+    success="1"
+fi
+
+if [ "$MODE" = "tests_listkit" ]; then
+    echo "Building & testing AsyncDisplayKit+IGListKit."
+    pod install --project-directory=SubspecWorkspaces/ASDKListKit
+    set -o pipefail && xcodebuild \
+        -workspace SubspecWorkspaces/ASDKListKit/ASDKListKit.xcworkspace \
+        -scheme ASDKListKitTests \
+        -sdk "$SDK" \
+        -destination "$PLATFORM" \
+        build-for-testing test | xcpretty $FORMATTER
+    success="1"
+fi
+
+if [ "$MODE" = "examples" -o "$MODE" = "all" ]; then
+    echo "Verifying that all AsyncDisplayKit examples compile."
+
+    for example in examples/*/; do
+        echo "Building (examples) $example."
+
+        build_example $example
+    done
+    success="1"
+fi
+
+if [ "$MODE" = "examples-pt1" ]; then
+    echo "Verifying that all AsyncDisplayKit examples compile."
+
+    for example in $((find ./examples -type d -maxdepth 1 \( ! -iname ".*" \)) | head -6 | head); do
+        echo "Building (examples-pt1) $example."
+
+        build_example $example
+    done
+    success="1"
+fi
+
+if [ "$MODE" = "examples-pt2" ]; then
+    echo "Verifying that all AsyncDisplayKit examples compile."
+
+    for example in $((find ./examples -type d -maxdepth 1 \( ! -iname ".*" \)) | head -12 | tail -6 | head); do
+        echo "Building $example (examples-pt2)."
+
+        build_example $example
+    done
+    success="1"
+fi
+
+if [ "$MODE" = "examples-pt3" ]; then
+    echo "Verifying that all AsyncDisplayKit examples compile."
+    for example in $((find ./examples -type d -maxdepth 1 \( ! -iname ".*" \)) | head -7 | head); do
+        echo "Building $example (examples-pt3)."
+
+        build_example $example
+    done
+    success="1"
+fi
+
+if [ "$MODE" = "examples-extra" ]; then
+    echo "Verifying that all AsyncDisplayKit examples compile."
+    for example in $((find ./examples_extra -type d -maxdepth 1 \( ! -iname ".*" \)) | head -7 | head); do
+        echo "Building $example (examples-extra)."
+
+        build_example $example
+    done
+    success="1"
+fi
+
+# Support building a specific example: sh build.sh example examples/ASDKLayoutTransition
+if [ "$MODE" = "example" ]; then
+    echo "Verifying that all AsyncDisplayKit examples compile."
+    build_example $2
+    success="1"
+fi
+
+if [ "$MODE" = "life-without-cocoapods" -o "$MODE" = "all" ]; then
+    echo "Verifying that AsyncDisplayKit functions as a static library."
+
+    set -o pipefail && xcodebuild \
+        -workspace "smoke-tests/Life Without CocoaPods/Life Without CocoaPods.xcworkspace" \
+        -scheme "Life Without CocoaPods" \
+        -sdk "$SDK" \
+        -destination "$PLATFORM" \
+        build | xcpretty $FORMATTER
+    success="1"
+fi
+
+if [ "$MODE" = "framework" -o "$MODE" = "all" ]; then
+    echo "Verifying that AsyncDisplayKit functions as a dynamic framework (for Swift/Carthage users)."
+
+    set -o pipefail && xcodebuild \
+        -project "smoke-tests/Framework/Sample.xcodeproj" \
+        -scheme Sample \
+        -sdk "$SDK" \
+        -destination "$PLATFORM" \
+        build | xcpretty $FORMATTER
+    success="1"
+fi
+
+if [ "$MODE" = "cocoapods-lint" -o "$MODE" = "all" ]; then
+    echo "Verifying that podspec lints."
+
+    set -o pipefail && pod env && pod lib lint --allow-warnings
+    success="1"
+fi
+
+if [ "$MODE" = "carthage" -o "$MODE" = "all" ]; then
+    echo "Verifying carthage works."
+    
+    set -o pipefail && carthage update && carthage build --no-skip-current
+fi
+
+if [ "$success" = "1" ]; then 
+  trap - EXIT
+  exit 0
+fi
+
+echo "Unrecognised mode '$MODE'."

--- a/build-new.sh
+++ b/build-new.sh
@@ -61,7 +61,7 @@ fi
 
 if [ "$MODE" = "tests" -o "$MODE" = "all" ]; then
     echo "Building & testing AsyncDisplayKit."
-    pod install
+    pod install --no-repo-update
     set -o pipefail && xcodebuild \
         -workspace AsyncDisplayKit.xcworkspace \
         -scheme AsyncDisplayKit \
@@ -73,7 +73,7 @@ fi
 
 if [ "$MODE" = "tests_listkit" ]; then
     echo "Building & testing AsyncDisplayKit+IGListKit."
-    pod install --project-directory=SubspecWorkspaces/ASDKListKit
+    pod install --project-directory=SubspecWorkspaces/ASDKListKit --no-repo-update
     set -o pipefail && xcodebuild \
         -workspace SubspecWorkspaces/ASDKListKit/ASDKListKit.xcworkspace \
         -scheme ASDKListKitTests \

--- a/build-new.sh
+++ b/build-new.sh
@@ -178,6 +178,7 @@ if [ "$MODE" = "carthage" -o "$MODE" = "all" ]; then
     echo "Verifying carthage works."
     
     set -o pipefail && carthage update && carthage build --no-skip-current
+    success="1"
 fi
 
 if [ "$success" = "1" ]; then 


### PR DESCRIPTION
@maicki @appleguy @nguyenhuy @garrettmoon 

What do we think? CircleCI is working, and fast. Unit tests finish in 7 minutes, and the last test (examples-pt2) finishes about 7 minutes later). Pricing is here https://circleci.com/pricing/#build-os-x

Notes:

- Bumps to Xcode 10.1 from 9.0.1
- Totally sandboxed – each run is its own VM.
- Ownership at CircleCI mirrors GitHub ownership, so any member of TextureGroup will have control over the CI.
- All CI status pages are visible to the public.
- No need to unblock builds. I think any member of the public can re-run the CI on their own PRs too.

All we have to do is decide:

- Do we want to do this? It costs money and it is a change but it will let us move and scale a lot faster.
- Who will pay for it? Pricing is here: https://circleci.com/pricing/#build-os-x Currently I'm paying for the Seed plan ($40/mo) which I think is comparable to the current setup.
- Are there any details we want to tweak?

If we decide to do it, all we have to do is:

- Land this PR.
- Remove the branch filter from the config.yml file in this PR.
- Turn the GitHub integration back on (off now because other diffs break).
- Turn off buildkite.
- Replace build.sh with build-new.sh and update config.
- Any open diffs should rebase to get CI going.

Build list: https://circleci.com/gh/TextureGroup/Texture