### PR TITLE
invalidate a11y 

### DIFF
--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -487,6 +487,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   let currentAttributedText = self.attributedText; // Grab attributed string again in case it changed in the meantime
   self.accessibilityLabel = self.defaultAccessibilityLabel;
   self.isAccessibilityElement = (currentAttributedText.length != 0); // We're an accessibility element by default if there is a string.
+  [self invalidateAccessibleElementsIfNeeded];
 
 #if AS_TEXTNODE_RECORD_ATTRIBUTED_STRINGS
   [ASTextNode _registerAttributedText:_attributedText];

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -410,7 +410,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   // Accessiblity
   self.accessibilityLabel = self.defaultAccessibilityLabel;
   self.isAccessibilityElement = (length != 0); // We're an accessibility element by default if there is a string.
-
+  [self invalidateAccessibleElementsIfNeeded];
 #if AS_TEXTNODE2_RECORD_ATTRIBUTED_STRINGS
   [ASTextNode _registerAttributedText:_attributedText];
 #endif

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -285,6 +285,28 @@ static _ASDisplayViewMethodOverrides GetASDisplayViewMethodOverrides(Class c)
 #endif
 }
 
+- (void)insertSubview:(UIView *)view atIndex:(NSInteger)index {
+  [super insertSubview:view atIndex:index];
+
+#ifndef ASDK_ACCESSIBILITY_DISABLE
+  self.accessibilityElements = nil;
+#endif
+}
+
+- (void)insertSubview:(UIView *)view aboveSubview:(UIView *)siblingSubview {
+  [super insertSubview:view aboveSubview:siblingSubview];
+#ifndef ASDK_ACCESSIBILITY_DISABLE
+  self.accessibilityElements = nil;
+#endif
+}
+
+- (void)insertSubview:(UIView *)view belowSubview:(UIView *)siblingSubview {
+  [super insertSubview:view aboveSubview:siblingSubview];
+#ifndef ASDK_ACCESSIBILITY_DISABLE
+  self.accessibilityElements = nil;
+#endif
+}
+
 - (void)willRemoveSubview:(UIView *)subview
 {
   [super willRemoveSubview:subview];

--- a/Source/Private/ASDisplayNode+FrameworkPrivate.h
+++ b/Source/Private/ASDisplayNode+FrameworkPrivate.h
@@ -314,6 +314,7 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyStateChange(ASHierarc
 
 @interface ASDisplayNode (AccessibilityInternal)
 - (NSArray *)accessibilityElements;
+- (void)invalidateAccessibleElementsIfNeeded;
 @end;
 
 @interface UIView (ASDisplayNodeInternal)

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -14,6 +14,8 @@
 
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
+#import <AsyncDisplayKit/ASTextNode.h>
+
 
 @interface ASDisplayViewAccessibilityTests : XCTestCase
 @end
@@ -80,6 +82,208 @@
   XCTAssertEqualObjects([node.view.accessibilityElements.firstObject accessibilityLabel], @"hello",
                         @"Container accessibility label override broken %@",
                         [node.view.accessibilityElements.firstObject accessibilityLabel]);
+}
+
+- (void)testAccessibilityLayerbackedNodesOperationInContainer {
+  ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
+  contianer.frame = CGRectMake(50, 50, 200, 400);
+  contianer.backgroundColor = [UIColor grayColor];
+  contianer.isAccessibilityContainer = YES;
+
+  // Do any additional setup after loading the view, typically from a nib.
+  ASTextNode *text1 = [[ASTextNode alloc] init];
+  text1.layerBacked = YES;
+  text1.attributedText = [[NSAttributedString alloc] initWithString:@"hello"];
+  text1.frame = CGRectMake(50, 100, 200, 200);
+  [contianer addSubnode:text1];
+
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+
+  NSArray<UIAccessibilityElement *> *elements = contianer.view.accessibilityElements;
+  XCTAssertTrue(elements.count == 1);
+  XCTAssertTrue([[elements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+
+  ASTextNode *text2 = [[ASTextNode alloc] init];
+  text2.layerBacked = YES;
+  text2.attributedText = [[NSAttributedString alloc] initWithString:@"world"];
+  text2.frame = CGRectMake(50, 300, 200, 200);
+  [contianer addSubnode:text2];
+
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements = contianer.view.accessibilityElements;
+  XCTAssertTrue(updatedElements.count == 1);
+  XCTAssertTrue([[updatedElements.firstObject accessibilityLabel] isEqualToString:@"hello, world"]);
+
+  ASTextNode *text3 = [[ASTextNode alloc] init];
+  text3.attributedText = [[NSAttributedString alloc] initWithString:@"!!!!"];
+  text3.frame = CGRectMake(50, 400, 200, 100);
+  text3.layerBacked = YES;
+  [text2 addSubnode:text3];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements2 = contianer.view.accessibilityElements;
+  XCTAssertTrue([[updatedElements2.firstObject accessibilityLabel] isEqualToString:@"hello, world, !!!!"]);
+}
+
+- (void)testAccessibilityNonLayerbackedNodesOperationInContainer {
+  ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
+  contianer.frame = CGRectMake(50, 50, 200, 600);
+  contianer.backgroundColor = [UIColor grayColor];
+  contianer.isAccessibilityContainer = YES;
+
+  // Do any additional setup after loading the view, typically from a nib.
+  ASTextNode *text1 = [[ASTextNode alloc] init];
+  text1.attributedText = [[NSAttributedString alloc] initWithString:@"hello"];
+  text1.frame = CGRectMake(50, 100, 200, 200);
+  [contianer addSubnode:text1];
+
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+
+  NSArray<UIAccessibilityElement *> *elements = contianer.view.accessibilityElements;
+  XCTAssertTrue(elements.count == 1);
+  XCTAssertTrue([[elements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+
+  ASTextNode *text2 = [[ASTextNode alloc] init];
+  text2.attributedText = [[NSAttributedString alloc] initWithString:@"world"];
+  text2.frame = CGRectMake(50, 300, 200, 200);
+  [contianer addSubnode:text2];
+
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements = contianer.view.accessibilityElements;
+  XCTAssertTrue(updatedElements.count == 1);
+  XCTAssertTrue([[updatedElements.firstObject accessibilityLabel] isEqualToString:@"hello, world"]);
+
+  ASTextNode *text3 = [[ASTextNode alloc] init];
+  text3.attributedText = [[NSAttributedString alloc] initWithString:@"!!!!"];
+  text3.frame = CGRectMake(50, 400, 200, 100);
+  [text2 addSubnode:text3];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements2 = contianer.view.accessibilityElements;
+  XCTAssertTrue([[updatedElements2.firstObject accessibilityLabel] isEqualToString:@"hello, world, !!!!"]);
+}
+
+- (void)testAccessibilityNonLayerbackedNodesOperationInNonContainer {
+  ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
+  contianer.frame = CGRectMake(50, 50, 200, 600);
+  contianer.backgroundColor = [UIColor grayColor];
+
+  // Do any additional setup after loading the view, typically from a nib.
+  ASTextNode *text1 = [[ASTextNode alloc] init];
+  text1.attributedText = [[NSAttributedString alloc] initWithString:@"hello"];
+  text1.frame = CGRectMake(50, 100, 200, 200);
+  [contianer addSubnode:text1];
+
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+
+  NSArray<UIAccessibilityElement *> *elements = contianer.view.accessibilityElements;
+  XCTAssertTrue(elements.count == 1);
+  XCTAssertTrue([[elements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+
+  ASTextNode *text2 = [[ASTextNode alloc] init];
+  text2.attributedText = [[NSAttributedString alloc] initWithString:@"world"];
+  text2.frame = CGRectMake(50, 300, 200, 200);
+  [contianer addSubnode:text2];
+
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements = contianer.view.accessibilityElements;
+  XCTAssertTrue(updatedElements.count == 2);
+  XCTAssertTrue([[updatedElements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  XCTAssertTrue([[updatedElements.lastObject accessibilityLabel] isEqualToString:@"world"]);
+
+
+  ASTextNode *text3 = [[ASTextNode alloc] init];
+  text3.attributedText = [[NSAttributedString alloc] initWithString:@"!!!!"];
+  text3.frame = CGRectMake(50, 400, 200, 100);
+  [text2 addSubnode:text3];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements2 = contianer.view.accessibilityElements;
+  //text3 won't be read out cause it's overshadowed by text2
+  XCTAssertTrue(updatedElements2.count == 2);
+  XCTAssertTrue([[updatedElements2.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  XCTAssertTrue([[updatedElements2.lastObject accessibilityLabel] isEqualToString:@"world"]);
+}
+
+- (void)testAccessibilityLayerbackedNodesOperationInNonContainer {
+  ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
+  contianer.frame = CGRectMake(50, 50, 200, 600);
+  contianer.backgroundColor = [UIColor grayColor];
+
+  // Do any additional setup after loading the view, typically from a nib.
+  ASTextNode *text1 = [[ASTextNode alloc] init];
+  text1.layerBacked = YES;
+  text1.attributedText = [[NSAttributedString alloc] initWithString:@"hello"];
+  text1.frame = CGRectMake(50, 0, 100, 100);
+  [contianer addSubnode:text1];
+
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+
+  NSArray<UIAccessibilityElement *> *elements = contianer.view.accessibilityElements;
+  XCTAssertTrue(elements.count == 1);
+  XCTAssertTrue([[elements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+
+  ASTextNode *text2 = [[ASTextNode alloc] init];
+  text2.layerBacked = YES;
+  text2.attributedText = [[NSAttributedString alloc] initWithString:@"world"];
+  text2.frame = CGRectMake(50, 100, 100, 100);
+  [contianer addSubnode:text2];
+
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements = contianer.view.accessibilityElements;
+  XCTAssertTrue(updatedElements.count == 2);
+  XCTAssertTrue([[updatedElements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  XCTAssertTrue([[updatedElements.lastObject accessibilityLabel] isEqualToString:@"world"]);
+
+  ASTextNode *text3 = [[ASTextNode alloc] init];
+  text3.layerBacked = YES;
+  text3.attributedText = [[NSAttributedString alloc] initWithString:@"!!!!"];
+  text3.frame = CGRectMake(50, 200, 100, 100);
+  [text2 addSubnode:text3];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+
+  NSArray<UIAccessibilityElement *> *updatedElements2 = contianer.view.accessibilityElements;
+  //text3 won't be read out cause it's overshadowed by text2
+  XCTAssertTrue(updatedElements2.count == 2);
+  XCTAssertTrue([[updatedElements2.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  XCTAssertTrue([[updatedElements2.lastObject accessibilityLabel] isEqualToString:@"world"]);
+}
+
+- (void)testAccessibilityUpdatesWithElementsChanges {
+  ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
+  contianer.frame = CGRectMake(50, 50, 200, 600);
+  contianer.backgroundColor = [UIColor grayColor];
+  contianer.isAccessibilityContainer = YES;
+  // Do any additional setup after loading the view, typically from a nib.
+  ASTextNode *text1 = [[ASTextNode alloc] init];
+  text1.layerBacked = YES;
+  text1.attributedText = [[NSAttributedString alloc] initWithString:@"hello"];
+  text1.frame = CGRectMake(50, 0, 100, 100);
+  [contianer addSubnode:text1];
+
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+
+  NSArray<UIAccessibilityElement *> *elements = contianer.view.accessibilityElements;
+  XCTAssertTrue(elements.count == 1);
+  XCTAssertTrue([[elements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+
+  text1.attributedText = [[NSAttributedString alloc] initWithString:@"greeting"];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+
+  NSArray<UIAccessibilityElement *> *elements2 = contianer.view.accessibilityElements;
+  XCTAssertTrue(elements2.count == 1);
+  XCTAssertTrue([[elements2.firstObject accessibilityLabel] isEqualToString:@"greeting"]);
 }
 
 @end


### PR DESCRIPTION
The invaidateAccessibilityElements is needed for following cases:
1. when there is a accessibilityContainer in the tree we need to make sure it's invalidated whenever insert a view or layer. 
2. If no accessibilityContainer involved, we still need to invalidate the first ancestor view to recollect new nodes. 
3. Whenever layer backed nodes changes themselves like attributedText change. 

They all covered in tests. 
Downside: it involves climbing the tree two times for 1 & 2. 
With all the work I still think it's better to just remove the cache (_accessibilityElements) in _ASDisplayView. 