### PR TITLE
Fix truncation precedence in ASTextNode2 (#1270)

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -407,6 +407,12 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     ASLayoutElementStyle *style = [self _locked_style];
     style.ascender = [[self class] ascenderWithAttributedString:attributedText];
     style.descender = [[attributedText attribute:NSFontAttributeName atIndex:attributedText.length - 1 effectiveRange:NULL] descender];
+
+    // Set our truncation ivar if a paragraph style is specified
+    NSParagraphStyle *paragraphStyle = [attributedText attribute:NSParagraphStyleAttributeName atIndex:attributedText.length - 1 effectiveRange:NULL];
+    if (paragraphStyle) {
+      _truncationMode = paragraphStyle.lineBreakMode;
+    }
   }
   
   // Tell the display node superclasses that the cached layout is incorrect now

--- a/Tests/ASTextNode2Tests.mm
+++ b/Tests/ASTextNode2Tests.mm
@@ -91,4 +91,27 @@
                 _textNode.defaultAccessibilityLabel, _attributedText.string);
 }
 
+- (void)testAttributedTextTruncationOverridesTruncationProperty
+{
+  // capture previous values, restore after testing
+  NSLineBreakMode prevMode = _textNode.truncationMode;
+  NSAttributedString *prevString = _textNode.attributedText;
+
+  // set the property to word-wrapping
+  _textNode.truncationMode = NSLineBreakByWordWrapping;
+
+  // set attributed text with middle truncation
+  NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+  paragraphStyle.lineBreakMode = NSLineBreakByTruncatingMiddle;
+  _textNode.attributedText = [[NSAttributedString alloc] initWithString:@"Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor "
+                                                             attributes:@{NSParagraphStyleAttributeName : paragraphStyle}];
+
+  // Assert that our attributed text overrides the property
+  XCTAssertEqual(_textNode.truncationMode, NSLineBreakByTruncatingMiddle);
+
+  // restore previous values
+  _textNode.truncationMode = prevMode;
+  _textNode.attributedText = prevString;
+}
+
 @end


### PR DESCRIPTION
Previously, setting attributed text with a truncation mode in ASTextNode2 wouldn't override the property which caused the truncation mode not to take affect. By setting the backing ivar in `setAttributedText:`, we can make the behavior match ASTextNode and what's in the docs.