### PR TITLE
Remove unnecessary dispatch_once calls.

### DIFF
--- a/Source/ASCellNode.mm
+++ b/Source/ASCellNode.mm
@@ -276,11 +276,7 @@
 
 + (BOOL)requestsVisibilityNotifications
 {
-  static NSCache<Class, NSNumber *> *cache;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    cache = [[NSCache alloc] init];
-  });
+  static NSCache<Class, NSNumber *> *cache = [[NSCache alloc] init];
   NSNumber *result = [cache objectForKey:self];
   if (result == nil) {
     BOOL overrides = ASSubclassOverridesSelector([ASCellNode class], self, @selector(cellNodeVisibilityEvent:inScrollView:withCellFrame:));

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -2322,13 +2322,9 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     // If we think we're going to animate, check if this node will prevent it.
     if (invalidationStyle == ASCollectionViewInvalidationStyleWithAnimation) {
       // TODO: Incorporate `shouldAnimateSizeChanges` into ASEnvironmentState for performance benefit.
-      static dispatch_once_t onceToken;
-      static BOOL (^shouldNotAnimateBlock)(ASDisplayNode *);
-      dispatch_once(&onceToken, ^{
-        shouldNotAnimateBlock = ^BOOL(ASDisplayNode * _Nonnull node) {
-          return (node.shouldAnimateSizeChanges == NO);
-        };
-      });
+      static BOOL (^shouldNotAnimateBlock)(ASDisplayNode *) = ^BOOL(ASDisplayNode * _Nonnull node) {
+        return (node.shouldAnimateSizeChanges == NO);
+      };
       if (ASDisplayNodeFindFirstNode(node, shouldNotAnimateBlock) != nil) {
         // One single non-animated node causes the whole layout update to be non-animated
         invalidationStyle = ASCollectionViewInvalidationStyleWithoutAnimation;

--- a/Source/ASConfigurationInternal.mm
+++ b/Source/ASConfigurationInternal.mm
@@ -24,11 +24,7 @@
 /// Return CFTypeRef to avoid retain/release on this singleton.
 + (CFTypeRef)sharedInstance
 {
-  static CFTypeRef inst;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    inst = (__bridge_retained CFTypeRef)[[ASConfigurationManager alloc] init];
-  });
+  static CFTypeRef inst = (__bridge_retained CFTypeRef)[[ASConfigurationManager alloc] init];
   return inst;
 }
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1695,11 +1695,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     if (visible) {
       for (int idx = 0; idx < NUM_CLIP_CORNER_LAYERS; idx++) {
         if (_clipCornerLayers[idx] == nil) {
-          static ASDisplayNodeCornerLayerDelegate *clipCornerLayers;
-          static dispatch_once_t onceToken;
-          dispatch_once(&onceToken, ^{
-            clipCornerLayers = [[ASDisplayNodeCornerLayerDelegate alloc] init];
-          });
+          static ASDisplayNodeCornerLayerDelegate *clipCornerLayers = [[ASDisplayNodeCornerLayerDelegate alloc] init];
           _clipCornerLayers[idx] = [[CALayer alloc] init];
           _clipCornerLayers[idx].zPosition = 99999;
           _clipCornerLayers[idx].delegate = clipCornerLayers;

--- a/Source/ASDisplayNodeExtras.mm
+++ b/Source/ASDisplayNodeExtras.mm
@@ -305,23 +305,13 @@ ASDisplayNode *ASDisplayNodeUltimateParentOfNode(ASDisplayNode *node)
 
 UIColor *ASDisplayNodeDefaultPlaceholderColor()
 {
-  static UIColor *defaultPlaceholderColor;
-
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    defaultPlaceholderColor = [UIColor colorWithWhite:0.95 alpha:1.0];
-  });
+  static UIColor *defaultPlaceholderColor = [UIColor colorWithWhite:0.95 alpha:1.0];
   return defaultPlaceholderColor;
 }
 
 UIColor *ASDisplayNodeDefaultTintColor()
 {
-  static UIColor *defaultTintColor;
-
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    defaultTintColor = [UIColor colorWithRed:0.0 green:0.478 blue:1.0 alpha:1.0];
-  });
+  static UIColor *defaultTintColor = [UIColor colorWithRed:0.0 green:0.478 blue:1.0 alpha:1.0];
   return defaultTintColor;
 }
 

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -436,11 +436,7 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 
 + (ASWeakMapEntry *)contentsForkey:(ASImageNodeContentsKey *)key drawParameters:(id)drawParameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelled
 {
-  static dispatch_once_t onceToken;
-  static ASDN::Mutex *cacheLock = nil;
-  dispatch_once(&onceToken, ^{
-    cacheLock = new ASDN::Mutex();
-  });
+  static ASDN::Mutex *cacheLock = new ASDN::Mutex();
   
   {
     ASDN::MutexLocker l(*cacheLock);

--- a/Source/ASMainThreadDeallocation.mm
+++ b/Source/ASMainThreadDeallocation.mm
@@ -65,11 +65,7 @@
  */
 + (NSValue * _Nonnull)_ivarsThatMayNeedMainDeallocation NS_RETURNS_RETAINED
 {
-  static NSCache<Class, NSValue *> *ivarsCache;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    ivarsCache = [[NSCache alloc] init];
-  });
+  static NSCache<Class, NSValue *> *ivarsCache = [[NSCache alloc] init];
   
   NSValue *result = [ivarsCache objectForKey:self];
   if (result != nil) {

--- a/Source/ASMapNode.mm
+++ b/Source/ASMapNode.mm
@@ -264,11 +264,7 @@
 
 + (UIImage *)defaultPinImageWithCenterOffset:(CGPoint *)centerOffset NS_RETURNS_RETAINED
 {
-  static MKAnnotationView *pin;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    pin = [[MKPinAnnotationView alloc] initWithAnnotation:nil reuseIdentifier:@""];
-  });
+  static MKAnnotationView *pin = [[MKPinAnnotationView alloc] initWithAnnotation:nil reuseIdentifier:@""];
   *centerOffset = pin.centerOffset;
   return pin.image;
 }

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -38,11 +38,7 @@ static void runLoopSourceCallback(void *info) {
 
 + (ASDeallocQueue *)sharedDeallocationQueue NS_RETURNS_RETAINED
 {
-  static ASDeallocQueue *deallocQueue = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    deallocQueue = [[ASDeallocQueue alloc] init];
-  });
+  static ASDeallocQueue *deallocQueue = [[ASDeallocQueue alloc] init];
   return deallocQueue;
 }
 
@@ -344,11 +340,7 @@ static int const kASASCATransactionQueueOrder = 1000000;
 
 + (ASCATransactionQueue *)sharedQueue NS_RETURNS_RETAINED
 {
-  static dispatch_once_t onceToken;
-  static ASCATransactionQueue *sharedQueue;
-  dispatch_once(&onceToken, ^{
-    sharedQueue = [[ASCATransactionQueue alloc] init];
-  });
+  static ASCATransactionQueue *sharedQueue = [[ASCATransactionQueue alloc] init];
   return sharedQueue;
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -47,11 +47,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 #define UITABLEVIEW_RESPONDS_TO_SELECTOR() \
   ({ \
-    static BOOL superResponds; \
-    static dispatch_once_t onceToken; \
-    dispatch_once(&onceToken, ^{ \
-      superResponds = [UITableView instancesRespondToSelector:_cmd]; \
-    }); \
+    static BOOL superResponds = [UITableView instancesRespondToSelector:_cmd]; \
     superResponds; \
   })
 

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -1168,11 +1168,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
 
 static NSAttributedString *DefaultTruncationAttributedString()
 {
-  static NSAttributedString *defaultTruncationAttributedString;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    defaultTruncationAttributedString = [[NSAttributedString alloc] initWithString:NSLocalizedString(@"\u2026", @"Default truncation string")];
-  });
+  static NSAttributedString *defaultTruncationAttributedString = [[NSAttributedString alloc] initWithString:NSLocalizedString(@"\u2026", @"Default truncation string")];
   return defaultTruncationAttributedString;
 }
 
@@ -1344,13 +1340,8 @@ static NSAttributedString *DefaultTruncationAttributedString()
 #if AS_TEXTNODE_RECORD_ATTRIBUTED_STRINGS
 + (void)_registerAttributedText:(NSAttributedString *)str
 {
-  static NSMutableArray *array;
-  static NSLock *lock;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    lock = [NSLock new];
-    array = [NSMutableArray new];
-  });
+  static NSMutableArray *array = [NSMutableArray new];
+  static NSLock *lock = [NSLock new];
   [lock lock];
   [array addObject:str];
   if (array.count % 20 == 0) {

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -54,13 +54,8 @@
  * NOTE: Be careful to copy `text` if needed.
  */
 static NS_RETURNS_RETAINED ASTextLayout *ASTextNodeCompatibleLayoutWithContainerAndText(ASTextContainer *container, NSAttributedString *text)  {
-  static dispatch_once_t onceToken;
-  static ASDN::Mutex *layoutCacheLock;
-  static NSCache<NSAttributedString *, ASTextCacheValue *> *textLayoutCache;
-  dispatch_once(&onceToken, ^{
-    layoutCacheLock = new ASDN::Mutex();
-    textLayoutCache = [[NSCache alloc] init];
-  });
+  static ASDN::Mutex *layoutCacheLock = new ASDN::Mutex();
+  static NSCache<NSAttributedString *, ASTextCacheValue *> *textLayoutCache = [[NSCache alloc] init];
 
   layoutCacheLock->lock();
 
@@ -1071,11 +1066,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
 static NSAttributedString *DefaultTruncationAttributedString()
 {
-  static NSAttributedString *defaultTruncationAttributedString;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    defaultTruncationAttributedString = [[NSAttributedString alloc] initWithString:NSLocalizedString(@"\u2026", @"Default truncation string")];
-  });
+  static NSAttributedString *defaultTruncationAttributedString = [[NSAttributedString alloc] initWithString:NSLocalizedString(@"\u2026", @"Default truncation string")];
   return defaultTruncationAttributedString;
 }
 
@@ -1272,13 +1263,8 @@ static NSAttributedString *DefaultTruncationAttributedString()
 #if AS_TEXTNODE2_RECORD_ATTRIBUTED_STRINGS
 + (void)_registerAttributedText:(NSAttributedString *)str
 {
-  static NSMutableArray *array;
-  static NSLock *lock;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    lock = [NSLock new];
-    array = [NSMutableArray new];
-  });
+  static NSMutableArray *array = [NSMutableArray new];
+  static NSLock *lock = [NSLock new];
   [lock lock];
   [array addObject:str];
   if (array.count % 20 == 0) {

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -151,11 +151,7 @@
 #endif
 
 #define ASCreateOnce(expr) ({ \
-  static dispatch_once_t onceToken; \
-  static __typeof__(expr) staticVar; \
-  dispatch_once(&onceToken, ^{ \
-    staticVar = expr; \
-  }); \
+  static __typeof__(expr) staticVar = expr; \
   staticVar; \
 })
 

--- a/Source/Details/ASBasicImageDownloader.mm
+++ b/Source/Details/ASBasicImageDownloader.mm
@@ -41,11 +41,7 @@ static NSMutableDictionary *currentRequests = nil;
 
 + (ASDN::Mutex *)currentRequestLock
 {
-  static dispatch_once_t onceToken;
-  static ASDN::Mutex *currentRequestsLock;
-  dispatch_once(&onceToken, ^{
-    currentRequestsLock = new ASDN::Mutex();
-  });
+  static ASDN::Mutex *currentRequestsLock = new ASDN::Mutex();
   return currentRequestsLock;
 }
 
@@ -208,11 +204,7 @@ static const char *kContextKey = NSStringFromClass(ASBasicImageDownloaderContext
 
 + (ASBasicImageDownloader *)sharedImageDownloader
 {
-  static ASBasicImageDownloader *sharedImageDownloader = nil;
-  static dispatch_once_t once = 0;
-  dispatch_once(&once, ^{
-    sharedImageDownloader = [[ASBasicImageDownloader alloc] _init];
-  });
+  static ASBasicImageDownloader *sharedImageDownloader = [[ASBasicImageDownloader alloc] _init];
   return sharedImageDownloader;
 }
 

--- a/Source/Details/ASEventLog.mm
+++ b/Source/Details/ASEventLog.mm
@@ -28,11 +28,7 @@
  */
 + (NSCache<ASEventLog *, NSMutableArray<ASTraceEvent *> *> *)contentsCache
 {
-  static NSCache *cache;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    cache = [[NSCache alloc] init];
-  });
+  static NSCache *cache = [[NSCache alloc] init];
   return cache;
 }
 

--- a/Source/Details/ASPINRemoteImageDownloader.mm
+++ b/Source/Details/ASPINRemoteImageDownloader.mm
@@ -182,11 +182,7 @@ static dispatch_once_t shared_init_predicate;
 
 - (BOOL)sharedImageManagerSupportsMemoryRemoval
 {
-  static BOOL sharedImageManagerSupportsMemoryRemoval = NO;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    sharedImageManagerSupportsMemoryRemoval = [[[self sharedPINRemoteImageManager] cache] respondsToSelector:@selector(removeObjectForKeyFromMemory:)];
-  });
+  static BOOL sharedImageManagerSupportsMemoryRemoval = [[[self sharedPINRemoteImageManager] cache] respondsToSelector:@selector(removeObjectForKeyFromMemory:)];
   return sharedImageManagerSupportsMemoryRemoval;
 }
 

--- a/Source/Details/ASPageTable.mm
+++ b/Source/Details/ASPageTable.mm
@@ -77,32 +77,19 @@ NSPointerArray *ASPageCoordinatesForPagesThatIntersectRect(CGRect rect, CGSize c
 
 + (instancetype)pageTableWithValuePointerFunctions:(NSPointerFunctions *)valueFuncs NS_RETURNS_RETAINED
 {
-  static NSPointerFunctions *pageCoordinatesFuncs;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    pageCoordinatesFuncs = [NSPointerFunctions pointerFunctionsWithOptions:NSPointerFunctionsIntegerPersonality | NSPointerFunctionsOpaqueMemory];
-  });
-  
+  static NSPointerFunctions *pageCoordinatesFuncs = [NSPointerFunctions pointerFunctionsWithOptions:NSPointerFunctionsIntegerPersonality | NSPointerFunctionsOpaqueMemory];
   return [[NSMapTable alloc] initWithKeyPointerFunctions:pageCoordinatesFuncs valuePointerFunctions:valueFuncs capacity:0];
 }
 
 + (ASPageTable *)pageTableForStrongObjectPointers NS_RETURNS_RETAINED
 {
-  static NSPointerFunctions *strongObjectPointerFuncs;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    strongObjectPointerFuncs = [NSPointerFunctions pointerFunctionsWithOptions:NSPointerFunctionsStrongMemory];
-  });
+  static NSPointerFunctions *strongObjectPointerFuncs = [NSPointerFunctions pointerFunctionsWithOptions:NSPointerFunctionsStrongMemory];
   return [self pageTableWithValuePointerFunctions:strongObjectPointerFuncs];
 }
 
 + (ASPageTable *)pageTableForWeakObjectPointers NS_RETURNS_RETAINED
 {
-  static NSPointerFunctions *weakObjectPointerFuncs;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    weakObjectPointerFuncs = [NSPointerFunctions pointerFunctionsWithOptions:NSPointerFunctionsWeakMemory];
-  });
+  static NSPointerFunctions *weakObjectPointerFuncs = [NSPointerFunctions pointerFunctionsWithOptions:NSPointerFunctionsWeakMemory];
   return [self pageTableWithValuePointerFunctions:weakObjectPointerFuncs];
 }
 

--- a/Source/Details/ASTraceEvent.mm
+++ b/Source/Details/ASTraceEvent.mm
@@ -23,12 +23,8 @@ static NSString *const ASTraceEventThreadDescriptionKey = @"ASThreadTraceEventDe
 {
   self = [super init];
   if (self != nil) {
-    static NSTimeInterval refTime;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      refTime = CACurrentMediaTime();
-    });
-    
+    static NSTimeInterval refTime = CACurrentMediaTime();
+
     // Create the format string passed to us.
     _message = [[NSString alloc] initWithFormat:format arguments:args];
 	  

--- a/Source/Details/NSArray+Diffing.mm
+++ b/Source/Details/NSArray+Diffing.mm
@@ -159,18 +159,11 @@ typedef BOOL (^compareBlock)(id _Nonnull lhs, id _Nonnull rhs);
   return common;
 }
 
-static compareBlock defaultCompare = nil;
-
 + (compareBlock)defaultCompareBlock
 {
-  static dispatch_once_t onceToken;
-
-  dispatch_once(&onceToken, ^{
-    defaultCompare = ^BOOL(id lhs, id rhs) {
-      return [lhs isEqual:rhs];
-    };
-  });
-
+  static compareBlock defaultCompare = ^BOOL(id lhs, id rhs) {
+    return [lhs isEqual:rhs];
+  };
   return defaultCompare;
 }
 

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -39,21 +39,17 @@ static void SortAccessibilityElements(NSMutableArray *elements)
 {
   ASDisplayNodeCAssertNotNil(elements, @"Should pass in a NSMutableArray");
   
-  static SortAccessibilityElementsComparator comparator = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-      comparator = ^NSComparisonResult(id<ASAccessibilityElementPositioning> a, id<ASAccessibilityElementPositioning> b) {
-        CGPoint originA = a.accessibilityFrame.origin;
-        CGPoint originB = b.accessibilityFrame.origin;
-        if (originA.y == originB.y) {
-          if (originA.x == originB.x) {
-            return NSOrderedSame;
-          }
-          return (originA.x < originB.x) ? NSOrderedAscending : NSOrderedDescending;
-        }
-        return (originA.y < originB.y) ? NSOrderedAscending : NSOrderedDescending;
-      };
-  });
+  static SortAccessibilityElementsComparator comparator = ^NSComparisonResult(id<ASAccessibilityElementPositioning> a, id<ASAccessibilityElementPositioning> b) {
+    CGPoint originA = a.accessibilityFrame.origin;
+    CGPoint originB = b.accessibilityFrame.origin;
+    if (originA.y == originB.y) {
+      if (originA.x == originB.x) {
+        return NSOrderedSame;
+      }
+      return (originA.x < originB.x) ? NSOrderedAscending : NSOrderedDescending;
+    }
+    return (originA.y < originB.y) ? NSOrderedAscending : NSOrderedDescending;
+  };
   [elements sortUsingComparator:comparator];
 }
 

--- a/Source/Layout/ASLayoutSpec+Subclasses.mm
+++ b/Source/Layout/ASLayoutSpec+Subclasses.mm
@@ -23,11 +23,7 @@
 
 + (ASNullLayoutSpec *)null
 {
-  static ASNullLayoutSpec *sharedNullLayoutSpec = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    sharedNullLayoutSpec = [[self alloc] init];
-  });
+  static ASNullLayoutSpec *sharedNullLayoutSpec = [[self alloc] init];
   return sharedNullLayoutSpec;
 }
 

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -140,14 +140,10 @@
   // If we pushed a transform, pop it by adding a display block that does nothing other than that.
   if (shouldDisplay) {
     // Since this block is pure, we can store it statically.
-    static dispatch_block_t popBlock;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      popBlock = ^{
-        CGContextRef context = UIGraphicsGetCurrentContext();
-        CGContextRestoreGState(context);
-      };
-    });
+    static dispatch_block_t popBlock = ^{
+      CGContextRef context = UIGraphicsGetCurrentContext();
+      CGContextRestoreGState(context);
+    };
     [displayBlocks addObject:popBlock];
   }
 }

--- a/Source/Private/ASIGListAdapterBasedDataSource.mm
+++ b/Source/Private/ASIGListAdapterBasedDataSource.mm
@@ -313,11 +313,7 @@ typedef struct {
 
 + (ASSupplementarySourceOverrides)overridesForSupplementarySourceClass:(Class)c
 {
-  static NSCache<Class, NSValue *> *cache;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    cache = [[NSCache alloc] init];
-  });
+  static NSCache<Class, NSValue *> *cache = [[NSCache alloc] init];
   NSValue *obj = [cache objectForKey:c];
   ASSupplementarySourceOverrides o;
   if (obj == nil) {
@@ -332,11 +328,7 @@ typedef struct {
 
 + (ASSectionControllerOverrides)overridesForSectionControllerClass:(Class)c
 {
-  static NSCache<Class, NSValue *> *cache;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    cache = [[NSCache alloc] init];
-  });
+  static NSCache<Class, NSValue *> *cache = [[NSCache alloc] init];
   NSValue *obj = [cache objectForKey:c];
   ASSectionControllerOverrides o;
   if (obj == nil) {

--- a/Source/Private/ASPendingStateController.mm
+++ b/Source/Private/ASPendingStateController.mm
@@ -40,10 +40,7 @@
 + (ASPendingStateController *)sharedInstance
 {
   static dispatch_once_t onceToken;
-  static ASPendingStateController *controller = nil;
-  dispatch_once(&onceToken, ^{
-    controller = [[ASPendingStateController alloc] init];
-  });
+  static ASPendingStateController *controller = [[ASPendingStateController alloc] init];
   return controller;
 }
 

--- a/Source/Private/ASTipProvider.mm
+++ b/Source/Private/ASTipProvider.mm
@@ -30,11 +30,7 @@
 
 + (NSArray<ASTipProvider *> *)all
 {
-  static NSArray<ASTipProvider *> *providers;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    providers = @[ [ASLayerBackingTipProvider new] ];
-  });
+  static NSArray<ASTipProvider *> *providers = @[ [ASLayerBackingTipProvider new] ];
   return providers;
 }
 

--- a/Source/Private/ASTipsController.mm
+++ b/Source/Private/ASTipsController.mm
@@ -47,11 +47,7 @@
 
 + (ASTipsController *)shared
 {
-  static ASTipsController *ctrl;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    ctrl = [[ASTipsController alloc] init];
-  });
+  static ASTipsController *ctrl = [[ASTipsController alloc] init];
   return ctrl;
 }
 

--- a/Source/Private/TextExperiment/Component/ASTextLayout.mm
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.mm
@@ -45,11 +45,7 @@ static inline UIEdgeInsets UIEdgeInsetRotateVertical(UIEdgeInsets insets) {
  attribute in iOS7. This should be a bug of CoreText, and may cause crash. Here's a workaround.
  */
 static CGColorRef ASTextGetCGColor(CGColorRef color) {
-  static UIColor *defaultColor;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    defaultColor = [UIColor blackColor];
-  });
+  static UIColor *defaultColor = [UIColor blackColor];
   if (!color) return defaultColor.CGColor;
   if ([((__bridge NSObject *)color) respondsToSelector:@selector(CGColor)]) {
     return ((__bridge UIColor *)color).CGColor;

--- a/Source/Private/TextExperiment/Utility/ASTextUtilities.mm
+++ b/Source/Private/TextExperiment/Utility/ASTextUtilities.mm
@@ -53,12 +53,7 @@ NSCharacterSet *ASTextVerticalFormRotateCharacterSet() {
 }
 
 NSCharacterSet *ASTextVerticalFormRotateAndMoveCharacterSet() {
-  static NSMutableCharacterSet *set;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    set = [NSMutableCharacterSet new];
-    [set addCharactersInString:@"，。、．"];
-  });
+  static NSCharacterSet *set = [NSCharacterSet characterSetWithCharactersInString:@"，。、．"];
   return set;
 }
 

--- a/Source/Private/TextExperiment/Utility/NSAttributedString+ASText.mm
+++ b/Source/Private/TextExperiment/Utility/NSAttributedString+ASText.mm
@@ -1191,17 +1191,13 @@ style. _attr_ = _attr_; \
 }
 
 + (NSArray *)as_allDiscontinuousAttributeKeys {
-  static NSArray *keys;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    keys = @[(id)kCTSuperscriptAttributeName,
-             (id)kCTRunDelegateAttributeName,
-             ASTextBackedStringAttributeName,
-             ASTextBindingAttributeName,
-             ASTextAttachmentAttributeName,
-             (id)kCTRubyAnnotationAttributeName,
-             NSAttachmentAttributeName];
-  });
+  static NSArray *keys = @[(id)kCTSuperscriptAttributeName,
+                           (id)kCTRunDelegateAttributeName,
+                           ASTextBackedStringAttributeName,
+                           ASTextBindingAttributeName,
+                           ASTextAttachmentAttributeName,
+                           (id)kCTRubyAnnotationAttributeName,
+                           NSAttachmentAttributeName];
   return keys;
 }
 

--- a/Source/TextKit/ASTextKitContext.mm
+++ b/Source/TextKit/ASTextKitContext.mm
@@ -34,11 +34,7 @@
 
 {
   if (self = [super init]) {
-    static dispatch_once_t onceToken;
-    static ASDN::Mutex *mutex;
-    dispatch_once(&onceToken, ^{
-      mutex = new ASDN::Mutex();
-    });
+    static ASDN::Mutex *mutex = new ASDN::Mutex();
     
     // Concurrently initialising TextKit components crashes (rdar://18448377) so we use a global lock.
     ASDN::MutexLocker l(*mutex);

--- a/Source/TextKit/ASTextKitCoreTextAdditions.mm
+++ b/Source/TextKit/ASTextKitCoreTextAdditions.mm
@@ -19,23 +19,19 @@
 #pragma mark - Public
 BOOL ASAttributeWithNameIsUnsupportedCoreTextAttribute(NSString *attributeName)
 {
-  static NSSet *coreTextAttributes;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    coreTextAttributes = [NSSet setWithObjects:(__bridge id)kCTForegroundColorAttributeName,
-                          kCTForegroundColorFromContextAttributeName,
-                          kCTForegroundColorAttributeName,
-                          kCTStrokeColorAttributeName,
-                          kCTUnderlineStyleAttributeName,
-                          kCTVerticalFormsAttributeName,
-                          kCTRunDelegateAttributeName,
-                          kCTBaselineClassAttributeName,
-                          kCTBaselineInfoAttributeName,
-                          kCTBaselineReferenceInfoAttributeName,
-                          kCTUnderlineColorAttributeName,
-                          kCTParagraphStyleAttributeName,
-                          nil];
-  });
+  static NSSet *coreTextAttributes = [NSSet setWithObjects:(__bridge id)kCTForegroundColorAttributeName,
+                                      kCTForegroundColorFromContextAttributeName,
+                                      kCTForegroundColorAttributeName,
+                                      kCTStrokeColorAttributeName,
+                                      kCTUnderlineStyleAttributeName,
+                                      kCTVerticalFormsAttributeName,
+                                      kCTRunDelegateAttributeName,
+                                      kCTBaselineClassAttributeName,
+                                      kCTBaselineInfoAttributeName,
+                                      kCTBaselineReferenceInfoAttributeName,
+                                      kCTUnderlineColorAttributeName,
+                                      kCTParagraphStyleAttributeName,
+                                      nil];
   return [coreTextAttributes containsObject:attributeName];
 }
 

--- a/Source/TextKit/ASTextKitShadower.mm
+++ b/Source/TextKit/ASTextKitShadower.mm
@@ -42,11 +42,7 @@ static inline UIEdgeInsets _invertInsets(UIEdgeInsets insets)
   /**
    * For all cases where no shadow is drawn, we share this singleton shadower to save resources.
    */
-  static dispatch_once_t onceToken;
-  static ASTextKitShadower *sharedNonShadower;
-  dispatch_once(&onceToken, ^{
-    sharedNonShadower = [[ASTextKitShadower alloc] initWithShadowOffset:CGSizeZero shadowColor:nil shadowOpacity:0 shadowRadius:0];
-  });
+  static ASTextKitShadower *sharedNonShadower = [[ASTextKitShadower alloc] initWithShadowOffset:CGSizeZero shadowColor:nil shadowOpacity:0 shadowRadius:0];
 
   BOOL hasShadow = shadowOpacity > 0 && (shadowRadius > 0 || CGSizeEqualToSize(shadowOffset, CGSizeZero) == NO) && CGColorGetAlpha(shadowColor.CGColor) > 0;
   if (hasShadow == NO) {

--- a/Source/UIImage+ASConvenience.mm
+++ b/Source/UIImage+ASConvenience.mm
@@ -18,14 +18,10 @@
 
 UIImage *cachedImageNamed(NSString *imageName, UITraitCollection *traitCollection) NS_RETURNS_RETAINED
 {
-  static NSCache *imageCache = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    // Because NSCache responds to memory warnings, we do not need an explicit limit.
-    // all of these objects contain compressed image data and are relatively small
-    // compared to the backing stores of text and image views.
-    imageCache = [[NSCache alloc] init];
-  });
+  // Because NSCache responds to memory warnings, we do not need an explicit limit.
+  // all of these objects contain compressed image data and are relatively small
+  // compared to the backing stores of text and image views.
+  static NSCache *imageCache = [[NSCache alloc] init];
 
   UIImage *image = nil;
   if ([imageName length] > 0) {


### PR DESCRIPTION
Dispatch once is not necessary for most static variable initialization in C++.
C++ already guarantees static initialization safety.