### PR TITLE
Forward hitTest:withEvent and piontInside:withEvent: to node within _ASCollectionViewCell

### DIFF
--- a/Source/Details/_ASCollectionViewCell.mm
+++ b/Source/Details/_ASCollectionViewCell.mm
@@ -8,6 +8,7 @@
 //
 
 #import <AsyncDisplayKit/_ASCollectionViewCell.h>
+#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
 
 #import <AsyncDisplayKit/ASCellNode+Internal.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>
@@ -92,6 +93,29 @@
 {
   [super layoutSubviews];
   self.node.frame = self.contentView.bounds;
+}
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  /**
+   * The documentation for hitTest:withEvent: on an UIView explicitly states the fact that:
+   * it ignores view objects that are hidden, that have disabled user interactions, or have an
+   * alpha level less than 0.01.
+   * To be able to determine if the collection view cell should skip going further down the tree
+   * based on the states above we use a valid point within the cells bounds and check the
+   * superclass hitTest:withEvent: implementation. If this returns a valid value we can go on with
+   * checking the node as it's expected to not be in one of these states.
+   */
+  if (![super hitTest:self.bounds.origin withEvent:event]) {
+    return nil;
+  }
+
+  return [self.node hitTest:point withEvent:event];
+}
+
+- (BOOL)pointInside:(CGPoint)point withEvent:(nullable UIEvent *)event
+{
+  return [self.node pointInside:point withEvent:event];
 }
 
 @end


### PR DESCRIPTION
This replaces #1268 that was unfortunately not enough to only forward the calls to the node. Extra checks need to be in place in case `UICollectionView`s animated updating API is used and hidden `UICollectionViewCell`'s are still within `UICollectionView`s subviews.

Thanks @stremsdoerfer for the initial PR!