### PR TITLE
Push root node ref down the tree

### DIFF
--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -78,7 +78,9 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
 
 @interface ASDisplayNode () <_ASTransitionContextCompletionDelegate>
 {
-@package
+@public
+  // Note: These ivars are declared public only for testing. Don't access them from outside please!
+  
   ASDN::RecursiveMutex __instanceLock__;
 
   _ASPendingState *_pendingViewState;
@@ -126,7 +128,7 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
     unsigned isDeallocating:1;
   } _flags;
   
-@protected
+  unowned ASDisplayNode *_rootNode;
   ASDisplayNode * __weak _supernode;
   NSMutableArray<ASDisplayNode *> *_subnodes;
 

--- a/Tests/ASDisplayNodeTests.mm
+++ b/Tests/ASDisplayNodeTests.mm
@@ -2698,4 +2698,22 @@ static bool stringContainsPointer(NSString *description, id p) {
   }
 }
 
+- (void)testRootNodePropagation
+{
+  // [A [B [C, D]]
+  ASDisplayNode *a = [ASDisplayNode new];
+  XCTAssertNil(a->_rootNode);
+  ASDisplayNode *b = [ASDisplayNode new];
+  [a addSubnode:b];
+  XCTAssertEqual(b->_rootNode, a);
+  ASDisplayNode *c = [ASDisplayNode new];
+  [b addSubnode:c];
+  ASDisplayNode *d = [ASDisplayNode new];
+  [b addSubnode:d];
+  XCTAssertEqual(d->_rootNode, a);
+  [b removeFromSupernode];
+  XCTAssertNil(b->_rootNode);
+  XCTAssertEqual(c->_rootNode, b);
+}
+
 @end


### PR DESCRIPTION
Discuss.

Theory is, in the future all tree accesses will require the root lock. We could use a reader/writer mutex if we wanted. This diff uses the instance lock for convenience.

Right now, the down-propagation is murky because tree modifications *don't* require the root lock, so the ordering there is kind of unclear.

What's nice about this, is you could call a `locked_` method directly on the root node, safely.

If we do composite operations on the tree, such as ASM updating, should we hold the root the whole time or separate it, for example? Interesting stuff.