### PR TITLE
ASThread: Remove Locker, Unlocker, and SharedMutex

### DIFF
--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -434,12 +434,12 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 
 static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 // Allocate cacheLock on the heap to prevent destruction at app exit (https://github.com/TextureGroup/Texture/issues/136)
-static ASDN::StaticMutex& cacheLock = *new ASDN::StaticMutex;
+static auto *cacheLock = new ASDN::Mutex;
 
 + (ASWeakMapEntry *)contentsForkey:(ASImageNodeContentsKey *)key drawParameters:(id)drawParameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelled
 {
   {
-    ASDN::StaticMutexLocker l(cacheLock);
+    ASDN::MutexLocker l(*cacheLock);
     if (!cache) {
       cache = [[ASWeakMap alloc] init];
     }
@@ -456,7 +456,7 @@ static ASDN::StaticMutex& cacheLock = *new ASDN::StaticMutex;
   }
 
   {
-    ASDN::StaticMutexLocker l(cacheLock);
+    ASDN::MutexLocker l(*cacheLock);
     return [cache setObject:contents forKey:key];
   }
 }

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -55,14 +55,14 @@
  */
 static NS_RETURNS_RETAINED ASTextLayout *ASTextNodeCompatibleLayoutWithContainerAndText(ASTextContainer *container, NSAttributedString *text)  {
   // Allocate layoutCacheLock on the heap to prevent destruction at app exit (https://github.com/TextureGroup/Texture/issues/136)
-  static ASDN::StaticMutex& layoutCacheLock = *new ASDN::StaticMutex;
+  static auto *layoutCacheLock = new ASDN::Mutex;
   static NSCache<NSAttributedString *, ASTextCacheValue *> *textLayoutCache;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     textLayoutCache = [[NSCache alloc] init];
   });
 
-  layoutCacheLock.lock();
+  layoutCacheLock->lock();
 
   ASTextCacheValue *cacheValue = [textLayoutCache objectForKey:text];
   if (cacheValue == nil) {
@@ -72,7 +72,7 @@ static NS_RETURNS_RETAINED ASTextLayout *ASTextNodeCompatibleLayoutWithContainer
 
   // Lock the cache item for the rest of the method. Only after acquiring can we release the NSCache.
   ASDN::MutexLocker lock(cacheValue->_m);
-  layoutCacheLock.unlock();
+  layoutCacheLock->unlock();
 
   CGRect containerBounds = (CGRect){ .size = container.size };
   {

--- a/Source/ASVideoNode.mm
+++ b/Source/ASVideoNode.mm
@@ -324,7 +324,6 @@ static NSString * const kRate = @"rate";
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
   ASDN::UniqueLock l(__instanceLock__);
-  ASLockScopeSelf();
 
   if (object == _currentPlayerItem) {
     if ([keyPath isEqualToString:kStatus]) {

--- a/Source/Details/ASBasicImageDownloader.mm
+++ b/Source/Details/ASBasicImageDownloader.mm
@@ -39,11 +39,11 @@ NSString * const kASBasicImageDownloaderContextCompletionBlock = @"kASBasicImage
 
 static NSMutableDictionary *currentRequests = nil;
 // Allocate currentRequestsLock on the heap to prevent destruction at app exit (https://github.com/TextureGroup/Texture/issues/136)
-static ASDN::StaticMutex& currentRequestsLock = *new ASDN::StaticMutex;
+static auto *currentRequestsLock = new ASDN::Mutex;
 
 + (ASBasicImageDownloaderContext *)contextForURL:(NSURL *)URL
 {
-  ASDN::StaticMutexLocker l(currentRequestsLock);
+  ASDN::MutexLocker l(*currentRequestsLock);
   if (!currentRequests) {
     currentRequests = [[NSMutableDictionary alloc] init];
   }
@@ -57,7 +57,7 @@ static ASDN::StaticMutex& currentRequestsLock = *new ASDN::StaticMutex;
 
 + (void)cancelContextWithURL:(NSURL *)URL
 {
-  ASDN::StaticMutexLocker l(currentRequestsLock);
+  ASDN::MutexLocker l(*currentRequestsLock);
   if (currentRequests) {
     [currentRequests removeObjectForKey:URL];
   }

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -10,6 +10,7 @@
 #import <Foundation/Foundation.h>
 
 #import <assert.h>
+#import <mutex>
 #import <os/lock.h>
 #import <pthread.h>
 #import <stdbool.h>
@@ -143,106 +144,6 @@ ASDISPLAYNODE_INLINE void _ASUnlockScopeCleanup(id<NSLocking> __strong *lockPtr)
 
 namespace ASDN {
   
-  template<class T>
-  class Locker
-  {
-    T &_l;
-
-#if TIME_LOCKER
-    CFTimeInterval _ti;
-    const char *_name;
-#endif
-
-  public:
-#if !TIME_LOCKER
-
-    Locker (T &l) noexcept : _l (l) {
-      _l.lock ();
-    }
-
-    ~Locker () {
-      _l.unlock ();
-    }
-
-    // non-copyable.
-    Locker(const Locker<T>&) = delete;
-    Locker &operator=(const Locker<T>&) = delete;
-
-#else
-
-    Locker (T &l, const char *name = NULL) noexcept : _l (l), _name(name) {
-      _ti = CACurrentMediaTime();
-      _l.lock ();
-    }
-
-    ~Locker () {
-      _l.unlock ();
-      if (_name) {
-        printf(_name, NULL);
-        printf(" dt:%f\n", CACurrentMediaTime() - _ti);
-      }
-    }
-
-#endif
-
-  };
-
-  template<class T>
-  class SharedLocker
-  {
-    std::shared_ptr<T> _l;
-    
-#if TIME_LOCKER
-    CFTimeInterval _ti;
-    const char *_name;
-#endif
-    
-  public:
-#if !TIME_LOCKER
-    
-    SharedLocker (std::shared_ptr<T> const& l) noexcept : _l (l) {
-      ASDisplayNodeCAssertTrue(_l != nullptr);
-      _l->lock ();
-    }
-    
-    ~SharedLocker () {
-      _l->unlock ();
-    }
-    
-    // non-copyable.
-    SharedLocker(const SharedLocker<T>&) = delete;
-    SharedLocker &operator=(const SharedLocker<T>&) = delete;
-    
-#else
-    
-    SharedLocker (std::shared_ptr<T> const& l, const char *name = NULL) noexcept : _l (l), _name(name) {
-      _ti = CACurrentMediaTime();
-      _l->lock ();
-    }
-    
-    ~SharedLocker () {
-      _l->unlock ();
-      if (_name) {
-        printf(_name, NULL);
-        printf(" dt:%f\n", CACurrentMediaTime() - _ti);
-      }
-    }
-    
-#endif
-    
-  };
-
-  template<class T>
-  class Unlocker
-  {
-    T &_l;
-  public:
-    Unlocker (T &l) noexcept : _l (l) { _l.unlock (); }
-    ~Unlocker () {_l.lock ();}
-    Unlocker(Unlocker<T>&) = delete;
-    Unlocker &operator=(Unlocker<T>&) = delete;
-  };
-
   // Set once in Mutex constructor. Linker fails if this is a member variable. ??
   static BOOL gMutex_unfair;
   
@@ -414,41 +315,8 @@ namespace ASDN {
     RecursiveMutex () : Mutex (true) {}
   };
 
-  typedef Locker<Mutex> MutexLocker;
-  typedef SharedLocker<Mutex> MutexSharedLocker;
-  typedef Unlocker<Mutex> MutexUnlocker;
-
-  /**
-   If you are creating a static mutex, use StaticMutex. This avoids expensive constructor overhead at startup (or worse, ordering
-   issues between different static objects). It also avoids running a destructor on app exit time (needless expense).
-
-   Note that you can, but should not, use StaticMutex for non-static objects. It will leak its mutex on destruction,
-   so avoid that!
-   */
-  struct StaticMutex
-  {
-    StaticMutex () : _m (PTHREAD_MUTEX_INITIALIZER) {}
-
-    // non-copyable.
-    StaticMutex(const StaticMutex&) = delete;
-    StaticMutex &operator=(const StaticMutex&) = delete;
-
-    void lock () {
-      AS_POSIX_ASSERT_NOERR(pthread_mutex_lock (this->mutex()));
-    }
-
-    void unlock () {
-      AS_POSIX_ASSERT_NOERR(pthread_mutex_unlock (this->mutex()));
-    }
-
-    pthread_mutex_t *mutex () { return &_m; }
-
-  private:
-    pthread_mutex_t _m;
-  };
-
-  typedef Locker<StaticMutex> StaticMutexLocker;
-  typedef Unlocker<StaticMutex> StaticMutexUnlocker;
+  typedef std::lock_guard<Mutex> MutexLocker;
+  typedef std::unique_lock<Mutex> UniqueLock;
 
 } // namespace ASDN
 

--- a/Source/Private/ASLayoutTransition.mm
+++ b/Source/Private/ASLayoutTransition.mm
@@ -81,7 +81,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (BOOL)isSynchronous
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(*__instanceLock__);
   return !ASLayoutCanTransitionAsynchronous(_pendingLayout.layout);
 }
 
@@ -93,7 +93,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (void)applySubnodeInsertionsAndMoves
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(*__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
   
   // Create an activity even if no subnodes affected.
@@ -131,7 +131,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 - (void)applySubnodeRemovals
 {
   as_activity_scope(as_activity_create("Apply subnode removals", AS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT));
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(*__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
 
   if (_removedSubnodes.count == 0) {
@@ -151,7 +151,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (void)calculateSubnodeOperationsIfNeeded
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(*__instanceLock__);
   if (_calculatedSubnodeOperations) {
     return;
   }
@@ -206,27 +206,27 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (NSArray<ASDisplayNode *> *)currentSubnodesWithTransitionContext:(_ASTransitionContext *)context
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(*__instanceLock__);
   return _node.subnodes;
 }
 
 - (NSArray<ASDisplayNode *> *)insertedSubnodesWithTransitionContext:(_ASTransitionContext *)context
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(*__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
   return _insertedSubnodes;
 }
 
 - (NSArray<ASDisplayNode *> *)removedSubnodesWithTransitionContext:(_ASTransitionContext *)context
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(*__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
   return _removedSubnodes;
 }
 
 - (ASLayout *)transitionContext:(_ASTransitionContext *)context layoutForKey:(NSString *)key
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(*__instanceLock__);
   if ([key isEqualToString:ASTransitionContextFromLayoutKey]) {
     return _previousLayout.layout;
   } else if ([key isEqualToString:ASTransitionContextToLayoutKey]) {
@@ -238,7 +238,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (ASSizeRange)transitionContext:(_ASTransitionContext *)context constrainedSizeForKey:(NSString *)key
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(*__instanceLock__);
   if ([key isEqualToString:ASTransitionContextFromLayoutKey]) {
     return _previousLayout.constrainedSize;
   } else if ([key isEqualToString:ASTransitionContextToLayoutKey]) {

--- a/Source/TextKit/ASTextKitContext.mm
+++ b/Source/TextKit/ASTextKitContext.mm
@@ -32,9 +32,9 @@
 {
   if (self = [super init]) {
     // Concurrently initialising TextKit components crashes (rdar://18448377) so we use a global lock.
-    // Allocate __staticMutex on the heap to prevent destruction at app exit (https://github.com/TextureGroup/Texture/issues/136)
-    static ASDN::StaticMutex& __staticMutex = *new ASDN::StaticMutex;
-    ASDN::StaticMutexLocker l(__staticMutex);
+    // Allocate mutex on the heap to prevent destruction at app exit (https://github.com/TextureGroup/Texture/issues/136)
+    static auto *mutex = new ASDN::Mutex;
+    ASDN::MutexLocker l(*mutex);
     
     __instanceLock__ = std::make_shared<ASDN::Mutex>();
     
@@ -66,7 +66,7 @@
                                                                       NSTextStorage *,
                                                                       NSTextContainer *))block
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(*__instanceLock__);
   if (block) {
     block(_layoutManager, _textStorage, _textContainer);
   }


### PR DESCRIPTION
Resolves: https://github.com/TextureGroup/Texture/projects/2#card-14537113

- Remove ASDN::Locker, Unlocker, and SharedLocker, along with their various aliases such as MutexLocker
- Redefine ASDN::MutexLocker as std::lock_guard<ASDN::Mutex>
- Add `typedef ASDN::UniqueLock std::unique_lock<ASDN::Mutex>` for when we want to unlock mid-scope.
- Replace SharedMutex, SharedLocker etc with things like `static auto *globalLock = new ASDN::Mutex`.