### PR TITLE
Disable a11y cache

### DIFF
--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -25,6 +25,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalFramesetterCache = 1 << 7,                  // exp_framesetter_cache
   ASExperimentalClearDataDuringDeallocation = 1 << 8,       // exp_clear_data_during_deallocation
   ASExperimentalDidEnterPreloadSkipASMLayout = 1 << 9,      // exp_did_enter_preload_skip_asm_layout
+  ASExperimentalDisableAccessibilityCache = 1 << 10,        // exp_disable_a11y_cache
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -21,7 +21,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_collection_teardown",
                                       @"exp_framesetter_cache",
                                       @"exp_clear_data_during_deallocation",
-                                      @"exp_did_enter_preload_skip_asm_layout"]));
+                                      @"exp_did_enter_preload_skip_asm_layout",
+                                      @"exp_disable_a11y_cache"]));
   
   if (flags == ASExperimentalFeatureAll) {
     return allNames;

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -273,7 +273,8 @@ static void CollectAccessibilityElementsForView(UIView *view, NSMutableArray *el
   if (viewNode == nil) {
     return @[];
   }
-  if (_accessibilityElements == nil) {
+
+  if (_accessibilityElements == nil || ASActivateExperimentalFeature(ASExperimentalDisableAccessibilityCache)) {
     _accessibilityElements = [viewNode accessibilityElements];
   }
   return _accessibilityElements;

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -22,7 +22,8 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalCollectionTeardown,
   ASExperimentalFramesetterCache,
   ASExperimentalClearDataDuringDeallocation,
-  ASExperimentalDidEnterPreloadSkipASMLayout
+  ASExperimentalDidEnterPreloadSkipASMLayout,
+  ASExperimentalDisableAccessibilityCache
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -45,6 +46,7 @@ static ASExperimentalFeatures features[] = {
     @"exp_framesetter_cache",
     @"exp_clear_data_during_deallocation",
     @"exp_did_enter_preload_skip_asm_layout",
+    @"exp_disable_a11y_cache"
   ];
 }
 

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -23,7 +23,8 @@
 
 @implementation ASDisplayViewAccessibilityTests
 
-- (void)setUp {
+- (void)setUp
+{
   ASConfiguration *config = [[ASConfiguration alloc] initWithDictionary:nil];
   config.experimentalFeatures = ASExperimentalDisableAccessibilityCache;
   [ASConfigurationManager test_resetWithConfiguration:config];
@@ -48,7 +49,8 @@
   XCTAssertEqual([node.view indexOfAccessibilityElement:node.view.accessibilityElements.firstObject], 0);*/
 }
 
-- (void)testThatSubnodeAccessibilityLabelAggregationWorks {
+- (void)testThatSubnodeAccessibilityLabelAggregationWorks
+{
   // Setup nodes
   ASDisplayNode *node = nil;
   ASDisplayNode *innerNode1 = nil;
@@ -71,7 +73,8 @@
                         [node.view.accessibilityElements.firstObject accessibilityLabel]);
 }
 
-- (void)testThatContainerAccessibilityLabelOverrideStopsAggregation {
+- (void)testThatContainerAccessibilityLabelOverrideStopsAggregation
+{
   // Setup nodes
   ASDisplayNode *node = nil;
   ASDisplayNode *innerNode = nil;
@@ -127,7 +130,9 @@
   NSArray<UIAccessibilityElement *> *updatedElements2 = contianer.view.accessibilityElements;
   XCTAssertTrue([[updatedElements2.firstObject accessibilityLabel] isEqualToString:@"hello, world, !!!!"]);
 }
-- (void)testAccessibilityNonLayerbackedNodesOperationInContainer {
+
+- (void)testAccessibilityNonLayerbackedNodesOperationInContainer
+{
   ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
   contianer.frame = CGRectMake(50, 50, 200, 600);
   contianer.backgroundColor = [UIColor grayColor];
@@ -160,7 +165,9 @@
   NSArray<UIAccessibilityElement *> *updatedElements2 = contianer.view.accessibilityElements;
   XCTAssertTrue([[updatedElements2.firstObject accessibilityLabel] isEqualToString:@"hello, world, !!!!"]);
 }
-- (void)testAccessibilityNonLayerbackedNodesOperationInNonContainer {
+
+- (void)testAccessibilityNonLayerbackedNodesOperationInNonContainer
+{
   ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
   contianer.frame = CGRectMake(50, 50, 200, 600);
   contianer.backgroundColor = [UIColor grayColor];
@@ -196,7 +203,8 @@
   XCTAssertTrue([[updatedElements2.firstObject accessibilityLabel] isEqualToString:@"hello"]);
   XCTAssertTrue([[updatedElements2.lastObject accessibilityLabel] isEqualToString:@"world"]);
 }
-- (void)testAccessibilityLayerbackedNodesOperationInNonContainer {
+- (void)testAccessibilityLayerbackedNodesOperationInNonContainer
+{
   ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
   contianer.frame = CGRectMake(50, 50, 200, 600);
   contianer.backgroundColor = [UIColor grayColor];
@@ -236,7 +244,8 @@
   XCTAssertTrue([[updatedElements2.lastObject accessibilityLabel] isEqualToString:@"world"]);
 }
 
-- (void)testAccessibilityUpdatesWithElementsChanges {
+- (void)testAccessibilityUpdatesWithElementsChanges
+{
   ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
   contianer.frame = CGRectMake(50, 50, 200, 600);
   contianer.backgroundColor = [UIColor grayColor];

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -14,11 +14,20 @@
 
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
+#import <AsyncDisplayKit/ASTextNode.h>
+#import "ASConfiguration.h"
+#import "ASConfigurationInternal.h"
 
 @interface ASDisplayViewAccessibilityTests : XCTestCase
 @end
 
 @implementation ASDisplayViewAccessibilityTests
+
+- (void)setUp {
+  ASConfiguration *config = [[ASConfiguration alloc] initWithDictionary:nil];
+  config.experimentalFeatures = ASExperimentalDisableAccessibilityCache;
+  [ASConfigurationManager test_resetWithConfiguration:config];
+}
 
 - (void)testAccessibilityElementsAccessors
 {
@@ -80,6 +89,175 @@
   XCTAssertEqualObjects([node.view.accessibilityElements.firstObject accessibilityLabel], @"hello",
                         @"Container accessibility label override broken %@",
                         [node.view.accessibilityElements.firstObject accessibilityLabel]);
+}
+
+- (void)testAccessibilityLayerbackedNodesOperationInContainer {
+  ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
+  contianer.frame = CGRectMake(50, 50, 200, 400);
+  contianer.backgroundColor = [UIColor grayColor];
+  contianer.isAccessibilityContainer = YES;
+  // Do any additional setup after loading the view, typically from a nib.
+  ASTextNode *text1 = [[ASTextNode alloc] init];
+  text1.layerBacked = YES;
+  text1.attributedText = [[NSAttributedString alloc] initWithString:@"hello"];
+  text1.frame = CGRectMake(50, 100, 200, 200);
+  [contianer addSubnode:text1];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *elements = contianer.view.accessibilityElements;
+  XCTAssertTrue(elements.count == 1);
+  XCTAssertTrue([[elements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  ASTextNode *text2 = [[ASTextNode alloc] init];
+  text2.layerBacked = YES;
+  text2.attributedText = [[NSAttributedString alloc] initWithString:@"world"];
+  text2.frame = CGRectMake(50, 300, 200, 200);
+  [contianer addSubnode:text2];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements = contianer.view.accessibilityElements;
+  XCTAssertTrue(updatedElements.count == 1);
+  XCTAssertTrue([[updatedElements.firstObject accessibilityLabel] isEqualToString:@"hello, world"]);
+  ASTextNode *text3 = [[ASTextNode alloc] init];
+  text3.attributedText = [[NSAttributedString alloc] initWithString:@"!!!!"];
+  text3.frame = CGRectMake(50, 400, 200, 100);
+  text3.layerBacked = YES;
+  [text2 addSubnode:text3];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements2 = contianer.view.accessibilityElements;
+  XCTAssertTrue([[updatedElements2.firstObject accessibilityLabel] isEqualToString:@"hello, world, !!!!"]);
+}
+- (void)testAccessibilityNonLayerbackedNodesOperationInContainer {
+  ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
+  contianer.frame = CGRectMake(50, 50, 200, 600);
+  contianer.backgroundColor = [UIColor grayColor];
+  contianer.isAccessibilityContainer = YES;
+  // Do any additional setup after loading the view, typically from a nib.
+  ASTextNode *text1 = [[ASTextNode alloc] init];
+  text1.attributedText = [[NSAttributedString alloc] initWithString:@"hello"];
+  text1.frame = CGRectMake(50, 100, 200, 200);
+  [contianer addSubnode:text1];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *elements = contianer.view.accessibilityElements;
+  XCTAssertTrue(elements.count == 1);
+  XCTAssertTrue([[elements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  ASTextNode *text2 = [[ASTextNode alloc] init];
+  text2.attributedText = [[NSAttributedString alloc] initWithString:@"world"];
+  text2.frame = CGRectMake(50, 300, 200, 200);
+  [contianer addSubnode:text2];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements = contianer.view.accessibilityElements;
+  XCTAssertTrue(updatedElements.count == 1);
+  XCTAssertTrue([[updatedElements.firstObject accessibilityLabel] isEqualToString:@"hello, world"]);
+  ASTextNode *text3 = [[ASTextNode alloc] init];
+  text3.attributedText = [[NSAttributedString alloc] initWithString:@"!!!!"];
+  text3.frame = CGRectMake(50, 400, 200, 100);
+  [text2 addSubnode:text3];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements2 = contianer.view.accessibilityElements;
+  XCTAssertTrue([[updatedElements2.firstObject accessibilityLabel] isEqualToString:@"hello, world, !!!!"]);
+}
+- (void)testAccessibilityNonLayerbackedNodesOperationInNonContainer {
+  ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
+  contianer.frame = CGRectMake(50, 50, 200, 600);
+  contianer.backgroundColor = [UIColor grayColor];
+  // Do any additional setup after loading the view, typically from a nib.
+  ASTextNode *text1 = [[ASTextNode alloc] init];
+  text1.attributedText = [[NSAttributedString alloc] initWithString:@"hello"];
+  text1.frame = CGRectMake(50, 100, 200, 200);
+  [contianer addSubnode:text1];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *elements = contianer.view.accessibilityElements;
+  XCTAssertTrue(elements.count == 1);
+  XCTAssertTrue([[elements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  ASTextNode *text2 = [[ASTextNode alloc] init];
+  text2.attributedText = [[NSAttributedString alloc] initWithString:@"world"];
+  text2.frame = CGRectMake(50, 300, 200, 200);
+  [contianer addSubnode:text2];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements = contianer.view.accessibilityElements;
+  XCTAssertTrue(updatedElements.count == 2);
+  XCTAssertTrue([[updatedElements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  XCTAssertTrue([[updatedElements.lastObject accessibilityLabel] isEqualToString:@"world"]);
+  ASTextNode *text3 = [[ASTextNode alloc] init];
+  text3.attributedText = [[NSAttributedString alloc] initWithString:@"!!!!"];
+  text3.frame = CGRectMake(50, 400, 200, 100);
+  [text2 addSubnode:text3];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements2 = contianer.view.accessibilityElements;
+  //text3 won't be read out cause it's overshadowed by text2
+  XCTAssertTrue(updatedElements2.count == 2);
+  XCTAssertTrue([[updatedElements2.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  XCTAssertTrue([[updatedElements2.lastObject accessibilityLabel] isEqualToString:@"world"]);
+}
+- (void)testAccessibilityLayerbackedNodesOperationInNonContainer {
+  ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
+  contianer.frame = CGRectMake(50, 50, 200, 600);
+  contianer.backgroundColor = [UIColor grayColor];
+  // Do any additional setup after loading the view, typically from a nib.
+  ASTextNode *text1 = [[ASTextNode alloc] init];
+  text1.layerBacked = YES;
+  text1.attributedText = [[NSAttributedString alloc] initWithString:@"hello"];
+  text1.frame = CGRectMake(50, 0, 100, 100);
+  [contianer addSubnode:text1];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *elements = contianer.view.accessibilityElements;
+  XCTAssertTrue(elements.count == 1);
+  XCTAssertTrue([[elements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  ASTextNode *text2 = [[ASTextNode alloc] init];
+  text2.layerBacked = YES;
+  text2.attributedText = [[NSAttributedString alloc] initWithString:@"world"];
+  text2.frame = CGRectMake(50, 100, 100, 100);
+  [contianer addSubnode:text2];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements = contianer.view.accessibilityElements;
+  XCTAssertTrue(updatedElements.count == 2);
+  XCTAssertTrue([[updatedElements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  XCTAssertTrue([[updatedElements.lastObject accessibilityLabel] isEqualToString:@"world"]);
+  ASTextNode *text3 = [[ASTextNode alloc] init];
+  text3.layerBacked = YES;
+  text3.attributedText = [[NSAttributedString alloc] initWithString:@"!!!!"];
+  text3.frame = CGRectMake(50, 200, 100, 100);
+  [text2 addSubnode:text3];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *updatedElements2 = contianer.view.accessibilityElements;
+  //text3 won't be read out cause it's overshadowed by text2
+  XCTAssertTrue(updatedElements2.count == 2);
+  XCTAssertTrue([[updatedElements2.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  XCTAssertTrue([[updatedElements2.lastObject accessibilityLabel] isEqualToString:@"world"]);
+}
+
+- (void)testAccessibilityUpdatesWithElementsChanges {
+  ASDisplayNode *contianer = [[ASDisplayNode alloc] init];
+  contianer.frame = CGRectMake(50, 50, 200, 600);
+  contianer.backgroundColor = [UIColor grayColor];
+  contianer.isAccessibilityContainer = YES;
+  // Do any additional setup after loading the view, typically from a nib.
+  ASTextNode *text1 = [[ASTextNode alloc] init];
+  text1.layerBacked = YES;
+  text1.attributedText = [[NSAttributedString alloc] initWithString:@"hello"];
+  text1.frame = CGRectMake(50, 0, 100, 100);
+  [contianer addSubnode:text1];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *elements = contianer.view.accessibilityElements;
+  XCTAssertTrue(elements.count == 1);
+  XCTAssertTrue([[elements.firstObject accessibilityLabel] isEqualToString:@"hello"]);
+  text1.attributedText = [[NSAttributedString alloc] initWithString:@"greeting"];
+  [contianer layoutIfNeeded];
+  [contianer.layer displayIfNeeded];
+  NSArray<UIAccessibilityElement *> *elements2 = contianer.view.accessibilityElements;
+  XCTAssertTrue(elements2.count == 1);
+  XCTAssertTrue([[elements2.firstObject accessibilityLabel] isEqualToString:@"greeting"]);
 }
 
 @end


### PR DESCRIPTION
Disable because a11y not update correctly as layer backed nodes inserted/removed/updated. 
A few other case will fail otherwise as shown in tests. 

Fixes:  #1161
Attempt to invalidate a11y (instead of disable cache) code is here: https://github.com/TextureGroup/Texture/pull/1260 while does not seem worth the effort. 
