### PR TITLE
Add experiments to skip waiting for updates of collection and table views

### DIFF
--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -25,7 +25,7 @@
                     "exp_did_enter_preload_skip_asm_layout",
                     "exp_disable_a11y_cache",
                     "exp_skip_a11y_wait",
-                    "exp_skip_default_cell_layout_mode"
+                    "exp_new_default_cell_layout_mode"
                 ]
     		}
 		}

--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -19,10 +19,12 @@
                     "exp_unfair_lock",
                     "exp_infer_layer_defaults",
                     "exp_network_image_queue",
-                    "exp_dealloc_queue_v2",
                     "exp_collection_teardown",
                     "exp_framesetter_cache",
-                    "exp_skip_clear_data"
+                    "exp_skip_clear_data",
+                    "exp_did_enter_preload_skip_asm_layout",
+                    "exp_disable_a11y_cache",
+                    "exp_skip_a11y_wait"
                 ]
     		}
 		}

--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -24,7 +24,8 @@
                     "exp_skip_clear_data",
                     "exp_did_enter_preload_skip_asm_layout",
                     "exp_disable_a11y_cache",
-                    "exp_skip_a11y_wait"
+                    "exp_skip_a11y_wait",
+                    "exp_skip_default_cell_layout_mode"
                 ]
     		}
 		}

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -2465,7 +2465,9 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (NSArray *)accessibilityElements
 {
-  [self waitUntilAllUpdatesAreCommitted];
+  if (!ASActivateExperimentalFeature(ASExperimentalSkipAccessibilityWait)) {
+    [self waitUntilAllUpdatesAreCommitted];
+  }
   return [super accessibilityElements];
 }
 

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -1869,14 +1869,20 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     return NO;
   }
   // The heuristics below apply to the ASCellLayoutModeNone.
-  // If we have very few ASCellNodes (besides UIKit passthrough ones), match UIKit by blocking.
-  if (changeSet.countForAsyncLayout < 2) {
-    return YES;
-  }
-  CGSize contentSize = self.contentSize;
-  CGSize boundsSize = self.bounds.size;
-  if (contentSize.height <= boundsSize.height && contentSize.width <= boundsSize.width) {
-    return YES;
+  if (!ASActivateExperimentalFeature(ASExperimentalSkipDefaultCellLayoutMode)) {
+    // Reload data is expensive, don't block main while doing so.
+    if (changeSet.includesReloadData) {
+      return NO;
+    }
+    // If we have very few ASCellNodes (besides UIKit passthrough ones), match UIKit by blocking.
+    if (changeSet.countForAsyncLayout < 2) {
+      return YES;
+    }
+    CGSize contentSize = self.contentSize;
+    CGSize boundsSize = self.bounds.size;
+    if (contentSize.height <= boundsSize.height && contentSize.width <= boundsSize.width) {
+      return YES;
+    }
   }
   return NO;
 }

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -317,6 +317,12 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   
   [self _configureCollectionViewLayout:layout];
   
+  if (ASActivateExperimentalFeature(ASExperimentalNewDefaultCellLayoutMode)) {
+    _cellLayoutMode = ASCellLayoutModeSyncForSmallContent;
+  } else {
+    _cellLayoutMode = ASCellLayoutModeNone;
+  }
+  
   return self;
 }
 
@@ -1868,8 +1874,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   if (ASCellLayoutModeIncludes(ASCellLayoutModeAlwaysAsync)) {
     return NO;
   }
-  // The heuristics below apply to the ASCellLayoutModeNone.
-  if (!ASActivateExperimentalFeature(ASExperimentalSkipDefaultCellLayoutMode)) {
+  if (ASCellLayoutModeIncludes(ASCellLayoutModeSyncForSmallContent)) {
     // Reload data is expensive, don't block main while doing so.
     if (changeSet.includesReloadData) {
       return NO;
@@ -1884,7 +1889,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
       return YES;
     }
   }
-  return NO;
+  return NO; // ASCellLayoutModeNone
 }
 
 - (BOOL)dataControllerShouldSerializeNodeCreation:(ASDataController *)dataController

--- a/Source/ASCollectionViewProtocols.h
+++ b/Source/ASCollectionViewProtocols.h
@@ -17,6 +17,11 @@ typedef NS_OPTIONS(NSUInteger, ASCellLayoutMode) {
    */
   ASCellLayoutModeNone = 0,
   /**
+   * If ASCellLayoutModeSyncForSmallContent is enabled it will cause ASDataController to wait on the
+   * background queue if the amount of new content is small.
+   */
+  ASCellLayoutModeSyncForSmallContent = 1 << 1,
+  /**
    * If ASCellLayoutModeAlwaysSync is enabled it will cause the ASDataController to wait on the
    * background queue, and this ensures that any new / changed cells are in the hierarchy by the
    * very next CATransaction / frame draw.
@@ -26,26 +31,26 @@ typedef NS_OPTIONS(NSUInteger, ASCellLayoutMode) {
    * default behavior is synchronous when there are 0 or 1 ASCellNodes in the data source, and
    * asynchronous when there are 2 or more.
   */
-  ASCellLayoutModeAlwaysSync = 1 << 1,                // Default OFF
-  ASCellLayoutModeAlwaysAsync = 1 << 2,               // Default OFF
-  ASCellLayoutModeForceIfNeeded = 1 << 3,             // Deprecated, default OFF.
-  ASCellLayoutModeAlwaysPassthroughDelegate = 1 << 4, // Deprecated, default ON.
+  ASCellLayoutModeAlwaysSync = 1 << 2,                // Default OFF
+  ASCellLayoutModeAlwaysAsync = 1 << 3,               // Default OFF
+  ASCellLayoutModeForceIfNeeded = 1 << 4,             // Deprecated, default OFF.
+  ASCellLayoutModeAlwaysPassthroughDelegate = 1 << 5, // Deprecated, default ON.
   /** Instead of using performBatchUpdates: prefer using reloadData for changes for collection view */
-  ASCellLayoutModeAlwaysReloadData = 1 << 5,          // Default OFF
+  ASCellLayoutModeAlwaysReloadData = 1 << 6,          // Default OFF
   /** If flag is enabled nodes are *not* gonna be range managed. */
-  ASCellLayoutModeDisableRangeController = 1 << 6,    // Default OFF
-  ASCellLayoutModeAlwaysLazy = 1 << 7,                // Deprecated, default OFF.
+  ASCellLayoutModeDisableRangeController = 1 << 7,    // Default OFF
+  ASCellLayoutModeAlwaysLazy = 1 << 8,                // Deprecated, default OFF.
   /**
    * Defines if the node creation should happen serialized and not in parallel within the
    * data controller
    */
-  ASCellLayoutModeSerializeNodeCreation = 1 << 8,     // Default OFF
+  ASCellLayoutModeSerializeNodeCreation = 1 << 9,     // Default OFF
   /**
    * When set, the performBatchUpdates: API (including animation) is used when handling Section
    * Reload operations. This is useful only when ASCellLayoutModeAlwaysReloadData is enabled and
    * cell height animations are desired.
    */
-  ASCellLayoutModeAlwaysBatchUpdateSectionReload = 1 << 9 // Default OFF
+  ASCellLayoutModeAlwaysBatchUpdateSectionReload = 1 << 10 // Default OFF
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -30,7 +30,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalDidEnterPreloadSkipASMLayout = 1 << 9,      // exp_did_enter_preload_skip_asm_layout
   ASExperimentalDisableAccessibilityCache = 1 << 10,        // exp_disable_a11y_cache
   ASExperimentalSkipAccessibilityWait = 1 << 11,            // exp_skip_a11y_wait
-  ASExperimentalSkipDefaultCellLayoutMode = 1 << 12,        // exp_skip_default_cell_layout_mode
+  ASExperimentalNewDefaultCellLayoutMode = 1 << 12,         // exp_new_default_cell_layout_mode
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -30,6 +30,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalDidEnterPreloadSkipASMLayout = 1 << 9,      // exp_did_enter_preload_skip_asm_layout
   ASExperimentalDisableAccessibilityCache = 1 << 10,        // exp_disable_a11y_cache
   ASExperimentalSkipAccessibilityWait = 1 << 11,            // exp_skip_a11y_wait
+  ASExperimentalSkipDefaultCellLayoutMode = 1 << 12,        // exp_skip_default_cell_layout_mode
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -29,6 +29,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalSkipClearData = 1 << 8,                     // exp_skip_clear_data
   ASExperimentalDidEnterPreloadSkipASMLayout = 1 << 9,      // exp_did_enter_preload_skip_asm_layout
   ASExperimentalDisableAccessibilityCache = 1 << 10,        // exp_disable_a11y_cache
+  ASExperimentalSkipAccessibilityWait = 1 << 11,            // exp_skip_a11y_wait
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -23,7 +23,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_skip_clear_data",
                                       @"exp_did_enter_preload_skip_asm_layout",
                                       @"exp_disable_a11y_cache",
-                                      @"exp_skip_a11y_wait"]));
+                                      @"exp_skip_a11y_wait",
+                                      @"exp_skip_default_cell_layout_mode"]));
   
   if (flags == ASExperimentalFeatureAll) {
     return allNames;

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -22,7 +22,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_framesetter_cache",
                                       @"exp_skip_clear_data",
                                       @"exp_did_enter_preload_skip_asm_layout",
-                                      @"exp_disable_a11y_cache"]));
+                                      @"exp_disable_a11y_cache",
+                                      @"exp_skip_a11y_wait"]));
   
   if (flags == ASExperimentalFeatureAll) {
     return allNames;

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -24,7 +24,7 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_did_enter_preload_skip_asm_layout",
                                       @"exp_disable_a11y_cache",
                                       @"exp_skip_a11y_wait",
-                                      @"exp_skip_default_cell_layout_mode"]));
+                                      @"exp_new_default_cell_layout_mode"]));
   
   if (flags == ASExperimentalFeatureAll) {
     return allNames;

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -1677,7 +1677,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (BOOL)dataController:(ASDataController *)dataController shouldSynchronouslyProcessChangeSet:(_ASHierarchyChangeSet *)changeSet
 {
-  if (!ASActivateExperimentalFeature(ASExperimentalSkipDefaultCellLayoutMode)) {
+  if (ASActivateExperimentalFeature(ASExperimentalNewDefaultCellLayoutMode)) {
     // Reload data is expensive, don't block main while doing so.
     if (changeSet.includesReloadData) {
       return NO;

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -2004,7 +2004,9 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (NSArray *)accessibilityElements
 {
-  [self waitUntilAllUpdatesAreCommitted];
+  if (!ASActivateExperimentalFeature(ASExperimentalSkipAccessibilityWait)) {
+    [self waitUntilAllUpdatesAreCommitted];
+  }
   return [super accessibilityElements];
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -1677,14 +1677,20 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (BOOL)dataController:(ASDataController *)dataController shouldSynchronouslyProcessChangeSet:(_ASHierarchyChangeSet *)changeSet
 {
-  // For more details on this method, see the comment in the ASCollectionView implementation.
-  if (changeSet.countForAsyncLayout < 2) {
-    return YES;
-  }
-  CGSize contentSize = self.contentSize;
-  CGSize boundsSize = self.bounds.size;
-  if (contentSize.height <= boundsSize.height && contentSize.width <= boundsSize.width) {
-    return YES;
+  if (!ASActivateExperimentalFeature(ASExperimentalSkipDefaultCellLayoutMode)) {
+    // Reload data is expensive, don't block main while doing so.
+    if (changeSet.includesReloadData) {
+      return NO;
+    }
+    // For more details on this method, see the comment in the ASCollectionView implementation.
+    if (changeSet.countForAsyncLayout < 2) {
+      return YES;
+    }
+    CGSize contentSize = self.contentSize;
+    CGSize boundsSize = self.bounds.size;
+    if (contentSize.height <= boundsSize.height && contentSize.width <= boundsSize.width) {
+      return YES;
+    }
   }
   return NO;
 }

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -1081,15 +1081,15 @@
 
   if (shouldWait) {
     XCTAssertTrue(cn.isProcessingUpdates, @"ASCollectionNode should still be processing updates after initial layoutIfNeeded call (reloadData)");
-    
+
     [cn onDidFinishProcessingUpdates:^{
       XCTAssertTrue(!cn.isProcessingUpdates, @"ASCollectionNode should no longer be processing updates inside -onDidFinishProcessingUpdates: block");
     }];
-    
+
     // Wait for ASDK reload to finish
     [cn waitUntilAllUpdatesAreProcessed];
   }
-  
+
   XCTAssertTrue(!cn.isProcessingUpdates, @"ASCollectionNode should no longer be processing updates after -wait call");
 
   // Force UIKit to read updated data & range controller to update and account for it

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -1048,10 +1048,6 @@
 
 - (void)testInitialRangeBounds
 {
-  ASConfiguration *config = [[ASConfiguration alloc] initWithDictionary:nil];
-  config.experimentalFeatures = ASExperimentalSkipDefaultCellLayoutMode;
-  [ASConfigurationManager test_resetWithConfiguration:config];
-  
   [self testInitialRangeBoundsWithCellLayoutMode:ASCellLayoutModeNone];
 }
 
@@ -1076,19 +1072,15 @@
   // Trigger the initial reload to start 
   [window layoutIfNeeded];
 
-  // Test the APIs that monitor ASCollectionNode update handling if collection node should
-  // layout asynchronously
-  if (![cn.view dataController:nil shouldSynchronouslyProcessChangeSet:nil]) {
-    XCTAssertTrue(cn.isProcessingUpdates, @"ASCollectionNode should still be processing updates after initial layoutIfNeeded call (reloadData)");
-
-    [cn onDidFinishProcessingUpdates:^{
-      XCTAssertTrue(!cn.isProcessingUpdates, @"ASCollectionNode should no longer be processing updates inside -onDidFinishProcessingUpdates: block");
-    }];
-
-    // Wait for ASDK reload to finish
-    [cn waitUntilAllUpdatesAreProcessed];
-  }
-
+  XCTAssertTrue(cn.isProcessingUpdates, @"ASCollectionNode should still be processing updates after initial layoutIfNeeded call (reloadData)");
+  
+  [cn onDidFinishProcessingUpdates:^{
+    XCTAssertTrue(!cn.isProcessingUpdates, @"ASCollectionNode should no longer be processing updates inside -onDidFinishProcessingUpdates: block");
+  }];
+  
+  // Wait for ASDK reload to finish
+  [cn waitUntilAllUpdatesAreProcessed];
+  
   XCTAssertTrue(!cn.isProcessingUpdates, @"ASCollectionNode should no longer be processing updates after -wait call");
 
   // Force UIKit to read updated data & range controller to update and account for it

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -10,7 +10,6 @@
 #import <XCTest/XCTest.h>
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 #import <AsyncDisplayKit/ASCollectionViewFlowLayoutInspector.h>
-#import <AsyncDisplayKit/ASConfigurationDelegate.h>
 #import <AsyncDisplayKit/ASDataController.h>
 #import <AsyncDisplayKit/ASSectionContext.h>
 #import <vector>

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -163,7 +163,6 @@
 @interface ASCollectionView (InternalTesting)
 
 - (NSArray<NSString *> *)dataController:(ASDataController *)dataController supplementaryNodeKindsInSections:(NSIndexSet *)sections;
-- (BOOL)dataController:(ASDataController *)dataController shouldSynchronouslyProcessChangeSet:(_ASHierarchyChangeSet *)changeSet;
 
 @end
 

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -1052,10 +1052,6 @@
 
 - (void)testInitialRangeBoundsCellLayoutModeSyncForSmallContent
 {
-  ASConfiguration *config = [[ASConfiguration alloc] initWithDictionary:nil];
-  config.experimentalFeatures = ASExperimentalNewDefaultCellLayoutMode;
-  [ASConfigurationManager test_resetWithConfiguration:config];
-  
   [self testInitialRangeBoundsWithCellLayoutMode:ASCellLayoutModeSyncForSmallContent
            shouldWaitUntilAllUpdatesAreProcessed:YES]; // Need to wait because the first initial data load is always async
 }

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -10,6 +10,7 @@
 #import <XCTest/XCTest.h>
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 #import <AsyncDisplayKit/ASCollectionViewFlowLayoutInspector.h>
+#import <AsyncDisplayKit/ASConfigurationDelegate.h>
 #import <AsyncDisplayKit/ASDataController.h>
 #import <AsyncDisplayKit/ASSectionContext.h>
 #import <vector>
@@ -1047,6 +1048,10 @@
 
 - (void)testInitialRangeBounds
 {
+  ASConfiguration *config = [[ASConfiguration alloc] initWithDictionary:nil];
+  config.experimentalFeatures = ASExperimentalSkipDefaultCellLayoutMode;
+  [ASConfigurationManager test_resetWithConfiguration:config];
+  
   [self testInitialRangeBoundsWithCellLayoutMode:ASCellLayoutModeNone];
 }
 

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -30,6 +30,7 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalDidEnterPreloadSkipASMLayout,
   ASExperimentalDisableAccessibilityCache,
   ASExperimentalSkipAccessibilityWait,
+  ASExperimentalSkipDefaultCellLayoutMode
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -53,7 +54,8 @@ static ASExperimentalFeatures features[] = {
     @"exp_skip_clear_data",
     @"exp_did_enter_preload_skip_asm_layout",
     @"exp_disable_a11y_cache",
-    @"exp_skip_a11y_wait"
+    @"exp_skip_a11y_wait",
+    @"exp_skip_default_cell_layout_mode"
   ];
 }
 

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -30,7 +30,7 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalDidEnterPreloadSkipASMLayout,
   ASExperimentalDisableAccessibilityCache,
   ASExperimentalSkipAccessibilityWait,
-  ASExperimentalSkipDefaultCellLayoutMode
+  ASExperimentalNewDefaultCellLayoutMode
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -55,7 +55,7 @@ static ASExperimentalFeatures features[] = {
     @"exp_did_enter_preload_skip_asm_layout",
     @"exp_disable_a11y_cache",
     @"exp_skip_a11y_wait",
-    @"exp_skip_default_cell_layout_mode"
+    @"exp_new_default_cell_layout_mode"
   ];
 }
 

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -28,7 +28,8 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalFramesetterCache,
   ASExperimentalSkipClearData,
   ASExperimentalDidEnterPreloadSkipASMLayout,
-  ASExperimentalDisableAccessibilityCache
+  ASExperimentalDisableAccessibilityCache,
+  ASExperimentalSkipAccessibilityWait,
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -51,7 +52,8 @@ static ASExperimentalFeatures features[] = {
     @"exp_framesetter_cache",
     @"exp_skip_clear_data",
     @"exp_did_enter_preload_skip_asm_layout",
-    @"exp_disable_a11y_cache"
+    @"exp_disable_a11y_cache",
+    @"exp_skip_a11y_wait"
   ];
 }
 


### PR DESCRIPTION
- `exp_skip_a11y_wait`: An experiment that skips a wait when accessibility elements of a collection/table view is collected. The wait was introduced in #1217. We suspect this causes some perf regressions and need to confirm via an experiment.
- `exp_skip_default_cell_layout_mode`: An experiment that skips a new default behavior of `ASCellLayoutModeNone`, introduced in #1273. The new behavior blocks main thread when 1) the collection/table view reloads data (including the initial load and any subsequent ones), 2) there is a small number of async cells to be laid out, or 3) the collection/table view hasn't had enough content to fill the visible viewport. While I agree that this new behavior may help with display latency when it's more important than FPS (i.e during app startup), I'm not sure if this is the right approach and, even if it is, we need to measure its perf implications within our app. My main concern is that blocking the main thread during app startup prevents the app from performing other equally important tasks that are intentionally scheduled during that time. The new behavior also affects apps that optimize the first page's size to fill the viewport, but doesn't necessarily fill it entirely due to various reasons. In such case, it's actually quite bad to block main thread for the second batch update, because users may (and are welcome to) interact with the content of the first page.