### PR TITLE
Have node and controller share lock

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -441,9 +441,6 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   _view.asyncdisplaykit_node = nil;
   _layer.asyncdisplaykit_node = nil;
 
-  [_strongNodeController nodeWillDeallocate];
-  // No need to call nodeWillDeallocate on weak controller, because it owns us.
-  
   // Remove any subnodes so they lose their connection to the now deallocated parent.  This can happen
   // because subnodes do not retain their supernode, but subnodes can legitimately remain alive if another
   // thing outside the view hierarchy system (e.g. async display, controller code, etc). keeps a retained

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -441,6 +441,9 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   _view.asyncdisplaykit_node = nil;
   _layer.asyncdisplaykit_node = nil;
 
+  [_strongNodeController nodeWillDeallocate];
+  // No need to call nodeWillDeallocate on weak controller, because it owns us.
+  
   // Remove any subnodes so they lose their connection to the now deallocated parent.  This can happen
   // because subnodes do not retain their supernode, but subnodes can legitimately remain alive if another
   // thing outside the view hierarchy system (e.g. async display, controller code, etc). keeps a retained

--- a/Source/ASNodeController+Beta.h
+++ b/Source/ASNodeController+Beta.h
@@ -10,18 +10,21 @@
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h> // for ASInterfaceState protocol
 
+NS_ASSUME_NONNULL_BEGIN
+
 /* ASNodeController is currently beta and open to change in the future */
 @interface ASNodeController<__covariant DisplayNodeType : ASDisplayNode *>
-    : NSObject <ASInterfaceStateDelegate, NSLocking>
+    : NSObject <ASInterfaceStateDelegate>
 
-@property (nonatomic, strong /* may be weak! */) DisplayNodeType node;
+@property (strong, readonly /* may be weak! */) DisplayNodeType node;
 
 // Until an ASNodeController can be provided in place of an ASCellNode, some apps may prefer to have
 // nodes keep their controllers alive (and a weak reference from controller to node)
 
 @property (nonatomic) BOOL shouldInvertStrongReference;
 
-- (void)loadNode;
+// called on an arbitrary thread by the framework. You do not call this. Return a new node instance.
+- (DisplayNodeType)createNode;
 
 // for descriptions see <ASInterfaceState> definition
 - (void)nodeDidLoad ASDISPLAYNODE_REQUIRES_SUPER;
@@ -48,6 +51,8 @@
 
 @interface ASDisplayNode (ASNodeController)
 
-@property(nonatomic, readonly) ASNodeController *nodeController;
+@property(nullable, readonly) ASNodeController *nodeController;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ASNodeController+Beta.h
+++ b/Source/ASNodeController+Beta.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /* ASNodeController is currently beta and open to change in the future */
 @interface ASNodeController<__covariant DisplayNodeType : ASDisplayNode *>
-    : NSObject <ASInterfaceStateDelegate>
+    : NSObject <ASInterfaceStateDelegate, ASLocking>
 
 @property (strong, readonly /* may be weak! */) DisplayNodeType node;
 
@@ -46,6 +46,9 @@ NS_ASSUME_NONNULL_BEGIN
                       fromState:(ASInterfaceState)oldState ASDISPLAYNODE_REQUIRES_SUPER;
 
 - (void)hierarchyDisplayDidFinish ASDISPLAYNODE_REQUIRES_SUPER;
+
+// Called when ownership is inverted and the node is deallocated.
+- (void)nodeWillDeallocate ASDISPLAYNODE_REQUIRES_SUPER;
 
 @end
 

--- a/Source/ASNodeController+Beta.h
+++ b/Source/ASNodeController+Beta.h
@@ -47,9 +47,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)hierarchyDisplayDidFinish ASDISPLAYNODE_REQUIRES_SUPER;
 
-// Called when ownership is inverted and the node is deallocated.
-- (void)nodeWillDeallocate ASDISPLAYNODE_REQUIRES_SUPER;
-
 @end
 
 @interface ASDisplayNode (ASNodeController)

--- a/Source/ASNodeController+Beta.mm
+++ b/Source/ASNodeController+Beta.mm
@@ -58,23 +58,6 @@
   }
 }
 
-- (void)lock
-{
-  [self.node lock];
-}
-
-- (void)unlock
-{
-  // Since the node is already locked, we don't need to 
-  ASDN::MutexLocker l(_nodeLock);
-  [_node unlock];
-}
-
-- (BOOL)tryLock
-{
-  return [self.node tryLock];
-}
-
 - (void)nodeWillDeallocate
 {
   ASDN::MutexLocker l(_nodeLock);
@@ -107,6 +90,25 @@
                       fromState:(ASInterfaceState)oldState {}
 
 - (void)hierarchyDisplayDidFinish {}
+
+#pragma mark NSLocking
+
+- (void)lock
+{
+  [self.node lock];
+}
+
+- (void)unlock
+{
+  // Since the node is already locked, we don't need to 
+  ASDN::MutexLocker l(_nodeLock);
+  [_node unlock];
+}
+
+- (BOOL)tryLock
+{
+  return [self.node tryLock];
+}
 
 @end
 

--- a/Source/ASNodeController+Beta.mm
+++ b/Source/ASNodeController+Beta.mm
@@ -32,6 +32,7 @@
       ASDisplayNodeCFailAssert(@"Returned nil from -createNode.");
       node = [[ASDisplayNode alloc] init];
     }
+    _node = node;
     if (!_shouldInvertStrongReference) {
       CFRetain((__bridge CFTypeRef)node);
     }


### PR DESCRIPTION
This prevents lock-interleaving deadlocks. The controller and node should stay in sync with each other conceptually anyway.