### PR TITLE
Fix A11Y for horizontal collection nodes in Texture

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -2390,4 +2390,11 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   return;
 }
 
+#pragma mark - Accessibility overrides
+
+- (NSArray *)accessibilityElements {
+  [self waitUntilAllUpdatesAreCommitted];
+  return [super accessibilityElements];
+}
+
 @end

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -2392,7 +2392,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 #pragma mark - Accessibility overrides
 
-- (NSArray *)accessibilityElements {
+- (NSArray *)accessibilityElements
+{
   [self waitUntilAllUpdatesAreCommitted];
   return [super accessibilityElements];
 }

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -1971,7 +1971,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 #pragma mark - Accessibility overrides
 
-- (NSArray *)accessibilityElements {
+- (NSArray *)accessibilityElements
+{
   [self waitUntilAllUpdatesAreCommitted];
   return [super accessibilityElements];
 }

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -1969,4 +1969,11 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   }
 }
 
+#pragma mark - Accessibility overrides
+
+- (NSArray *)accessibilityElements {
+  [self waitUntilAllUpdatesAreCommitted];
+  return [super accessibilityElements];
+}
+
 @end

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -11,10 +11,12 @@
 
 #import <AsyncDisplayKit/_ASDisplayView.h>
 #import <AsyncDisplayKit/ASAvailability.h>
+#import <AsyncDisplayKit/ASCollectionNode.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h>
+#import <AsyncDisplayKit/ASTableNode.h>
 
 #import <queue>
 
@@ -208,7 +210,13 @@ static void CollectAccessibilityElementsForView(UIView *view, NSMutableArray *el
   
   ASDisplayNode *node = view.asyncdisplaykit_node;
 
-  if (node.isAccessibilityContainer) {
+  BOOL anySubNodeIsCollection = (nil != ASDisplayNodeFindFirstNode(node,
+      ^BOOL(ASDisplayNode *nodeToCheck) {
+    return ASDynamicCast(nodeToCheck, ASCollectionNode) != nil ||
+           ASDynamicCast(nodeToCheck, ASTableNode) != nil;
+  }));
+
+  if (node.isAccessibilityContainer && !anySubNodeIsCollection) {
     CollectAccessibilityElementsForContainer(node, view, elements);
     return;
   }


### PR DESCRIPTION
Collections have their own handling in UIKit that we shouldn't mess with. As such no nodes that contain CollectionNodes should ever be treated as AccessibilityContainers.