### PR TITLE
Fixed truncation error for ASTextNode2.

### DIFF
--- a/Source/Private/TextExperiment/Component/ASTextLayout.mm
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.mm
@@ -850,25 +850,17 @@ dispatch_semaphore_signal(_lock);
                   [lastLineText insertAttributedString:truncationToken atIndex:0];
               }
           } else if (type == kCTLineTruncationMiddle) {
-              NSMutableAttributedString *tailText = [NSMutableAttributedString new];
-              while (atLeastOneLine < truncatedWidth && i < removedLines.count) {
-                  NSMutableAttributedString *nextLineText = [text attributedSubstringFromRange:removedLines[i].range].mutableCopy;
-                  if (nextLineText.length > 0 && [nextLineText.string characterAtIndex:nextLineText.string.length - 1] == '\n') { // Explicit newlines are always "long enough".
-                    [nextLineText deleteCharactersInRange:NSMakeRange(nextLineText.string.length - 1, 1)];
-                    break;
-                }
-                  [tailText insertAttributedString:nextLineText atIndex:0];
-                  atLeastOneLine += removedLines[i++].width;
+              i = (int)removedLines.count - 1;
+              while (i >= 0) {
+                  NSAttributedString *nextLineText = [text attributedSubstringFromRange:removedLines[i].range];
+                  [lastLineText appendAttributedString:nextLineText];
+                  atLeastOneLine += removedLines[i--].width;
               }
-              if (atLeastOneLine > truncatedWidth) {
-                  [lastLineText appendAttributedString:tailText];
-              } else {
-                  if (lastLineText.length > 0 && [lastLineText.string characterAtIndex:lastLineText.string.length - 1] == '\n') {
-                      [lastLineText deleteCharactersInRange:NSMakeRange(lastLineText.string.length - 1, 1)];
-                  }
+              if (atLeastOneLine <= truncatedWidth) {
+                  lastLineText = [text attributedSubstringFromRange:lastLine.range].mutableCopy;
                   // The result might be greater than truncatedWidth.
                   [lastLineText appendAttributedString:truncationToken];
-                  // We should set type to end which is likes UILabel's behavior.
+                  // We should set type to end which is like UILabel's behavior.
                   type = kCTLineTruncationEnd;
               }
           } else {

--- a/Source/Private/TextExperiment/Component/ASTextLayout.mm
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.mm
@@ -835,6 +835,7 @@ dispatch_semaphore_signal(_lock);
           }
           int i = 0;
           if (type == kCTLineTruncationStart) {
+              // If it is the start type, the last line is made up of the removed lines from the back to the front.
               atLeastOneLine = 0;
               lastLineText = [NSMutableAttributedString new];
               while (atLeastOneLine < truncatedWidth && i < removedLines.count) {
@@ -846,16 +847,21 @@ dispatch_semaphore_signal(_lock);
                   [lastLineText insertAttributedString:nextLineText atIndex:0];
                   atLeastOneLine += removedLines[i++].width;
               }
+              // If the last line width is not greater than truncatedWidth, we should insert truncationToken to head.
+              // Because the CTLineCreateTruncatedLine() method will do nothing.
               if (atLeastOneLine <= truncatedWidth) {
                   [lastLineText insertAttributedString:truncationToken atIndex:0];
               }
           } else if (type == kCTLineTruncationMiddle) {
+              // If it is the middle type, we do't known where is the middle position.
+              // So that the last line should add all removed lines and the CTLineCreateTruncatedLine() method make truncation correct.
               i = (int)removedLines.count - 1;
               while (i >= 0) {
                   NSAttributedString *nextLineText = [text attributedSubstringFromRange:removedLines[i].range];
                   [lastLineText appendAttributedString:nextLineText];
                   atLeastOneLine += removedLines[i--].width;
               }
+              // If the last line width is not greater than truncatedWidth, we can't make truncation is middle type.
               if (atLeastOneLine <= truncatedWidth) {
                   lastLineText = [text attributedSubstringFromRange:lastLine.range].mutableCopy;
                   // The result might be greater than truncatedWidth.
@@ -864,6 +870,7 @@ dispatch_semaphore_signal(_lock);
                   type = kCTLineTruncationEnd;
               }
           } else {
+              // If it is the end type, we simply add it to the end.
               [lastLineText appendAttributedString:truncationToken];
           }
 

--- a/Source/Private/TextExperiment/Component/ASTextLayout.mm
+++ b/Source/Private/TextExperiment/Component/ASTextLayout.mm
@@ -868,14 +868,8 @@ dispatch_semaphore_signal(_lock);
                   }
                   // The result might be greater than truncatedWidth.
                   [lastLineText appendAttributedString:truncationToken];
-                  CGRect lastLineBoundingRect = [lastLineText boundingRectWithSize:ASTextContainerMaxSize
-                                                                         options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
-                                                                         context:nil];
-                  CGFloat lastLineWidth = isVerticalForm ? CGRectGetHeight(lastLineBoundingRect) : CGRectGetWidth(lastLineBoundingRect);
-                  // If the result greater than truncatedWidth, we should set type to end.
-                  if (lastLineWidth > truncatedWidth) {
-                      type = kCTLineTruncationEnd;
-                  }
+                  // We should set type to end which is likes UILabel's behavior.
+                  type = kCTLineTruncationEnd;
               }
           } else {
               [lastLineText appendAttributedString:truncationToken];


### PR DESCRIPTION
I got a truncation error for Kittens sample.

An error occurred when I set the NSLineBreakMode to NSLineBreakByTruncatingMiddle. 

![simulator screen shot - iphone xr - 2018-12-20 at 19 15 08](https://user-images.githubusercontent.com/14258488/50288759-c7369680-04a1-11e9-9966-8d0a717b1937.png)
 