### PR TITLE
Move ASSectionController and ASSupplementaryNodeSource method to be optional

### DIFF
--- a/Source/ASSectionController.h
+++ b/Source/ASSectionController.h
@@ -16,12 +16,13 @@ NS_ASSUME_NONNULL_BEGIN
 @class ASBatchContext;
 
 /**
- * A protocol that your section controllers should conform to,
- * in order to be used with AsyncDisplayKit.
+ * A protocol that your section controllers should conform to, in order to be used with Texture.
  *
  * @note Your supplementary view source should conform to @c ASSupplementaryNodeSource.
  */
 @protocol ASSectionController <NSObject>
+
+@optional
 
 /**
  * A method to provide the node block for the item at the given index.
@@ -47,8 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
  *   this method is not called when the item is about to display.
  */
 - (ASCellNode *)nodeForItemAtIndex:(NSInteger)index;
-
-@optional
 
 /**
  * Asks the section controller whether it should batch fetch because the user is

--- a/Source/ASSupplementaryNodeSource.h
+++ b/Source/ASSupplementaryNodeSource.h
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ASSupplementaryNodeSource <NSObject>
 
+@optional
+
 /**
  * A method to provide the node-block for the supplementary element.
  *
@@ -32,8 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @param index The index of the item.
  */
 - (ASCellNode *)nodeForSupplementaryElementOfKind:(NSString *)kind atIndex:(NSInteger)index;
-
-@optional
 
 /**
  * A method to provide the size range used for measuring the supplementary

--- a/Source/Private/ASIGListAdapterBasedDataSource.mm
+++ b/Source/Private/ASIGListAdapterBasedDataSource.mm
@@ -215,12 +215,16 @@ typedef struct {
 
 - (ASCellNodeBlock)collectionNode:(ASCollectionNode *)collectionNode nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  return [[self sectionControllerForSection:indexPath.section] nodeBlockForItemAtIndex:indexPath.item];
+  ASIGSectionController *ctrl = [self sectionControllerForSection:indexPath.section];
+  ASDisplayNodeAssert([ctrl respondsToSelector:@selector(nodeBlockForItemAtIndex:)], @"Expected section controller to respond to to %@. Controller: %@", NSStringFromSelector(@selector(nodeBlockForItemAtIndex:)), ctrl);
+  return [ctrl nodeBlockForItemAtIndex:indexPath.item];
 }
 
 - (ASCellNode *)collectionNode:(ASCollectionNode *)collectionNode nodeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  return [[self sectionControllerForSection:indexPath.section] nodeForItemAtIndex:indexPath.item];
+  ASIGSectionController *ctrl = [self sectionControllerForSection:indexPath.section];
+  ASDisplayNodeAssert([ctrl respondsToSelector:@selector(nodeForItemAtIndex:)], @"Expected section controller to respond to to %@. Controller: %@", NSStringFromSelector(@selector(nodeForItemAtIndex:)), ctrl);
+  return [ctrl nodeForItemAtIndex:indexPath.item];
 }
 
 - (ASSizeRange)collectionNode:(ASCollectionNode *)collectionNode constrainedSizeForItemAtIndexPath:(NSIndexPath *)indexPath
@@ -235,12 +239,16 @@ typedef struct {
 
 - (ASCellNodeBlock)collectionNode:(ASCollectionNode *)collectionNode nodeBlockForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
 {
-  return [[self supplementaryElementSourceForSection:indexPath.section] nodeBlockForSupplementaryElementOfKind:kind atIndex:indexPath.item];
+  id<ASSupplementaryNodeSource> ctrl = [self supplementaryElementSourceForSection:indexPath.section];
+  ASDisplayNodeAssert([ctrl respondsToSelector:@selector(nodeBlockForSupplementaryElementOfKind:atIndex:)], @"Expected section controller to respond to to %@. Controller: %@", NSStringFromSelector(@selector(nodeBlockForSupplementaryElementOfKind:atIndex:)), ctrl);
+  return [ctrl nodeBlockForSupplementaryElementOfKind:kind atIndex:indexPath.item];
 }
 
 - (ASCellNode *)collectionNode:(ASCollectionNode *)collectionNode nodeForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
 {
-  return [[self supplementaryElementSourceForSection:indexPath.section] nodeForSupplementaryElementOfKind:kind atIndex:indexPath.item];
+  id<ASSupplementaryNodeSource> ctrl = [self supplementaryElementSourceForSection:indexPath.section];
+  ASDisplayNodeAssert([ctrl respondsToSelector:@selector(nodeForSupplementaryElementOfKind:atIndex:)], @"Expected section controller to respond to to %@. Controller: %@", NSStringFromSelector(@selector(nodeForSupplementaryElementOfKind:atIndex:)), ctrl);
+  return [ctrl nodeForSupplementaryElementOfKind:kind atIndex:indexPath.item];
 }
 
 - (NSArray<NSString *> *)collectionNode:(ASCollectionNode *)collectionNode supplementaryElementKindsInSection:(NSInteger)section


### PR DESCRIPTION
After #1273 was merged it's possible to implement either `nodeBlockForItemAtIndex:` or `nodeForItemAtIndex:` in the `ASSectionController` case and `nodeBlockForSupplementaryElementOfKind:atIndex:` or `nodeForSupplementaryElementOfKind:atIndex` in the `ASSupplementaryNodeSource` case.

As it's an or case now instead of having the required we move them to optional and throw an assertion if no one of the two is implemented.