### PR TITLE
Set automaticallyAdjustsContentOffset to ASTableView when view is load

### DIFF
--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -163,6 +163,7 @@
     view.allowsSelectionDuringEditing         = pendingState.allowsSelectionDuringEditing;
     view.allowsMultipleSelection              = pendingState.allowsMultipleSelection;
     view.allowsMultipleSelectionDuringEditing = pendingState.allowsMultipleSelectionDuringEditing;
+    view.automaticallyAdjustsContentOffset    = pendingState.automaticallyAdjustsContentOffset;
 
     UIEdgeInsets contentInset = pendingState.contentInset;
     if (!UIEdgeInsetsEqualToEdgeInsets(contentInset, UIEdgeInsetsZero)) {

--- a/Tests/ASTableViewTests.mm
+++ b/Tests/ASTableViewTests.mm
@@ -801,7 +801,7 @@
 - (void)testAutomaticallyAdjustingContentOffset
 {
   ASTableNode *node = [[ASTableNode alloc] initWithStyle:UITableViewStylePlain];
-  node.view.automaticallyAdjustsContentOffset = YES;
+  node.automaticallyAdjustsContentOffset = YES;
   node.bounds = CGRectMake(0, 0, 100, 100);
   ASTableViewFilledDataSource *ds = [[ASTableViewFilledDataSource alloc] init];
   node.dataSource = ds;


### PR DESCRIPTION
Before ASTableView is loaded, the property `automaticallyAdjustsContentOffset` is stored on `pendingState` but never set to view.
This PR may fix this issue #23.