### PR TITLE
Add way to compile out ASTextNode + TextKit dependencies

### DIFF
--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -16,7 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalGraphicsContexts = 1 << 0,                  // exp_graphics_contexts
+#if AS_ENABLE_TEXTNODE
   ASExperimentalTextNode = 1 << 1,                          // exp_text_node
+#endif
   ASExperimentalInterfaceStateCoalescing = 1 << 2,          // exp_interface_state_coalesce
   ASExperimentalUnfairLock = 1 << 3,                        // exp_unfair_lock
   ASExperimentalLayerDefaults = 1 << 4,                     // exp_infer_layer_defaults

--- a/Source/ASTextNode.h
+++ b/Source/ASTextNode.h
@@ -8,8 +8,16 @@
 //
 
 #import <AsyncDisplayKit/ASAvailability.h>
+
 #import <AsyncDisplayKit/ASControlNode.h>
 #import <AsyncDisplayKit/ASTextNodeCommon.h>
+
+#if (!AS_ENABLE_TEXTNODE)
+
+// Pull in ASTextNode2 to replace ASTextNode with ASTextNode2
+#import <AsyncDisplayKit/ASTextNode2.h>
+
+#else
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -251,3 +259,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -8,6 +8,9 @@
 //
 
 #import <AsyncDisplayKit/ASTextNode.h>
+
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASTextNode2.h>
 
 #import <AsyncDisplayKit/ASTextNode+Beta.h>
@@ -1427,3 +1430,5 @@ static NSAttributedString *DefaultTruncationAttributedString()
 }
 
 @end
+
+#endif

--- a/Source/ASTextNode2.h
+++ b/Source/ASTextNode2.h
@@ -17,7 +17,11 @@ NS_ASSUME_NONNULL_BEGIN
  @abstract Draws interactive rich text.
  @discussion Backed by the code in TextExperiment folder, on top of CoreText.
  */
+#if AS_ENABLE_TEXTNODE
 @interface ASTextNode2 : ASControlNode
+#else
+@interface ASTextNode : ASControlNode
+#endif
 
 /**
  @abstract The styled text displayed by the node.
@@ -215,7 +219,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+#if AS_ENABLE_TEXTNODE
 @interface ASTextNode2 (Unavailable)
+#else
+@interface ASTextNode (Unavailable)
+#endif
 
 - (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 

--- a/Source/ASTextNode2.h
+++ b/Source/ASTextNode2.h
@@ -231,6 +231,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+#if (!AS_ENABLE_TEXTNODE)
+// For the time beeing remap ASTextNode2 to ASTextNode
+#define ASTextNode2 ASTextNode
+#endif
+
 NS_ASSUME_NONNULL_END
 
 

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -141,11 +141,19 @@ static const CGFloat ASTextNodeHighlightLightOpacity = 0.11;
 static const CGFloat ASTextNodeHighlightDarkOpacity = 0.22;
 static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncationAttribute";
 
+#if AS_ENABLE_TEXTNODE
 @interface ASTextNode2 () <UIGestureRecognizerDelegate>
+#else
+@interface ASTextNode () <UIGestureRecognizerDelegate>
+#endif
 
 @end
 
+#if AS_ENABLE_TEXTNODE
 @implementation ASTextNode2 {
+#else
+@implementation ASTextNode {
+#endif
   ASTextContainer *_textContainer;
   
   CGSize _shadowOffset;

--- a/Source/ASTextNodeCommon.h
+++ b/Source/ASTextNodeCommon.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <AsyncDisplayKit/ASAvailability.h>
+
 @class ASTextNode;
 
 #define AS_TEXT_ALERT_UNIMPLEMENTED_FEATURE() { \

--- a/Source/Base/ASAvailability.h
+++ b/Source/Base/ASAvailability.h
@@ -17,6 +17,10 @@
   #define AS_TLS_AVAILABLE 1
 #endif
 
+#ifndef AS_ENABLE_TEXTNODE
+  #define AS_ENABLE_TEXTNODE 1 // Enable old TextNode by default
+#endif
+
 // This needs to stay in sync with Weaver
 #ifndef AS_USE_VIDEO
   #define AS_USE_VIDEO 0

--- a/Source/TextKit/ASTextKitAttributes.h
+++ b/Source/TextKit/ASTextKitAttributes.h
@@ -10,6 +10,11 @@
 #pragma once
 
 #import <UIKit/UIKit.h>
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASEqualityHelpers.h>
 
 AS_EXTERN NSString *const ASTextKitTruncationAttributeName;
@@ -119,3 +124,5 @@ struct ASTextKitAttributes {
 
   size_t hash() const;
 };
+
+#endif

--- a/Source/TextKit/ASTextKitAttributes.mm
+++ b/Source/TextKit/ASTextKitAttributes.mm
@@ -9,6 +9,8 @@
 
 #import <AsyncDisplayKit/ASTextKitAttributes.h>
 
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASHashing.h>
 
 NSString *const ASTextKitTruncationAttributeName = @"ck_truncation";
@@ -44,3 +46,5 @@ size_t ASTextKitAttributes::hash() const
   };
   return ASHashBytes(&data, sizeof(data));
 }
+
+#endif

--- a/Source/TextKit/ASTextKitComponents.h
+++ b/Source/TextKit/ASTextKitComponents.h
@@ -8,6 +8,7 @@
 //
 
 #import <UIKit/UIKit.h>
+
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Source/TextKit/ASTextKitContext.h
+++ b/Source/TextKit/ASTextKitContext.h
@@ -8,6 +8,11 @@
 //
 
 #import <UIKit/UIKit.h>
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
 /**
@@ -44,3 +49,5 @@ AS_SUBCLASSING_RESTRICTED
                                                           NSTextContainer *textContainer))block;
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitContext.mm
+++ b/Source/TextKit/ASTextKitContext.mm
@@ -8,6 +8,9 @@
 //
 
 #import <AsyncDisplayKit/ASTextKitContext.h>
+
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASLayoutManager.h>
 #import <AsyncDisplayKit/ASThread.h>
 
@@ -73,3 +76,5 @@
 }
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitCoreTextAdditions.h
+++ b/Source/TextKit/ASTextKitCoreTextAdditions.h
@@ -7,8 +7,11 @@
 //  Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
 //
 
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_ENABLE_TEXTNODE
 
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
@@ -82,3 +85,5 @@ AS_EXTERN NSAttributedString *ASCleanseAttributedStringOfCoreTextAttributes(NSAt
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/Source/TextKit/ASTextKitCoreTextAdditions.mm
+++ b/Source/TextKit/ASTextKitCoreTextAdditions.mm
@@ -9,6 +9,8 @@
 
 #import <AsyncDisplayKit/ASTextKitCoreTextAdditions.h>
 
+#if AS_ENABLE_TEXTNODE
+
 #import <CoreText/CTFont.h>
 #import <CoreText/CTStringAttributes.h>
 
@@ -333,3 +335,5 @@ NSAttributedString *ASCleanseAttributedStringOfCoreTextAttributes(NSAttributedSt
 }
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitEntityAttribute.h
+++ b/Source/TextKit/ASTextKitEntityAttribute.h
@@ -8,6 +8,11 @@
 //
 
 #import <Foundation/Foundation.h>
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
 /**
@@ -27,3 +32,5 @@ AS_SUBCLASSING_RESTRICTED
 - (instancetype)initWithEntity:(id<NSObject>)entity;
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitEntityAttribute.mm
+++ b/Source/TextKit/ASTextKitEntityAttribute.mm
@@ -9,6 +9,8 @@
 
 #import <AsyncDisplayKit/ASTextKitEntityAttribute.h>
 
+#if AS_ENABLE_TEXTNODE
+
 @implementation ASTextKitEntityAttribute
 
 - (instancetype)initWithEntity:(id<NSObject>)entity
@@ -37,3 +39,5 @@
 }
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitFontSizeAdjuster.h
+++ b/Source/TextKit/ASTextKitFontSizeAdjuster.h
@@ -8,8 +8,12 @@
 //
 
 #import <UIKit/UIKit.h>
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASTextKitAttributes.h>
-#import <AsyncDisplayKit/ASBaseDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -50,3 +54,5 @@ AS_SUBCLASSING_RESTRICTED
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/Source/TextKit/ASTextKitFontSizeAdjuster.mm
+++ b/Source/TextKit/ASTextKitFontSizeAdjuster.mm
@@ -10,6 +10,8 @@
 
 #import <AsyncDisplayKit/ASTextKitFontSizeAdjuster.h>
 
+#if AS_ENABLE_TEXTNODE
+
 #import <tgmath.h>
 #import <mutex>
 
@@ -235,3 +237,5 @@
 }
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitRenderer+Positioning.h
+++ b/Source/TextKit/ASTextKitRenderer+Positioning.h
@@ -9,6 +9,8 @@
 
 #import <AsyncDisplayKit/ASTextKitRenderer.h>
 
+#if AS_ENABLE_TEXTNODE
+
 typedef void (^as_text_component_index_block_t)(NSUInteger characterIndex,
                                                 CGRect glyphBoundingRect,
                                                 BOOL *stop);
@@ -100,3 +102,5 @@ typedef NS_ENUM(NSUInteger, ASTextKitRendererMeasureOption) {
 - (CGRect)trailingRect;
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitRenderer+Positioning.mm
+++ b/Source/TextKit/ASTextKitRenderer+Positioning.mm
@@ -9,6 +9,8 @@
 
 #import <AsyncDisplayKit/ASTextKitRenderer+Positioning.h>
 
+#if AS_ENABLE_TEXTNODE
+
 #import <CoreText/CoreText.h>
 #import <tgmath.h>
 
@@ -380,3 +382,5 @@ static const CGFloat ASTextKitRendererTextCapHeightPadding = 1.3;
 }
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitRenderer+TextChecking.h
+++ b/Source/TextKit/ASTextKitRenderer+TextChecking.h
@@ -9,6 +9,8 @@
 
 #import <AsyncDisplayKit/ASTextKitRenderer.h>
 
+#if AS_ENABLE_TEXTNODE
+
 /**
  Application extensions to NSTextCheckingType. We're allowed to do this (see NSTextCheckingAllCustomTypes).
  */
@@ -26,3 +28,5 @@ static uint64_t const ASTextKitTextCheckingTypeTruncation =           1ULL << 34
 - (NSTextCheckingResult *)textCheckingResultAtPoint:(CGPoint)point;
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitRenderer+TextChecking.mm
+++ b/Source/TextKit/ASTextKitRenderer+TextChecking.mm
@@ -9,6 +9,8 @@
 
 #import <AsyncDisplayKit/ASTextKitRenderer+TextChecking.h>
 
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASTextKitEntityAttribute.h>
 #import <AsyncDisplayKit/ASTextKitRenderer+Positioning.h>
 #import <AsyncDisplayKit/ASTextKitTailTruncater.h>
@@ -98,3 +100,5 @@
 }
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitRenderer.h
+++ b/Source/TextKit/ASTextKitRenderer.h
@@ -7,11 +7,15 @@
 //  Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
 //
 
-#import <vector>
-
 #import <UIKit/UIKit.h>
 
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASTextKitAttributes.h>
+
+#import <vector>
 
 @class ASTextKitContext;
 @class ASTextKitShadower;
@@ -100,3 +104,5 @@
 @property (nonatomic, readonly) NSRange firstVisibleRange;
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitRenderer.mm
+++ b/Source/TextKit/ASTextKitRenderer.mm
@@ -9,6 +9,8 @@
 
 #import <AsyncDisplayKit/ASTextKitRenderer.h>
 
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASAssert.h>
 
 #import <AsyncDisplayKit/ASTextKitContext.h>
@@ -289,3 +291,5 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
 }
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitShadower.h
+++ b/Source/TextKit/ASTextKitShadower.h
@@ -8,6 +8,11 @@
 //
 
 #import <UIKit/UIKit.h>
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
 /**
@@ -69,3 +74,5 @@ AS_SUBCLASSING_RESTRICTED
 - (void)setShadowInContext:(CGContextRef)context;
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitShadower.mm
+++ b/Source/TextKit/ASTextKitShadower.mm
@@ -9,6 +9,8 @@
 
 #import <AsyncDisplayKit/ASTextKitShadower.h>
 
+#if AS_ENABLE_TEXTNODE
+
 #import <tgmath.h>
 
 static inline CGSize _insetSize(CGSize size, UIEdgeInsets insets)
@@ -171,3 +173,5 @@ static inline UIEdgeInsets _invertInsets(UIEdgeInsets insets)
 }
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitTailTruncater.h
+++ b/Source/TextKit/ASTextKitTailTruncater.h
@@ -9,10 +9,13 @@
 
 #import <UIKit/UIKit.h>
 
-#import <AsyncDisplayKit/ASBaseDefines.h>
 #import <AsyncDisplayKit/ASTextKitTruncating.h>
+
+#if AS_ENABLE_TEXTNODE
 
 AS_SUBCLASSING_RESTRICTED
 @interface ASTextKitTailTruncater : NSObject <ASTextKitTruncating>
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitTailTruncater.mm
+++ b/Source/TextKit/ASTextKitTailTruncater.mm
@@ -7,8 +7,11 @@
 //  Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
 //
 
-#import <AsyncDisplayKit/ASTextKitContext.h>
 #import <AsyncDisplayKit/ASTextKitTailTruncater.h>
+
+#if AS_ENABLE_TEXTNODE
+
+#import <AsyncDisplayKit/ASTextKitContext.h>
 
 @implementation ASTextKitTailTruncater
 {
@@ -189,3 +192,5 @@
 }
 
 @end
+
+#endif

--- a/Source/TextKit/ASTextKitTruncating.h
+++ b/Source/TextKit/ASTextKitTruncating.h
@@ -8,6 +8,13 @@
 //
 
 #import <Foundation/Foundation.h>
+
+#import <AsyncDisplayKit/ASAvailability.h>
+
+#if AS_ENABLE_TEXTNODE
+
+#import <AsyncDisplayKit/ASBaseDefines.h>
+
 #import <vector>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -50,3 +57,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/Source/TextKit/ASTextNodeWordKerner.h
+++ b/Source/TextKit/ASTextNodeWordKerner.h
@@ -9,6 +9,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/NSLayoutManager.h>
+
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -8,13 +8,16 @@
 
 #import <XCTest/XCTest.h>
 #import "ASTestCase.h"
+#import "ASAvailability.h"
 #import "ASConfiguration.h"
 #import "ASConfigurationDelegate.h"
 #import "ASConfigurationInternal.h"
 
 static ASExperimentalFeatures features[] = {
   ASExperimentalGraphicsContexts,
+#if AS_ENABLE_TEXTNODE
   ASExperimentalTextNode,
+#endif
   ASExperimentalInterfaceStateCoalescing,
   ASExperimentalUnfairLock,
   ASExperimentalLayerDefaults,
@@ -56,6 +59,8 @@ static ASExperimentalFeatures features[] = {
   return allFeatures;
 }
 
+#if AS_ENABLE_TEXTNODE
+
 - (void)testExperimentalFeatureConfig
 {
   // Set the config
@@ -80,6 +85,8 @@ static ASExperimentalFeatures features[] = {
   // But we should get another callback.
   [self waitForExpectationsWithTimeout:3 handler:nil];
 }
+
+#endif
 
 - (void)textureDidActivateExperimentalFeatures:(ASExperimentalFeatures)feature
 {

--- a/Tests/ASTextKitCoreTextAdditionsTests.mm
+++ b/Tests/ASTextKitCoreTextAdditionsTests.mm
@@ -13,6 +13,8 @@
 
 #import <AsyncDisplayKit/ASTextKitCoreTextAdditions.h>
 
+#if AS_ENABLE_TEXTNODE
+
 BOOL floatsCloseEnough(CGFloat float1, CGFloat float2) {
   CGFloat epsilon = 0.00001;
   return (fabs(float1 - float2) < epsilon);
@@ -68,3 +70,5 @@ BOOL floatsCloseEnough(CGFloat float1, CGFloat float2) {
 }
 
 @end
+
+#endif

--- a/Tests/ASTextKitFontSizeAdjusterTests.mm
+++ b/Tests/ASTextKitFontSizeAdjusterTests.mm
@@ -9,6 +9,8 @@
 #import <AsyncDisplayKit/ASTextKitFontSizeAdjuster.h>
 #import <XCTest/XCTest.h>
 
+#if AS_ENABLE_TEXTNODE
+
 @interface ASFontSizeAdjusterTests : XCTestCase
 
 @end
@@ -45,3 +47,5 @@
 }
 
 @end
+
+#endif

--- a/Tests/ASTextKitTests.mm
+++ b/Tests/ASTextKitTests.mm
@@ -13,6 +13,9 @@
 #import <FBSnapshotTestCase/FBSnapshotTestController.h>
 
 #import <AsyncDisplayKit/ASTextKitAttributes.h>
+
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASTextKitComponents.h>
 #import <AsyncDisplayKit/ASTextKitEntityAttribute.h>
 #import <AsyncDisplayKit/ASTextKitRenderer.h>
@@ -221,3 +224,5 @@ static BOOL checkAttributes(const ASTextKitAttributes &attributes, const CGSize 
 }
 
 @end
+
+#endif

--- a/Tests/ASTextKitTruncationTests.mm
+++ b/Tests/ASTextKitTruncationTests.mm
@@ -11,6 +11,9 @@
 #import <XCTest/XCTest.h>
 
 #import <AsyncDisplayKit/ASTextKitContext.h>
+
+#if AS_ENABLE_TEXTNODE
+
 #import <AsyncDisplayKit/ASTextKitTailTruncater.h>
 
 @interface ASTextKitTruncationTests : XCTestCase
@@ -158,3 +161,5 @@
 }
 
 @end
+
+#endif

--- a/Tests/ASTextNode2SnapshotTests.mm
+++ b/Tests/ASTextNode2SnapshotTests.mm
@@ -24,7 +24,9 @@
   // This will use ASTextNode2 for snapshot tests.
   // All tests are duplicated from ASTextNodeSnapshotTests.
   ASConfiguration *config = [[ASConfiguration alloc] initWithDictionary:nil];
+#if AS_ENABLE_TEXTNODE
   config.experimentalFeatures = ASExperimentalTextNode;
+#endif
   [ASConfigurationManager test_resetWithConfiguration:config];
 
   self.recordMode = NO;

--- a/Tests/ASTextNodeTests.mm
+++ b/Tests/ASTextNodeTests.mm
@@ -13,6 +13,7 @@
 
 #import <OCMock/OCMock.h>
 
+#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASLayout.h>
 #import <AsyncDisplayKit/ASTextNode.h>
 
@@ -235,6 +236,7 @@
   XCTAssertGreaterThan(sizeWithExclusionPaths.height, sizeWithoutExclusionPaths.height, @"Setting exclusions paths should invalidate the calculated size and return a greater size");
 }
 
+#if AS_ENABLE_TEXTNODE
 - (void)testThatTheExperimentWorksCorrectly
 {
   ASConfiguration *config = [ASConfiguration new];
@@ -303,6 +305,7 @@
   exp = nil;
   [textNodeBucket removeAllObjects];
 }
+#endif
 
 @end
 

--- a/Texture.podspec
+++ b/Texture.podspec
@@ -54,6 +54,12 @@ Pod::Spec.new do |spec|
     yoga.dependency 'Yoga', '1.6.0'
     yoga.dependency 'Texture/Core'
   end
+  
+  # If flag is enabled the old TextNode with all dependencies will be compiled out
+  spec.subspec 'TextNode2' do |text_node|
+    text_node.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) AS_ENABLE_TEXTNODE=0' }
+    text_node.dependency 'Texture/Core'
+  end
 
   spec.subspec 'Video' do |video|
     video.frameworks = ['AVFoundation', 'CoreMedia']


### PR DESCRIPTION
Currently we are having ASTextNode and ASTextNode2 which are adding quit a bit of size to Texture. As it becomes more and more clear that ASTextNode2 gonna be the future of text node within Texture we will provide a way to opt out of ASTextNode and make ASTextNode2 the default by default.

To be able to completly opt out of ASTextNode and all of it's TextKit dependency we are introducing a compiler flag called `AS_ENABLE_TEXTNODE`. By default the value is `YES / 1` to reflect the old behavior.

Furthermore there is a CocoaPods subspec added to disable the flag.

If the flag is disabled and ASTextNode2 is used only this will reduce around 300kb of Texture size.