### PR TITLE
Wrap supplementary node blocks to enable resizing them.

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -2019,7 +2019,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   __weak __typeof__(self) weakSelf = self;
   return ^{
     __typeof__(self) strongSelf = weakSelf;
-    ASCellNode *node = (block ? block() : cell);
+    ASCellNode *node = block();
     ASDisplayNodeAssert([node isKindOfClass:[ASCellNode class]],
                         @"ASCollectionNode provided a non-ASCellNode! %@, %@", node, strongSelf);
 

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -2015,7 +2015,22 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     block = ^{ return cell; };
   }
 
-  return block;
+  // Wrap the node block
+  __weak __typeof__(self) weakSelf = self;
+  return ^{
+    __typeof__(self) strongSelf = weakSelf;
+    ASCellNode *node = (block ? block() : cell);
+    ASDisplayNodeAssert([node isKindOfClass:[ASCellNode class]],
+                        @"ASCollectionNode provided a non-ASCellNode! %@, %@", node, strongSelf);
+
+    if (node.interactionDelegate == nil) {
+      node.interactionDelegate = strongSelf;
+    }
+    if (strongSelf.inverted) {
+      node.transform = CATransform3DMakeScale(1, -1, 1);
+    }
+    return node;
+  };
 }
 
 - (NSArray<NSString *> *)dataController:(ASDataController *)dataController supplementaryNodeKindsInSections:(NSIndexSet *)sections


### PR DESCRIPTION
Most ASCellNodeBlocks are wrapped by ASCollectionView.mm to add an `interactionDelegate` as well as calling `enterHierarchyState` on the node and setting its transform to a reflection if `inverted` is set on the collectionView.

This PR adds this behavior to supplementary nodes as well.