### PR TITLE
_ASCollectionViewCell - The point isn't converted before to send to node, impossible to touch button into the node hierarchy

### DIFF
--- a/Source/Details/_ASCollectionViewCell.mm
+++ b/Source/Details/_ASCollectionViewCell.mm
@@ -110,12 +110,12 @@
     return nil;
   }
 
-  return [self.node hitTest:point withEvent:event];
+  return [super hitTest:point withEvent:event];
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(nullable UIEvent *)event
 {
-  return [self.node pointInside:point withEvent:event];
+  return [super pointInside:point withEvent:event];
 }
 
 @end

--- a/Source/Details/_ASCollectionViewCell.mm
+++ b/Source/Details/_ASCollectionViewCell.mm
@@ -110,22 +110,14 @@
     return nil;
   }
 
-  if ([self.node isNodeLoaded] && self.node.view) {
-    CGPoint pointOnNode = [self.node.view convertPoint:point fromView:self];
-    return [self.node hitTest:pointOnNode withEvent:event];
-  } else {
-    return [self.node hitTest:point withEvent:event];
-  }
+  CGPoint pointOnNode = [self.node.view convertPoint:point fromView:self];
+  return [self.node hitTest:pointOnNode withEvent:event];
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(nullable UIEvent *)event
 {
-  if ([self.node isNodeLoaded] && self.node.view) {
-    CGPoint pointOnNode = [self.node.view convertPoint:point fromView:self];
-    return [self.node pointInside:pointOnNode withEvent:event];
-  } else {
-    return [self.node pointInside:point withEvent:event];
-  }
+  CGPoint pointOnNode = [self.node.view convertPoint:point fromView:self];
+  return [self.node pointInside:pointOnNode withEvent:event];
 }
 
 @end

--- a/Source/Details/_ASCollectionViewCell.mm
+++ b/Source/Details/_ASCollectionViewCell.mm
@@ -110,12 +110,22 @@
     return nil;
   }
 
-  return [super hitTest:point withEvent:event];
+  if ([self.node isNodeLoaded] && self.node.view) {
+    CGPoint pointOnNode = [self.node.view convertPoint:point fromView:self];
+    return [self.node hitTest:pointOnNode withEvent:event];
+  } else {
+    return [self.node hitTest:point withEvent:event];
+  }
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(nullable UIEvent *)event
 {
-  return [super pointInside:point withEvent:event];
+  if ([self.node isNodeLoaded] && self.node.view) {
+    CGPoint pointOnNode = [self.node.view convertPoint:point fromView:self];
+    return [self.node pointInside:pointOnNode withEvent:event];
+  } else {
+    return [self.node pointInside:point withEvent:event];
+  }
 }
 
 @end


### PR DESCRIPTION
Hi,

The first step of this modification was:
- The node can have a transformation, the point is not converted to the scaled node.

Second step:
use convertPoint
`
CGPoint pointOnNode = [self.node.view convertPoint:point fromView:self]
return [self.node hitTest:pointOnNode withEvent:event];
`

But...
With this situation
- _ASCollectionViewCell calls ASDisplayNode
- ASDisplayNode calls ASDisplayView1
- ASDisplayView1 calls ASDisplayNode
- ASDisplayNode calls ASDisplayView1
- ASDisplayView1 calls Super.... finished
We need to calculate the new point (for node with view only, because touch for layerBacked is not supported)

This this modification, we win 1 loop for nothing...
- _ASCollectionViewCell calls ASDisplayView
- ASDisplayView1 calls ASDisplayNode
- ASDisplayNode calls ASDisplayView1
- ASDisplayView1 calls Super.... finished
And the transformation is computed by the OS.

Now, with the call to 'super', [self.node hitTest:point withEvent:event] is called, but with the converted point.