### PR TITLE
Add extension points for global node behaviors, potentially replacing interface state delegates

### DIFF
--- a/Source/ASDisplayNode+Beta.h
+++ b/Source/ASDisplayNode+Beta.h
@@ -143,7 +143,14 @@ typedef struct {
  * this hook could be called up to 1 + (pJPEGcount * pJPEGrenderCount) times. The render count depends on how many times the downloader calls the
  * progressImage block.
  */
-- (void)hierarchyDisplayDidFinish;
+AS_CATEGORY_IMPLEMENTABLE
+- (void)hierarchyDisplayDidFinish NS_REQUIRES_SUPER;
+
+/**
+ * Only called on the root during yoga layout.
+ */
+AS_CATEGORY_IMPLEMENTABLE
+- (void)willCalculateLayout:(ASSizeRange)constrainedSize NS_REQUIRES_SUPER;
 
 /**
  * Only ASLayoutRangeModeVisibleOnly or ASLayoutRangeModeLowMemory are recommended.  Default is ASLayoutRangeModeVisibleOnly,

--- a/Source/ASDisplayNode+Subclasses.h
+++ b/Source/ASDisplayNode+Subclasses.h
@@ -69,8 +69,22 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This is the best time to add gesture recognizers to the view.
  */
+AS_CATEGORY_IMPLEMENTABLE
 - (void)didLoad ASDISPLAYNODE_REQUIRES_SUPER;
 
+/**
+ * An empty method that you can implement in a category to add global
+ * node initialization behavior. This method will be called by [ASDisplayNode init].
+ */
+AS_CATEGORY_IMPLEMENTABLE
+- (void)baseDidInit;
+
+/**
+ * An empty method that you can implement in a category to add global
+ * node deallocation behavior. This method will be called by [ASDisplayNode dealloc].
+ */
+AS_CATEGORY_IMPLEMENTABLE
+- (void)baseWillDealloc;
 
 #pragma mark - Layout
 /** @name Layout */
@@ -88,6 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion Gives a chance for subclasses to perform actions after the subclass and superclass have finished laying
  * out.
  */
+AS_CATEGORY_IMPLEMENTABLE
 - (void)layoutDidFinish ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**
@@ -96,6 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion When the .calculatedLayout property is set to a new ASLayout (directly from -calculateLayoutThatFits: or
  * calculated via use of -layoutSpecThatFits:), subclasses may inspect it here.
  */
+AS_CATEGORY_IMPLEMENTABLE
 - (void)calculatedLayoutDidChange ASDISPLAYNODE_REQUIRES_SUPER;
 
 
@@ -162,15 +178,25 @@ NS_ASSUME_NONNULL_BEGIN
   * For descriptions, see <ASInterfaceStateDelegate> definition.
   */
 
+AS_CATEGORY_IMPLEMENTABLE
 - (void)didEnterVisibleState ASDISPLAYNODE_REQUIRES_SUPER;
+
+AS_CATEGORY_IMPLEMENTABLE
 - (void)didExitVisibleState  ASDISPLAYNODE_REQUIRES_SUPER;
 
+AS_CATEGORY_IMPLEMENTABLE
 - (void)didEnterDisplayState ASDISPLAYNODE_REQUIRES_SUPER;
+
+AS_CATEGORY_IMPLEMENTABLE
 - (void)didExitDisplayState  ASDISPLAYNODE_REQUIRES_SUPER;
 
+AS_CATEGORY_IMPLEMENTABLE
 - (void)didEnterPreloadState ASDISPLAYNODE_REQUIRES_SUPER;
+
+AS_CATEGORY_IMPLEMENTABLE
 - (void)didExitPreloadState  ASDISPLAYNODE_REQUIRES_SUPER;
 
+AS_CATEGORY_IMPLEMENTABLE
 - (void)interfaceStateDidChange:(ASInterfaceState)newState
                       fromState:(ASInterfaceState)oldState ASDISPLAYNODE_REQUIRES_SUPER;
 
@@ -179,6 +205,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses can override this method to react to a trait collection change.
  */
+AS_CATEGORY_IMPLEMENTABLE
 - (void)asyncTraitCollectionDidChange;
 
 #pragma mark - Drawing

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -338,6 +338,7 @@
     return;
   }
 
+  [self willCalculateLayout:rootConstrainedSize];
   [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate>  _Nonnull delegate) {
     if ([delegate respondsToSelector:@selector(nodeWillCalculateLayout:)]) {
       [delegate nodeWillCalculateLayout:rootConstrainedSize];

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -97,8 +97,9 @@ AS_EXTERN NSInteger const ASDefaultDrawingPriority;
 @interface ASDisplayNode : NSObject <ASLocking> {
 @public
   /**
-   * A field for clients to use as they please, for example in implementing category methods on
-   * the base class. Example usage can be found in CatDealsCollectionView.
+   * The _context ivar is unused by Texture, but provided to enable advanced clients to make powerful extensions to base class functionality.
+   * For example, _context can be used to implement category methods on ASDisplayNode that add functionality to all node subclass types.
+   * Code demonstrating this technique can be found in the CatDealsCollectionView example.
    */
   void *_context;
 }

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -94,7 +94,14 @@ AS_EXTERN NSInteger const ASDefaultDrawingPriority;
  *
  */
 
-@interface ASDisplayNode : NSObject <ASLocking>
+@interface ASDisplayNode : NSObject <ASLocking> {
+@public
+  /**
+   * A field for clients to use as they please, for example in implementing category methods on
+   * the base class. Example usage can be found in CatDealsCollectionView.
+   */
+  void *_context;
+}
 
 /** @name Initializing a node object */
 

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -24,6 +24,12 @@
 #define AS_BUILD_UIUSERINTERFACESTYLE 0
 #endif
 
+/**
+ * Decorates methods that clients can implement in categories on our base class. These methods
+ * will be stubbed with an empty implementation if no implementation is provided.
+ */
+#define AS_CATEGORY_IMPLEMENTABLE
+
 #ifdef __GNUC__
 # define ASDISPLAYNODE_GNUC(major, minor) \
 (__GNUC__ > (major) || (__GNUC__ == (major) && __GNUC_MINOR__ >= (minor)))

--- a/examples/CatDealsCollectionView/Sample.xcodeproj/project.pbxproj
+++ b/examples/CatDealsCollectionView/Sample.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		AC3C4A671A11F47200143C57 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AC3C4A661A11F47200143C57 /* AppDelegate.m */; };
 		AC3C4A6A1A11F47200143C57 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AC3C4A691A11F47200143C57 /* ViewController.m */; };
 		AC3C4A8E1A11F80C00143C57 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AC3C4A8D1A11F80C00143C57 /* Images.xcassets */; };
+		CC142599219742CA009851B7 /* ASDisplayNode+CatDeals.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC142598219742CA009851B7 /* ASDisplayNode+CatDeals.mm */; };
 		FC3FCA801C2B1564009F6D6D /* PresentingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FC3FCA7F1C2B1564009F6D6D /* PresentingViewController.m */; };
 /* End PBXBuildFile section */
 
@@ -45,6 +46,8 @@
 		AC3C4A681A11F47200143C57 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		AC3C4A691A11F47200143C57 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
 		AC3C4A8D1A11F80C00143C57 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		CC142598219742CA009851B7 /* ASDisplayNode+CatDeals.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "ASDisplayNode+CatDeals.mm"; sourceTree = "<group>"; };
+		CC14259A219746C2009851B7 /* ASDisplayNode+CatDeals.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+CatDeals.h"; sourceTree = "<group>"; };
 		F1E539014E1F516F00A8F167 /* libPods-Sample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Sample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F3A72D578C378357FF56486A /* Pods-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig"; sourceTree = "<group>"; };
 		FC3FCA7E1C2B1564009F6D6D /* PresentingViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PresentingViewController.h; sourceTree = "<group>"; };
@@ -97,6 +100,8 @@
 				AC3C4A661A11F47200143C57 /* AppDelegate.m */,
 				AC3C4A681A11F47200143C57 /* ViewController.h */,
 				AC3C4A691A11F47200143C57 /* ViewController.m */,
+				CC14259A219746C2009851B7 /* ASDisplayNode+CatDeals.h */,
+				CC142598219742CA009851B7 /* ASDisplayNode+CatDeals.mm */,
 				7ACD5F941C4847C000E7BE16 /* PlaceholderNetworkImageNode.h */,
 				7ACD5F951C4847C000E7BE16 /* PlaceholderNetworkImageNode.m */,
 				FC3FCA7E1C2B1564009F6D6D /* PresentingViewController.h */,
@@ -261,6 +266,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CC142599219742CA009851B7 /* ASDisplayNode+CatDeals.mm in Sources */,
 				25FDEC921BF31EE700CEB123 /* ItemNode.m in Sources */,
 				7ACD5F891C415B7500E7BE16 /* LoadingNode.m in Sources */,
 				AC3C4A6A1A11F47200143C57 /* ViewController.m in Sources */,

--- a/examples/CatDealsCollectionView/Sample/ASDisplayNode+CatDeals.h
+++ b/examples/CatDealsCollectionView/Sample/ASDisplayNode+CatDeals.h
@@ -1,0 +1,19 @@
+//
+//  ASDisplayNode+CatDeals.h
+//  Sample
+//
+//  Copyright (c) Pinterest, Inc.  All rights reserved.
+//  Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ASDisplayNode (CatDeals)
+
+@property (nullable, copy) NSString *catsLoggingID;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/examples/CatDealsCollectionView/Sample/ASDisplayNode+CatDeals.mm
+++ b/examples/CatDealsCollectionView/Sample/ASDisplayNode+CatDeals.mm
@@ -1,0 +1,61 @@
+//
+//  ASDisplayNode+CatDeals.mm
+//  Texture
+//
+//  Copyright (c) Pinterest, Inc.  All rights reserved.
+//  Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+#import "ASDisplayNode+CatDeals.h"
+
+#import <AsyncDisplayKit/ASThread.h>
+
+// A place to store info on any display node in this app.
+struct CatDealsNodeContext {
+  NSString *loggingID = nil;
+};
+
+// Convenience to cast _context into our struct reference.
+NS_INLINE CatDealsNodeContext &GetNodeContext(ASDisplayNode *node) {
+  return *static_cast<CatDealsNodeContext *>(node->_context);
+}
+
+@implementation ASDisplayNode (CatDeals)
+
+- (void)baseDidInit
+{
+  _context = new CatDealsNodeContext;
+}
+
+- (void)baseWillDealloc
+{
+  delete &GetNodeContext(self);
+}
+
+- (void)setCatsLoggingID:(NSString *)catsLoggingID
+{
+  NSString *copy = [catsLoggingID copy];
+  ASLockScopeSelf();
+  GetNodeContext(self).loggingID = copy;
+}
+
+- (NSString *)catsLoggingID
+{
+  ASLockScopeSelf();
+  return GetNodeContext(self).loggingID;
+}
+
+- (void)didEnterVisibleState
+{
+  if (NSString *loggingID = self.catsLoggingID) {
+    NSLog(@"Visible: %@", loggingID);
+  }
+}
+
+- (void)didExitVisibleState
+{
+  if (NSString *loggingID = self.catsLoggingID) {
+    NSLog(@"NotVisible: %@", loggingID);
+  }
+}
+
+@end

--- a/examples/CatDealsCollectionView/Sample/ItemNode.m
+++ b/examples/CatDealsCollectionView/Sample/ItemNode.m
@@ -8,6 +8,8 @@
 //
 
 #import "ItemNode.h"
+
+#import "ASDisplayNode+CatDeals.h"
 #import "ItemStyles.h"
 #import "PlaceholderNetworkImageNode.h"
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
@@ -71,6 +73,7 @@ const CGFloat kSoldOutGBHeight = 50.0;
 {
   [super setNodeModel:nodeModel];
   
+  self.catsLoggingID = [NSString stringWithFormat:@"CatDeal#%ld", (long)nodeModel.identifier];
   [self updateLabels];
   [self updateAccessibilityIdentifier];
 }


### PR DESCRIPTION
right at the outset: 
- Causes no compiler warnings
- Does nothing unsafe or undocumented

Node controllers were added as a way for clients to customize node behavior globally. If you subclass ASTextNode and ASImageNode, you have to duplicate any common logic you want to add.

Node controllers however introduce additional complexity and duplication – if ASNetworkImageNode can fire off network requests, why does it need a controller? Nodes are in fact a sort of tiny view controller and we should stick with the original abstraction instead of adding a different one in.

This diff does something pretty strange, but I think useful. It modifies the node API to (1) offer a public ivar to ASDisplayNode and (2) guarantee that certain `ASDisplayNode+Subclass` category methods e.g. interface state methods are not implemented by the base class, and thus can be overridden safely in categories. To make it safe, we put in empty stubs for methods that they don't choose to implement.

I modified CatDealsCollectionView to demonstrate how this extension point could be used to add visibility logging events at the application level. 

I propose that this API *informally deprecates* the Beta `ASNodeController` and the `interfaceStateDelegates` APIs. Those systems will be removed.