### PR TITLE
Add forwarding of UIAccessibilityAction methods

### DIFF
--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -298,4 +298,32 @@ static void CollectAccessibilityElementsForView(UIView *view, NSMutableArray *el
 
 @end
 
+@implementation _ASDisplayView (UIAccessibilityAction)
+
+- (BOOL)accessibilityActivate {
+  return [self.asyncdisplaykit_node accessibilityActivate];
+}
+
+- (void)accessibilityIncrement {
+  [self.asyncdisplaykit_node accessibilityIncrement];
+}
+
+- (void)accessibilityDecrement {
+  [self.asyncdisplaykit_node accessibilityDecrement];
+}
+
+- (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
+  return [self.asyncdisplaykit_node accessibilityScroll:direction];
+}
+
+- (BOOL)accessibilityPerformEscape {
+  return [self.asyncdisplaykit_node accessibilityPerformEscape];
+}
+
+- (BOOL)accessibilityPerformMagicTap {
+  return [self.asyncdisplaykit_node accessibilityPerformMagicTap];
+}
+
+@end
+
 #endif

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -18,6 +18,49 @@
 #import <AsyncDisplayKit/ASConfiguration.h>
 #import <AsyncDisplayKit/ASConfigurationInternal.h>
 
+@interface ASAccessiblityForwardingTestDisplayNode : ASDisplayNode
+
+@property (nonatomic, readonly) BOOL didReceiveAccessibilityActivate;
+@property (nonatomic, readonly) BOOL didReceiveAccessibilityIncrement;
+@property (nonatomic, readonly) BOOL didReceiveAccessibilityDecrement;
+@property (nonatomic, readonly) BOOL didReceiveAccessibilityScroll;
+@property (nonatomic, readonly) BOOL didReceiveAccessibilityPerformEscape;
+@property (nonatomic, readonly) BOOL didReceiveAccessibilityPerformMagicTap;
+
+@end
+
+@implementation ASAccessiblityForwardingTestDisplayNode
+
+- (BOOL)accessibilityActivate {
+  _didReceiveAccessibilityActivate = YES;
+  return YES;
+}
+
+- (void)accessibilityIncrement {
+  _didReceiveAccessibilityIncrement = YES;
+}
+
+- (void)accessibilityDecrement {
+  _didReceiveAccessibilityDecrement = YES;
+}
+
+- (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
+  _didReceiveAccessibilityScroll = YES;
+  return YES;
+}
+
+- (BOOL)accessibilityPerformEscape {
+  _didReceiveAccessibilityPerformEscape = YES;
+  return YES;
+}
+
+- (BOOL)accessibilityPerformMagicTap {
+  _didReceiveAccessibilityPerformMagicTap = YES;
+  return YES;
+}
+
+@end
+
 @interface ASDisplayViewAccessibilityTests : XCTestCase
 @end
 
@@ -267,6 +310,27 @@
   NSArray<UIAccessibilityElement *> *elements2 = contianer.view.accessibilityElements;
   XCTAssertTrue(elements2.count == 1);
   XCTAssertTrue([[elements2.firstObject accessibilityLabel] isEqualToString:@"greeting"]);
+}
+
+#pragma mark -
+#pragma mark UIAccessibilityAction Forwarding
+
+- (void)testActionForwarding {
+  ASAccessiblityForwardingTestDisplayNode *node = [ASAccessiblityForwardingTestDisplayNode new];
+  UIView *view = node.view;
+  
+  [view accessibilityActivate];
+  XCTAssertTrue(node.didReceiveAccessibilityActivate);
+  [view accessibilityIncrement];
+  XCTAssertTrue(node.didReceiveAccessibilityIncrement);
+  [view accessibilityDecrement];
+  XCTAssertTrue(node.didReceiveAccessibilityDecrement);
+  [view accessibilityScroll:UIAccessibilityScrollDirectionDown];
+  XCTAssertTrue(node.didReceiveAccessibilityScroll);
+  [view accessibilityPerformEscape];
+  XCTAssertTrue(node.didReceiveAccessibilityPerformEscape);
+  [view accessibilityPerformMagicTap];
+  XCTAssertTrue(node.didReceiveAccessibilityPerformMagicTap);
 }
 
 @end

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -17,49 +17,7 @@
 #import <AsyncDisplayKit/ASTextNode.h>
 #import <AsyncDisplayKit/ASConfiguration.h>
 #import <AsyncDisplayKit/ASConfigurationInternal.h>
-
-@interface ASAccessiblityForwardingTestDisplayNode : ASDisplayNode
-
-@property (nonatomic, readonly) BOOL didReceiveAccessibilityActivate;
-@property (nonatomic, readonly) BOOL didReceiveAccessibilityIncrement;
-@property (nonatomic, readonly) BOOL didReceiveAccessibilityDecrement;
-@property (nonatomic, readonly) BOOL didReceiveAccessibilityScroll;
-@property (nonatomic, readonly) BOOL didReceiveAccessibilityPerformEscape;
-@property (nonatomic, readonly) BOOL didReceiveAccessibilityPerformMagicTap;
-
-@end
-
-@implementation ASAccessiblityForwardingTestDisplayNode
-
-- (BOOL)accessibilityActivate {
-  _didReceiveAccessibilityActivate = YES;
-  return YES;
-}
-
-- (void)accessibilityIncrement {
-  _didReceiveAccessibilityIncrement = YES;
-}
-
-- (void)accessibilityDecrement {
-  _didReceiveAccessibilityDecrement = YES;
-}
-
-- (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
-  _didReceiveAccessibilityScroll = YES;
-  return YES;
-}
-
-- (BOOL)accessibilityPerformEscape {
-  _didReceiveAccessibilityPerformEscape = YES;
-  return YES;
-}
-
-- (BOOL)accessibilityPerformMagicTap {
-  _didReceiveAccessibilityPerformMagicTap = YES;
-  return YES;
-}
-
-@end
+#import <OCMock/OCMock.h>
 
 @interface ASDisplayViewAccessibilityTests : XCTestCase
 @end
@@ -316,21 +274,30 @@
 #pragma mark UIAccessibilityAction Forwarding
 
 - (void)testActionForwarding {
-  ASAccessiblityForwardingTestDisplayNode *node = [ASAccessiblityForwardingTestDisplayNode new];
+  ASDisplayNode *node = [ASDisplayNode new];
   UIView *view = node.view;
   
+  id mockNode = OCMPartialMock(node);
+  
+  OCMExpect([mockNode accessibilityActivate]);
   [view accessibilityActivate];
-  XCTAssertTrue(node.didReceiveAccessibilityActivate);
+  
+  OCMExpect([mockNode accessibilityIncrement]);
   [view accessibilityIncrement];
-  XCTAssertTrue(node.didReceiveAccessibilityIncrement);
+
+  OCMExpect([mockNode accessibilityDecrement]);
   [view accessibilityDecrement];
-  XCTAssertTrue(node.didReceiveAccessibilityDecrement);
+
+  OCMExpect([mockNode accessibilityScroll:UIAccessibilityScrollDirectionDown]);
   [view accessibilityScroll:UIAccessibilityScrollDirectionDown];
-  XCTAssertTrue(node.didReceiveAccessibilityScroll);
+
+  OCMExpect([mockNode accessibilityPerformEscape]);
   [view accessibilityPerformEscape];
-  XCTAssertTrue(node.didReceiveAccessibilityPerformEscape);
+
+  OCMExpect([mockNode accessibilityPerformMagicTap]);
   [view accessibilityPerformMagicTap];
-  XCTAssertTrue(node.didReceiveAccessibilityPerformMagicTap);
+
+  OCMVerifyAll(mockNode);
 }
 
 @end


### PR DESCRIPTION
I was working on accessibility in our app and noticed these weren't implemented yet. There's no checking if the node implements the method because `NSObject` provides default implementations.