### PR TITLE
Rename ASDN C++ namespace to AS

### DIFF
--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -106,7 +106,7 @@
 
 @interface ASCollectionNode ()
 {
-  ASDN::RecursiveMutex _environmentStateLock;
+  AS::RecursiveMutex _environmentStateLock;
   Class _collectionViewClass;
   id<ASBatchFetchingDelegate> _batchFetchingDelegate;
 }

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -21,6 +21,8 @@
 #import <AsyncDisplayKit/ASDisplayNode+Yoga.h>
 #import <AsyncDisplayKit/NSArray+Diffing.h>
 
+using AS::MutexLocker;
+
 @interface ASDisplayNode (ASLayoutElementStyleDelegate) <ASLayoutElementStyleDelegate>
 @end
 
@@ -42,7 +44,7 @@
 
 - (BOOL)implementsLayoutMethod
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return (_methodOverrides & (ASDisplayNodeMethodOverrideLayoutSpecThatFits |
                               ASDisplayNodeMethodOverrideCalcLayoutThatFits |
                               ASDisplayNodeMethodOverrideCalcSizeThatFits)) != 0 || _layoutSpecBlock != nil;
@@ -51,7 +53,7 @@
 
 - (ASLayoutElementStyle *)style
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return [self _locked_style];
 }
 
@@ -165,7 +167,7 @@ ASLayoutElementStyleExtensibilityForwarding
 - (ASLayoutEngineType)layoutEngineType
 {
 #if YOGA
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   YGNodeRef yogaNode = _style.yogaNode;
   BOOL hasYogaParent = (_yogaParent != nil);
   BOOL hasYogaChildren = (_yogaChildren.count > 0);
@@ -179,13 +181,13 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (ASLayout *)calculatedLayout
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return _calculatedDisplayNodeLayout.layout;
 }
 
 - (CGSize)calculatedSize
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   if (_pendingDisplayNodeLayout.isValid(_layoutVersion)) {
     return _pendingDisplayNodeLayout.layout.size;
   }
@@ -194,7 +196,7 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (ASSizeRange)constrainedSizeForCalculatedLayout
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return [self _locked_constrainedSizeForCalculatedLayout];
 }
 
@@ -447,7 +449,7 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (ASSizeRange)_constrainedSizeForLayoutPass
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return [self _locked_constrainedSizeForLayoutPass];
 }
 
@@ -487,7 +489,7 @@ ASLayoutElementStyleExtensibilityForwarding
   
   ASLayout *layout;
   {
-    ASDN::MutexLocker l(__instanceLock__);
+    MutexLocker l(__instanceLock__);
     if (_calculatedDisplayNodeLayout.version < _layoutVersion) {
       return;
     }
@@ -517,13 +519,13 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (BOOL)automaticallyManagesSubnodes
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return _automaticallyManagesSubnodes;
 }
 
 - (void)setAutomaticallyManagesSubnodes:(BOOL)automaticallyManagesSubnodes
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   _automaticallyManagesSubnodes = automaticallyManagesSubnodes;
 }
 
@@ -536,7 +538,7 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (BOOL)_isLayoutTransitionInvalid
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return [self _locked_isLayoutTransitionInvalid];
 }
 
@@ -598,7 +600,7 @@ ASLayoutElementStyleExtensibilityForwarding
   }
     
   {
-    ASDN::MutexLocker l(__instanceLock__);
+    MutexLocker l(__instanceLock__);
 
     // Check if we are a subnode in a layout transition.
     // In this case no measurement is needed as we're part of the layout transition.
@@ -680,7 +682,7 @@ ASLayoutElementStyleExtensibilityForwarding
       {
         // Grab __instanceLock__ here to make sure this transition isn't invalidated
         // right after it passed the validation test and before it proceeds
-        ASDN::MutexLocker l(__instanceLock__);
+        MutexLocker l(__instanceLock__);
         
         // Update calculated layout
         const auto previousLayout = _calculatedDisplayNodeLayout;
@@ -750,37 +752,37 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (void)setDefaultLayoutTransitionDuration:(NSTimeInterval)defaultLayoutTransitionDuration
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   _defaultLayoutTransitionDuration = defaultLayoutTransitionDuration;
 }
 
 - (NSTimeInterval)defaultLayoutTransitionDuration
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return _defaultLayoutTransitionDuration;
 }
 
 - (void)setDefaultLayoutTransitionDelay:(NSTimeInterval)defaultLayoutTransitionDelay
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   _defaultLayoutTransitionDelay = defaultLayoutTransitionDelay;
 }
 
 - (NSTimeInterval)defaultLayoutTransitionDelay
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return _defaultLayoutTransitionDelay;
 }
 
 - (void)setDefaultLayoutTransitionOptions:(UIViewAnimationOptions)defaultLayoutTransitionOptions
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   _defaultLayoutTransitionOptions = defaultLayoutTransitionOptions;
 }
 
 - (UIViewAnimationOptions)defaultLayoutTransitionOptions
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return _defaultLayoutTransitionOptions;
 }
 
@@ -942,7 +944,7 @@ ASLayoutElementStyleExtensibilityForwarding
     return;
   }
 
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   NSArray<ASLayout *> *sublayouts = _calculatedDisplayNodeLayout.layout.sublayouts;
   unowned ASLayout *cSublayouts[sublayouts.count];
   [sublayouts getObjects:cSublayouts range:NSMakeRange(0, AS_ARRAY_SIZE(cSublayouts))];
@@ -993,7 +995,7 @@ ASLayoutElementStyleExtensibilityForwarding
   [self calculatedLayoutDidChange];
 
   // Grab lock after calling out to subclass
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
 
   // We generate placeholders at -layoutThatFits: time so that a node is guaranteed to have a placeholder ready to go.
   // This is also because measurement is usually asynchronous, but placeholders need to be set up synchronously.
@@ -1027,7 +1029,7 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (void)_setCalculatedDisplayNodeLayout:(const ASDisplayNodeLayout &)displayNodeLayout
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   [self _locked_setCalculatedDisplayNodeLayout:displayNodeLayout];
 }
 

--- a/Source/ASDisplayNode+LayoutSpec.mm
+++ b/Source/ASDisplayNode+LayoutSpec.mm
@@ -26,19 +26,19 @@
   // For now there should never be an override of layoutSpecThatFits: and a layoutSpecBlock together.
   ASDisplayNodeAssert(!(_methodOverrides & ASDisplayNodeMethodOverrideLayoutSpecThatFits),
                       @"Nodes with a .layoutSpecBlock must not also implement -layoutSpecThatFits:");
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   _layoutSpecBlock = layoutSpecBlock;
 }
 
 - (ASLayoutSpecBlock)layoutSpecBlock
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   return _layoutSpecBlock;
 }
 
 - (ASLayout *)calculateLayoutLayoutSpec:(ASSizeRange)constrainedSize
 {
-  ASDN::UniqueLock l(__instanceLock__);
+  AS::UniqueLock l(__instanceLock__);
 
   // Manual size calculation via calculateSizeThatFits:
   if (_layoutSpecBlock == NULL && (_methodOverrides & ASDisplayNodeMethodOverrideLayoutSpecThatFits) == 0) {
@@ -82,7 +82,7 @@
 
   // Manually propagate the trait collection here so that any layoutSpec children of layoutSpec will get a traitCollection
   {
-    ASDN::SumScopeTimer t(_layoutSpecTotalTime, measureLayoutSpec);
+    AS::SumScopeTimer t(_layoutSpecTotalTime, measureLayoutSpec);
     ASTraitCollectionPropagateDown(layoutElement, self.primitiveTraitCollection);
   }
 
@@ -93,7 +93,7 @@
 
   // Layout element layout creation
   ASLayout *layout = ({
-    ASDN::SumScopeTimer t(_layoutComputationTotalTime, measureLayoutComputation);
+    AS::SumScopeTimer t(_layoutComputationTotalTime, measureLayoutComputation);
     [layoutElement layoutThatFits:constrainedSize];
   });
   ASDisplayNodeAssertNotNil(layout, @"[ASLayoutElement layoutThatFits:] should never return nil! %@, %@", self, layout);
@@ -123,13 +123,13 @@
 
   if (_layoutSpecBlock != NULL) {
     return ({
-      ASDN::MutexLocker l(__instanceLock__);
-      ASDN::SumScopeTimer t(_layoutSpecTotalTime, measureLayoutSpec);
+      AS::MutexLocker l(__instanceLock__);
+      AS::SumScopeTimer t(_layoutSpecTotalTime, measureLayoutSpec);
       _layoutSpecBlock(self, constrainedSize);
     });
   } else {
     return ({
-      ASDN::SumScopeTimer t(_layoutSpecTotalTime, measureLayoutSpec);
+      AS::SumScopeTimer t(_layoutSpecTotalTime, measureLayoutSpec);
       [self layoutSpecThatFits:constrainedSize];
     });
   }

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -305,7 +305,7 @@
 
 - (ASLayout *)calculateLayoutYoga:(ASSizeRange)constrainedSize
 {
-  ASDN::UniqueLock l(__instanceLock__);
+  AS::UniqueLock l(__instanceLock__);
 
   // There are several cases where Yoga could arrive here:
   // - This node is not in a Yoga tree: it has neither a yogaParent nor yogaChildren.

--- a/Source/ASEditableTextNode.mm
+++ b/Source/ASEditableTextNode.mm
@@ -117,14 +117,14 @@
   BOOL _delegateDidUpdateEnqueued;
 
   // TextKit.
-  ASDN::RecursiveMutex _textKitLock;
+  AS::RecursiveMutex _textKitLock;
   ASTextKitComponents *_textKitComponents;
   ASTextKitComponents *_placeholderTextKitComponents;
   // Forwards NSLayoutManagerDelegate methods related to word kerning
   ASTextNodeWordKerner *_wordKerner;
   
   // UITextInputTraits
-  ASDN::RecursiveMutex _textInputTraitsLock;
+  AS::RecursiveMutex _textInputTraitsLock;
   _ASTextInputTraitsPendingState *_textInputTraits;
 
   // Misc. State.
@@ -188,7 +188,7 @@
     
     // Configure textView with UITextInputTraits
     {
-      ASDN::MutexLocker l(_textInputTraitsLock);
+      AS::MutexLocker l(_textInputTraitsLock);
       if (_textInputTraits) {
         textView.autocapitalizationType         = _textInputTraits.autocapitalizationType;
         textView.autocorrectionType             = _textInputTraits.autocorrectionType;
@@ -204,7 +204,7 @@
     [self.view addSubview:textView];
   };
 
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   // Create and configure the placeholder text view.
   _placeholderTextKitComponents.textView = [[ASTextKitComponentsTextView alloc] initWithFrame:CGRectZero textContainer:_placeholderTextKitComponents.textContainer];
@@ -259,7 +259,7 @@
 {
   [super setBackgroundColor:backgroundColor];
 
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   // If showing the placeholder, don't propagate backgroundColor/opaque to the editable textView.  It is positioned over the placeholder to accept taps to begin editing, and if it's opaque/colored then it'll obscure the placeholder.
   // The backgroundColor/opaque will be propagated to the editable textView when editing begins.
@@ -271,7 +271,7 @@
 
 - (void)setTextContainerInset:(UIEdgeInsets)textContainerInset
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   _textContainerInset = textContainerInset;
   _textKitComponents.textView.textContainerInset = textContainerInset;
@@ -282,7 +282,7 @@
 {
   [super setOpaque:opaque];
 
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   // If showing the placeholder, don't propagate backgroundColor/opaque to the editable textView.  It is positioned over the placeholder to accept taps to begin editing, and if it's opaque/colored then it'll obscure the placeholder.
   // The backgroundColor/opaque will be propagated to the editable textView when editing begins.
@@ -308,7 +308,7 @@
 
 - (void)setScrollEnabled:(BOOL)scrollEnabled
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
   _scrollEnabled = scrollEnabled;
   [_textKitComponents.textView setScrollEnabled:_scrollEnabled];
 }
@@ -342,7 +342,7 @@
 
   _typingAttributes = [typingAttributes copy];
 
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   _textKitComponents.textView.typingAttributes = _typingAttributes;
 }
@@ -352,13 +352,13 @@
 
 - (NSRange)selectedRange
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
   return _textKitComponents.textView.selectedRange;
 }
 
 - (void)setSelectedRange:(NSRange)selectedRange
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
   _textKitComponents.textView.selectedRange = selectedRange;
 }
 
@@ -372,14 +372,14 @@
 @dynamic attributedPlaceholderText;
 - (NSAttributedString *)attributedPlaceholderText
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   return [_placeholderTextKitComponents.textStorage copy];
 }
 
 - (void)setAttributedPlaceholderText:(NSAttributedString *)attributedPlaceholderText
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   if (ASObjectIsEqual(_placeholderTextKitComponents.textStorage, attributedPlaceholderText))
     return;
@@ -396,14 +396,14 @@
   if ([self isDisplayingPlaceholder])
     return nil;
 
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   return [_textKitComponents.textStorage copy];
 }
 
 - (void)setAttributedText:(NSAttributedString *)attributedText
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   // If we (_cmd) are called while the text view itself is updating (-textViewDidUpdate:), you cannot update the text storage and expect perfect propagation to the text view.
   // Thus, we always update the textview directly if it's been created already.
@@ -445,7 +445,7 @@
 #pragma mark - Core
 - (void)_updateDisplayingPlaceholder
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   // Show the placeholder if necessary.
   _displayingPlaceholder = (_textKitComponents.textStorage.length == 0);
@@ -463,7 +463,7 @@
 
 - (void)_layoutTextView
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   // Layout filling our bounds.
   _textKitComponents.textView.frame = self.bounds;
@@ -481,35 +481,35 @@
 @dynamic textInputMode;
 - (UITextInputMode *)textInputMode
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
   return [_textKitComponents.textView textInputMode];
 }
 
 - (BOOL)isFirstResponder
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
   return [_textKitComponents.textView isFirstResponder];
 }
 
 - (BOOL)canBecomeFirstResponder {
-    ASDN::MutexLocker l(_textKitLock);
+    AS::MutexLocker l(_textKitLock);
     return [_textKitComponents.textView canBecomeFirstResponder];
 }
 
 - (BOOL)becomeFirstResponder
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
   return [_textKitComponents.textView becomeFirstResponder];
 }
 
 - (BOOL)canResignFirstResponder {
-    ASDN::MutexLocker l(_textKitLock);
+    AS::MutexLocker l(_textKitLock);
     return [_textKitComponents.textView canResignFirstResponder];
 }
 
 - (BOOL)resignFirstResponder
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
   return [_textKitComponents.textView resignFirstResponder];
 }
 
@@ -525,7 +525,7 @@
 
 - (void)setAutocapitalizationType:(UITextAutocapitalizationType)autocapitalizationType
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     [self.textView setAutocapitalizationType:autocapitalizationType];
   } else {
@@ -535,7 +535,7 @@
 
 - (UITextAutocapitalizationType)autocapitalizationType
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     return [self.textView autocapitalizationType];
   } else {
@@ -545,7 +545,7 @@
 
 - (void)setAutocorrectionType:(UITextAutocorrectionType)autocorrectionType
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     [self.textView setAutocorrectionType:autocorrectionType];
   } else {
@@ -555,7 +555,7 @@
 
 - (UITextAutocorrectionType)autocorrectionType
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     return [self.textView autocorrectionType];
   } else {
@@ -565,7 +565,7 @@
 
 - (void)setSpellCheckingType:(UITextSpellCheckingType)spellCheckingType
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     [self.textView setSpellCheckingType:spellCheckingType];
   } else {
@@ -575,7 +575,7 @@
 
 - (UITextSpellCheckingType)spellCheckingType
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     return [self.textView spellCheckingType];
   } else {
@@ -585,7 +585,7 @@
 
 - (void)setEnablesReturnKeyAutomatically:(BOOL)enablesReturnKeyAutomatically
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     [self.textView setEnablesReturnKeyAutomatically:enablesReturnKeyAutomatically];
   } else {
@@ -595,7 +595,7 @@
 
 - (BOOL)enablesReturnKeyAutomatically
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     return [self.textView enablesReturnKeyAutomatically];
   } else {
@@ -605,7 +605,7 @@
 
 - (void)setKeyboardAppearance:(UIKeyboardAppearance)setKeyboardAppearance
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     [self.textView setKeyboardAppearance:setKeyboardAppearance];
   } else {
@@ -615,7 +615,7 @@
 
 - (UIKeyboardAppearance)keyboardAppearance
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     return [self.textView keyboardAppearance];
   } else {
@@ -625,7 +625,7 @@
 
 - (void)setKeyboardType:(UIKeyboardType)keyboardType
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     [self.textView setKeyboardType:keyboardType];
   } else {
@@ -635,7 +635,7 @@
 
 - (UIKeyboardType)keyboardType
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     return [self.textView keyboardType];
   } else {
@@ -645,7 +645,7 @@
 
 - (void)setReturnKeyType:(UIReturnKeyType)returnKeyType
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     [self.textView setReturnKeyType:returnKeyType];
   } else {
@@ -655,7 +655,7 @@
 
 - (UIReturnKeyType)returnKeyType
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     return [self.textView returnKeyType];
   } else {
@@ -665,7 +665,7 @@
 
 - (void)setSecureTextEntry:(BOOL)secureTextEntry
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     [self.textView setSecureTextEntry:secureTextEntry];
   } else {
@@ -675,7 +675,7 @@
 
 - (BOOL)isSecureTextEntry
 {
-  ASDN::MutexLocker l(_textInputTraitsLock);
+  AS::MutexLocker l(_textInputTraitsLock);
   if (self.isNodeLoaded) {
     return [self.textView isSecureTextEntry];
   } else {
@@ -704,7 +704,7 @@
 
 - (void)textViewDidChange:(UITextView *)textView
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   // Note we received a text changed event.
   // This is used by _delegateDidChangeSelectionFromSelectedRange:toSelectedRange: to distinguish between selection changes that happen because of editing or pure selection changes.
@@ -767,7 +767,7 @@
 #pragma mark - Geometry
 - (CGRect)frameForTextRange:(NSRange)textRange
 {
-  ASDN::MutexLocker l(_textKitLock);
+  AS::MutexLocker l(_textKitLock);
 
   // Bail on invalid range.
   if (NSMaxRange(textRange) > [_textKitComponents.textStorage length]) {

--- a/Source/ASImageNode+AnimatedImage.mm
+++ b/Source/ASImageNode+AnimatedImage.mm
@@ -166,13 +166,13 @@
 
 - (NSString *)animatedImageRunLoopMode
 {
-  ASDN::MutexLocker l(_displayLinkLock);
+  AS::MutexLocker l(_displayLinkLock);
   return _animatedImageRunLoopMode;
 }
 
 - (void)setAnimatedImageRunLoopMode:(NSString *)runLoopMode
 {
-  ASDN::MutexLocker l(_displayLinkLock);
+  AS::MutexLocker l(_displayLinkLock);
 
   if (runLoopMode == nil) {
     runLoopMode = ASAnimatedImageDefaultRunLoopMode;
@@ -249,7 +249,7 @@
 
   // Get frame interval before holding display link lock to avoid deadlock
   NSUInteger frameInterval = self.animatedImage.frameInterval;
-  ASDN::MutexLocker l(_displayLinkLock);
+  AS::MutexLocker l(_displayLinkLock);
   if (_displayLink == nil) {
     _playHead = 0;
     _displayLink = [CADisplayLink displayLinkWithTarget:[ASWeakProxy weakProxyWithTarget:self] selector:@selector(displayLinkFired:)];
@@ -279,7 +279,7 @@
   NSLog(@"stopping animation: %p", self);
 #endif
   ASDisplayNodeAssertMainThread();
-  ASDN::MutexLocker l(_displayLinkLock);
+  AS::MutexLocker l(_displayLinkLock);
   _displayLink.paused = YES;
   self.lastDisplayLinkFire = 0;
   
@@ -398,7 +398,7 @@
 
 - (void)invalidateAnimatedImage
 {
-  ASDN::MutexLocker l(_displayLinkLock);
+  AS::MutexLocker l(_displayLinkLock);
 #if ASAnimatedImageDebug
   if (_displayLink) {
     NSLog(@"invalidating display link");

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -202,7 +202,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
     return nil;
   }
   
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   
   ASGraphicsBeginImageContextWithOptions(size, NO, 1);
   [self.placeholderColor setFill];
@@ -229,7 +229,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 
 - (void)setImage:(UIImage *)image
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   [self _locked_setImage:image];
 }
 
@@ -436,13 +436,13 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 + (ASWeakMapEntry *)contentsForkey:(ASImageNodeContentsKey *)key drawParameters:(id)drawParameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelled
 {
   static dispatch_once_t onceToken;
-  static ASDN::Mutex *cacheLock = nil;
+  static AS::Mutex *cacheLock = nil;
   dispatch_once(&onceToken, ^{
-    cacheLock = new ASDN::Mutex();
+    cacheLock = new AS::Mutex();
   });
   
   {
-    ASDN::MutexLocker l(*cacheLock);
+    AS::MutexLocker l(*cacheLock);
     if (!cache) {
       cache = [[ASWeakMap alloc] init];
     }
@@ -459,7 +459,7 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
   }
 
   {
-    ASDN::MutexLocker l(*cacheLock);
+    AS::MutexLocker l(*cacheLock);
     return [cache setObject:contents forKey:key];
   }
 }
@@ -581,7 +581,7 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 
   // Stash the block and call-site queue. We'll invoke it in -displayDidFinish.
   {
-    ASDN::MutexLocker l(__instanceLock__);
+    AS::MutexLocker l(__instanceLock__);
     if (_displayCompletionBlock != displayCompletionBlock) {
       _displayCompletionBlock = displayCompletionBlock;
     }
@@ -596,7 +596,7 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 {
   [super clearContents];
   
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   _weakCacheEntry = nil;  // release contents from the cache.
 }
 
@@ -604,7 +604,7 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 
 - (BOOL)isCropEnabled
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   return _cropEnabled;
 }
 
@@ -640,14 +640,14 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 
 - (CGRect)cropRect
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   return _cropRect;
 }
 
 - (void)setCropRect:(CGRect)cropRect
 {
   {
-    ASDN::MutexLocker l(__instanceLock__);
+    AS::MutexLocker l(__instanceLock__);
     if (CGRectEqualToRect(_cropRect, cropRect)) {
       return;
     }
@@ -670,37 +670,37 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 
 - (BOOL)forceUpscaling
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   return _forceUpscaling;
 }
 
 - (void)setForceUpscaling:(BOOL)forceUpscaling
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   _forceUpscaling = forceUpscaling;
 }
 
 - (CGSize)forcedSize
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   return _forcedSize;
 }
 
 - (void)setForcedSize:(CGSize)forcedSize
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   _forcedSize = forcedSize;
 }
 
 - (asimagenode_modification_block_t)imageModificationBlock
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   return _imageModificationBlock;
 }
 
 - (void)setImageModificationBlock:(asimagenode_modification_block_t)imageModificationBlock
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   _imageModificationBlock = imageModificationBlock;
 }
 

--- a/Source/ASMultiplexImageNode.mm
+++ b/Source/ASMultiplexImageNode.mm
@@ -491,7 +491,7 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   if (_downloaderFlags.downloaderImplementsSetPriority) {
     // Read our interface state before locking so that we don't lock super while holding our lock.
     ASInterfaceState interfaceState = self.interfaceState;
-    ASDN::MutexLocker l(_downloadIdentifierLock);
+    MutexLocker l(_downloadIdentifierLock);
 
     if (_downloadIdentifier != nil) {
       ASImageDownloaderPriority priority = defaultPriority;
@@ -850,7 +850,7 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
     if (!strongSelf)
       return;
 
-    ASDN::MutexLocker l(strongSelf->_downloadIdentifierLock);
+    MutexLocker l(strongSelf->_downloadIdentifierLock);
     //Getting a result back for a different download identifier, download must not have been successfully canceled
     if (ASObjectIsEqual(strongSelf->_downloadIdentifier, downloadIdentifier) == NO && downloadIdentifier != nil) {
       return;

--- a/Source/ASNodeController+Beta.mm
+++ b/Source/ASNodeController+Beta.mm
@@ -18,7 +18,7 @@
 {
   ASDisplayNode *_strongNode;
   __weak ASDisplayNode *_weakNode;
-  ASDN::RecursiveMutex __instanceLock__;
+  AS::RecursiveMutex __instanceLock__;
 }
 
 - (void)loadNode

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -100,7 +100,7 @@
 
 @interface ASTableNode ()
 {
-  ASDN::RecursiveMutex _environmentStateLock;
+  AS::RecursiveMutex _environmentStateLock;
   id<ASBatchFetchingDelegate> _batchFetchingDelegate;
 }
 

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -32,7 +32,7 @@
 
 @interface ASTextCacheValue : NSObject {
   @package
-  ASDN::Mutex _m;
+  AS::Mutex _m;
   std::deque<std::tuple<CGSize, ASTextLayout *>> _layouts;
 }
 @end
@@ -55,10 +55,10 @@
  */
 static NS_RETURNS_RETAINED ASTextLayout *ASTextNodeCompatibleLayoutWithContainerAndText(ASTextContainer *container, NSAttributedString *text)  {
   static dispatch_once_t onceToken;
-  static ASDN::Mutex *layoutCacheLock;
+  static AS::Mutex *layoutCacheLock;
   static NSCache<NSAttributedString *, ASTextCacheValue *> *textLayoutCache;
   dispatch_once(&onceToken, ^{
-    layoutCacheLock = new ASDN::Mutex();
+    layoutCacheLock = new AS::Mutex();
     textLayoutCache = [[NSCache alloc] init];
   });
 
@@ -71,7 +71,7 @@ static NS_RETURNS_RETAINED ASTextLayout *ASTextNodeCompatibleLayoutWithContainer
   }
 
   // Lock the cache item for the rest of the method. Only after acquiring can we release the NSCache.
-  ASDN::MutexLocker lock(cacheValue->_m);
+  AS::MutexLocker lock(cacheValue->_m);
   layoutCacheLock->unlock();
 
   CGRect containerBounds = (CGRect){ .size = container.size };

--- a/Source/ASVideoNode.mm
+++ b/Source/ASVideoNode.mm
@@ -326,7 +326,7 @@ static NSString * const kRate = @"rate";
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-  ASDN::UniqueLock l(__instanceLock__);
+  AS::UniqueLock l(__instanceLock__);
 
   if (object == _currentPlayerItem) {
     if ([keyPath isEqualToString:kStatus]) {

--- a/Source/Details/ASCollectionLayoutState.mm
+++ b/Source/Details/ASCollectionLayoutState.mm
@@ -32,7 +32,7 @@
 @end
 
 @implementation ASCollectionLayoutState {
-  ASDN::Mutex __instanceLock__;
+  AS::Mutex __instanceLock__;
   CGSize _contentSize;
   ASCollectionLayoutContext *_context;
   NSMapTable<ASCollectionElement *, UICollectionViewLayoutAttributes *> *_elementToLayoutAttributesTable;
@@ -182,7 +182,7 @@ elementToLayoutAttributesTable:[NSMapTable elementToLayoutAttributesTable]];
   CGSize pageSize = _context.viewportSize;
   CGSize contentSize = _contentSize;
 
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   if (_unmeasuredPageToLayoutAttributesTable.count == 0 || CGRectIsNull(rect) || CGRectIsEmpty(rect) || CGSizeEqualToSize(CGSizeZero, contentSize) || CGSizeEqualToSize(CGSizeZero, pageSize)) {
     return nil;
   }

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -567,7 +567,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   
   NSTimeInterval transactionQueueFlushDuration = 0.0f;
   {
-    ASDN::ScopeTimer t(transactionQueueFlushDuration);
+    AS::ScopeTimer t(transactionQueueFlushDuration);
     dispatch_group_wait(_editingTransactionGroup, DISPATCH_TIME_FOREVER);
   }
   

--- a/Source/Details/ASEventLog.mm
+++ b/Source/Details/ASEventLog.mm
@@ -13,7 +13,7 @@
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 
 @implementation ASEventLog {
-  ASDN::RecursiveMutex __instanceLock__;
+  AS::RecursiveMutex __instanceLock__;
 
   // The index of the most recent log entry. -1 until first entry.
   NSInteger _eventLogHead;
@@ -61,7 +61,7 @@
                                                       arguments:args];
   va_end(args);
 
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   NSCache *cache = [ASEventLog contentsCache];
   NSMutableArray<ASTraceEvent *> *events = [cache objectForKey:self];
   if (events == nil) {
@@ -87,7 +87,7 @@
     return nil;
   }
 
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   NSUInteger tail = (_eventLogHead + 1);
   NSUInteger count = events.count;
   

--- a/Source/Details/ASMainSerialQueue.mm
+++ b/Source/Details/ASMainSerialQueue.mm
@@ -14,7 +14,7 @@
 
 @interface ASMainSerialQueue ()
 {
-  ASDN::Mutex _serialQueueLock;
+  AS::Mutex _serialQueueLock;
   NSMutableArray *_blocks;
 }
 
@@ -34,14 +34,14 @@
 
 - (NSUInteger)numberOfScheduledBlocks
 {
-  ASDN::MutexLocker l(_serialQueueLock);
+  AS::MutexLocker l(_serialQueueLock);
   return _blocks.count;
 }
 
 - (void)performBlockOnMainThread:(dispatch_block_t)block
 {
 
-  ASDN::UniqueLock l(_serialQueueLock);
+  AS::UniqueLock l(_serialQueueLock);
   [_blocks addObject:block];
   {
     l.unlock();
@@ -53,7 +53,7 @@
 - (void)runBlocks
 {
   dispatch_block_t mainThread = ^{
-    ASDN::UniqueLock l(self->_serialQueueLock);
+    AS::UniqueLock l(self->_serialQueueLock);
     do {
       dispatch_block_t block;
       if (self->_blocks.count > 0) {

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -101,7 +101,7 @@ ASDISPLAYNODE_INLINE void _ASUnlockScopeCleanup(id<NSLocking> __strong *lockPtr)
 #define ASAssertLocked(m) m.AssertHeld()
 #define ASAssertUnlocked(m) m.AssertNotHeld()
 
-namespace ASDN {
+namespace AS {
   
   // Set once in Mutex constructor. Linker fails if this is a member variable. ??
   static bool gMutex_unfair;
@@ -290,6 +290,6 @@ namespace ASDN {
   typedef std::lock_guard<Mutex> MutexLocker;
   typedef std::unique_lock<Mutex> UniqueLock;
 
-} // namespace ASDN
+} // namespace AS
 
 #endif /* __cplusplus */

--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -119,7 +119,7 @@ AS_EXTERN void ASTraitCollectionPropagateDown(id<ASLayoutElement> element, ASPri
 #define ASLayoutElementCollectionTableSetTraitCollection(lock) \
 - (void)setPrimitiveTraitCollection:(ASPrimitiveTraitCollection)traitCollection\
 {\
-  ASDN::MutexLocker l(lock);\
+  AS::MutexLocker l(lock);\
 \
   ASPrimitiveTraitCollection oldTraits = self.primitiveTraitCollection;\
   [super setPrimitiveTraitCollection:traitCollection];\

--- a/Source/Layout/ASLayoutElement.mm
+++ b/Source/Layout/ASLayoutElement.mm
@@ -17,6 +17,8 @@
 
 #import <atomic>
 
+using AS::MutexLocker;
+
 #if YOGA
   #import YOGA_HEADER_PATH
   #import <AsyncDisplayKit/ASYogaUtilities.h>
@@ -160,7 +162,7 @@ do {\
 } while(0)
 
 @implementation ASLayoutElementStyle {
-  ASDN::RecursiveMutex __instanceLock__;
+  AS::RecursiveMutex __instanceLock__;
   ASLayoutElementStyleExtensions _extensions;
 
   std::atomic<ASLayoutElementSize> _size;
@@ -545,7 +547,7 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
 {
   NSCAssert(idx < kMaxLayoutElementBoolExtensions, @"Setting index outside of max bool extensions space");
   
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   _extensions.boolExtensions[idx] = value;
 }
 
@@ -553,7 +555,7 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
 {
   NSCAssert(idx < kMaxLayoutElementBoolExtensions, @"Accessing index outside of max bool extensions space");
   
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return _extensions.boolExtensions[idx];
 }
 
@@ -561,7 +563,7 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
 {
   NSCAssert(idx < kMaxLayoutElementStateIntegerExtensions, @"Setting index outside of max integer extensions space");
   
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   _extensions.integerExtensions[idx] = value;
 }
 
@@ -569,7 +571,7 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
 {
   NSCAssert(idx < kMaxLayoutElementStateIntegerExtensions, @"Accessing index outside of max integer extensions space");
   
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return _extensions.integerExtensions[idx];
 }
 
@@ -577,7 +579,7 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
 {
   NSCAssert(idx < kMaxLayoutElementStateEdgeInsetExtensions, @"Setting index outside of max edge insets extensions space");
   
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   _extensions.edgeInsetsExtensions[idx] = value;
 }
 
@@ -585,7 +587,7 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
 {
   NSCAssert(idx < kMaxLayoutElementStateEdgeInsetExtensions, @"Accessing index outside of max edge insets extensions space");
   
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return _extensions.edgeInsetsExtensions[idx];
 }
 

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -62,7 +62,7 @@
 
 - (ASLayoutElementStyle *)style
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   if (_style == nil) {
     _style = [[ASLayoutElementStyle alloc] init];
   }
@@ -142,7 +142,7 @@ ASLayoutElementLayoutCalculationDefaults
 
 - (ASTraitCollection *)asyncTraitCollection
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   return [ASTraitCollection traitCollectionWithASPrimitiveTraitCollection:self.primitiveTraitCollection];
 }
 
@@ -221,13 +221,13 @@ ASLayoutElementStyleExtensibilityForwarding
 
 - (NSString *)debugName
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   return _debugName;
 }
 
 - (void)setDebugName:(NSString *)debugName
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   if (!ASObjectIsEqual(_debugName, debugName)) {
     _debugName = [debugName copy];
   }

--- a/Source/Private/ASCollectionLayoutCache.mm
+++ b/Source/Private/ASCollectionLayoutCache.mm
@@ -13,8 +13,10 @@
 #import <AsyncDisplayKit/ASElementMap.h>
 #import <AsyncDisplayKit/ASThread.h>
 
+using AS::MutexLocker;
+
 @implementation ASCollectionLayoutCache {
-  ASDN::Mutex __instanceLock__;
+  AS::Mutex __instanceLock__;
 
   /**
    * The underlying data structure of this cache.
@@ -46,7 +48,7 @@
     return nil;
   }
 
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return [[_map objectForKey:elements] objectForKey:context];
 }
 
@@ -57,7 +59,7 @@
     return;
   }
 
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   auto innerMap = [_map objectForKey:elements];
   if (innerMap == nil) {
     innerMap = [NSMapTable strongToStrongObjectsMapTable];
@@ -73,13 +75,13 @@
     return;
   }
 
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   [[_map objectForKey:elements] removeObjectForKey:context];
 }
 
 - (void)removeAllLayouts
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   [_map removeAllObjects];
 }
 

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -18,6 +18,7 @@
 #import <AsyncDisplayKit/ASSignpost.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
 
+using AS::MutexLocker;
 
 @interface ASDisplayNode () <_ASDisplayLayerDelegate>
 @end
@@ -467,25 +468,25 @@
 
 - (ASDisplayNodeContextModifier)willDisplayNodeContentWithRenderingContext
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return _willDisplayNodeContentWithRenderingContext;
 }
 
 - (ASDisplayNodeContextModifier)didDisplayNodeContentWithRenderingContext
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   return _didDisplayNodeContentWithRenderingContext;
 }
 
 - (void)setWillDisplayNodeContentWithRenderingContext:(ASDisplayNodeContextModifier)contextModifier
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   _willDisplayNodeContentWithRenderingContext = contextModifier;
 }
 
 - (void)setDidDisplayNodeContentWithRenderingContext:(ASDisplayNodeContextModifier)contextModifier;
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  MutexLocker l(__instanceLock__);
   _didDisplayNodeContentWithRenderingContext = contextModifier;
 }
 

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -34,8 +34,8 @@
 #define DISPLAYNODE_USE_LOCKS 1
 
 #if DISPLAYNODE_USE_LOCKS
-#define _bridge_prologue_read ASDN::MutexLocker l(__instanceLock__); ASDisplayNodeAssertThreadAffinity(self)
-#define _bridge_prologue_write ASDN::MutexLocker l(__instanceLock__)
+#define _bridge_prologue_read AS::MutexLocker l(__instanceLock__); ASDisplayNodeAssertThreadAffinity(self)
+#define _bridge_prologue_write AS::MutexLocker l(__instanceLock__)
 #else
 #define _bridge_prologue_read ASDisplayNodeAssertThreadAffinity(self)
 #define _bridge_prologue_write
@@ -175,7 +175,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
 
 - (CGFloat)cornerRadius
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   return _cornerRadius;
 }
 
@@ -186,7 +186,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
 
 - (ASCornerRoundingType)cornerRoundingType
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   return _cornerRoundingType;
 }
 

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -79,7 +79,7 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
 @interface ASDisplayNode () <_ASTransitionContextCompletionDelegate>
 {
 @package
-  ASDN::RecursiveMutex __instanceLock__;
+  AS::RecursiveMutex __instanceLock__;
 
   _ASPendingState *_pendingViewState;
   ASInterfaceState _pendingInterfaceState;

--- a/Source/Private/ASImageNode+AnimatedImagePrivate.h
+++ b/Source/Private/ASImageNode+AnimatedImagePrivate.h
@@ -13,7 +13,7 @@
 
 @interface ASImageNode ()
 {
-  ASDN::Mutex _displayLinkLock;
+  AS::Mutex _displayLinkLock;
   id <ASAnimatedImageProtocol> _animatedImage;
   BOOL _animatedImagePaused;
   NSString *_animatedImageRunLoopMode;

--- a/Source/Private/ASLayoutTransition.mm
+++ b/Source/Private/ASLayoutTransition.mm
@@ -22,6 +22,8 @@
 #import <AsyncDisplayKit/ASLayout+IGListKit.h>
 #endif
 
+using AS::MutexLocker;
+
 /**
  * Search the whole layout stack if at least one layout has a layoutElement object that can not be layed out asynchronous.
  * This can be the case for example if a node was already loaded
@@ -52,7 +54,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 }
 
 @implementation ASLayoutTransition {
-  std::shared_ptr<ASDN::RecursiveMutex> __instanceLock__;
+  std::shared_ptr<AS::RecursiveMutex> __instanceLock__;
   
   BOOL _calculatedSubnodeOperations;
   NSArray<ASDisplayNode *> *_insertedSubnodes;
@@ -69,7 +71,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 {
   self = [super init];
   if (self) {
-    __instanceLock__ = std::make_shared<ASDN::RecursiveMutex>();
+    __instanceLock__ = std::make_shared<AS::RecursiveMutex>();
       
     _node = node;
     _pendingLayout = pendingLayout;
@@ -80,7 +82,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (BOOL)isSynchronous
 {
-  ASDN::MutexLocker l(*__instanceLock__);
+  MutexLocker l(*__instanceLock__);
   return !ASLayoutCanTransitionAsynchronous(_pendingLayout.layout);
 }
 
@@ -92,7 +94,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (void)applySubnodeInsertionsAndMoves
 {
-  ASDN::MutexLocker l(*__instanceLock__);
+  MutexLocker l(*__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
   
   // Create an activity even if no subnodes affected.
@@ -130,7 +132,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 - (void)applySubnodeRemovals
 {
   as_activity_scope(as_activity_create("Apply subnode removals", AS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT));
-  ASDN::MutexLocker l(*__instanceLock__);
+  MutexLocker l(*__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
 
   if (_removedSubnodes.count == 0) {
@@ -150,7 +152,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (void)calculateSubnodeOperationsIfNeeded
 {
-  ASDN::MutexLocker l(*__instanceLock__);
+  MutexLocker l(*__instanceLock__);
   if (_calculatedSubnodeOperations) {
     return;
   }
@@ -205,27 +207,27 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (NSArray<ASDisplayNode *> *)currentSubnodesWithTransitionContext:(_ASTransitionContext *)context
 {
-  ASDN::MutexLocker l(*__instanceLock__);
+  MutexLocker l(*__instanceLock__);
   return _node.subnodes;
 }
 
 - (NSArray<ASDisplayNode *> *)insertedSubnodesWithTransitionContext:(_ASTransitionContext *)context
 {
-  ASDN::MutexLocker l(*__instanceLock__);
+  MutexLocker l(*__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
   return _insertedSubnodes;
 }
 
 - (NSArray<ASDisplayNode *> *)removedSubnodesWithTransitionContext:(_ASTransitionContext *)context
 {
-  ASDN::MutexLocker l(*__instanceLock__);
+  MutexLocker l(*__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
   return _removedSubnodes;
 }
 
 - (ASLayout *)transitionContext:(_ASTransitionContext *)context layoutForKey:(NSString *)key
 {
-  ASDN::MutexLocker l(*__instanceLock__);
+  MutexLocker l(*__instanceLock__);
   if ([key isEqualToString:ASTransitionContextFromLayoutKey]) {
     return _previousLayout.layout;
   } else if ([key isEqualToString:ASTransitionContextToLayoutKey]) {
@@ -237,7 +239,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (ASSizeRange)transitionContext:(_ASTransitionContext *)context constrainedSizeForKey:(NSString *)key
 {
-  ASDN::MutexLocker l(*__instanceLock__);
+  MutexLocker l(*__instanceLock__);
   if ([key isEqualToString:ASTransitionContextFromLayoutKey]) {
     return _previousLayout.constrainedSize;
   } else if ([key isEqualToString:ASTransitionContextToLayoutKey]) {

--- a/Source/Private/ASPendingStateController.mm
+++ b/Source/Private/ASPendingStateController.mm
@@ -14,7 +14,7 @@
 
 @interface ASPendingStateController()
 {
-  ASDN::Mutex _lock;
+  AS::Mutex _lock;
 
   struct ASPendingStateControllerFlags {
     unsigned pendingFlush:1;
@@ -52,7 +52,7 @@
 - (void)registerNode:(ASDisplayNode *)node
 {
   ASDisplayNodeAssert(node.nodeLoaded, @"Expected display node to be loaded before it was registered with ASPendingStateController. Node: %@", node);
-  ASDN::MutexLocker l(_lock);
+  AS::MutexLocker l(_lock);
   [_dirtyNodes addObject:node];
 
   [self scheduleFlushIfNeeded];

--- a/Source/Private/Layout/ASLayoutSpecPrivate.h
+++ b/Source/Private/Layout/ASLayoutSpecPrivate.h
@@ -19,7 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ASLayoutSpec() {
-  ASDN::RecursiveMutex __instanceLock__;
+  AS::RecursiveMutex __instanceLock__;
   std::atomic <ASPrimitiveTraitCollection> _primitiveTraitCollection;
   ASLayoutElementStyle *_style;
   NSMutableArray *_childrenArray;

--- a/Source/Private/_ASScopeTimer.h
+++ b/Source/Private/_ASScopeTimer.h
@@ -18,14 +18,14 @@
 
  {
    // some scope
-   ASDisplayNode::ScopeTimer t(placeToStoreTiming);
+   AS::ScopeTimer t(placeToStoreTiming);
    DoPotentiallySlowWork();
    MorePotentiallySlowWork();
  }
 
  */
 
-namespace ASDN {
+namespace AS {
   struct ScopeTimer {
     NSTimeInterval begin;
     NSTimeInterval &outT;

--- a/Source/TextKit/ASTextKitContext.mm
+++ b/Source/TextKit/ASTextKitContext.mm
@@ -19,7 +19,7 @@
 @implementation ASTextKitContext
 {
   // All TextKit operations (even non-mutative ones) must be executed serially.
-  std::shared_ptr<ASDN::Mutex> __instanceLock__;
+  std::shared_ptr<AS::Mutex> __instanceLock__;
 
   NSLayoutManager *_layoutManager;
   NSTextStorage *_textStorage;
@@ -35,15 +35,15 @@
 {
   if (self = [super init]) {
     static dispatch_once_t onceToken;
-    static ASDN::Mutex *mutex;
+    static AS::Mutex *mutex;
     dispatch_once(&onceToken, ^{
-      mutex = new ASDN::Mutex();
+      mutex = new AS::Mutex();
     });
     
     // Concurrently initialising TextKit components crashes (rdar://18448377) so we use a global lock.
-    ASDN::MutexLocker l(*mutex);
+    AS::MutexLocker l(*mutex);
     
-    __instanceLock__ = std::make_shared<ASDN::Mutex>();
+    __instanceLock__ = std::make_shared<AS::Mutex>();
     
     // Create the TextKit component stack with our default configuration.
     
@@ -73,7 +73,7 @@
                                                                       NSTextStorage *,
                                                                       NSTextContainer *))block
 {
-  ASDN::MutexLocker l(*__instanceLock__);
+  AS::MutexLocker l(*__instanceLock__);
   if (block) {
     block(_layoutManager, _textStorage, _textContainer);
   }

--- a/Source/TextKit/ASTextKitFontSizeAdjuster.mm
+++ b/Source/TextKit/ASTextKitFontSizeAdjuster.mm
@@ -33,7 +33,7 @@
   ASTextKitAttributes _attributes;
   BOOL _measured;
   CGFloat _scaleFactor;
-  ASDN::Mutex __instanceLock__;
+  AS::Mutex __instanceLock__;
 }
 
 @synthesize sizingLayoutManager = _sizingLayoutManager;
@@ -127,7 +127,7 @@
 
 - (NSLayoutManager *)sizingLayoutManager
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  AS::MutexLocker l(__instanceLock__);
   if (_sizingLayoutManager == nil) {
     _sizingLayoutManager = [[ASLayoutManager alloc] init];
     _sizingLayoutManager.usesFontLeading = NO;


### PR DESCRIPTION
Referring to the framework as ASDisplayNode is pretty out-dated and verbose. See CoreAnimation which uses CA for their internal namespace.

As we use more C++, having a visually clean namespace will matter more.