### PR TITLE
Early exit editing transaction queue consumption during deallocation

### DIFF
--- a/Source/Details/ASDataController.h
+++ b/Source/Details/ASDataController.h
@@ -113,6 +113,19 @@ AS_EXTERN NSString * const ASCollectionInvalidUpdateException;
  */
 - (void)dataController:(ASDataController *)dataController updateWithChangeSet:(_ASHierarchyChangeSet *)changeSet updates:(dispatch_block_t)updates;
 
+/**
+ * Communicate to the child whether or not its parent is scheduled for deallocation.
+ *
+ * @discussion This is in response to a hard to reproduce crash where
+ * `performBatchUpdates` is sent on a valid pointer, however the internal UIKit
+ * collection view components such as _UICollectionViewData later reference a nil shared
+ * indexPath store during their many block invokes for a colleciton view update.
+ * This could be attributed the editingQueue still consuming its tasks
+ * while the collection view is being async deallocated. We want to early return
+ * at editing transation block invocation time since we can not destroy queued blocks;
+ */
+- (BOOL)isDeallocating;
+
 @end
 
 @protocol ASDataControllerLayoutDelegate <NSObject>


### PR DESCRIPTION
This is in response to a hard to reproduce crash where `performBatchUpdates` is sent on a valid pointer, however the internal UIKit collection view components such as _UICollectionViewData later reference a nil shared indexPath store during their many block invokes for a collection view update. Looking in hopper and fabric, these crashes are spread across many points in the _UICollectionView interfaces, but they all crash on using the indexPath as a key for a dictionary. This is what leads me to think that the indexPaths, which are referenced through to the parent _UICollectionView or _UICollectionViewData have been nilled, where there is still a long series of block invocations happening

This could be attributed the editingQueue still consuming its tasks while the collection view is being async deallocated. We want to early return at editing transation block invocation time since we can not destroy queued blocks.