### PR TITLE
Introduce ASCellLayoutMode

### DIFF
--- a/Source/ASCollectionNode+Beta.h
+++ b/Source/ASCollectionNode+Beta.h
@@ -33,21 +33,23 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, weak) id<ASBatchFetchingDelegate> batchFetchingDelegate;
 
 /**
- * When this mode is enabled, ASCollectionView matches the timing of UICollectionView as closely as possible, 
- * ensuring that all reload and edit operations are performed on the main thread as blocking calls. 
+ * When this mode is enabled, ASCollectionView matches the timing of UICollectionView as closely as
+ * possible, ensuring that all reload and edit operations are performed on the main thread as
+ * blocking calls.
  *
- * This mode is useful for applications that are debugging issues with their collection view implementation. 
- * In particular, some applications do not properly conform to the API requirement of UICollectionView, and these 
- * applications may experience difficulties with ASCollectionView. Providing this mode allows for developers to 
- * work towards resolving technical debt in their collection view data source, while ramping up asynchronous 
- * collection layout.
+ * This mode is useful for applications that are debugging issues with their collection view
+ * implementation. In particular, some applications do not properly conform to the API requirement
+ * of UICollectionView, and these applications may experience difficulties with ASCollectionView.
+ * Providing this mode allows for developers to work towards resolving technical debt in their
+ * collection view data source, while ramping up asynchronous collection layout.
  *
- * NOTE: Because this mode results in expensive operations like cell layout being performed on the main thread, 
- * it should be used as a tool to resolve data source conformance issues with Apple collection view API.
+ * NOTE: Because this mode results in expensive operations like cell layout being performed on the
+ * main thread, it should be used as a tool to resolve data source conformance issues with Apple
+ * collection view API.
  *
- * @default defaults to NO.
+ * @default defaults to ASCellLayoutModeNone.
  */
-@property (nonatomic) BOOL usesSynchronousDataLoading;
+@property (nonatomic) ASCellLayoutMode cellLayoutMode;
 
 /**
  *  Returns YES if the ASCollectionNode contents are completely synchronized with the underlying collection-view layout.
@@ -71,9 +73,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)endUpdatesAnimated:(BOOL)animated ASDISPLAYNODE_DEPRECATED_MSG("Use -performBatchUpdates:completion: instead.");
 
 - (void)endUpdatesAnimated:(BOOL)animated completion:(nullable void (^)(BOOL))completion ASDISPLAYNODE_DEPRECATED_MSG("Use -performBatchUpdates:completion: instead.");
-
-- (void)invalidateFlowLayoutDelegateMetrics;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ASCollectionNode+Beta.h
+++ b/Source/ASCollectionNode+Beta.h
@@ -73,6 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)endUpdatesAnimated:(BOOL)animated ASDISPLAYNODE_DEPRECATED_MSG("Use -performBatchUpdates:completion: instead.");
 
 - (void)endUpdatesAnimated:(BOOL)animated completion:(nullable void (^)(BOOL))completion ASDISPLAYNODE_DEPRECATED_MSG("Use -performBatchUpdates:completion: instead.");
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -42,7 +42,7 @@
 @property (nonatomic) BOOL allowsSelection; // default is YES
 @property (nonatomic) BOOL allowsMultipleSelection; // default is NO
 @property (nonatomic) BOOL inverted; //default is NO
-@property (nonatomic) BOOL usesSynchronousDataLoading;
+@property (nonatomic) ASCellLayoutMode cellLayoutMode;
 @property (nonatomic) CGFloat leadingScreensForBatching;
 @property (nonatomic, weak) id <ASCollectionViewLayoutInspecting> layoutInspector;
 @property (nonatomic) BOOL alwaysBounceVertical;
@@ -193,7 +193,7 @@
     view.inverted                       = pendingState.inverted;
     view.allowsSelection                = pendingState.allowsSelection;
     view.allowsMultipleSelection        = pendingState.allowsMultipleSelection;
-    view.usesSynchronousDataLoading     = pendingState.usesSynchronousDataLoading;
+    view.cellLayoutMode                 = pendingState.cellLayoutMode;
     view.layoutInspector                = pendingState.layoutInspector;
     view.showsVerticalScrollIndicator   = pendingState.showsVerticalScrollIndicator;
     view.showsHorizontalScrollIndicator = pendingState.showsHorizontalScrollIndicator;
@@ -628,21 +628,21 @@
   return _batchFetchingDelegate;
 }
 
-- (BOOL)usesSynchronousDataLoading
+- (ASCellLayoutMode)cellLayoutMode
 {
   if ([self pendingState]) {
-    return _pendingState.usesSynchronousDataLoading; 
+    return _pendingState.cellLayoutMode;
   } else {
-    return self.view.usesSynchronousDataLoading;
+    return self.view.cellLayoutMode;
   }
 }
 
-- (void)setUsesSynchronousDataLoading:(BOOL)usesSynchronousDataLoading
+- (void)setCellLayoutMode:(ASCellLayoutMode)cellLayoutMode
 {
   if ([self pendingState]) {
-    _pendingState.usesSynchronousDataLoading = usesSynchronousDataLoading; 
+    _pendingState.cellLayoutMode = cellLayoutMode;
   } else {
-    self.view.usesSynchronousDataLoading = usesSynchronousDataLoading;
+    self.view.cellLayoutMode = cellLayoutMode;
   }
 }
 

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -791,7 +791,9 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   return visibleNodes;
 }
 
-- (void)invalidateFlowLayoutDelegateMetrics {
+- (void)invalidateFlowLayoutDelegateMetrics
+{
+  // Subclass hook
 }
 
 #pragma mark Internal
@@ -2148,8 +2150,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (BOOL)rangeControllerShouldUpdateRanges:(ASRangeController *)rangeController
 {
-  BOOL disableRangeController = ASCellLayoutModeIncludes(ASCellLayoutModeDisableRangeController);
-  return !disableRangeController;
+  return !ASCellLayoutModeIncludes(ASCellLayoutModeDisableRangeController);
 }
 
 - (void)rangeController:(ASRangeController *)rangeController updateWithChangeSet:(_ASHierarchyChangeSet *)changeSet updates:(dispatch_block_t)updates
@@ -2190,7 +2191,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
       [_layoutFacilitator collectionViewWillPerformBatchUpdates];
       
       __block NSUInteger numberOfUpdates = 0;
-      void(^completion)(BOOL finished) = ^(BOOL finished){
+      let completion = ^(BOOL finished) {
         as_activity_scope(as_activity_create("Handle collection update completion", changeSet.rootActivity, OS_ACTIVITY_FLAG_DEFAULT));
         as_log_verbose(ASCollectionLog(), "Update animation finished %{public}@", self.collectionNode);
         // Flush any range changes that happened as part of the update animations ending.
@@ -2213,39 +2214,39 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
         [super reloadData];
         completion(YES);
       } else {
-      [self _superPerformBatchUpdates:^{
-        updates();
+        [self _superPerformBatchUpdates:^{
+          updates();
 
-        for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeReload]) {
-          [super reloadItemsAtIndexPaths:change.indexPaths];
-          numberOfUpdates++;
-        }
-        
-        for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeReload]) {
-          [super reloadSections:change.indexSet];
-          numberOfUpdates++;
-        }
-        
-        for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeOriginalDelete]) {
-          [super deleteItemsAtIndexPaths:change.indexPaths];
-          numberOfUpdates++;
-        }
-        
-        for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeOriginalDelete]) {
-          [super deleteSections:change.indexSet];
-          numberOfUpdates++;
-        }
-        
-        for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeOriginalInsert]) {
-          [super insertSections:change.indexSet];
-          numberOfUpdates++;
-        }
-        
-        for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeOriginalInsert]) {
-          [super insertItemsAtIndexPaths:change.indexPaths];
-          numberOfUpdates++;
-        }
-      } completion:completion];
+          for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeReload]) {
+            [super reloadItemsAtIndexPaths:change.indexPaths];
+            numberOfUpdates++;
+          }
+
+          for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeReload]) {
+            [super reloadSections:change.indexSet];
+            numberOfUpdates++;
+          }
+
+          for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeOriginalDelete]) {
+            [super deleteItemsAtIndexPaths:change.indexPaths];
+            numberOfUpdates++;
+          }
+
+          for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeOriginalDelete]) {
+            [super deleteSections:change.indexSet];
+            numberOfUpdates++;
+          }
+
+          for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeOriginalInsert]) {
+            [super insertSections:change.indexSet];
+            numberOfUpdates++;
+          }
+
+          for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeOriginalInsert]) {
+            [super insertItemsAtIndexPaths:change.indexPaths];
+            numberOfUpdates++;
+          }
+        } completion:completion];
       }
 
       as_log_debug(ASCollectionLog(), "Completed batch update %{public}@", self.collectionNode);

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -348,7 +348,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
  */
 - (void)reloadData
 {
-  [super reloadData];
+  [self _superReloadData:nil completion:nil];
 
   // UICollectionView calls -reloadData during first layoutSubviews and when the data source changes.
   // This fires off the first load of cell nodes.
@@ -2183,7 +2183,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     if (changeSet.includesReloadData) {
       _superIsPendingDataLoad = YES;
       updates();
-      [super reloadData];
+      [self _superReloadData:nil completion:nil];
       as_log_debug(ASCollectionLog(), "Did reloadData %@", self.collectionNode);
       [changeSet executeCompletionHandlerWithFinished:YES];
     } else {

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -1874,7 +1874,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   if (ASCellLayoutModeIncludes(ASCellLayoutModeAlwaysAsync)) {
     return NO;
   }
-  // The heuristics below apply to the ASCellLayoutModeDefault.
+  // The heuristics below apply to the ASCellLayoutModeNone.
   // If we have very few ASCellNodes (besides UIKit passthrough ones), match UIKit by blocking.
   if (changeSet.countForAsyncLayout < 2) {
     return YES;

--- a/Source/ASCollectionViewProtocols.h
+++ b/Source/ASCollectionViewProtocols.h
@@ -10,6 +10,41 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
+typedef NS_OPTIONS(NSUInteger, ASCellLayoutMode) {
+  /** No options set. Default value. */
+  ASCellLayoutModeNone = 0,
+  /**
+   * If ASCellLayoutModeAlwaysSync is enabled it will cause the ASDataController to wait on the
+   * background queue, and this ensures that any new / changed cells are in the hierarchy by the
+   * very next CATransaction / frame draw.
+   *
+   * Note: Sync & Async flags force the behavior to be always one or the other, regardless of the
+   * items. Default: If neither ASCellLayoutModeAlwaysSync or ASCellLayoutModeAlwaysAsync is set,
+   * default behavior is synchronous when there are 0 or 1 ASCellNodes in the data source, and
+   * asynchronous when there are 2 or more.
+  */
+  ASCellLayoutModeAlwaysSync = 1 << 1,
+  ASCellLayoutModeAlwaysAsync = 1 << 2,
+  ASCellLayoutModeForceIfNeeded = 1 << 3,             // Deprecated, default OFF.
+  ASCellLayoutModeAlwaysPassthroughDelegate = 1 << 4, // Deprecated, default ON.
+  /** Instead of using performBatchUpdates: prefer using reloadData for changes for collection view */
+  ASCellLayoutModeAlwaysReloadData = 1 << 5,
+  /** If flag is enabled nodes are *not* gonna be range managed. */
+  ASCellLayoutModeDisableRangeController = 1 << 6,
+  ASCellLayoutModeAlwaysLazy = 1 << 7,                // Deprecated, default OFF.
+  /**
+   * Defines if the node creation should happen serialized and not in parallel within the
+   * data controller
+   */
+  ASCellLayoutModeSerializeNodeCreation = 1 << 8,
+  /**
+   * When set, the performBatchUpdates: API (including animation) is used when handling Section
+   * Reload operations. This is useful only when ASCellLayoutModeAlwaysReloadData is enabled and
+   * cell height animations are desired.
+   */
+  ASCellLayoutModeAlwaysBatchUpdateSectionReload = 1 << 9
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/Source/ASCollectionViewProtocols.h
+++ b/Source/ASCollectionViewProtocols.h
@@ -11,7 +11,10 @@
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
 typedef NS_OPTIONS(NSUInteger, ASCellLayoutMode) {
-  /** No options set. Default value. */
+  /**
+   * No options set. If cell layout mode is set to ASCellLayoutModeNone, the default values for
+   * each flag listed below is used.
+   */
   ASCellLayoutModeNone = 0,
   /**
    * If ASCellLayoutModeAlwaysSync is enabled it will cause the ASDataController to wait on the
@@ -23,26 +26,26 @@ typedef NS_OPTIONS(NSUInteger, ASCellLayoutMode) {
    * default behavior is synchronous when there are 0 or 1 ASCellNodes in the data source, and
    * asynchronous when there are 2 or more.
   */
-  ASCellLayoutModeAlwaysSync = 1 << 1,
-  ASCellLayoutModeAlwaysAsync = 1 << 2,
+  ASCellLayoutModeAlwaysSync = 1 << 1,                // Default OFF
+  ASCellLayoutModeAlwaysAsync = 1 << 2,               // Default OFF
   ASCellLayoutModeForceIfNeeded = 1 << 3,             // Deprecated, default OFF.
   ASCellLayoutModeAlwaysPassthroughDelegate = 1 << 4, // Deprecated, default ON.
   /** Instead of using performBatchUpdates: prefer using reloadData for changes for collection view */
-  ASCellLayoutModeAlwaysReloadData = 1 << 5,
+  ASCellLayoutModeAlwaysReloadData = 1 << 5,          // Default OFF
   /** If flag is enabled nodes are *not* gonna be range managed. */
-  ASCellLayoutModeDisableRangeController = 1 << 6,
+  ASCellLayoutModeDisableRangeController = 1 << 6,    // Default OFF
   ASCellLayoutModeAlwaysLazy = 1 << 7,                // Deprecated, default OFF.
   /**
    * Defines if the node creation should happen serialized and not in parallel within the
    * data controller
    */
-  ASCellLayoutModeSerializeNodeCreation = 1 << 8,
+  ASCellLayoutModeSerializeNodeCreation = 1 << 8,     // Default OFF
   /**
    * When set, the performBatchUpdates: API (including animation) is used when handling Section
    * Reload operations. This is useful only when ASCellLayoutModeAlwaysReloadData is enabled and
    * cell height animations are desired.
    */
-  ASCellLayoutModeAlwaysBatchUpdateSectionReload = 1 << 9
+  ASCellLayoutModeAlwaysBatchUpdateSectionReload = 1 << 9 // Default OFF
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Source/ASSectionController.h
+++ b/Source/ASSectionController.h
@@ -35,6 +35,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (ASCellNodeBlock)nodeBlockForItemAtIndex:(NSInteger)index;
 
+/**
+ * Similar to -collectionView:cellForItemAtIndexPath:.
+ *
+ * Note: only called if nodeBlockForItemAtIndex: returns nil.
+ *
+ * @param index The index of the item.
+ *
+ * @return A node to display for the given item. This will be called on the main thread and should
+ *   not implement reuse (it will be called once per item).  Unlike UICollectionView's version,
+ *   this method is not called when the item is about to display.
+ */
+- (ASCellNode *)nodeForItemAtIndex:(NSInteger)index;
+
 @optional
 
 /**

--- a/Source/ASSupplementaryNodeSource.h
+++ b/Source/ASSupplementaryNodeSource.h
@@ -25,6 +25,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (ASCellNodeBlock)nodeBlockForSupplementaryElementOfKind:(NSString *)elementKind atIndex:(NSInteger)index;
 
+/**
+ * Asks the controller to provide a node to display for the given supplementary element.
+ *
+ * @param kind The kind of supplementary element.
+ * @param index The index of the item.
+ */
+- (ASCellNode *)nodeForSupplementaryElementOfKind:(NSString *)kind atIndex:(NSInteger)index;
+
 @optional
 
 /**

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -1519,6 +1519,11 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 #pragma mark - ASRangeControllerDelegate
 
+- (BOOL)rangeControllerShouldUpdateRanges:(ASRangeController *)rangeController
+{
+  return YES;
+}
+
 - (void)rangeController:(ASRangeController *)rangeController updateWithChangeSet:(_ASHierarchyChangeSet *)changeSet updates:(dispatch_block_t)updates
 {
   ASDisplayNodeAssertMainThread();
@@ -1666,13 +1671,42 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 #pragma mark - ASDataControllerSource
 
+- (BOOL)dataController:(ASDataController *)dataController shouldEagerlyLayoutNode:(ASCellNode *)node
+{
+  return YES;
+}
+
+- (BOOL)dataControllerShouldSerializeNodeCreation:(ASDataController *)dataController {
+  return NO;
+}
+
+- (BOOL)dataController:(ASDataController *)dataController shouldSynchronouslyProcessChangeSet:(_ASHierarchyChangeSet *)changeSet
+{
+  // For more details on this method, see the comment in the ASCollectionView implementation.
+  if (changeSet.countForAsyncLayout < 2) {
+    return YES;
+  }
+  CGSize contentSize = self.contentSize;
+  CGSize boundsSize = self.bounds.size;
+  if (contentSize.height <= boundsSize.height && contentSize.width <= boundsSize.width) {
+    return YES;
+  }
+  return NO;
+}
+
+- (void)dataControllerDidFinishWaiting:(ASDataController *)dataController
+{
+  // ASCellLayoutMode is not currently supported on ASTableView (see ASCollectionView for details).
+}
+
 - (id)dataController:(ASDataController *)dataController nodeModelForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   // Not currently supported for tables. Will be added when the collection API stabilizes.
   return nil;
 }
 
-- (ASCellNodeBlock)dataController:(ASDataController *)dataController nodeBlockAtIndexPath:(NSIndexPath *)indexPath {
+- (ASCellNodeBlock)dataController:(ASDataController *)dataController nodeBlockAtIndexPath:(NSIndexPath *)indexPath shouldAsyncLayout:(BOOL *)shouldAsyncLayout
+{
   ASCellNodeBlock block = nil;
 
   if (_asyncDataSourceFlags.tableNodeNodeBlockForRow) {
@@ -1720,6 +1754,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   return ^{
     __typeof__(self) strongSelf = weakSelf;
     ASCellNode *node = (block != nil ? block() : [[ASCellNode alloc] init]);
+    ASDisplayNodeAssert([node isKindOfClass:[ASCellNode class]], @"ASTableNode provided a non-ASCellNode! %@, %@", node, strongSelf);
+
     [node enterHierarchyState:ASHierarchyStateRangeManaged];
     if (node.interactionDelegate == nil) {
       node.interactionDelegate = strongSelf;

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -1676,7 +1676,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   return YES;
 }
 
-- (BOOL)dataControllerShouldSerializeNodeCreation:(ASDataController *)dataController {
+- (BOOL)dataControllerShouldSerializeNodeCreation:(ASDataController *)dataController
+{
   return NO;
 }
 

--- a/Source/Details/ASCollectionInternal.h
+++ b/Source/Details/ASCollectionInternal.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @see ASCollectionNode+Beta.h for full documentation.
  */
-@property (nonatomic) BOOL usesSynchronousDataLoading;
+@property (nonatomic) ASCellLayoutMode cellLayoutMode;
 
 /**
  * Attempt to get the view-layer index path for the item with the given index path.

--- a/Source/Details/ASDataController.h
+++ b/Source/Details/ASDataController.h
@@ -52,7 +52,7 @@ AS_EXTERN NSString * const ASCollectionInvalidUpdateException;
 /**
  Fetch the ASCellNode block for specific index path. This block should return the ASCellNode for the specified index path.
  */
-- (ASCellNodeBlock)dataController:(ASDataController *)dataController nodeBlockAtIndexPath:(NSIndexPath *)indexPath;
+- (ASCellNodeBlock)dataController:(ASDataController *)dataController nodeBlockAtIndexPath:(NSIndexPath *)indexPath shouldAsyncLayout:(BOOL *)shouldAsyncLayout;
 
 /**
  Fetch the number of rows in specific section.
@@ -71,6 +71,18 @@ AS_EXTERN NSString * const ASCollectionInvalidUpdateException;
 - (BOOL)dataController:(ASDataController *)dataController presentedSizeForElement:(ASCollectionElement *)element matchesSize:(CGSize)size;
 
 - (nullable id)dataController:(ASDataController *)dataController nodeModelForItemAtIndexPath:(NSIndexPath *)indexPath;
+
+/**
+ * Called just after dispatching ASCellNode allocation and layout to the concurrent background queue.
+ * In some cases, for example on the first content load for a screen, it may be desirable to call
+ * -waitUntilAllUpdatesAreProcessed at this point.
+ *
+ * Returning YES will cause the ASDataController to wait on the background queue, and this ensures
+ * that any new / changed cells are in the hierarchy by the very next CATransaction / frame draw.
+ */
+- (BOOL)dataController:(ASDataController *)dataController shouldSynchronouslyProcessChangeSet:(_ASHierarchyChangeSet *)changeSet;
+- (BOOL)dataController:(ASDataController *)dataController shouldEagerlyLayoutNode:(ASCellNode *)node;
+- (BOOL)dataControllerShouldSerializeNodeCreation:(ASDataController *)dataController;
 
 @optional
 
@@ -221,11 +233,6 @@ AS_EXTERN NSString * const ASCollectionInvalidUpdateException;
  */
 @property (nonatomic, readonly) ASEventLog *eventLog;
 #endif
-
-/**
- * @see ASCollectionNode+Beta.h for full documentation.
- */
-@property (nonatomic) BOOL usesSynchronousDataLoading;
 
 /** @name Data Updating */
 

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -156,10 +156,14 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   {
     as_activity_create_for_scope("Data controller batch");
 
-    // TODO: Should we use USER_INITIATED here since the user is probably waiting?
-    dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0);
-    ASDispatchApply(nodeCount, queue, 0, ^(size_t i) {
-      if (!weakDataSource) {
+    dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+    NSUInteger threadCount = 0;
+    if ([_dataSource dataControllerShouldSerializeNodeCreation:self]) {
+      threadCount = 1;
+    }
+    ASDispatchApply(nodeCount, queue, threadCount, ^(size_t i) {
+      __strong id<ASDataControllerSource> strongDataSource = weakDataSource;
+      if (strongDataSource == nil) {
         return;
       }
 
@@ -181,6 +185,9 @@ typedef void (^ASDataControllerSynchronizationBlock)();
  */
 - (void)_layoutNode:(ASCellNode *)node withConstrainedSize:(ASSizeRange)constrainedSize
 {
+  if (![_dataSource dataController:self shouldEagerlyLayoutNode:node]) {
+    return;
+  }
   ASDisplayNodeAssert(ASSizeRangeHasSignificantArea(constrainedSize), @"Attempt to layout cell node with invalid size range %@", NSStringFromASSizeRange(constrainedSize));
 
   CGRect frame = CGRectZero;
@@ -368,6 +375,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   LOG(@"Populating elements of kind: %@, for index paths: %@", kind, indexPaths);
   id<ASDataControllerSource> dataSource = self.dataSource;
   id<ASRangeManagingNode> node = self.node;
+  BOOL shouldAsyncLayout = YES;
   for (NSIndexPath *indexPath in indexPaths) {
     ASCellNodeBlock nodeBlock;
     id nodeModel;
@@ -389,13 +397,12 @@ typedef void (^ASDataControllerSynchronizationBlock)();
         }
       }
       if (nodeBlock == nil) {
-        nodeBlock = [dataSource dataController:self nodeBlockAtIndexPath:indexPath];
+        nodeBlock = [dataSource dataController:self nodeBlockAtIndexPath:indexPath shouldAsyncLayout:&shouldAsyncLayout];
       }
     } else {
-      BOOL shouldAsyncLayout = YES;
       nodeBlock = [dataSource dataController:self supplementaryNodeBlockOfKind:kind atIndexPath:indexPath shouldAsyncLayout:&shouldAsyncLayout];
     }
-    
+
     ASSizeRange constrainedSize = ASSizeRangeUnconstrained;
     if (shouldFetchSizeRanges) {
       constrainedSize = [self constrainedSizeForNodeOfKind:kind atIndexPath:indexPath];
@@ -408,6 +415,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
                                                                        owningNode:node
                                                                   traitCollection:traitCollection];
     [map insertElement:element atIndexPath:indexPath];
+    changeSet.countForAsyncLayout += (shouldAsyncLayout ? 1 : 0);
   }
 }
 
@@ -666,8 +674,15 @@ typedef void (^ASDataControllerSynchronizationBlock)();
     }];
     --_editingTransactionGroupCount;
   });
-  
-  if (_usesSynchronousDataLoading) {
+
+  // We've now dispatched node allocation and layout to a concurrent background queue.
+  // In some cases, it's advantageous to prevent the main thread from returning, to ensure the next
+  // frame displayed to the user has the view updates in place. Doing this does slightly reduce
+  // total latency, by donating the main thread's priority to the background threads. As such, the
+  // two cases where it makes sense to block:
+  // 1. There is very little work to be performed in the background (UIKit passthrough)
+  // 2. There is a higher priority on display latency than smoothness, e.g. app startup.
+  if ([_dataSource dataController:self shouldSynchronouslyProcessChangeSet:changeSet]) {
     [self waitUntilAllUpdatesAreProcessed];
   }
 }
@@ -869,7 +884,12 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   _visibleMap = _pendingMap;
 
   for (ASCollectionElement *element in _visibleMap) {
+    // Ignore this element if it is no longer in the latest data. It is still recognized in the UIKit world but will be deleted soon.
     NSIndexPath *indexPathInPendingMap = [_pendingMap indexPathForElement:element];
+    if (indexPathInPendingMap == nil) {
+      continue;
+    }
+
     NSString *kind = element.supplementaryElementKind ?: ASDataControllerRowNodeKind;
     ASSizeRange newConstrainedSize = [self constrainedSizeForNodeOfKind:kind atIndexPath:indexPathInPendingMap];
 

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -188,6 +188,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   if (![_dataSource dataController:self shouldEagerlyLayoutNode:node]) {
     return;
   }
+  
   ASDisplayNodeAssert(ASSizeRangeHasSignificantArea(constrainedSize), @"Attempt to layout cell node with invalid size range %@", NSStringFromASSizeRange(constrainedSize));
 
   CGRect frame = CGRectZero;

--- a/Source/Details/ASRangeController.h
+++ b/Source/Details/ASRangeController.h
@@ -160,6 +160,8 @@ AS_SUBCLASSING_RESTRICTED
  */
 - (void)rangeController:(ASRangeController *)rangeController updateWithChangeSet:(_ASHierarchyChangeSet *)changeSet updates:(dispatch_block_t)updates;
 
+- (BOOL)rangeControllerShouldUpdateRanges:(ASRangeController *)rangeController;
+
 @end
 
 @interface ASRangeController (ASRangeControllerUpdateRangeProtocol) <ASRangeControllerUpdateRangeProtocol>

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -208,7 +208,11 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   if (!_layoutController || !_dataSource) {
     return;
   }
-  
+
+  if ([_delegate rangeControllerShouldUpdateRanges:self] == NO) {
+    return;
+  }
+
 #if AS_RANGECONTROLLER_LOG_UPDATE_FREQ
   _updateCountThisFrame += 1;
 #endif

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -209,7 +209,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
     return;
   }
 
-  if ([_delegate rangeControllerShouldUpdateRanges:self] == NO) {
+  if (![_delegate rangeControllerShouldUpdateRanges:self]) {
     return;
   }
 

--- a/Source/IGListAdapter+AsyncDisplayKit.mm
+++ b/Source/IGListAdapter+AsyncDisplayKit.mm
@@ -31,7 +31,7 @@
   }
 
   // Make a data source and retain it.
-  dataSource = [[ASIGListAdapterBasedDataSource alloc] initWithListAdapter:self];
+  dataSource = [[ASIGListAdapterBasedDataSource alloc] initWithListAdapter:self collectionDelegate:collectionNode.delegate];
   objc_setAssociatedObject(self, _cmd, dataSource, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
   // Attach the data source to the collection node.

--- a/Source/Private/ASIGListAdapterBasedDataSource.h
+++ b/Source/Private/ASIGListAdapterBasedDataSource.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED
 @interface ASIGListAdapterBasedDataSource : NSObject <ASCollectionDataSourceInterop, ASCollectionDelegateInterop, ASCollectionDelegateFlowLayout>
 
-- (instancetype)initWithListAdapter:(IGListAdapter *)listAdapter;
+- (instancetype)initWithListAdapter:(IGListAdapter *)listAdapter collectionDelegate:(nullable id<ASCollectionDelegate>)collectionDelegate;
 
 @end
 

--- a/Source/Private/ASIGListAdapterBasedDataSource.mm
+++ b/Source/Private/ASIGListAdapterBasedDataSource.mm
@@ -38,6 +38,7 @@ typedef struct {
 @property (nonatomic, weak, readonly) IGListAdapter *listAdapter;
 @property (nonatomic, readonly) id<UICollectionViewDelegateFlowLayout> delegate;
 @property (nonatomic, readonly) id<UICollectionViewDataSource> dataSource;
+@property (nonatomic, weak, readonly) id<ASCollectionDelegate> collectionDelegate;
 
 /**
  * The section controller that we will forward beginBatchFetchWithContext: to.
@@ -52,7 +53,7 @@ typedef struct {
 
 @implementation ASIGListAdapterBasedDataSource
 
-- (instancetype)initWithListAdapter:(IGListAdapter *)listAdapter
+- (instancetype)initWithListAdapter:(IGListAdapter *)listAdapter collectionDelegate:(nullable id<ASCollectionDelegate>)collectionDelegate
 {
   if (self = [super init]) {
 #if IG_LIST_COLLECTION_VIEW
@@ -63,6 +64,7 @@ typedef struct {
     ASDisplayNodeAssert([listAdapter conformsToProtocol:@protocol(UICollectionViewDataSource)], @"Expected IGListAdapter to conform to UICollectionViewDataSource.");
     ASDisplayNodeAssert([listAdapter conformsToProtocol:@protocol(UICollectionViewDelegateFlowLayout)], @"Expected IGListAdapter to conform to UICollectionViewDelegateFlowLayout.");
     _listAdapter = listAdapter;
+    _collectionDelegate = collectionDelegate;
   }
   return self;
 }
@@ -114,6 +116,10 @@ typedef struct {
 
 - (BOOL)shouldBatchFetchForCollectionNode:(ASCollectionNode *)collectionNode
 {
+  if ([_collectionDelegate respondsToSelector:@selector(shouldBatchFetchForCollectionNode:)]) {
+    return [_collectionDelegate shouldBatchFetchForCollectionNode:collectionNode];
+  }
+
   NSInteger sectionCount = [self numberOfSectionsInCollectionNode:collectionNode];
   if (sectionCount == 0) {
     return NO;
@@ -131,6 +137,10 @@ typedef struct {
 
 - (void)collectionNode:(ASCollectionNode *)collectionNode willBeginBatchFetchWithContext:(ASBatchContext *)context
 {
+  if ([_collectionDelegate respondsToSelector:@selector(collectionNode:willBeginBatchFetchWithContext:)]) {
+    [_collectionDelegate collectionNode:collectionNode willBeginBatchFetchWithContext:context];
+    return;
+  }
   ASIGSectionController *ctrl = self.sectionControllerForBatchFetching;
   self.sectionControllerForBatchFetching = nil;
   [ctrl beginBatchFetchWithContext:context];
@@ -207,6 +217,11 @@ typedef struct {
   return [[self sectionControllerForSection:indexPath.section] nodeBlockForItemAtIndex:indexPath.item];
 }
 
+- (ASCellNode *)collectionNode:(ASCollectionNode *)collectionNode nodeForItemAtIndexPath:(NSIndexPath *)indexPath
+{
+  return [[self sectionControllerForSection:indexPath.section] nodeForItemAtIndex:indexPath.item];
+}
+
 - (ASSizeRange)collectionNode:(ASCollectionNode *)collectionNode constrainedSizeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   ASIGSectionController *ctrl = [self sectionControllerForSection:indexPath.section];
@@ -220,6 +235,11 @@ typedef struct {
 - (ASCellNodeBlock)collectionNode:(ASCollectionNode *)collectionNode nodeBlockForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
 {
   return [[self supplementaryElementSourceForSection:indexPath.section] nodeBlockForSupplementaryElementOfKind:kind atIndex:indexPath.item];
+}
+
+- (ASCellNode *)collectionNode:(ASCollectionNode *)collectionNode nodeForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
+{
+  return [[self supplementaryElementSourceForSection:indexPath.section] nodeForSupplementaryElementOfKind:kind atIndex:indexPath.item];
 }
 
 - (NSArray<NSString *> *)collectionNode:(ASCollectionNode *)collectionNode supplementaryElementKindsInSection:(NSInteger)section

--- a/Source/Private/ASIGListAdapterBasedDataSource.mm
+++ b/Source/Private/ASIGListAdapterBasedDataSource.mm
@@ -141,6 +141,7 @@ typedef struct {
     [_collectionDelegate collectionNode:collectionNode willBeginBatchFetchWithContext:context];
     return;
   }
+  
   ASIGSectionController *ctrl = self.sectionControllerForBatchFetching;
   self.sectionControllerForBatchFetching = nil;
   [ctrl beginBatchFetchWithContext:context];

--- a/Source/Private/_ASHierarchyChangeSet.h
+++ b/Source/Private/_ASHierarchyChangeSet.h
@@ -113,6 +113,9 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType);
 /// Indicates whether the change set is empty, that is it includes neither reload data nor per item or section changes.
 @property (nonatomic, readonly) BOOL isEmpty;
 
+/// The count of new ASCellNodes that can undergo async layout calculation. May be zero if all UIKit passthrough cells.
+@property (nonatomic, assign) NSUInteger countForAsyncLayout;
+
 /// The top-level activity for this update.
 @property (nonatomic, OS_ACTIVITY_NULLABLE) os_activity_t rootActivity;
 

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -119,6 +119,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 @end
 
 @implementation _ASHierarchyChangeSet {
+  NSUInteger _countForAsyncLayout;
   std::vector<NSInteger> _oldItemCounts;
   std::vector<NSInteger> _newItemCounts;
   void (^_completionHandler)(BOOL finished);
@@ -127,6 +128,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 @synthesize reverseSectionMapping = _reverseSectionMapping;
 @synthesize itemMappings = _itemMappings;
 @synthesize reverseItemMappings = _reverseItemMappings;
+@synthesize countForAsyncLayout = _countForAsyncLayout;
 
 - (instancetype)init
 {

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -1049,6 +1049,7 @@
   UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   ASCollectionViewTestController *testController = [[ASCollectionViewTestController alloc] initWithNibName:nil bundle:nil];
   ASCollectionNode *cn = testController.collectionNode;
+  cn.cellLayoutMode = ASCellLayoutModeAlwaysAsync;
   [cn setTuningParameters:{ .leadingBufferScreenfuls = 2, .trailingBufferScreenfuls = 0 } forRangeMode:ASLayoutRangeModeMinimum rangeType:ASLayoutRangeTypePreload];
   window.rootViewController = testController;
 

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -163,6 +163,7 @@
 @interface ASCollectionView (InternalTesting)
 
 - (NSArray<NSString *> *)dataController:(ASDataController *)dataController supplementaryNodeKindsInSections:(NSIndexSet *)sections;
+- (BOOL)dataController:(ASDataController *)dataController shouldSynchronouslyProcessChangeSet:(_ASHierarchyChangeSet *)changeSet;
 
 @end
 
@@ -1046,25 +1047,42 @@
 
 - (void)testInitialRangeBounds
 {
+  [self testInitialRangeBoundsWithCellLayoutMode:ASCellLayoutModeNone];
+}
+
+- (void)testInitialRangeBoundsCellLayoutModeAlwaysAsync
+{
+  [self testInitialRangeBoundsWithCellLayoutMode:ASCellLayoutModeAlwaysAsync];
+}
+
+- (void)testInitialRangeBoundsWithCellLayoutMode:(ASCellLayoutMode)cellLayoutMode
+{
   UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   ASCollectionViewTestController *testController = [[ASCollectionViewTestController alloc] initWithNibName:nil bundle:nil];
   ASCollectionNode *cn = testController.collectionNode;
-  cn.cellLayoutMode = ASCellLayoutModeAlwaysAsync;
+  cn.cellLayoutMode = cellLayoutMode;
   [cn setTuningParameters:{ .leadingBufferScreenfuls = 2, .trailingBufferScreenfuls = 0 } forRangeMode:ASLayoutRangeModeMinimum rangeType:ASLayoutRangeTypePreload];
   window.rootViewController = testController;
+
+  [testController.collectionNode.collectionViewLayout invalidateLayout];
+  [testController.collectionNode.collectionViewLayout prepareLayout];
 
   [window makeKeyAndVisible];
   // Trigger the initial reload to start 
   [window layoutIfNeeded];
 
-  // Test the APIs that monitor ASCollectionNode update handling
-  XCTAssertTrue(cn.isProcessingUpdates, @"ASCollectionNode should still be processing updates after initial layoutIfNeeded call (reloadData)");
-  [cn onDidFinishProcessingUpdates:^{
-    XCTAssertTrue(!cn.isProcessingUpdates, @"ASCollectionNode should no longer be processing updates inside -onDidFinishProcessingUpdates: block");
-  }];
+  // Test the APIs that monitor ASCollectionNode update handling if collection node should
+  // layout asynchronously
+  if (![cn.view dataController:nil shouldSynchronouslyProcessChangeSet:nil]) {
+    XCTAssertTrue(cn.isProcessingUpdates, @"ASCollectionNode should still be processing updates after initial layoutIfNeeded call (reloadData)");
 
-  // Wait for ASDK reload to finish
-  [cn waitUntilAllUpdatesAreProcessed];
+    [cn onDidFinishProcessingUpdates:^{
+      XCTAssertTrue(!cn.isProcessingUpdates, @"ASCollectionNode should no longer be processing updates inside -onDidFinishProcessingUpdates: block");
+    }];
+
+    // Wait for ASDK reload to finish
+    [cn waitUntilAllUpdatesAreProcessed];
+  }
 
   XCTAssertTrue(!cn.isProcessingUpdates, @"ASCollectionNode should no longer be processing updates after -wait call");
 


### PR DESCRIPTION
`ASCellLayoutMode`s  are flexible settings for applications to improve the flexibility of integrating Texture within an app. 
Providing this mode allows for developers to debug potential issues or work towards resolving technical debt in their collection view data source, while ramping up asynchronous collection layout.