### PR TITLE
Remove let and var macros now that we're all-C++

### DIFF
--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -216,11 +216,11 @@
       [view setContentOffset:contentOffset animated:pendingState.animatesContentOffset];
     }
     
-    let tuningParametersVector = pendingState->_tuningParameters;
-    let tuningParametersVectorSize = tuningParametersVector.size();
+    const auto tuningParametersVector = pendingState->_tuningParameters;
+    const auto tuningParametersVectorSize = tuningParametersVector.size();
     for (NSInteger rangeMode = 0; rangeMode < tuningParametersVectorSize; rangeMode++) {
-      let tuningparametersRangeModeVector = tuningParametersVector[rangeMode];
-      let tuningParametersVectorRangeModeSize = tuningparametersRangeModeVector.size();
+      const auto tuningparametersRangeModeVector = tuningParametersVector[rangeMode];
+      const auto tuningParametersVectorRangeModeSize = tuningparametersRangeModeVector.size();
       for (NSInteger rangeType = 0; rangeType < tuningParametersVectorRangeModeSize; rangeType++) {
         ASRangeTuningParameters tuningParameters = tuningparametersRangeModeVector[rangeType];
         [_rangeController setTuningParameters:tuningParameters

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -1562,7 +1562,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
   // If the data source implements canMoveItem, let them decide.
   if (_asyncDataSourceFlags.collectionNodeCanMoveItem) {
-    if (let cellNode = [self nodeForItemAtIndexPath:indexPath]) {
+    if (ASCellNode *cellNode = [self nodeForItemAtIndexPath:indexPath]) {
       GET_COLLECTIONNODE_OR_RETURN(collectionNode, NO);
       return [_asyncDataSource collectionNode:collectionNode canMoveItemWithNode:cellNode];
     }
@@ -1578,7 +1578,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   
   // Inform the data source first, in case they call nodeForItemAtIndexPath:.
   // We want to make sure we return them the node for the item they have in mind.
-  if (let collectionNode = self.collectionNode) {
+  if (ASCollectionNode *collectionNode = self.collectionNode) {
     [_asyncDataSource collectionNode:collectionNode moveItemAtIndexPath:sourceIndexPath toIndexPath:destinationIndexPath];
   }
   

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -2083,7 +2083,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 - (NSArray<NSString *> *)dataController:(ASDataController *)dataController supplementaryNodeKindsInSections:(NSIndexSet *)sections
 {
   if (_asyncDataSourceFlags.collectionNodeSupplementaryElementKindsInSection) {
-    let kinds = [[NSMutableSet<NSString *> alloc] init];
+    const auto kinds = [[NSMutableSet<NSString *> alloc] init];
     GET_COLLECTIONNODE_OR_RETURN(collectionNode, @[]);
     [sections enumerateIndexesUsingBlock:^(NSUInteger section, BOOL * _Nonnull stop) {
       NSArray<NSString *> *kindsForSection = [_asyncDataSource collectionNode:collectionNode supplementaryElementKindsInSection:section];
@@ -2218,7 +2218,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
       [_layoutFacilitator collectionViewWillPerformBatchUpdates];
       
       __block NSUInteger numberOfUpdates = 0;
-      let completion = ^(BOOL finished) {
+      const auto completion = ^(BOOL finished) {
         as_activity_scope(as_activity_create("Handle collection update completion", changeSet.rootActivity, OS_ACTIVITY_FLAG_DEFAULT));
         as_log_verbose(ASCollectionLog(), "Update animation finished %{public}@", self.collectionNode);
         // Flush any range changes that happened as part of the update animations ending.
@@ -2319,7 +2319,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     return;
   }
 
-  let uikitIndexPaths = ASArrayByFlatMapping(nodes, ASCellNode *node, [self indexPathForNode:node]);
+  const auto uikitIndexPaths = ASArrayByFlatMapping(nodes, ASCellNode *node, [self indexPathForNode:node]);
   
   [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:uikitIndexPaths batched:NO];
   

--- a/Source/ASConfiguration.mm
+++ b/Source/ASConfiguration.mm
@@ -17,8 +17,8 @@
 {
   if (self = [super init]) {
     if (dictionary != nil) {
-      let featureStrings = ASDynamicCast(dictionary[@"experimental_features"], NSArray);
-      let version = ASDynamicCast(dictionary[@"version"], NSNumber).integerValue;
+      const auto featureStrings = ASDynamicCast(dictionary[@"experimental_features"], NSArray);
+      const auto version = ASDynamicCast(dictionary[@"version"], NSNumber).integerValue;
       if (version != ASConfigurationSchemaCurrentVersion) {
         NSLog(@"Texture warning: configuration schema is old version (%ld vs %ld)", (long)version, (long)ASConfigurationSchemaCurrentVersion);
       }

--- a/Source/ASConfigurationInternal.mm
+++ b/Source/ASConfigurationInternal.mm
@@ -62,7 +62,7 @@
   }
   _frameworkInitialized = YES;
   
-  let delegate = _config.delegate;
+  const auto delegate = _config.delegate;
   if ([delegate respondsToSelector:@selector(textureDidInitialize)]) {
     [delegate textureDidInitialize];
   }

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -654,8 +654,8 @@ ASLayoutElementStyleExtensibilityForwarding
         ASDN::MutexLocker l(__instanceLock__);
         
         // Update calculated layout
-        let previousLayout = _calculatedDisplayNodeLayout;
-        let pendingLayout = ASDisplayNodeLayout(newLayout,
+        const auto previousLayout = _calculatedDisplayNodeLayout;
+        const auto pendingLayout = ASDisplayNodeLayout(newLayout,
                                                 constrainedSize,
                                                 constrainedSize.max,
                                                 newLayoutVersion);
@@ -775,10 +775,10 @@ ASLayoutElementStyleExtensibilityForwarding
   
   NSArray<ASDisplayNode *> *removedSubnodes = [context removedSubnodes];
   NSMutableArray<ASDisplayNode *> *insertedSubnodes = [[context insertedSubnodes] mutableCopy];
-  let movedSubnodes = [[NSMutableArray<ASDisplayNode *> alloc] init];
+  const auto movedSubnodes = [[NSMutableArray<ASDisplayNode *> alloc] init];
   
-  let insertedSubnodeContexts = [[NSMutableArray<_ASAnimatedTransitionContext *> alloc] init];
-  let removedSubnodeContexts = [[NSMutableArray<_ASAnimatedTransitionContext *> alloc] init];
+  const auto insertedSubnodeContexts = [[NSMutableArray<_ASAnimatedTransitionContext *> alloc] init];
+  const auto removedSubnodeContexts = [[NSMutableArray<_ASAnimatedTransitionContext *> alloc] init];
   
   for (ASDisplayNode *subnode in [context subnodesForKey:ASTransitionContextToLayoutKey]) {
     if ([insertedSubnodes containsObject:subnode] == NO) {
@@ -916,9 +916,9 @@ ASLayoutElementStyleExtensibilityForwarding
   NSArray *subnodes = [self subnodes];
   NSArray *sublayouts = _calculatedDisplayNodeLayout.layout.sublayouts;
 
-  let currentSubnodes = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality
+  const auto currentSubnodes = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality
                                                      capacity:subnodes.count];
-  let layoutSubnodes  = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality
+  const auto layoutSubnodes  = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality
                                                      capacity:sublayouts.count];;
   for (ASDisplayNode *subnode in subnodes) {
     [currentSubnodes addObject:subnode];

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -195,7 +195,7 @@
   for (ASDisplayNode *subnode in self.yogaChildren) {
     rawSublayouts[i++] = [subnode layoutForYogaNode];
   }
-  let sublayouts = [NSArray<ASLayout *> arrayByTransferring:rawSublayouts count:childCount];
+  const auto sublayouts = [NSArray<ASLayout *> arrayByTransferring:rawSublayouts count:childCount];
 
   // The layout for self should have position CGPointNull, but include the calculated size.
   CGSize size = CGSizeMake(YGNodeLayoutGetWidth(yogaNode), YGNodeLayoutGetHeight(yogaNode));

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -561,7 +561,7 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   [self didLoad];
   
   __instanceLock__.lock();
-  let onDidLoadBlocks = ASTransferStrong(_onDidLoadBlocks);
+  const auto onDidLoadBlocks = ASTransferStrong(_onDidLoadBlocks);
   __instanceLock__.unlock();
   
   for (ASDisplayNodeDidLoadBlock block in onDidLoadBlocks) {
@@ -3784,7 +3784,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (NSString *)debugDescription
 {
   ASPushMainThreadAssertionsDisabled();
-  let result = ASObjectDescriptionMake(self, [self propertiesForDebugDescription]);
+  const auto result = ASObjectDescriptionMake(self, [self propertiesForDebugDescription]);
   ASPopMainThreadAssertionsDisabled();
   return result;
 }
@@ -3869,7 +3869,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 {
   ASPushMainThreadAssertionsDisabled();
   ASDN::MutexLocker l(__instanceLock__);
-  let props = [[NSMutableArray<NSDictionary *> alloc] init];
+  const auto props = [[NSMutableArray<NSDictionary *> alloc] init];
 
   [props addObject:@{ @"layoutVersion": @(_layoutVersion.load()) }];
   [props addObject:@{ @"bounds": [NSValue valueWithCGRect:self.bounds] }];

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -217,7 +217,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
-  let image = ASLockedSelf(_image);
+  const auto image = ASLockedSelf(_image);
 
   if (image == nil) {
     return [super calculateSizeThatFits:constrainedSize];

--- a/Source/ASMainThreadDeallocation.mm
+++ b/Source/ASMainThreadDeallocation.mm
@@ -142,7 +142,7 @@
 
 + (BOOL)needsMainThreadDeallocation
 {
-  let name = class_getName(self);
+  const auto name = class_getName(self);
   if (0 == strncmp(name, "AV", 2) || 0 == strncmp(name, "UI", 2) || 0 == strncmp(name, "CA", 2)) {
     return YES;
   }

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -368,7 +368,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
         // Call out to the delegate.
         if (_delegateFlags.delegateDidLoadImageWithInfo) {
           ASUnlockScope(self);
-          let info = [[ASNetworkImageLoadInfo alloc] initWithURL:url sourceType:ASNetworkImageSourceSynchronousCache downloadIdentifier:nil userInfo:nil];
+          const auto info = [[ASNetworkImageLoadInfo alloc] initWithURL:url sourceType:ASNetworkImageSourceSynchronousCache downloadIdentifier:nil userInfo:nil];
           [delegate imageNode:self didLoadImage:result info:info];
         } else if (_delegateFlags.delegateDidLoadImage) {
           ASUnlockScope(self);
@@ -662,7 +662,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
         } else {
           // First try to load the path directly, for efficiency assuming a developer who
           // doesn't want caching is trying to be as minimal as possible.
-          var nonAnimatedImage = [[UIImage alloc] initWithContentsOfFile:URL.path];
+          auto nonAnimatedImage = [[UIImage alloc] initWithContentsOfFile:URL.path];
           if (nonAnimatedImage == nil) {
             // If we couldn't find it, execute an -imageNamed:-like search so we can find resources even if the
             // extension is not provided in the path.  This allows the same path to work regardless of shouldCacheImage.
@@ -675,7 +675,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
           // If the file may be an animated gif and then created an animated image.
           id<ASAnimatedImageProtocol> animatedImage = nil;
           if (self->_downloaderFlags.downloaderImplementsAnimatedImage) {
-            let data = [[NSData alloc] initWithContentsOfURL:URL];
+            const auto data = [[NSData alloc] initWithContentsOfURL:URL];
             if (data != nil) {
               animatedImage = [self->_downloader animatedImageWithData:data];
 
@@ -698,7 +698,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 
         if (self->_delegateFlags.delegateDidLoadImageWithInfo) {
           ASUnlockScope(self);
-          let info = [[ASNetworkImageLoadInfo alloc] initWithURL:URL sourceType:ASNetworkImageSourceFileURL downloadIdentifier:nil userInfo:nil];
+          const auto info = [[ASNetworkImageLoadInfo alloc] initWithURL:URL sourceType:ASNetworkImageSourceFileURL downloadIdentifier:nil userInfo:nil];
           [delegate imageNode:self didLoadImage:self.image info:info];
         } else if (self->_delegateFlags.delegateDidLoadImage) {
           ASUnlockScope(self);
@@ -707,7 +707,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
       });
     } else {
       __weak __typeof__(self) weakSelf = self;
-      let finished = ^(id <ASImageContainerProtocol>imageContainer, NSError *error, id downloadIdentifier, ASNetworkImageSourceType imageSource, id userInfo) {
+      const auto finished = ^(id <ASImageContainerProtocol>imageContainer, NSError *error, id downloadIdentifier, ASNetworkImageSourceType imageSource, id userInfo) {
         ASPerformBlockOnBackgroundThread(^{
           __typeof__(self) strongSelf = weakSelf;
           if (strongSelf == nil) {
@@ -753,7 +753,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
           if (newImage) {
             if (strongSelf->_delegateFlags.delegateDidLoadImageWithInfo) {
               calloutBlock = ^(ASNetworkImageNode *strongSelf) {
-                let info = [[ASNetworkImageLoadInfo alloc] initWithURL:URL sourceType:imageSource downloadIdentifier:downloadIdentifier userInfo:userInfo];
+                const auto info = [[ASNetworkImageLoadInfo alloc] initWithURL:URL sourceType:imageSource downloadIdentifier:downloadIdentifier userInfo:userInfo];
                 [delegate imageNode:strongSelf didLoadImage:newImage info:info];
               };
             } else if (strongSelf->_delegateFlags.delegateDidLoadImage) {

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -56,13 +56,13 @@ static void runLoopSourceCallback(void *info) {
   NSParameterAssert(objectPtr != NULL);
   
   // Cast to CFType so we can manipulate retain count manually.
-  let cfPtr = (CFTypeRef *)(void *)objectPtr;
+  const auto cfPtr = (CFTypeRef *)(void *)objectPtr;
   if (!cfPtr || !*cfPtr) {
     return;
   }
   
   _lock.lock();
-  let isFirstEntry = _queue.empty();
+  const auto isFirstEntry = _queue.empty();
   // Push the pointer into our queue and clear their pointer.
   // This "steals" the +1 from ARC and nils their pointer so they can't
   // access or release the object.
@@ -80,7 +80,7 @@ static void runLoopSourceCallback(void *info) {
 - (void)drain
 {
   _lock.lock();
-  let q = std::move(_queue);
+  const auto q = std::move(_queue);
   _lock.unlock();
   for (let ref : q) {
     // NOTE: Could check that retain count is 1 and retry later if not.
@@ -256,10 +256,10 @@ static void runLoopSourceCallback(void *info) {
   }
 
   // itemsToProcess will be empty if _queueConsumer == nil so no need to check again.
-  let count = itemsToProcess.size();
+  const auto count = itemsToProcess.size();
   if (count > 0) {
     as_activity_scope_verbose(as_activity_create("Process run loop queue batch", _rootActivity, OS_ACTIVITY_FLAG_DEFAULT));
-    let itemsEnd = itemsToProcess.cend();
+    const auto itemsEnd = itemsToProcess.cend();
     for (var iterator = itemsToProcess.begin(); iterator < itemsEnd; iterator++) {
       __unsafe_unretained id value = *iterator;
       _queueConsumer(value, isQueueDrained && iterator == itemsEnd - 1);
@@ -460,10 +460,10 @@ static int const kASASCATransactionQueueOrder = 1000000;
   }
 
   // itemsToProcess will be empty if _queueConsumer == nil so no need to check again.
-  let count = itemsToProcess.size();
+  const auto count = itemsToProcess.size();
   if (count > 0) {
     as_activity_scope_verbose(as_activity_create("Process run loop queue batch", _rootActivity, OS_ACTIVITY_FLAG_DEFAULT));
-    let itemsEnd = itemsToProcess.cend();
+    const auto itemsEnd = itemsToProcess.cend();
     for (var iterator = itemsToProcess.begin(); iterator < itemsEnd; iterator++) {
       __unsafe_unretained id value = *iterator;
       [value prepareForCATransactionCommit];

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -82,7 +82,7 @@ static void runLoopSourceCallback(void *info) {
   _lock.lock();
   const auto q = std::move(_queue);
   _lock.unlock();
-  for (let ref : q) {
+  for (CFTypeRef ref : q) {
     // NOTE: Could check that retain count is 1 and retry later if not.
     CFRelease(ref);
   }

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -260,7 +260,7 @@ static void runLoopSourceCallback(void *info) {
   if (count > 0) {
     as_activity_scope_verbose(as_activity_create("Process run loop queue batch", _rootActivity, OS_ACTIVITY_FLAG_DEFAULT));
     const auto itemsEnd = itemsToProcess.cend();
-    for (var iterator = itemsToProcess.begin(); iterator < itemsEnd; iterator++) {
+    for (auto iterator = itemsToProcess.begin(); iterator < itemsEnd; iterator++) {
       __unsafe_unretained id value = *iterator;
       _queueConsumer(value, isQueueDrained && iterator == itemsEnd - 1);
       as_log_verbose(ASDisplayLog(), "processed %@", value);
@@ -464,7 +464,7 @@ static int const kASASCATransactionQueueOrder = 1000000;
   if (count > 0) {
     as_activity_scope_verbose(as_activity_create("Process run loop queue batch", _rootActivity, OS_ACTIVITY_FLAG_DEFAULT));
     const auto itemsEnd = itemsToProcess.cend();
-    for (var iterator = itemsToProcess.begin(); iterator < itemsEnd; iterator++) {
+    for (auto iterator = itemsToProcess.begin(); iterator < itemsEnd; iterator++) {
       __unsafe_unretained id value = *iterator;
       [value prepareForCATransactionCommit];
       as_log_verbose(ASDisplayLog(), "processed %@", value);

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -175,11 +175,11 @@
       [view setContentOffset:contentOffset animated:pendingState.animatesContentOffset];
     }
       
-    let tuningParametersVector = pendingState->_tuningParameters;
-    let tuningParametersVectorSize = tuningParametersVector.size();
+    const auto tuningParametersVector = pendingState->_tuningParameters;
+    const auto tuningParametersVectorSize = tuningParametersVector.size();
     for (NSInteger rangeMode = 0; rangeMode < tuningParametersVectorSize; rangeMode++) {
-      let tuningparametersRangeModeVector = tuningParametersVector[rangeMode];
-      let tuningParametersVectorRangeModeSize = tuningparametersRangeModeVector.size();
+      const auto tuningparametersRangeModeVector = tuningParametersVector[rangeMode];
+      const auto tuningParametersVectorRangeModeSize = tuningparametersRangeModeVector.size();
       for (NSInteger rangeType = 0; rangeType < tuningParametersVectorRangeModeSize; rangeType++) {
         ASRangeTuningParameters tuningParameters = tuningparametersRangeModeVector[rangeType];
         [_rangeController setTuningParameters:tuningParameters

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -679,7 +679,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (NSArray<ASCellNode *> *)visibleNodes
 {
-  let elements = [self visibleElementsForRangeController:_rangeController];
+  const auto elements = [self visibleElementsForRangeController:_rangeController];
   return ASArrayByFlatMapping(elements, ASCollectionElement *e, e.node);
 }
 
@@ -765,7 +765,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
       NSArray<ASCellNode *> *nodes = [_cellsForLayoutUpdates allObjects];
       [_cellsForLayoutUpdates removeAllObjects];
 
-      let nodesSizeChanged = [[NSMutableArray<ASCellNode *> alloc] init];
+      const auto nodesSizeChanged = [[NSMutableArray<ASCellNode *> alloc] init];
       [_dataController relayoutNodes:nodes nodesSizeChanged:nodesSizeChanged];
       if (nodesSizeChanged.count > 0) {
         [self requeryNodeHeights];

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -494,7 +494,7 @@ static NSArray *DefaultLinkAttributeNames() {
   [self setNeedsDisplay];
   
   // Accessiblity
-  let currentAttributedText = self.attributedText; // Grab attributed string again in case it changed in the meantime
+  const auto currentAttributedText = self.attributedText; // Grab attributed string again in case it changed in the meantime
   self.accessibilityLabel = self.defaultAccessibilityLabel;
   self.isAccessibilityElement = (currentAttributedText.length != 0); // We're an accessibility element by default if there is a string.
 
@@ -883,7 +883,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   ASLockScopeSelf();
   
   NSArray *rects = [[self _locked_renderer] rectsForTextRange:textRange measureOption:measureOption];
-  let adjustedRects = [[NSMutableArray<NSValue *> alloc] init];
+  const auto adjustedRects = [[NSMutableArray<NSValue *> alloc] init];
 
   for (NSValue *rectValue in rects) {
     CGRect rect = [rectValue CGRectValue];

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -76,7 +76,7 @@ static NS_RETURNS_RETAINED ASTextLayout *ASTextNodeCompatibleLayoutWithContainer
 
   CGRect containerBounds = (CGRect){ .size = container.size };
   {
-    for (let &t : cacheValue->_layouts) {
+    for (const auto &t : cacheValue->_layouts) {
       CGSize constrainedSize = std::get<0>(t);
       ASTextLayout *layout = std::get<1>(t);
 

--- a/Source/ASVideoPlayerNode.mm
+++ b/Source/ASVideoPlayerNode.mm
@@ -661,7 +661,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
     }];
     _spinnerNode.style.preferredSize = CGSizeMake(44.0, 44.0);
     
-    let spinnerNode = _spinnerNode;
+    const auto spinnerNode = _spinnerNode;
     {
       ASUnlockScope(self);
       [self addSubnode:spinnerNode];

--- a/Source/ASVideoPlayerNode.mm
+++ b/Source/ASVideoPlayerNode.mm
@@ -286,7 +286,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
       
       {
         ASUnlockScope(self);
-        for (var subnode : subnodes) {
+        for (ASDisplayNode *subnode : subnodes) {
           [self addSubnode:subnode];
         }
       }

--- a/Source/Base/ASAssert.mm
+++ b/Source/Base/ASAssert.mm
@@ -43,14 +43,14 @@ BOOL ASMainThreadAssertionsAreDisabled() {
 }
 
 void ASPushMainThreadAssertionsDisabled() {
-  let key = ASMainThreadAssertionsDisabledKey();
-  let oldVal = (intptr_t)pthread_getspecific(key);
+  const auto key = ASMainThreadAssertionsDisabledKey();
+  const auto oldVal = (intptr_t)pthread_getspecific(key);
   pthread_setspecific(key, (void *)(oldVal + 1));
 }
 
 void ASPopMainThreadAssertionsDisabled() {
-  let key = ASMainThreadAssertionsDisabledKey();
-  let oldVal = (intptr_t)pthread_getspecific(key);
+  const auto key = ASMainThreadAssertionsDisabledKey();
+  const auto oldVal = (intptr_t)pthread_getspecific(key);
   pthread_setspecific(key, (void *)(oldVal - 1));
   ASDisplayNodeCAssert(oldVal > 0, @"Attempt to pop thread assertion-disabling without corresponding push.");
 }

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -12,15 +12,6 @@
 #define AS_EXTERN FOUNDATION_EXTERN
 #define unowned __unsafe_unretained
 
-// TODO: Remove these now that we're all-C++.
-#if defined(__cplusplus)
-# define var auto
-# define let const auto
-#else
-# define var __auto_type
-# define let const __auto_type
-#endif
-
 /**
  * Hack to support building for iOS with Xcode 9. UIUserInterfaceStyle was previously tvOS-only,
  * and it was added to iOS 12. Xcode 9 (iOS 11 SDK) will flat-out refuse to build anything that
@@ -246,7 +237,7 @@
 /**
  * Capture-and-clear a strong reference without the intervening retain/release pair.
  *
- * E.g. let localVar = ASTransferStrong(_myIvar);
+ * E.g. const auto localVar = ASTransferStrong(_myIvar);
  * Post-condition: localVar has the strong value from _myIvar and _myIvar is nil.
  * No retain/release is emitted when the optimizer is on.
  */

--- a/Source/Details/ASAbstractLayoutController.mm
+++ b/Source/Details/ASAbstractLayoutController.mm
@@ -89,7 +89,7 @@ CGRect CGRectExpandToRangeWithScrollableDirections(CGRect rect, ASRangeTuningPar
 
 + (std::vector<std::vector<ASRangeTuningParameters>>)defaultTuningParameters
 {
-  var tuningParameters = std::vector<std::vector<ASRangeTuningParameters>> (ASLayoutRangeModeCount, std::vector<ASRangeTuningParameters> (ASLayoutRangeTypeCount));
+  auto tuningParameters = std::vector<std::vector<ASRangeTuningParameters>> (ASLayoutRangeModeCount, std::vector<ASRangeTuningParameters> (ASLayoutRangeTypeCount));
 
   tuningParameters[ASLayoutRangeModeFull][ASLayoutRangeTypeDisplay] = {
     .leadingBufferScreenfuls = 1.0,

--- a/Source/Details/ASBasicImageDownloader.mm
+++ b/Source/Details/ASBasicImageDownloader.mm
@@ -249,7 +249,7 @@ static const void *ContextKey() {
   // cause significant performance issues.
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     // associate metadata with it
-    let callbackData = [[NSMutableDictionary alloc] init];
+    const auto callbackData = [[NSMutableDictionary alloc] init];
     callbackData[kASBasicImageDownloaderContextCallbackQueue] = callbackQueue ? : dispatch_get_main_queue();
 
     if (downloadProgress) {

--- a/Source/Details/ASCollectionLayoutState.mm
+++ b/Source/Details/ASCollectionLayoutState.mm
@@ -155,7 +155,7 @@ elementToLayoutAttributesTable:[NSMapTable elementToLayoutAttributesTable]];
   }
 
   // Use a set here because some items may span multiple pages
-  let result = [[NSMutableSet<UICollectionViewLayoutAttributes *> alloc] init];
+  const auto result = [[NSMutableSet<UICollectionViewLayoutAttributes *> alloc] init];
   for (id pagePtr in pages) {
     ASPageCoordinate page = (ASPageCoordinate)pagePtr;
     NSArray<UICollectionViewLayoutAttributes *> *allAttrs = [_pageToLayoutAttributesTable objectForPage:page];

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -206,7 +206,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
     return @[];
   }
   
-  let indexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
+  const auto indexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
   if ([kind isEqualToString:ASDataControllerRowNodeKind]) {
     std::vector<NSInteger> counts = [self itemCountsFromDataSource];
     [sections enumerateRangesUsingBlock:^(NSRange range, BOOL * _Nonnull stop) {
@@ -645,7 +645,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
     if (canDelegate) {
       [layoutDelegateClass calculateLayoutWithContext:layoutContext];
     } else {
-      let elementsToProcess = [[NSMutableArray<ASCollectionElement *> alloc] init];
+      const auto elementsToProcess = [[NSMutableArray<ASCollectionElement *> alloc] init];
       for (ASCollectionElement *element in newMap) {
         ASCellNode *nodeIfAllocated = element.nodeIfAllocated;
         if (nodeIfAllocated.shouldUseUIKitCell) {
@@ -824,10 +824,10 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   }
   
   id<ASDataControllerSource> dataSource = self.dataSource;
-  let visibleMap = self.visibleMap;
-  let pendingMap = self.pendingMap;
+  const auto visibleMap = self.visibleMap;
+  const auto pendingMap = self.pendingMap;
   for (ASCellNode *node in nodes) {
-    let element = node.collectionElement;
+    const auto element = node.collectionElement;
     NSIndexPath *indexPathInPendingMap = [pendingMap indexPathForElement:element];
     // Ensure the element is present in both maps or skip it. If it's not in the visible map,
     // then we can't check the presented size. If it's not in the pending map, we can't get the constrained size.

--- a/Source/Details/ASIntegerMap.mm
+++ b/Source/Details/ASIntegerMap.mm
@@ -98,7 +98,7 @@
     return NSNotFound;
   }
 
-  let result = _map.find(key);
+  const auto result = _map.find(key);
   return result != _map.end() ? result->second : NSNotFound;
 }
 
@@ -118,7 +118,7 @@
     return self;
   }
 
-  let result = [[ASIntegerMap alloc] init];
+  const auto result = [[ASIntegerMap alloc] init];
   
   for (let &e : _map) {
     result->_map[e.second] = e.first;
@@ -134,7 +134,7 @@
     return self;
   }
 
-  let newMap = [[ASIntegerMap allocWithZone:zone] init];
+  const auto newMap = [[ASIntegerMap allocWithZone:zone] init];
   newMap->_map = _map;
   return newMap;
 }

--- a/Source/Details/ASIntegerMap.mm
+++ b/Source/Details/ASIntegerMap.mm
@@ -120,7 +120,7 @@
 
   const auto result = [[ASIntegerMap alloc] init];
   
-  for (let &e : _map) {
+  for (const auto &e : _map) {
     result->_map[e.second] = e.first;
   }
   return result;
@@ -152,7 +152,7 @@
   } else {
     // { 1->2 3->4 5->6 }
     NSMutableString *str = [NSMutableString string];
-    for (let &e : _map) {
+    for (const auto &e : _map) {
       [str appendFormat:@" %ld->%ld", (long)e.first, (long)e.second];
     }
     // Remove leading space
@@ -176,7 +176,7 @@
     return YES;
   }
 
-  if (let otherMap = ASDynamicCast(object, ASIntegerMap)) {
+  if (ASIntegerMap *otherMap = ASDynamicCast(object, ASIntegerMap)) {
     return otherMap->_map == _map;
   }
   return NO;

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -221,7 +221,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
 
   // TODO: Consider if we need to use this codepath, or can rely on something more similar to the data & display ranges
   // Example: ... = [_layoutController indexPathsForScrolling:scrollDirection rangeType:ASLayoutRangeTypeVisible];
-  var visibleElements = [_dataSource visibleElementsForRangeController:self];
+  auto visibleElements = [_dataSource visibleElementsForRangeController:self];
   NSHashTable *newVisibleNodes = [NSHashTable hashTableWithOptions:NSHashTableObjectPointerPersonality];
 
   ASSignpostStart(ASSignpostRangeControllerUpdate);

--- a/Source/Layout/ASAbsoluteLayoutSpec.mm
+++ b/Source/Layout/ASAbsoluteLayoutSpec.mm
@@ -81,7 +81,7 @@
     sublayout.position = layoutPosition;
     rawSublayouts[i++] = sublayout;
   }
-  let sublayouts = [NSArray<ASLayout *> arrayByTransferring:rawSublayouts count:i];
+  const auto sublayouts = [NSArray<ASLayout *> arrayByTransferring:rawSublayouts count:i];
 
   if (_sizing == ASAbsoluteLayoutSpecSizingSizeToFit || isnan(size.width)) {
     size.width = constrainedSize.min.width;

--- a/Source/Layout/ASBackgroundLayoutSpec.mm
+++ b/Source/Layout/ASBackgroundLayoutSpec.mm
@@ -61,7 +61,7 @@ static NSUInteger const kBackgroundChildIndex = 1;
   contentsLayout.position = CGPointZero;
   rawSublayouts[i++] = contentsLayout;
 
-  let sublayouts = [NSArray<ASLayout *> arrayByTransferring:rawSublayouts count:i];
+  const auto sublayouts = [NSArray<ASLayout *> arrayByTransferring:rawSublayouts count:i];
   return [ASLayout layoutWithLayoutElement:self size:contentsLayout.size sublayouts:sublayouts];
 }
 

--- a/Source/Layout/ASDimension.mm
+++ b/Source/Layout/ASDimension.mm
@@ -89,8 +89,8 @@ struct _Range {
 
 ASSizeRange ASSizeRangeIntersect(ASSizeRange sizeRange, ASSizeRange otherSizeRange)
 {
-  let w = _Range({sizeRange.min.width, sizeRange.max.width}).intersect({otherSizeRange.min.width, otherSizeRange.max.width});
-  let h = _Range({sizeRange.min.height, sizeRange.max.height}).intersect({otherSizeRange.min.height, otherSizeRange.max.height});
+  const auto w = _Range({sizeRange.min.width, sizeRange.max.width}).intersect({otherSizeRange.min.width, otherSizeRange.max.width});
+  const auto h = _Range({sizeRange.min.height, sizeRange.max.height}).intersect({otherSizeRange.min.height, otherSizeRange.max.height});
   return {{w.min, h.min}, {w.max, h.max}};
 }
 

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -223,7 +223,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
     if (ASLayoutIsDisplayNodeType(layout)) {
       if (sublayoutsCount > 0 || CGPointEqualToPoint(ASCeilPointValues(absolutePosition), layout.position) == NO) {
         // Only create a new layout if the existing one can't be reused, which means it has either some sublayouts or an invalid absolute position.
-        let newLayout = [ASLayout layoutWithLayoutElement:layout->_layoutElement
+        const auto newLayout = [ASLayout layoutWithLayoutElement:layout->_layoutElement
                                                      size:layout.size
                                                  position:absolutePosition
                                                sublayouts:@[]];
@@ -330,7 +330,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
     [result addObject:@{ @"layoutElement" : layoutElement }];
   }
 
-  let pos = self.position;
+  const auto pos = self.position;
   if (!ASPointIsNull(pos)) {
     [result addObject:@{ @"position" : [NSValue valueWithCGPoint:pos] }];
   }

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -151,7 +151,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
   if (_retainSublayoutElements.load()) {
     for (ASLayout *sublayout in _sublayouts) {
       // We retained this, so there's no risk of it deallocating on us.
-      if (let cfElement = (__bridge CFTypeRef)sublayout->_layoutElement) {
+      if (CFTypeRef cfElement = (__bridge CFTypeRef)sublayout->_layoutElement) {
         CFRelease(cfElement);
       }
     }
@@ -326,7 +326,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
   NSMutableArray *result = [NSMutableArray array];
   [result addObject:@{ @"size" : [NSValue valueWithCGSize:self.size] }];
 
-  if (let layoutElement = self.layoutElement) {
+  if (id<ASLayoutElement> layoutElement = self.layoutElement) {
     [result addObject:@{ @"layoutElement" : layoutElement }];
   }
 

--- a/Source/Layout/ASLayoutElement.mm
+++ b/Source/Layout/ASLayoutElement.mm
@@ -82,20 +82,20 @@ void ASLayoutElementPushContext(ASLayoutElementContext *context)
   // NOTE: It would be easy to support nested contexts – just use an NSMutableArray here.
   ASDisplayNodeCAssertNil(pthread_getspecific(ASLayoutElementContextKey()), @"Nested ASLayoutElementContexts aren't supported.");
   
-  let cfCtx = (__bridge_retained CFTypeRef)context;
+  const auto cfCtx = (__bridge_retained CFTypeRef)context;
   pthread_setspecific(ASLayoutElementContextKey(), cfCtx);
 }
 
 ASLayoutElementContext *ASLayoutElementGetCurrentContext()
 {
   // Don't retain here. Caller will retain if it wants to!
-  let ctxPtr = pthread_getspecific(ASLayoutElementContextKey());
+  const auto ctxPtr = pthread_getspecific(ASLayoutElementContextKey());
   return (__bridge ASLayoutElementContext *)ctxPtr;
 }
 
 void ASLayoutElementPopContext()
 {
-  let ctx = (CFTypeRef)pthread_getspecific(ASLayoutElementContextKey());
+  const auto ctx = (CFTypeRef)pthread_getspecific(ASLayoutElementContextKey());
   ASDisplayNodeCAssertNotNil(ctx, @"Attempt to pop context when there wasn't a context!");
   CFRelease(ctx);
   pthread_setspecific(ASLayoutElementContextKey(), NULL);

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -156,10 +156,10 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (NSMutableArray<NSDictionary *> *)propertiesForDescription
 {
-  let result = [NSMutableArray<NSDictionary *> array];
+  const auto result = [NSMutableArray<NSDictionary *> array];
   if (NSArray *children = self.children) {
     // Use tiny descriptions because these trees can get nested very deep.
-    let tinyDescriptions = ASArrayByFlatMapping(children, id object, ASObjectDescriptionMakeTiny(object));
+    const auto tinyDescriptions = ASArrayByFlatMapping(children, id object, ASObjectDescriptionMakeTiny(object));
     [result addObject:@{ @"children": tinyDescriptions }];
   }
   return result;
@@ -289,7 +289,7 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
 {
   NSArray *children = self.children;
-  let count = children.count;
+  const auto count = children.count;
   ASLayout *rawSublayouts[count];
   int i = 0;
   
@@ -303,7 +303,7 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
     
     rawSublayouts[i++] = sublayout;
   }
-  let sublayouts = [NSArray<ASLayout *> arrayByTransferring:rawSublayouts count:i];
+  const auto sublayouts = [NSArray<ASLayout *> arrayByTransferring:rawSublayouts count:i];
   return [ASLayout layoutWithLayoutElement:self size:size sublayouts:sublayouts];
 }
 

--- a/Source/Layout/ASOverlayLayoutSpec.mm
+++ b/Source/Layout/ASOverlayLayoutSpec.mm
@@ -81,7 +81,7 @@ static NSUInteger const kOverlayChildIndex = 1;
     rawSublayouts[i++] = overlayLayout;
   }
   
-  let sublayouts = [NSArray<ASLayout *> arrayByTransferring:rawSublayouts count:i];
+  const auto sublayouts = [NSArray<ASLayout *> arrayByTransferring:rawSublayouts count:i];
   return [ASLayout layoutWithLayoutElement:self size:contentsLayout.size sublayouts:sublayouts];
 }
 

--- a/Source/Layout/ASRatioLayoutSpec.mm
+++ b/Source/Layout/ASRatioLayoutSpec.mm
@@ -75,7 +75,7 @@
   }
 
   // Choose the size closest to the desired ratio.
-  let &bestSize = std::max_element(sizeOptions.begin(), sizeOptions.end(), [&](const CGSize &a, const CGSize &b){
+  const auto &bestSize = std::max_element(sizeOptions.begin(), sizeOptions.end(), [&](const CGSize &a, const CGSize &b){
     return std::fabs((a.height / a.width) - _ratio) > std::fabs((b.height / b.width) - _ratio);
   });
 

--- a/Source/Layout/ASStackLayoutSpec.mm
+++ b/Source/Layout/ASStackLayoutSpec.mm
@@ -159,7 +159,7 @@
     rawSublayouts[i++] = item.layout;
   }
 
-  let sublayouts = [NSArray<ASLayout *> arrayByTransferring:rawSublayouts count:i];
+  const auto sublayouts = [NSArray<ASLayout *> arrayByTransferring:rawSublayouts count:i];
   return [ASLayout layoutWithLayoutElement:self size:positionedLayout.size sublayouts:sublayouts];
 }
 

--- a/Source/Private/ASCollectionLayoutCache.mm
+++ b/Source/Private/ASCollectionLayoutCache.mm
@@ -58,7 +58,7 @@
   }
 
   ASDN::MutexLocker l(__instanceLock__);
-  var innerMap = [_map objectForKey:elements];
+  auto innerMap = [_map objectForKey:elements];
   if (innerMap == nil) {
     innerMap = [NSMapTable strongToStrongObjectsMapTable];
     [_map setObject:innerMap forKey:elements];

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -240,7 +240,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 - (NSIndexSet *)indexesForItemChangesOfType:(_ASHierarchyChangeType)changeType inSection:(NSUInteger)section
 {
   [self _ensureCompleted];
-  let result = [[NSMutableIndexSet alloc] init];
+  const auto result = [[NSMutableIndexSet alloc] init];
   for (_ASHierarchyItemChange *change in [self itemChangesOfType:changeType]) {
     [result addIndexes:[NSIndexSet as_indexSetFromIndexPaths:change.indexPaths inSection:section]];
   }
@@ -282,8 +282,8 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 
   if (_itemMappings == nil) {
     _itemMappings = [[NSMutableArray alloc] init];
-    let insertMap = [_ASHierarchyItemChange sectionToIndexSetMapFromChanges:_originalInsertItemChanges];
-    let deleteMap = [_ASHierarchyItemChange sectionToIndexSetMapFromChanges:_originalDeleteItemChanges];
+    const auto insertMap = [_ASHierarchyItemChange sectionToIndexSetMapFromChanges:_originalInsertItemChanges];
+    const auto deleteMap = [_ASHierarchyItemChange sectionToIndexSetMapFromChanges:_originalDeleteItemChanges];
     NSInteger oldSection = 0;
     for (let oldCount : _oldItemCounts) {
       NSInteger newSection = [self newSectionForOldSection:oldSection];
@@ -500,7 +500,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
     for (_ASHierarchyItemChange *change in _reloadItemChanges) {
       NSAssert(change.changeType == _ASHierarchyChangeTypeReload, @"It must be a reload change to be in here");
 
-      let newIndexPaths = ASArrayByFlatMapping(change.indexPaths, NSIndexPath *indexPath, [self newIndexPathForOldIndexPath:indexPath]);
+      const auto newIndexPaths = ASArrayByFlatMapping(change.indexPaths, NSIndexPath *indexPath, [self newIndexPathForOldIndexPath:indexPath]);
       
       // All reload changes are translated into deletes and inserts
       // We delete the items that needs reload together with other deleted items, at their original index
@@ -754,7 +754,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   NSMutableArray *result = [[NSMutableArray alloc] init];
   
   __block ASDataControllerAnimationOptions currentOptions = 0;
-  let currentIndexes = [[NSMutableIndexSet alloc] init];
+  const auto currentIndexes = [[NSMutableIndexSet alloc] init];
 
   BOOL reverse = type == _ASHierarchyChangeTypeDelete || type == _ASHierarchyChangeTypeOriginalDelete;
   NSEnumerationOptions options = reverse ? NSEnumerationReverse : kNilOptions;
@@ -793,7 +793,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 
 + (NSMutableIndexSet *)allIndexesInSectionChanges:(NSArray<_ASHierarchySectionChange *> *)changes
 {
-  let indexes = [[NSMutableIndexSet alloc] init];
+  const auto indexes = [[NSMutableIndexSet alloc] init];
   for (_ASHierarchySectionChange *change in changes) {
     [indexes addIndexes:change.indexSet];
   }
@@ -920,10 +920,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   ASDisplayNodeAssert(ASHierarchyChangeTypeIsFinal(type), @"Attempt to sort and coalesce item changes of intermediary type %@. Why?", NSStringFromASHierarchyChangeType(type));
     
   // Lookup table [NSIndexPath: AnimationOptions]
-  let animationOptions = [[NSMutableDictionary<NSIndexPath *, NSNumber *> alloc] init];
+  const auto animationOptions = [[NSMutableDictionary<NSIndexPath *, NSNumber *> alloc] init];
   
   // All changed index paths, sorted
-  let allIndexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
+  const auto allIndexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
   
   for (_ASHierarchyItemChange *change in changes) {
     for (NSIndexPath *indexPath in change.indexPaths) {
@@ -938,10 +938,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   [allIndexPaths sortUsingSelector:sorting];
 
   // Create new changes by grouping sorted changes by animation option
-  let result = [[NSMutableArray<_ASHierarchyItemChange *> alloc] init];
+  const auto result = [[NSMutableArray<_ASHierarchyItemChange *> alloc] init];
 
   ASDataControllerAnimationOptions currentOptions = 0;
-  let currentIndexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
+  const auto currentIndexPaths = [[NSMutableArray<NSIndexPath *> alloc] init];
 
   for (NSIndexPath *indexPath in allIndexPaths) {
     ASDataControllerAnimationOptions options = [animationOptions[indexPath] integerValue];

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -285,7 +285,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
     const auto insertMap = [_ASHierarchyItemChange sectionToIndexSetMapFromChanges:_originalInsertItemChanges];
     const auto deleteMap = [_ASHierarchyItemChange sectionToIndexSetMapFromChanges:_originalDeleteItemChanges];
     NSInteger oldSection = 0;
-    for (let oldCount : _oldItemCounts) {
+    for (NSInteger oldCount : _oldItemCounts) {
       NSInteger newSection = [self newSectionForOldSection:oldSection];
       ASIntegerMap *table;
       if (newSection == NSNotFound) {

--- a/Tests/ASLayoutEngineTests.mm
+++ b/Tests/ASLayoutEngineTests.mm
@@ -294,7 +294,7 @@
       // are common to both fixture2 and fixture4 are available from the cache.
     } else {
       // Incorrect behavior: nodeC will get measured against its new bounds on main.
-      let cPendingSize = [fixture2 layoutForNode:nodeC].size;
+      const auto cPendingSize = [fixture2 layoutForNode:nodeC].size;
       OCMExpect([nodeC.mock calculateLayoutThatFits:ASSizeRangeMake(cPendingSize)]).onMainThread();
     }
     [window layoutIfNeeded];
@@ -364,16 +364,16 @@
 
 - (void)verifyFixture:(ASTLayoutFixture *)fixture
 {
-  let expected = fixture.layout;
+  const auto expected = fixture.layout;
 
   // Ensure expected == frames
-  let frames = [fixture.rootNode currentLayoutBasedOnFrames];
+  const auto frames = [fixture.rootNode currentLayoutBasedOnFrames];
   if (![expected isEqual:frames]) {
     XCTFail(@"\n*** Layout verification failed – frames don't match expected. ***\nGot:\n%@\nExpected:\n%@", [frames recursiveDescription], [expected recursiveDescription]);
   }
 
   // Ensure expected == calculatedLayout
-  let calculated = fixture.rootNode.calculatedLayout;
+  const auto calculated = fixture.rootNode.calculatedLayout;
   if (![expected isEqual:calculated]) {
     XCTFail(@"\n*** Layout verification failed – calculated layout doesn't match expected. ***\nGot:\n%@\nExpected:\n%@", [calculated recursiveDescription], [expected recursiveDescription]);
   }
@@ -402,22 +402,22 @@
  */
 - (ASTLayoutFixture *)createFixture1
 {
-  let fixture = [[ASTLayoutFixture alloc] init];
+  const auto fixture = [[ASTLayoutFixture alloc] init];
 
   // nodeB
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeB];
-  let layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
+  const auto layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
 
   // nodeC
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeC];
-  let layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{2,1} position:{4,0} sublayouts:nil];
+  const auto layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{2,1} position:{4,0} sublayouts:nil];
 
   // nodeD
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeD];
-  let layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{1,1} position:{9,0} sublayouts:nil];
+  const auto layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{1,1} position:{9,0} sublayouts:nil];
 
   [fixture addSizeRange:{{10, 1}, {10, 1}} forNode:nodeA];
-  let layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutD ]];
+  const auto layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutD ]];
   fixture.layout = layoutA;
 
   [fixture.layoutSpecBlocks setObject:fixture1and3and5NodeALayoutSpecBlock forKey:nodeA];
@@ -437,22 +437,22 @@
  */
 - (ASTLayoutFixture *)createFixture2
 {
-  let fixture = [[ASTLayoutFixture alloc] init];
+  const auto fixture = [[ASTLayoutFixture alloc] init];
 
   // nodeB
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeB];
-  let layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
+  const auto layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
 
   // nodeC
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeC];
-  let layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{4,1} position:{3,0} sublayouts:nil];
+  const auto layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{4,1} position:{3,0} sublayouts:nil];
 
   // nodeE
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeE];
-  let layoutE = [ASLayout layoutWithLayoutElement:nodeE size:{1,1} position:{9,0} sublayouts:nil];
+  const auto layoutE = [ASLayout layoutWithLayoutElement:nodeE size:{1,1} position:{9,0} sublayouts:nil];
 
   [fixture addSizeRange:{{10, 1}, {10, 1}} forNode:nodeA];
-  let layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutE ]];
+  const auto layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutE ]];
   fixture.layout = layoutA;
 
   ASLayoutSpecBlock specBlockA = ^ASLayoutSpec * _Nonnull(__kindof ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
@@ -473,24 +473,24 @@
  */
 - (ASTLayoutFixture *)createFixture3
 {
-  let fixture = [[ASTLayoutFixture alloc] init];
+  const auto fixture = [[ASTLayoutFixture alloc] init];
 
   // nodeB wants 8,1 but it will settle for 7,1
   [fixture setReturnedSize:{8,1} forNode:nodeB];
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeB];
   [fixture addSizeRange:{{7, 0}, {7, 1}} forNode:nodeB];
-  let layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{7,1} position:{0,0} sublayouts:nil];
+  const auto layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{7,1} position:{0,0} sublayouts:nil];
 
   // nodeC
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeC];
-  let layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{2,1} position:{7,0} sublayouts:nil];
+  const auto layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{2,1} position:{7,0} sublayouts:nil];
 
   // nodeD
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeD];
-  let layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{1,1} position:{9,0} sublayouts:nil];
+  const auto layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{1,1} position:{9,0} sublayouts:nil];
 
   [fixture addSizeRange:{{10, 1}, {10, 1}} forNode:nodeA];
-  let layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutD ]];
+  const auto layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutD ]];
   fixture.layout = layoutA;
 
   [fixture.layoutSpecBlocks setObject:fixture1and3and5NodeALayoutSpecBlock forKey:nodeA];
@@ -516,22 +516,22 @@
  */
 - (ASTLayoutFixture *)createFixture4
 {
-  let fixture = [[ASTLayoutFixture alloc] init];
+  const auto fixture = [[ASTLayoutFixture alloc] init];
 
   // nodeB
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeB];
-  let layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
+  const auto layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
 
   // nodeD
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeD];
-  let layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{2,1} position:{4,0} sublayouts:nil];
+  const auto layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{2,1} position:{4,0} sublayouts:nil];
 
   // nodeE
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeE];
-  let layoutE = [ASLayout layoutWithLayoutElement:nodeE size:{1,1} position:{9,0} sublayouts:nil];
+  const auto layoutE = [ASLayout layoutWithLayoutElement:nodeE size:{1,1} position:{9,0} sublayouts:nil];
 
   [fixture addSizeRange:{{10, 1}, {10, 1}} forNode:nodeA];
-  let layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutD, layoutE ]];
+  const auto layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{10,1} position:ASPointNull sublayouts:@[ layoutB, layoutD, layoutE ]];
   fixture.layout = layoutA;
 
   ASLayoutSpecBlock specBlockA = ^ASLayoutSpec * _Nonnull(__kindof ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
@@ -548,22 +548,22 @@
  */
 - (ASTLayoutFixture *)createFixture5
 {
-  let fixture = [[ASTLayoutFixture alloc] init];
+  const auto fixture = [[ASTLayoutFixture alloc] init];
 
   // nodeB
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeB];
-  let layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
+  const auto layoutB = [ASLayout layoutWithLayoutElement:nodeB size:{1,1} position:{0,0} sublayouts:nil];
 
   // nodeC
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeC];
-  let layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{2,1} position:{4,0} sublayouts:nil];
+  const auto layoutC = [ASLayout layoutWithLayoutElement:nodeC size:{2,1} position:{4,0} sublayouts:nil];
 
   // nodeD
   [fixture addSizeRange:{{0, 0}, {INFINITY, 1}} forNode:nodeD];
-  let layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{1,1} position:{9,0} sublayouts:nil];
+  const auto layoutD = [ASLayout layoutWithLayoutElement:nodeD size:{1,1} position:{9,0} sublayouts:nil];
 
   [fixture addSizeRange:{{15, 1}, {15, 1}} forNode:nodeA];
-  let layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{15,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutD ]];
+  const auto layoutA = [ASLayout layoutWithLayoutElement:nodeA size:{15,1} position:ASPointNull sublayouts:@[ layoutB, layoutC, layoutD ]];
   fixture.layout = layoutA;
 
   [fixture.layoutSpecBlocks setObject:fixture1and3and5NodeALayoutSpecBlock forKey:nodeA];

--- a/Tests/ASLayoutTestNode.mm
+++ b/Tests/ASLayoutTestNode.mm
@@ -35,7 +35,7 @@
 
 - (ASLayout *)_currentLayoutBasedOnFramesForRootNode:(BOOL)isRootNode
 {
-  let sublayouts = [[NSMutableArray<ASLayout *> alloc] init];
+  const auto sublayouts = [[NSMutableArray<ASLayout *> alloc] init];
   for (ASLayoutTestNode *subnode in self.subnodes) {
     [sublayouts addObject:[subnode _currentLayoutBasedOnFramesForRootNode:NO]];
   }
@@ -60,7 +60,7 @@
     return [super calculateLayoutThatFits:constrainedSize];
   } else {
     // Interestingly, the infra will auto-clamp sizes from calculateSizeThatFits, but not from calculateLayoutThatFits.
-    let size = ASSizeRangeClamp(constrainedSize, self.testSize);
+    const auto size = ASSizeRangeClamp(constrainedSize, self.testSize);
     return [ASLayout layoutWithLayoutElement:self size:size];
   }
 }

--- a/Tests/ASTLayoutFixture.mm
+++ b/Tests/ASTLayoutFixture.mm
@@ -33,7 +33,7 @@
 
 - (void)addSizeRange:(ASSizeRange)sizeRange forNode:(ASLayoutTestNode *)node
 {
-  var ranges = [_sizeRanges objectForKey:node];
+  auto ranges = [_sizeRanges objectForKey:node];
   if (ranges == nil) {
     ranges = [[NSMutableArray alloc] init];
     [_sizeRanges setObject:ranges forKey:node];
@@ -48,7 +48,7 @@
 
 - (ASSizeRange)firstSizeRangeForNode:(ASLayoutTestNode *)node
 {
-  let val = [_sizeRanges objectForKey:node].firstObject;
+  const auto val = [_sizeRanges objectForKey:node].firstObject;
   ASSizeRange r;
   [val getValue:&r];
   return r;
@@ -100,7 +100,7 @@
 
 - (NSSet<ASLayoutTestNode *> *)allNodes
 {
-  let allLayouts = [NSMutableArray array];
+  const auto allLayouts = [NSMutableArray array];
   [ASTLayoutFixture collectAllLayoutsFromLayout:self.layout array:allLayouts];
   return [NSSet setWithArray:[allLayouts valueForKey:@"layoutElement"]];
 }
@@ -109,7 +109,7 @@
 {
   // Update layoutSpecBlock for parent nodes, set automatic subnode management
   for (ASDisplayNode *node in _layoutSpecBlocks) {
-    let block = [_layoutSpecBlocks objectForKey:node];
+    const auto block = [_layoutSpecBlocks objectForKey:node];
     if (node.layoutSpecBlock != block) {
       node.automaticallyManagesSubnodes = YES;
       node.layoutSpecBlock = block;
@@ -124,9 +124,9 @@
 /// to the layout size if needed, then call -setNeedsLayout
 - (void)setTestSizesOfLeafNodesInLayout:(ASLayout *)layout
 {
-  let node = (ASLayoutTestNode *)layout.layoutElement;
+  const auto node = (ASLayoutTestNode *)layout.layoutElement;
   if (layout.sublayouts.count == 0) {
-    let override = [self.returnedSizes objectForKey:node];
+    const auto override = [self.returnedSizes objectForKey:node];
     node.testSize = override ? override.CGSizeValue : layout.size;
   } else {
     node.testSize = CGSizeZero;


### PR DESCRIPTION
Not only are these a little icky but the label "var" is used in Abseil header functions which causes it to choke when imported after Texture.