### PR TITLE
[Text Nodes] Maintain isAccessibilityElement setting on text nodes when updating text

### DIFF
--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -462,12 +462,16 @@ static NSArray *DefaultLinkAttributeNames() {
     attributedText = [[NSAttributedString alloc] initWithString:@"" attributes:nil];
   }
 
+  NSAttributedString *oldAttributedText = nil;
+  
   {
     ASLockScopeSelf();
     if (ASObjectIsEqual(attributedText, _attributedText)) {
       return;
     }
 
+    oldAttributedText = _attributedText;
+    
     NSAttributedString *cleanedAttributedString = ASCleanseAttributedStringOfCoreTextAttributes(attributedText);
 
     // Invalidating the truncation text must be done while we still hold the lock. Because after we release it,
@@ -496,7 +500,12 @@ static NSArray *DefaultLinkAttributeNames() {
   // Accessiblity
   const auto currentAttributedText = self.attributedText; // Grab attributed string again in case it changed in the meantime
   self.accessibilityLabel = self.defaultAccessibilityLabel;
-  self.isAccessibilityElement = (currentAttributedText.length != 0); // We're an accessibility element by default if there is a string.
+  
+  // We update the isAccessibilityElement setting if this node is not switching between strings.
+  if (oldAttributedText.length == 0 || currentAttributedText.length == 0) {
+    // We're an accessibility element by default if there is a string.
+    self.isAccessibilityElement = (currentAttributedText.length != 0);
+  }
 
 #if AS_TEXTNODE_RECORD_ATTRIBUTED_STRINGS
   [ASTextNode _registerAttributedText:_attributedText];

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -402,6 +402,7 @@ static NSArray *DefaultLinkAttributeNames() {
   // Holding it for the duration of the method is more efficient in this case.
   ASLockScopeSelf();
 
+  NSAttributedString *oldAttributedText = _attributedText;
   if (!ASCompareAssignCopy(_attributedText, attributedText)) {
     return;
   }
@@ -424,7 +425,12 @@ static NSArray *DefaultLinkAttributeNames() {
 
   // Accessiblity
   self.accessibilityLabel = self.defaultAccessibilityLabel;
-  self.isAccessibilityElement = (length != 0); // We're an accessibility element by default if there is a string.
+  
+  // We update the isAccessibilityElement setting if this node is not switching between strings.
+  if (oldAttributedText.length == 0 || length == 0) {
+    // We're an accessibility element by default if there is a string.
+    self.isAccessibilityElement = (length != 0);
+  }
 
 #if AS_TEXTNODE2_RECORD_ATTRIBUTED_STRINGS
   [ASTextNode _registerAttributedText:_attributedText];

--- a/Tests/ASTextNode2Tests.mm
+++ b/Tests/ASTextNode2Tests.mm
@@ -91,4 +91,20 @@
                 _textNode.defaultAccessibilityLabel, _attributedText.string);
 }
 
+- (void)testRespectingAccessibilitySetting
+{
+  ASTextNode2 *textNode = [[ASTextNode2 alloc] init];
+  textNode.attributedText = _attributedText;
+  textNode.isAccessibilityElement = NO;
+  
+  textNode.attributedText = [[NSAttributedString alloc] initWithString:@"new string"];
+  XCTAssertFalse(textNode.isAccessibilityElement);
+  
+  // Ensure removing string on an accessible text node updates the setting.
+  ASTextNode2 *accessibleTextNode = [ASTextNode2 new];
+  accessibleTextNode.attributedText = _attributedText;
+  accessibleTextNode.attributedText = nil;
+  XCTAssertFalse(accessibleTextNode.isAccessibilityElement);
+}
+
 @end

--- a/Tests/ASTextNodeTests.mm
+++ b/Tests/ASTextNodeTests.mm
@@ -175,6 +175,23 @@
   XCTAssertTrue([_textNode.accessibilityLabel isEqualToString:_attributedText.string], @"Accessibility label is incorrectly set to \n%@\n when it should be \n%@\n", _textNode.accessibilityLabel, _attributedText.string);
 }
 
+- (void)testRespectingAccessibilitySetting
+{
+  ASTextNode *textNode = [ASTextNode new];
+  
+  textNode.attributedText = _attributedText;
+  textNode.isAccessibilityElement = NO;
+  
+  textNode.attributedText = [[NSAttributedString alloc] initWithString:@"new string"];
+  XCTAssertFalse(textNode.isAccessibilityElement);
+  
+  // Ensure removing string on an accessible text node updates the setting.
+  ASTextNode *accessibleTextNode = [ASTextNode new];
+  accessibleTextNode.attributedText = _attributedText;
+  accessibleTextNode.attributedText = nil;
+  XCTAssertFalse(accessibleTextNode.isAccessibilityElement);
+}
+
 - (void)testLinkAttribute
 {
   NSString *linkAttributeName = @"MockLinkAttributeName";


### PR DESCRIPTION
I'd like to propose a change in the way `isAccessibilityElement` is updated when setting the `attributedText` property on `ASTextNode` and `ASTextNode2`. 

Currently this always happen when the `attributedText` property is updated. This makes sense in most cases. But when you set a string and you configure the text node's `isAccessibilityElement` property to `NO`, it will change back to yes if you update the string. Meaning you always need to update `isAccessibilityElement` after updating the text. 

I think that in the case where the `attributedText` property has been set, and the `isAccessibilityElement` has been explicitly set to `NO`, and you update the text (not set the property to `nil`) it makes sense to respect this setting and making the user of the text node responsible for changing it if that's necessary.