### PR TITLE
Forwards cell's hitTest:withEvent and pointInside:withEvent calls to node.

### DIFF
--- a/Source/Details/_ASCollectionViewCell.mm
+++ b/Source/Details/_ASCollectionViewCell.mm
@@ -98,7 +98,8 @@
 /**
  * Forwards the call of hitTest to its node so that it manages taps outside of its bounds.
  */
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event{
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
   return [self.node hitTest:point withEvent:event];
 }
 

--- a/Source/Details/_ASCollectionViewCell.mm
+++ b/Source/Details/_ASCollectionViewCell.mm
@@ -105,7 +105,8 @@
 /**
  * Forwards the call of pointInside to its node so that it manages taps outside of its bounds.
  */
-- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event{
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
+{
   return [self.node pointInside:point withEvent:event];
 }
 

--- a/Source/Details/_ASCollectionViewCell.mm
+++ b/Source/Details/_ASCollectionViewCell.mm
@@ -27,7 +27,7 @@
   ASCellNode *node = element.node;
   node.layoutAttributes = _layoutAttributes;
   _element = element;
-
+  
   [node __setSelectedFromUIKit:self.selected];
   [node __setHighlightedFromUIKit:self.highlighted];
 }

--- a/Source/Details/_ASCollectionViewCell.mm
+++ b/Source/Details/_ASCollectionViewCell.mm
@@ -8,6 +8,7 @@
 //
 
 #import <AsyncDisplayKit/_ASCollectionViewCell.h>
+#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
 
 #import <AsyncDisplayKit/ASCellNode+Internal.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>
@@ -26,7 +27,7 @@
   ASCellNode *node = element.node;
   node.layoutAttributes = _layoutAttributes;
   _element = element;
-  
+
   [node __setSelectedFromUIKit:self.selected];
   [node __setHighlightedFromUIKit:self.highlighted];
 }
@@ -92,6 +93,20 @@
 {
   [super layoutSubviews];
   self.node.frame = self.contentView.bounds;
+}
+
+/**
+ * Forwards the call of hitTest to its node so that it manages taps outside of its bounds.
+ */
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event{
+  return [self.node hitTest:point withEvent:event];
+}
+
+/**
+ * Forwards the call of pointInside to its node so that it manages taps outside of its bounds.
+ */
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event{
+  return [self.node pointInside:point withEvent:event];
 }
 
 @end


### PR DESCRIPTION
Unlike ASDisplayView, ASCollectionView doesn't redirect its hitTest:withEvent and pointInside:withEvent calls to its node. As a result, if a cell has a node that has a hitTestSlop that goes beyond the cell bounds it will be ignored.
This PR fixes that issue by forwarding the cell hitTest and pointInside calls to the node.