### PR TITLE
Add clang-format for a common source code format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,37 @@
 BasedOnStyle:  Google
 
-# Objc allows 120 instead of the traditional 80.
+## Indentation
 ColumnLimit: 120
+IndentWidth: 2
+
+## Line Break
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      true
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+
+## ObjC
+ObjCBinPackProtocolList: Always
+ObjCSpaceAfterProperty: false
+
+## Comments
+AlignTrailingComments: true
+
+## Arguments / Parameters
+
+# If false, a function call’s or function definition’s arguments will either
+# all be on the same line or will have one line each.
+BinPackArguments: false
 
 # If false, a function call’s or function definition’s parameters will either
 # all be on the same line or will have one line each.
@@ -14,3 +44,10 @@ BinPackParameters: false
 #             bar,
 #             baz);
 AllowAllParametersOfDeclarationOnNextLine: true
+
+## Single Line
+AllowShortBlocksOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,16 @@
+BasedOnStyle:  Google
+
+# Objc allows 120 instead of the traditional 80.
+ColumnLimit: 120
+
+# If false, a function call’s or function definition’s parameters will either
+# all be on the same line or will have one line each.
+BinPackParameters: false
+
+# Allow putting all parameters of a function declaration onto the next line even
+# if BinPackParameters is false.
+# For example this should be ok:
+# someFunction(foo,
+#             bar,
+#             baz);
+AllowAllParametersOfDeclarationOnNextLine: true

--- a/format
+++ b/format
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Script uses clang-format to format all of the source files in a
+# default format.
+#
+
+# The absolute path of the directory containing this script.
+DIR="$( cd "$( dirname "$0" )" && pwd)"
+# Define top level project directory
+PROJECT_DIR="${DIR}"
+
+METHOD="GIT"
+if [ -n "$1" ]; then
+ METHOD=$1
+fi
+
+# Paths to format
+MONITOR=()
+MONITOR+=( "${PROJECT_DIR}/Source" )
+
+if [ "$METHOD" == "ALL" ]; then
+    # Format all Source files
+    for FILE in $(find ${MONITOR[*]} -type f \( -iname "*.mm" -o -iname "*.m" -o -iname "*.h" \))
+    do
+        clang-format -style=file -i "$FILE" &
+    done
+elif [ "$METHOD" == "GIT" ]; then
+    # Gather all added or modified files from git and format them
+    CHANGED_FILES=$(git ls-files --other --modified --exclude-standard | grep ".*[\.m|\.mm|\.h|\.hpp]$")
+    for CHANGED_FILE in $CHANGED_FILES
+    do
+        clang-format -style=file -i "${PROJECT_DIR}/$CHANGED_FILE" &
+    done
+else
+    echo "Usage: $0 [GIT|ALL]";
+    echo "GIT: Only format added or modified files"
+    echo "ALL: Format all files"
+fi
+
+
+# Wait until all clang-format invoctations are done
+wait


### PR DESCRIPTION
@Adlai-Holler @appleguy @nguyenhuy @garrettmoon I would appreciate for any input on the code format. For now I added a `.clang-format` file to discuss and iterate on.

Preview: https://github.com/TextureGroup/Texture/compare/master...MSClangFormatPreview