### PR TITLE
Remove redundant accessibility values and clean up

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -96,7 +96,7 @@ BOOL ASDisplayNodeNeedsSpecialPropertiesHandling(BOOL isSynchronous, BOOL isLaye
 
 _ASPendingState *ASDisplayNodeGetPendingState(ASDisplayNode *node)
 {
-  ASLockScope(node);
+  ASDN::MutexLocker l(node->__instanceLock__);
   _ASPendingState *result = node->_pendingViewState;
   if (result == nil) {
     result = [[_ASPendingState alloc] init];
@@ -3532,13 +3532,13 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (void)setIsAccessibilityContainer:(BOOL)isAccessibilityContainer
 {
   ASDN::MutexLocker l(__instanceLock__);
-  _isAccessibilityContainer = isAccessibilityContainer;
+  _flags.isAccessibilityContainer = isAccessibilityContainer;
 }
 
 - (BOOL)isAccessibilityContainer
 {
   ASDN::MutexLocker l(__instanceLock__);
-  return _isAccessibilityContainer;
+  return _flags.isAccessibilityContainer;
 }
 
 - (NSString *)defaultAccessibilityLabel

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -99,6 +99,7 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
     unsigned shouldBypassEnsureDisplay:1;
     unsigned displaySuspended:1;
     unsigned shouldAnimateSizeChanges:1;
+    unsigned isAccessibilityContainer:1;
     
     // Wrapped view handling
     
@@ -218,29 +219,6 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
 
   ASDisplayNodeContextModifier _willDisplayNodeContentWithRenderingContext;
   ASDisplayNodeContextModifier _didDisplayNodeContentWithRenderingContext;
-
-
-  // Accessibility support
-  BOOL _isAccessibilityElement;
-  NSString *_accessibilityLabel;
-  NSAttributedString *_accessibilityAttributedLabel;
-  NSString *_accessibilityHint;
-  NSAttributedString *_accessibilityAttributedHint;
-  NSString *_accessibilityValue;
-  NSAttributedString *_accessibilityAttributedValue;
-  UIAccessibilityTraits _accessibilityTraits;
-  CGRect _accessibilityFrame;
-  NSString *_accessibilityLanguage;
-  BOOL _accessibilityElementsHidden;
-  BOOL _accessibilityViewIsModal;
-  BOOL _shouldGroupAccessibilityChildren;
-  NSString *_accessibilityIdentifier;
-  UIAccessibilityNavigationStyle _accessibilityNavigationStyle;
-  NSArray *_accessibilityHeaderElements;
-  CGPoint _accessibilityActivationPoint;
-  UIBezierPath *_accessibilityPath;
-  BOOL _isAccessibilityContainer;
-
 
   // Safe Area support
   // These properties are used on iOS 10 and lower, where safe area is not supported by UIKit.


### PR DESCRIPTION
Our display node instances are big. One (small) reason for this is that accessibility properties are currently stored in two places: in the pending state, before view load, and in the node itself, for layer-backed nodes.

There's no need for this redundancy. The pending state is a fine place to act as the storage for such properties, and we use it that way for other UIView-only properties like `userInteractionEnabled`.

This diff aligns our accessibility storage strategy with those other properties and gets rid of the duplicate storage.