### PR TITLE
Correct unified-locking behavior

### DIFF
--- a/Source/ASNodeController+Beta.mm
+++ b/Source/ASNodeController+Beta.mm
@@ -43,7 +43,7 @@
 
 - (void)setupReferencesWithNode:(ASDisplayNode *)node
 {
-  ASLockScopeSelf();
+  ASDN::MutexLocker l(_nodeLock);
   if (_shouldInvertStrongReference) {
     // The node should own the controller; weak reference from controller to node.
     _weakNode = node;


### PR DESCRIPTION
Since `node` might be `nil` or change, we should use the `_nodeLock` when updating `node`
instead of trying to rely on the node's lock in this case.