### PR TITLE
Add a way to opt out of always-clear-data behavior in ASCollectionView and ASTableView

### DIFF
--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -22,7 +22,7 @@
                     "exp_dealloc_queue_v2",
                     "exp_collection_teardown",
                     "exp_framesetter_cache",
-                    "exp_clear_data_during_deallocation"
+                    "exp_skip_clear_data"
                 ]
     		}
 		}

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -581,10 +581,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 {
   ASDisplayNodeAssertMainThread();
 
-  if (_asyncDataSource == nil && _asyncDelegate == nil) {
-    if (! ASActivateExperimentalFeature(ASExperimentalSkipClearData)) {
-      [_dataController clearData];
-    }
+  if (_asyncDataSource == nil && _asyncDelegate == nil && !ASActivateExperimentalFeature(ASExperimentalSkipClearData)) {
+    [_dataController clearData];
   }
 }
 

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -581,9 +581,12 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 {
   ASDisplayNodeAssertMainThread();
 
-  if (_asyncDataSource == nil && _asyncDelegate == nil && _isDeallocating
+  if (_asyncDataSource == nil && _asyncDelegate == nil
       && ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
-    [_dataController clearData];
+    if (_isDeallocating) {
+      [_dataController clearData];
+    }
+    // We may want to test other cases in which clear data is needed.
   }
 }
 

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -581,12 +581,13 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 {
   ASDisplayNodeAssertMainThread();
 
-  if (_asyncDataSource == nil && _asyncDelegate == nil
-      && ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
-    if (_isDeallocating) {
-      [_dataController clearData];
+  if (_asyncDataSource == nil && _asyncDelegate == nil) {
+    if (ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
+      if (_isDeallocating) {
+        [_dataController clearData];
+      }
+      // We may want to test other cases in which clear data is needed.
     }
-    // We may want to test other cases in which clear data is needed.
   }
 }
 

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -581,15 +581,10 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 {
   ASDisplayNodeAssertMainThread();
 
-  if (_asyncDataSource == nil && _asyncDelegate == nil) {
-    if (ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
-      if (_isDeallocating) {
-        [_dataController clearData];          
-      }
-    } else {
-      [_dataController clearData];
-    }
-  }  
+  if (_asyncDataSource == nil && _asyncDelegate == nil && _isDeallocating
+      && ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
+    [_dataController clearData];
+  }
 }
 
 - (void)setCollectionViewLayout:(nonnull UICollectionViewLayout *)collectionViewLayout

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -582,11 +582,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   ASDisplayNodeAssertMainThread();
 
   if (_asyncDataSource == nil && _asyncDelegate == nil) {
-    if (ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
-      if (_isDeallocating) {
-        [_dataController clearData];
-      }
-      // We may want to test other cases in which clear data is needed.
+    if (! ASActivateExperimentalFeature(ASExperimentalSkipClearData)) {
+      [_dataController clearData];
     }
   }
 }

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -26,7 +26,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalNetworkImageQueue = 1 << 5,                 // exp_network_image_queue
   ASExperimentalCollectionTeardown = 1 << 6,                // exp_collection_teardown
   ASExperimentalFramesetterCache = 1 << 7,                  // exp_framesetter_cache
-  ASExperimentalClearDataDuringDeallocation = 1 << 8,       // exp_clear_data_during_deallocation
+  ASExperimentalSkipClearData = 1 << 8,                     // exp_skip_clear_data
   ASExperimentalDidEnterPreloadSkipASMLayout = 1 << 9,      // exp_did_enter_preload_skip_asm_layout
   ASExperimentalDisableAccessibilityCache = 1 << 10,        // exp_disable_a11y_cache
   ASExperimentalFeatureAll = 0xFFFFFFFF

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -20,7 +20,7 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_network_image_queue",
                                       @"exp_collection_teardown",
                                       @"exp_framesetter_cache",
-                                      @"exp_clear_data_during_deallocation",
+                                      @"exp_skip_clear_data",
                                       @"exp_did_enter_preload_skip_asm_layout",
                                       @"exp_disable_a11y_cache"]));
   

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -514,10 +514,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 {
   ASDisplayNodeAssertMainThread();
  
-  if (_asyncDataSource == nil && _asyncDelegate == nil) {
-    if (! ASActivateExperimentalFeature(ASExperimentalSkipClearData)) {
-      [_dataController clearData];
-    }
+  if (_asyncDataSource == nil && _asyncDelegate == nil && !ASActivateExperimentalFeature(ASExperimentalSkipClearData)) {
+    [_dataController clearData];
   }
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -514,9 +514,12 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 {
   ASDisplayNodeAssertMainThread();
  
-  if (_asyncDataSource == nil && _asyncDelegate == nil && _isDeallocating
+  if (_asyncDataSource == nil && _asyncDelegate == nil
       && ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
-    [_dataController clearData];
+    if (_isDeallocating) {
+      [_dataController clearData];
+    }
+    // We may want to test other cases in which clear data is needed.
   }
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -514,14 +514,9 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 {
   ASDisplayNodeAssertMainThread();
  
-  if (_asyncDataSource == nil && _asyncDelegate == nil) {
-    if (ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
-      if (_isDeallocating) {
-        [_dataController clearData];          
-      }
-    } else {
-      [_dataController clearData];
-    }
+  if (_asyncDataSource == nil && _asyncDelegate == nil && _isDeallocating
+      && ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
+    [_dataController clearData];
   }
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -514,12 +514,13 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 {
   ASDisplayNodeAssertMainThread();
  
-  if (_asyncDataSource == nil && _asyncDelegate == nil
-      && ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
-    if (_isDeallocating) {
-      [_dataController clearData];
+  if (_asyncDataSource == nil && _asyncDelegate == nil) {
+    if (ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
+      if (_isDeallocating) {
+        [_dataController clearData];
+      }
+      // We may want to test other cases in which clear data is needed.
     }
-    // We may want to test other cases in which clear data is needed.
   }
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -515,11 +515,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   ASDisplayNodeAssertMainThread();
  
   if (_asyncDataSource == nil && _asyncDelegate == nil) {
-    if (ASActivateExperimentalFeature(ASExperimentalClearDataDuringDeallocation)) {
-      if (_isDeallocating) {
-        [_dataController clearData];
-      }
-      // We may want to test other cases in which clear data is needed.
+    if (! ASActivateExperimentalFeature(ASExperimentalSkipClearData)) {
+      [_dataController clearData];
     }
   }
 }

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -24,7 +24,7 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalNetworkImageQueue,
   ASExperimentalCollectionTeardown,
   ASExperimentalFramesetterCache,
-  ASExperimentalClearDataDuringDeallocation,
+  ASExperimentalSkipClearData,
   ASExperimentalDidEnterPreloadSkipASMLayout,
   ASExperimentalDisableAccessibilityCache
 };
@@ -47,7 +47,7 @@ static ASExperimentalFeatures features[] = {
     @"exp_network_image_queue",
     @"exp_collection_teardown",
     @"exp_framesetter_cache",
-    @"exp_clear_data_during_deallocation",
+    @"exp_skip_clear_data",
     @"exp_did_enter_preload_skip_asm_layout",
     @"exp_disable_a11y_cache"
   ];


### PR DESCRIPTION
Through crashes in the past, we established that:
1. We can't clear data if the collection/table view is still being used. (#1155)
2. We may clear data during deallocation, and even so, we want to do it if user is in `ASExperimentalClearDataDuringDeallocation` experiment.

As such, the logic change introduced in #1200 is not correct. It causes `-clearData` to **always** be executed if user is not in the experiment (which is true by default).

<img width="1680" alt="screen shot 2018-12-13 at 9 41 24 pm" src="https://user-images.githubusercontent.com/587874/49985789-1a4c9e80-ff22-11e8-9f85-ab96051e30bf.png">

I suspect what you wanted to do is setting up an experiment and hook up with Texture. And even then, we need to fix the implementation of `clearData`. I'm seeing a crash in production (1st screenshot below) which looks like a memory issue when `self` (i.e the collection view) is gone and accessing the editing queue (i.e `self->_editingTransactionGroup`) after that is problematic (see 2nd screenshot).

<img width="1292" alt="screen shot 2018-12-13 at 10 16 37 pm" src="https://user-images.githubusercontent.com/587874/49986432-cdb69280-ff24-11e8-864a-e15c0f790935.png">

<img width="1680" alt="screen shot 2018-12-13 at 10 08 15 pm" src="https://user-images.githubusercontent.com/587874/49986451-e030cc00-ff24-11e8-8b66-b865f00275c0.png">

I think `clearData` needs to *avoid* calling `-waitUntilAllUpdatesAreProcessed` altogether. Instead, it needs to:
1. Destroy the editing queue.
2. Destroy the main serial queue.
3. Clear out the visible and pending maps.