### PR TITLE
Add an experimental flag to use native dispatch_apply

### DIFF
--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -25,7 +25,8 @@
                     "exp_did_enter_preload_skip_asm_layout",
                     "exp_disable_a11y_cache",
                     "exp_skip_a11y_wait",
-                    "exp_new_default_cell_layout_mode"
+                    "exp_new_default_cell_layout_mode",
+                    "exp_dispatch_apply"
                 ]
     		}
 		}

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -31,6 +31,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalDisableAccessibilityCache = 1 << 10,        // exp_disable_a11y_cache
   ASExperimentalSkipAccessibilityWait = 1 << 11,            // exp_skip_a11y_wait
   ASExperimentalNewDefaultCellLayoutMode = 1 << 12,         // exp_new_default_cell_layout_mode
+  ASExperimentalDispatchApply = 1 << 13,                    // exp_dispatch_apply
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -24,7 +24,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_did_enter_preload_skip_asm_layout",
                                       @"exp_disable_a11y_cache",
                                       @"exp_skip_a11y_wait",
-                                      @"exp_new_default_cell_layout_mode"]));
+                                      @"exp_new_default_cell_layout_mode",
+                                      @"exp_dispatch_apply"]));
   
   if (flags == ASExperimentalFeatureAll) {
     return allNames;

--- a/Source/Private/ASDispatch.mm
+++ b/Source/Private/ASDispatch.mm
@@ -7,6 +7,8 @@
 //
 
 #import <AsyncDisplayKit/ASDispatch.h>
+#import <AsyncDisplayKit/ASConfigurationInternal.h>
+
 
 // Prefer C atomics in this file because ObjC blocks can't capture C++ atomics well.
 #import <stdatomic.h>
@@ -19,6 +21,10 @@
  */
 void ASDispatchApply(size_t iterationCount, dispatch_queue_t queue, NSUInteger threadCount, NS_NOESCAPE void(^work)(size_t i)) {
   if (threadCount == 0) {
+    if (ASActivateExperimentalFeature(ASExperimentalDispatchApply)) {
+      dispatch_apply(iterationCount, queue, work);
+      return;
+    }
     threadCount = NSProcessInfo.processInfo.activeProcessorCount * 2;
   }
   dispatch_group_t group = dispatch_group_create();

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -30,7 +30,8 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalDidEnterPreloadSkipASMLayout,
   ASExperimentalDisableAccessibilityCache,
   ASExperimentalSkipAccessibilityWait,
-  ASExperimentalNewDefaultCellLayoutMode
+  ASExperimentalNewDefaultCellLayoutMode,
+  ASExperimentalDispatchApply
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -55,7 +56,8 @@ static ASExperimentalFeatures features[] = {
     @"exp_did_enter_preload_skip_asm_layout",
     @"exp_disable_a11y_cache",
     @"exp_skip_a11y_wait",
-    @"exp_new_default_cell_layout_mode"
+    @"exp_new_default_cell_layout_mode",
+    @"exp_dispatch_apply"
   ];
 }
 


### PR DESCRIPTION
This has shown performance wins against our current core_count*2 approach in some profiling, possibly due to reduced context switching.