### PR TITLE
Removed locked jekyll version

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gem 'github-pages'
 gem 'rouge', '~>1.7'
-gem 'jekyll', '~>3.6.3'
+gem 'jekyll'


### PR DESCRIPTION
See issue #1321 jekyll 3.6.3 has no compatible github-pages version