### PR TITLE
Revert "Have node and controller share lock"

### DIFF
--- a/Source/ASNodeController+Beta.h
+++ b/Source/ASNodeController+Beta.h
@@ -10,21 +10,18 @@
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h> // for ASInterfaceState protocol
 
-NS_ASSUME_NONNULL_BEGIN
-
 /* ASNodeController is currently beta and open to change in the future */
 @interface ASNodeController<__covariant DisplayNodeType : ASDisplayNode *>
-    : NSObject <ASInterfaceStateDelegate, ASLocking>
+    : NSObject <ASInterfaceStateDelegate, NSLocking>
 
-@property (strong, readonly /* may be weak! */) DisplayNodeType node;
+@property (nonatomic, strong /* may be weak! */) DisplayNodeType node;
 
 // Until an ASNodeController can be provided in place of an ASCellNode, some apps may prefer to have
 // nodes keep their controllers alive (and a weak reference from controller to node)
 
 @property (nonatomic) BOOL shouldInvertStrongReference;
 
-// called on an arbitrary thread by the framework. You do not call this. Return a new node instance.
-- (DisplayNodeType)createNode;
+- (void)loadNode;
 
 // for descriptions see <ASInterfaceState> definition
 - (void)nodeDidLoad ASDISPLAYNODE_REQUIRES_SUPER;
@@ -51,8 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASDisplayNode (ASNodeController)
 
-@property(nullable, readonly) ASNodeController *nodeController;
+@property(nonatomic, readonly) ASNodeController *nodeController;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/Source/ASNodeController+Beta.mm
+++ b/Source/ASNodeController+Beta.mm
@@ -18,27 +18,22 @@
 {
   ASDisplayNode *_strongNode;
   __weak ASDisplayNode *_weakNode;
-  ASDN::Mutex _nodeLock;
+  ASDN::RecursiveMutex __instanceLock__;
 }
 
-- (ASDisplayNode *)createNode
+- (void)loadNode
 {
-  return [[ASDisplayNode alloc] init];
+  ASLockScopeSelf();
+  self.node = [[ASDisplayNode alloc] init];
 }
 
 - (ASDisplayNode *)node
 {
-  ASDN::MutexLocker l(_nodeLock);
-  ASDisplayNode *node = _node;
-  if (!node) {
-    node = [self createNode];
-    if (!node) {
-      ASDisplayNodeCFailAssert(@"Returned nil from -createNode.");
-      node = [[ASDisplayNode alloc] init];
-    }
-    [self setupReferencesWithNode:node];
+  ASLockScopeSelf();
+  if (_node == nil) {
+    [self loadNode];
   }
-  return node;
+  return _node;
 }
 
 - (void)setupReferencesWithNode:(ASDisplayNode *)node
@@ -56,6 +51,12 @@
 
   [node __setNodeController:self];
   [node addInterfaceStateDelegate:self];
+}
+
+- (void)setNode:(ASDisplayNode *)node
+{
+  ASLockScopeSelf();
+  [self setupReferencesWithNode:node];
 }
 
 - (void)setShouldInvertStrongReference:(BOOL)shouldInvertStrongReference
@@ -92,19 +93,12 @@
 
 - (void)lock
 {
-  [self.node lock];
+  __instanceLock__.lock();
 }
 
 - (void)unlock
 {
-  // Since the node was already locked on this thread, we don't need to call our accessor or take our lock.
-  ASDisplayNodeAssertNotNil(_node, @"Node deallocated while locked.");
-  [_node unlock];
-}
-
-- (BOOL)tryLock
-{
-  return [self.node tryLock];
+  __instanceLock__.unlock();
 }
 
 @end


### PR DESCRIPTION
Reverts TextureGroup/Texture#1227

This problem with this is, if you call `self.node` from within `-createNode` (say, a few methods deep) you will not have finished creating the node and you'll get a deadlock. Using a recursive mutex you would get infinite recursion. Using some kind of flag you would get nil.

Until we can think through the best fix here, reverting.