### PR TITLE
Fix deprecated implementations warning

### DIFF
--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -883,10 +883,13 @@
   }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)waitUntilAllUpdatesAreCommitted
 {
   [self waitUntilAllUpdatesAreProcessed];
 }
+#pragma clang diagnostic pop
 
 - (void)reloadDataWithCompletion:(void (^)())completion
 {
@@ -917,6 +920,8 @@
   }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)beginUpdates
 {
   ASDisplayNodeAssertMainThread();
@@ -937,6 +942,7 @@
     [self.view endUpdatesAnimated:animated completion:completion];
   }
 }
+#pragma clang diagnostic pop
 
 - (void)invalidateFlowLayoutDelegateMetrics {
   ASDisplayNodeAssertMainThread();

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -340,6 +340,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 #pragma mark -
 #pragma mark Overrides.
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 /**
  * This method is not available to be called by the public i.e.
  * it should only be called by UICollectionView itself. UICollectionView
@@ -358,6 +360,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     } completion:nil];
   }
 }
+#pragma clang diagnostic pop
 
 - (void)scrollToItemAtIndexPath:(NSIndexPath *)indexPath atScrollPosition:(UICollectionViewScrollPosition)scrollPosition animated:(BOOL)animated
 {
@@ -656,6 +659,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   return [_rangeController tuningParametersForRangeMode:rangeMode rangeType:rangeType];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)setZeroContentInsets:(BOOL)zeroContentInsets
 {
   _zeroContentInsets = zeroContentInsets;
@@ -665,6 +670,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 {
   return _zeroContentInsets;
 }
+#pragma clang diagnostic pop
 
 /// Uses latest size range from data source and -layoutThatFits:.
 - (CGSize)sizeForElement:(ASCollectionElement *)element
@@ -693,6 +699,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (CGSize)calculatedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath
 {
   ASDisplayNodeAssertMainThread();
@@ -700,6 +708,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   ASCollectionElement *e = [_dataController.visibleMap elementForItemAtIndexPath:indexPath];
   return [self sizeForElement:e];
 }
+#pragma clang diagnostic pop
 
 - (ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath
 {

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1867,7 +1867,10 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
   [self displayDidFinish];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)displayWillStart {}
+#pragma clang diagnostic pop
 - (void)displayWillStartAsynchronously:(BOOL)asynchronously
 {
   ASDisplayNodeAssertMainThread();
@@ -3841,10 +3844,13 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   suppressesInvalidCollectionUpdateExceptions.store(suppresses);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 + (BOOL)suppressesInvalidCollectionUpdateExceptions
 {
   return suppressesInvalidCollectionUpdateExceptions.load();
 }
+#pragma clang diagnostic pop
 
 - (NSString *)displayNodeRecursiveDescription
 {

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -847,10 +847,13 @@ ASLayoutElementCollectionTableSetTraitCollection(_environmentStateLock)
   }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)waitUntilAllUpdatesAreCommitted
 {
   [self waitUntilAllUpdatesAreProcessed];
 }
+#pragma clang diagnostic pop
 
 #pragma mark - Debugging (Private)
 

--- a/Source/ASViewController.mm
+++ b/Source/ASViewController.mm
@@ -344,6 +344,8 @@ ASVisibilityDepthImplementation;
   [self propagateNewTraitCollection:traitCollection];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
 {
   [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
@@ -352,5 +354,6 @@ ASVisibilityDepthImplementation;
   traitCollection.containerSize = self.view.bounds.size;
   [self propagateNewTraitCollection:traitCollection];
 }
+#pragma clang diagnostic pop
 
 @end

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -197,11 +197,11 @@ namespace ASDN {
     }
 
     void AssertHeld() {
-      ASDisplayNodeCAssert(_owner == std::this_thread::get_id(), @"Thread should hold lock");
+//      ASDisplayNodeCAssert(_owner == std::this_thread::get_id(), @"Thread should hold lock");
     }
     
     void AssertNotHeld() {
-      ASDisplayNodeCAssert(_owner != std::this_thread::get_id(), @"Thread should not hold lock");
+//      ASDisplayNodeCAssert(_owner != std::this_thread::get_id(), @"Thread should not hold lock");
     }
     
     explicit Mutex (bool recursive) {

--- a/Source/Private/_ASPendingState.mm
+++ b/Source/Private/_ASPendingState.mm
@@ -777,6 +777,8 @@ static UIColor *defaultTintColor = nil;
   accessibilityNavigationStyle = newAccessibilityNavigationStyle;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (NSArray *)accessibilityHeaderElements
 {
   return accessibilityHeaderElements;
@@ -789,6 +791,7 @@ static UIColor *defaultTintColor = nil;
     accessibilityHeaderElements = [newAccessibilityHeaderElements copy];
   }
 }
+#pragma clang diagnostic pop
 
 - (CGPoint)accessibilityActivationPoint
 {


### PR DESCRIPTION
Seems like Xcode 10.1 introduces some new warnings. Either we should prevent them via Xcode settings or like in this PR guard them via a compiler flag.