### PR TITLE
[ASPrimitiveTraitCollection] Fix ASPrimitiveTraitCollectionMakeDefault and implement containerSize

### DIFF
--- a/Source/Details/ASTraitCollection.mm
+++ b/Source/Details/ASTraitCollection.mm
@@ -26,7 +26,10 @@ void ASTraitCollectionPropagateDown(id<ASLayoutElement> element, ASPrimitiveTrai
 }
 
 ASPrimitiveTraitCollection ASPrimitiveTraitCollectionMakeDefault() {
-  ASPrimitiveTraitCollection tc;
+  ASPrimitiveTraitCollection tc = {};
+  tc.userInterfaceIdiom = UIUserInterfaceIdiomUnspecified;
+  tc.forceTouchCapability = UIForceTouchCapabilityUnknown;
+  tc.displayScale = 0.0;
   tc.horizontalSizeClass = UIUserInterfaceSizeClassUnspecified;
   tc.verticalSizeClass = UIUserInterfaceSizeClassUnspecified;
   tc.containerSize = CGSizeZero;
@@ -212,6 +215,10 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
 - (UITraitEnvironmentLayoutDirection)layoutDirection
 {
   return _prim.layoutDirection;
+}
+- (CGSize)containerSize
+{
+  return _prim.containerSize;
 }
 #if AS_BUILD_UIUSERINTERFACESTYLE
 - (UIUserInterfaceStyle)userInterfaceStyle


### PR DESCRIPTION
With the changes to `ASPrimitiveTraitCollection` in https://github.com/TextureGroup/Texture/commit/e392f832f42897da41a7c0106709b55427efcea4 a new `ASPrimitiveTraitCollectionMakeDefault` was created. The new method didn’t give all values in an `ASPrimitiveTraitCollection` a default value (or initialize the struct with `{}`). This was causing fields like `userInterfaceIdiom`, `forceTouchCapability`, and `displayScale` to be filled with garbage, leading to `ASPrimitiveTraitCollectionIsEqualToASPrimitiveTraitCollection` to return `YES` when the trait collection hadn’t really changed.

It also looks like the getter `containerSize` was not implemented.