### PR TITLE
Move assertions so they are valid.

### DIFF
--- a/Source/Details/ASPINRemoteImageDownloader.mm
+++ b/Source/Details/ASPINRemoteImageDownloader.mm
@@ -115,6 +115,7 @@ static PINRemoteImageManager *sharedPINRemoteImageManager = nil;
 
 + (void)setSharedImageManagerWithConfiguration:(nullable NSURLSessionConfiguration *)configuration
 {
+  NSAssert(sharedDownloader == nil, @"Singleton has been created and session can no longer be configured.");
   PINRemoteImageManager *sharedManager = [self PINRemoteImageManagerWithConfiguration:configuration imageCache:nil];
   [self setSharedPreconfiguredRemoteImageManager:sharedManager];
 }
@@ -122,6 +123,7 @@ static PINRemoteImageManager *sharedPINRemoteImageManager = nil;
 + (void)setSharedImageManagerWithConfiguration:(nullable NSURLSessionConfiguration *)configuration
                                     imageCache:(nullable id<PINRemoteImageCaching>)imageCache
 {
+  NSAssert(sharedDownloader == nil, @"Singleton has been created and session can no longer be configured.");
   PINRemoteImageManager *sharedManager = [self PINRemoteImageManagerWithConfiguration:configuration imageCache:imageCache];
   [self setSharedPreconfiguredRemoteImageManager:sharedManager];
 }
@@ -131,7 +133,6 @@ static dispatch_once_t shared_init_predicate;
 + (void)setSharedPreconfiguredRemoteImageManager:(PINRemoteImageManager *)preconfiguredPINRemoteImageManager
 {
   NSAssert(preconfiguredPINRemoteImageManager != nil, @"setSharedPreconfiguredRemoteImageManager requires a non-nil parameter");
-  NSAssert(sharedDownloader == nil, @"Singleton has been created and session can no longer be configured.");
   NSAssert1(sharedPINRemoteImageManager == nil, @"An instance of %@ has been set. Either configuration or preconfigured image manager can be set at a time and only once.", [[sharedPINRemoteImageManager class] description]);
 
   dispatch_once(&shared_init_predicate, ^{


### PR DESCRIPTION
If PIN_ANIMATED is enabled, the creation of a PINRemoteImageManager
will create a sharedDownloader also. Thus we cannot assert that it
doesn't exist. We will move this assertion up to the methods that
create the preconfiguredSharedManager and before said manager is
allocated.