### PR TITLE
Clean up our mutex, fix try_lock not hooking into assert mechanism

### DIFF
--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -114,13 +114,6 @@ namespace ASDN {
   class Mutex
   {
   public:
-    enum Type {
-      Plain,
-      Recursive,
-      Unfair,
-      RecursiveUnfair
-    };
-    
     /// Constructs a plain mutex (the default).
     Mutex () : Mutex (false) {}
 
@@ -241,6 +234,13 @@ namespace ASDN {
     }
     
   private:
+    enum Type {
+      Plain,
+      Recursive,
+      Unfair,
+      RecursiveUnfair
+    };
+
     void WillUnlock() {
 #if ASDISPLAYNODE_ASSERTIONS_ENABLED
       if (--_count == 0) {

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -94,6 +94,7 @@ ASDISPLAYNODE_INLINE void _ASUnlockScopeCleanup(id<NSLocking> __strong *lockPtr)
 
 #include <memory>
 #include <mutex>
+#include <new>
 #include <thread>
 
 // These macros are here for legacy reasons. We may get rid of them later.

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -9,11 +9,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import <assert.h>
 #import <os/lock.h>
 #import <pthread.h>
-#import <stdbool.h>
-#import <stdlib.h>
 
 #import <AsyncDisplayKit/ASAssert.h>
 #import <AsyncDisplayKit/ASAvailability.h>
@@ -82,7 +79,7 @@ ASDISPLAYNODE_INLINE void _ASLockScopeUnownedCleanup(id<NSLocking> __unsafe_unre
 #define ASSynthesizeLockingMethodsWithMutex(mutex) \
 - (void)lock { mutex.lock(); } \
 - (void)unlock { mutex.unlock(); } \
-- (BOOL)tryLock { return mutex.tryLock(); }
+- (BOOL)tryLock { return (BOOL)mutex.try_lock(); }
 
 #define ASSynthesizeLockingMethodsWithObject(object) \
 - (void)lock { [object lock]; } \
@@ -95,155 +92,124 @@ ASDISPLAYNODE_INLINE void _ASUnlockScopeCleanup(id<NSLocking> __strong *lockPtr)
 
 #ifdef __cplusplus
 
-/**
- * Enable this flag to collect information on the owning thread and ownership level of a mutex.
- * These properties are useful to determine if a mutex has been acquired and in case of a recursive mutex, how many times that happened.
- * 
- * This flag also enable locking assertions (e.g ASAssertUnlocked(node)).
- * The assertions are useful when you want to indicate and enforce the locking policy/expectation of methods.
- * To determine when and which methods acquired a (recursive) mutex (to debug deadlocks, for example),
- * put breakpoints at some assertions. When the breakpoints hit, walk through stack trace frames 
- * and check ownership count of the mutex.
- */
-#if ASDISPLAYNODE_ASSERTIONS_ENABLED
-#define CHECK_LOCKING_SAFETY 1
-#else
-#define CHECK_LOCKING_SAFETY 0
-#endif
-
 #include <memory>
 #include <mutex>
+#include <thread>
 
-// This MUST always execute, even when assertions are disabled. Otherwise all lock operations become no-ops!
-// (To be explicit, do not turn this into an NSAssert, assert(), or any other kind of statement where the
-// evaluation of x_ can be compiled out.)
-#define AS_POSIX_ASSERT_NOERR(x_) ({ \
-  __unused int res = (x_); \
-  ASDisplayNodeCAssert(res == 0, @"Expected %s to return 0, got %d instead. Error: %s", #x_, res, strerror(res)); \
-})
-
-/**
- * Assert if the current thread owns a mutex.
- * This assertion is useful when you want to indicate and enforce the locking policy/expectation of methods.
- * To determine when and which methods acquired a (recursive) mutex (to debug deadlocks, for example),
- * put breakpoints at some of these assertions. When the breakpoints hit, walk through stack trace frames
- * and check ownership count of the mutex.
- */
-#if CHECK_LOCKING_SAFETY
-#define ASAssertUnlocked(lock) ASDisplayNodeAssertFalse(lock.locked())
-#define ASAssertLocked(lock) ASDisplayNodeAssert(lock.locked(), @"Lock must be held by current thread")
-#else
-#define ASAssertUnlocked(lock)
-#define ASAssertLocked(lock)
-#endif
+// These macros are here for legacy reasons. We may get rid of them later.
+#define ASAssertLocked(m) m.AssertHeld()
+#define ASAssertUnlocked(m) m.AssertNotHeld()
 
 namespace ASDN {
   
   // Set once in Mutex constructor. Linker fails if this is a member variable. ??
-  static BOOL gMutex_unfair;
-  
+  static bool gMutex_unfair;
+
 // Silence unguarded availability warnings in here, because
 // perf is critical and we will check availability once
 // and not again.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
-  struct Mutex
+  class Mutex
   {
-    /// Constructs a non-recursive mutex (the default).
+  public:
+    enum Type {
+      Plain,
+      Recursive,
+      Unfair,
+      RecursiveUnfair
+    };
+    
+    /// Constructs a plain mutex (the default).
     Mutex () : Mutex (false) {}
 
     ~Mutex () {
-      if (gMutex_unfair) {
-        // nop
-      } else {
-        AS_POSIX_ASSERT_NOERR(pthread_mutex_destroy (&_m));
+      // Manually destroy since unions can't do it.
+      switch (_type) {
+        case Plain:
+          _plain.~mutex();
+          break;
+        case Recursive:
+          _recursive.~recursive_mutex();
+          break;
+        case Unfair:
+          // nop
+          break;
+        case RecursiveUnfair:
+          // nop
+          break;
       }
-#if CHECK_LOCKING_SAFETY
-      _owner = 0;
-      _count = 0;
-#endif
     }
 
     Mutex (const Mutex&) = delete;
     Mutex &operator=(const Mutex&) = delete;
 
-    bool tryLock() {
-      if (gMutex_unfair) {
-        if (_recursive) {
-          return ASRecursiveUnfairLockTryLock(&_runfair);
-        } else {
-          return os_unfair_lock_trylock(&_unfair);
-        }
-      } else {
-        let result = pthread_mutex_trylock(&_m);
-        if (result == 0) {
-          return true;
-        } else if (result == EBUSY) {
-          return false;
-        } else {
-          ASDisplayNodeCFailAssert(@"Locking error: %s", strerror(result));
-          return true; // if we return false we may enter an infinite loop.
-        }
+    bool try_lock() {
+      bool success = false;
+      switch (_type) {
+        case Plain:
+          success = _plain.try_lock();
+          break;
+        case Recursive:
+          success = _recursive.try_lock();
+          break;
+        case Unfair:
+          success = os_unfair_lock_trylock(&_unfair);
+          break;
+        case RecursiveUnfair:
+          success = ASRecursiveUnfairLockTryLock(&_runfair);
+          break;
       }
+      if (success) {
+        DidLock();
+      }
+      return success;
     }
-    void lock() {
-      if (gMutex_unfair) {
-        if (_recursive) {
-          ASRecursiveUnfairLockLock(&_runfair);
-        } else {
-          os_unfair_lock_lock(&_unfair);
-        }
-      } else {
-        AS_POSIX_ASSERT_NOERR(pthread_mutex_lock(&_m));
-      }
-#if CHECK_LOCKING_SAFETY
-      mach_port_t thread_id = pthread_mach_thread_np(pthread_self());
-      if (thread_id != _owner) {
-        // New owner. Since this mutex can't be acquired by another thread if there is an existing owner, _owner and _count must be 0.
-        ASDisplayNodeCAssertTrue(0 == _owner);
-        ASDisplayNodeCAssertTrue(0 == _count);
-        _owner = thread_id;
-      } else {
-        // Existing owner tries to reacquire this (recursive) mutex. _count must already be positive.
-        ASDisplayNodeCAssertTrue(_count > 0);
-      }
-      ++_count;
-#endif
-    }
-
-    void unlock () {
-#if CHECK_LOCKING_SAFETY
-      mach_port_t thread_id = pthread_mach_thread_np(pthread_self());
-      // Unlocking a mutex on an unowning thread causes undefined behaviour. Assert and fail early.
-      ASDisplayNodeCAssertTrue(thread_id == _owner);
-      // Current thread owns this mutex. _count must be positive.
-      ASDisplayNodeCAssertTrue(_count > 0);
-      --_count;
-      if (0 == _count) {
-        // Current thread is no longer the owner.
-        _owner = 0;
-      }
-#endif
-      if (gMutex_unfair) {
-        if (_recursive) {
-          ASRecursiveUnfairLockUnlock(&_runfair);
-        } else {
-          os_unfair_lock_unlock(&_unfair);
-        }
-      } else {
-        AS_POSIX_ASSERT_NOERR(pthread_mutex_unlock(&_m));
-      }
-    }
-
-    pthread_mutex_t *mutex () { return &_m; }
-
-#if CHECK_LOCKING_SAFETY
-    bool locked() {
-      return _count > 0 && pthread_mach_thread_np(pthread_self()) == _owner;
-    }
-#endif
     
-  protected:
+    void lock() {
+      switch (_type) {
+        case Plain:
+          _plain.lock();
+          break;
+        case Recursive:
+          _recursive.lock();
+          break;
+        case Unfair:
+          os_unfair_lock_lock(&_unfair);
+          break;
+        case RecursiveUnfair:
+          ASRecursiveUnfairLockLock(&_runfair);
+          break;
+      }
+      DidLock();
+    }
+
+    void unlock() {
+      WillUnlock();
+      switch (_type) {
+        case Plain:
+          _plain.unlock();
+          break;
+        case Recursive:
+          _recursive.unlock();
+          break;
+        case Unfair:
+          os_unfair_lock_unlock(&_unfair);
+          break;
+        case RecursiveUnfair:
+          ASRecursiveUnfairLockUnlock(&_runfair);
+          break;
+      }
+    }
+
+    void AssertHeld() {
+      ASDisplayNodeCAssert(_owner == std::this_thread::get_id(), @"Thread should hold lock");
+    }
+    
+    void AssertNotHeld() {
+      ASDisplayNodeCAssert(_owner != std::this_thread::get_id(), @"Thread should not hold lock");
+    }
+    
     explicit Mutex (bool recursive) {
       
       // Check if we can use unfair lock and store in static var.
@@ -254,44 +220,53 @@ namespace ASDN {
         }
       });
       
-      _recursive = recursive;
-      
-      if (gMutex_unfair) {
-        if (recursive) {
+      if (recursive) {
+        if (gMutex_unfair) {
+          _type = RecursiveUnfair;
           _runfair = AS_RECURSIVE_UNFAIR_LOCK_INIT;
         } else {
-          _unfair = OS_UNFAIR_LOCK_INIT;
+          _type = Recursive;
+          new (&_recursive) std::recursive_mutex();
         }
       } else {
-        if (!recursive) {
-          AS_POSIX_ASSERT_NOERR(pthread_mutex_init (&_m, NULL));
+        if (gMutex_unfair) {
+          _type = Unfair;
+          _unfair = OS_UNFAIR_LOCK_INIT;
         } else {
-          // Fall back to recursive mutex.
-          static pthread_mutexattr_t attr;
-          static dispatch_once_t onceToken;
-          dispatch_once(&onceToken, ^{
-            AS_POSIX_ASSERT_NOERR(pthread_mutexattr_init (&attr));
-            AS_POSIX_ASSERT_NOERR(pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_RECURSIVE));
-          });
-          AS_POSIX_ASSERT_NOERR(pthread_mutex_init(&_m, &attr));
+          _type = Plain;
+          new (&_plain) std::mutex();
         }
       }
-#if CHECK_LOCKING_SAFETY
-      _owner = 0;
-      _count = 0;
-#endif
     }
     
   private:
-    BOOL _recursive;
+    void WillUnlock() {
+#if ASDISPLAYNODE_ASSERTIONS_ENABLED
+      if (--_count == 0) {
+        _owner = std::thread::id();
+      }
+#endif
+    }
+    
+    void DidLock() {
+#if ASDISPLAYNODE_ASSERTIONS_ENABLED
+      if (++_count == 1) {
+        // New owner.
+        _owner = std::this_thread::get_id();
+      }
+#endif
+    }
+    
+    Type _type;
     union {
       os_unfair_lock _unfair;
       ASRecursiveUnfairLock _runfair;
-      pthread_mutex_t _m;
+      std::mutex _plain;
+      std::recursive_mutex _recursive;
     };
-#if CHECK_LOCKING_SAFETY
-    mach_port_t _owner;
-    uint32_t _count;
+#if ASDISPLAYNODE_ASSERTIONS_ENABLED
+    std::thread::id _owner;
+    int _count;
 #endif
   };
 #pragma clang diagnostic pop // ignored "-Wunguarded-availability"
@@ -305,8 +280,9 @@ namespace ASDN {
    http://www.zaval.org/resources/library/butenhof1.html
    http://www.fieryrobot.com/blog/2008/10/14/recursive-locks-will-kill-you/
    */
-  struct RecursiveMutex : Mutex
+  class RecursiveMutex : public Mutex
   {
+  public:
     RecursiveMutex () : Mutex (true) {}
   };
 


### PR DESCRIPTION
Might want to use split diff for this.

Just a major overhaul to clear some space. Note: AS_CHECK_LOCKING_SAFETY is gone – if we have asserts that are failing despite correct usage of our APIs, we need to comment them out and address them.