### PR TITLE
Replace ASDynamicCast macros with inline C++ functions

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -38,6 +38,9 @@
 #import <AsyncDisplayKit/ASLayout.h>
 #import <AsyncDisplayKit/ASThread.h>
 
+using AS::DynamicCast;
+using AS::DynamicCastStrict;
+
 /**
  * A macro to get self.collectionNode and assign it to a local variable, or return
  * the given value if nil.
@@ -59,7 +62,7 @@
 
 #define ASFlowLayoutDefault(layout, property, default)                                        \
 ({                                                                                            \
-  UICollectionViewFlowLayout *flowLayout = ASDynamicCast(layout, UICollectionViewFlowLayout); \
+  UICollectionViewFlowLayout *flowLayout = DynamicCast<UICollectionViewFlowLayout>(layout); \
   flowLayout ? flowLayout.property : default;                                                 \
 })
 
@@ -1161,7 +1164,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     view = [self dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:kReuseIdentifier forIndexPath:indexPath];
   }
   
-  if (_ASCollectionReusableView *reusableView = ASDynamicCastStrict(view, _ASCollectionReusableView)) {
+  if (_ASCollectionReusableView *reusableView = DynamicCastStrict<_ASCollectionReusableView>(view)) {
     reusableView.element = element;
   }
   
@@ -1191,7 +1194,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   ASDisplayNodeAssert(element != nil, @"Element should exist. indexPath = %@, collectionDataSource = %@", indexPath, self);
   ASDisplayNodeAssert(cell != nil, @"UICollectionViewCell must not be nil. indexPath = %@, collectionDataSource = %@", indexPath, self);
 
-  if (_ASCollectionViewCell *asCell = ASDynamicCastStrict(cell, _ASCollectionViewCell)) {
+  if (_ASCollectionViewCell *asCell = DynamicCastStrict<_ASCollectionViewCell>(cell)) {
     asCell.element = element;
     [_rangeController configureContentView:cell.contentView forCellNode:node];
   }
@@ -1208,7 +1211,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     }
   }
 
-  _ASCollectionViewCell *cell = ASDynamicCastStrict(rawCell, _ASCollectionViewCell);
+  _ASCollectionViewCell *cell = DynamicCastStrict<_ASCollectionViewCell>(rawCell);
   if (cell == nil) {
     [_rangeController setNeedsUpdate];
     return;
@@ -1269,7 +1272,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     }
   }
 
-  _ASCollectionViewCell *cell = ASDynamicCastStrict(rawCell, _ASCollectionViewCell);
+  _ASCollectionViewCell *cell = DynamicCastStrict<_ASCollectionViewCell>(rawCell);
   if (cell == nil) {
     [_rangeController setNeedsUpdate];
     return;
@@ -1314,7 +1317,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     }
   }
 
-  _ASCollectionReusableView *view = ASDynamicCastStrict(rawView, _ASCollectionReusableView);
+  _ASCollectionReusableView *view = DynamicCastStrict<_ASCollectionReusableView>(rawView);
   if (view == nil) {
     return;
   }
@@ -1354,7 +1357,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     }
   }
 
-  _ASCollectionReusableView *view = ASDynamicCastStrict(rawView, _ASCollectionReusableView);
+  _ASCollectionReusableView *view = DynamicCastStrict<_ASCollectionReusableView>(rawView);
   if (view == nil) {
     return;
   }
@@ -1943,7 +1946,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 #pragma clang diagnostic pop
 
   if (block == nil) {
-    if (cell == nil || ASDynamicCast(cell, ASCellNode) == nil) {
+    if (cell == nil || DynamicCast<ASCellNode>(cell) == nil) {
       // In this case, either the client is expecting a UIKit passthrough cell to be created automatically,
       // or it is an error.
       if (_asyncDataSourceFlags.interop) {
@@ -2044,7 +2047,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   }
 
   if (block == nil) {
-    if (cell == nil || ASDynamicCast(cell, ASCellNode) == nil) {
+    if (cell == nil || DynamicCast<ASCellNode>(cell) == nil) {
       // In this case, the app code returned nil for the node and the nodeBlock.
       // If the UIKit method is implemented, then we should use a passthrough cell.
       // Otherwise the CGSizeZero default will cause UIKit to not show it (so this isn't an error like the cellForItem case).

--- a/Source/ASConfiguration.mm
+++ b/Source/ASConfiguration.mm
@@ -8,6 +8,7 @@
 
 #import <AsyncDisplayKit/ASConfiguration.h>
 #import <AsyncDisplayKit/ASConfigurationInternal.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 
 /// Not too performance-sensitive here.
 
@@ -17,8 +18,8 @@
 {
   if (self = [super init]) {
     if (dictionary != nil) {
-      const auto featureStrings = ASDynamicCast(dictionary[@"experimental_features"], NSArray);
-      const auto version = ASDynamicCast(dictionary[@"version"], NSNumber).integerValue;
+      const auto featureStrings = AS::DynamicCast<NSArray>(dictionary[@"experimental_features"]);
+      const auto version = AS::DynamicCast<NSNumber>(dictionary[@"version"]).integerValue;
       if (version != ASConfigurationSchemaCurrentVersion) {
         NSLog(@"Texture warning: configuration schema is old version (%ld vs %ld)", (long)version, (long)ASConfigurationSchemaCurrentVersion);
       }

--- a/Source/ASDisplayNode+Convenience.mm
+++ b/Source/ASDisplayNode+Convenience.mm
@@ -12,6 +12,7 @@
 #import <UIKit/UIViewController.h>
 
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASResponderChainEnumerator.h>
 
 @implementation ASDisplayNode (Convenience)
@@ -29,8 +30,7 @@
   UIView *view = ASFindClosestViewOfLayer(self.layer);
   // Travel up the responder chain to find a view controller.
   for (UIResponder *responder in [view asdk_responderChainEnumerator]) {
-    UIViewController *vc = ASDynamicCast(responder, UIViewController);
-    if (vc != nil) {
+    if (UIViewController *vc = AS::DynamicCast<UIViewController>(responder)) {
       return vc;
     }
   }

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -209,7 +209,7 @@
 #if ASDISPLAYNODE_ASSERTIONS_ENABLED
   // Assert that the sublayout is already flattened.
   for (ASLayout *sublayout in layout.sublayouts) {
-    if (sublayout.sublayouts.count > 0 || ASDynamicCast(sublayout.layoutElement, ASDisplayNode) == nil) {
+    if (sublayout.sublayouts.count > 0 || AS::DynamicCast(sublayout.layoutElement, ASDisplayNode) == nil) {
       ASDisplayNodeAssert(NO, @"Yoga sublayout is not flattened! %@, %@", self, sublayout);
     }
   }

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3616,7 +3616,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   // and run up the chain ourselves.
   if (_view != nil) {
     for (UIResponder *responder in [_view asdk_responderChainEnumerator]) {
-      UIViewController *vc = ASDynamicCast(responder, UIViewController);
+      UIViewController *vc = AS::DynamicCast<UIViewController>(responder);
       if (vc) {
         [result addObject:@{ @"viewController" : ASObjectDescriptionMakeTiny(vc) }];
         break;

--- a/Source/ASDisplayNodeExtras.mm
+++ b/Source/ASDisplayNodeExtras.mm
@@ -11,6 +11,7 @@
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h>
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
 #import <AsyncDisplayKit/ASDisplayNode+Ancestry.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 
 #import <queue>
 #import <AsyncDisplayKit/ASRunLoopQueue.h>
@@ -257,7 +258,7 @@ static inline BOOL _ASDisplayNodeIsAncestorOfDisplayNode(ASDisplayNode *possible
 UIWindow * _Nullable ASFindWindowOfLayer(CALayer *layer)
 {
   UIView *view = ASFindClosestViewOfLayer(layer);
-  if (UIWindow *window = ASDynamicCast(view, UIWindow)) {
+  if (UIWindow *window = AS::DynamicCast<UIWindow>(view)) {
     return window;
   } else {
     return view.window;
@@ -267,7 +268,7 @@ UIWindow * _Nullable ASFindWindowOfLayer(CALayer *layer)
 UIView * _Nullable ASFindClosestViewOfLayer(CALayer *layer)
 {
   while (layer != nil) {
-    if (UIView *view = ASDynamicCast(layer.delegate, UIView)) {
+    if (UIView *view = AS::DynamicCast<UIView>(layer.delegate)) {
       return view;
     }
     layer = layer.superlayer;

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -158,18 +158,6 @@
   staticVar; \
 })
 
-/// Ensure that class is of certain kind
-#define ASDynamicCast(x, c) ({ \
-  id __val = x;\
-  ((c *) ([__val isKindOfClass:[c class]] ? __val : nil));\
-})
-
-/// Ensure that class is of certain kind, assuming it is subclass restricted
-#define ASDynamicCastStrict(x, c) ({ \
-  id __val = x;\
-  ((c *) ([__val class] == [c class] ? __val : nil));\
-})
-
 // Compare two primitives, assign if different. Returns whether the assignment happened.
 #define ASCompareAssign(lvalue, newValue) ({  \
   BOOL result = (lvalue != newValue);         \

--- a/Source/Details/ASCollectionFlowLayoutDelegate.mm
+++ b/Source/Details/ASCollectionFlowLayoutDelegate.mm
@@ -16,6 +16,7 @@
 #import <AsyncDisplayKit/ASCollectionLayoutDefines.h>
 #import <AsyncDisplayKit/ASCollections.h>
 #import <AsyncDisplayKit/ASElementMap.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASLayout.h>
 #import <AsyncDisplayKit/ASStackLayoutSpec.h>
 
@@ -70,7 +71,7 @@
   ASLayout *layout = [stackSpec layoutThatFits:sizeRange];
 
   return [[ASCollectionLayoutState alloc] initWithContext:context layout:layout getElementBlock:^ASCollectionElement * _Nullable(ASLayout * _Nonnull sublayout) {
-    ASCellNode *node = ASDynamicCast(sublayout.layoutElement, ASCellNode);
+    ASCellNode *node = AS::DynamicCast<ASCellNode>(sublayout.layoutElement);
     return node ? node.collectionElement : nil;
   }];
 }

--- a/Source/Details/ASCollectionGalleryLayoutDelegate.mm
+++ b/Source/Details/ASCollectionGalleryLayoutDelegate.mm
@@ -18,6 +18,7 @@
 #import <AsyncDisplayKit/ASCollectionLayoutDefines.h>
 #import <AsyncDisplayKit/ASCollectionLayoutState.h>
 #import <AsyncDisplayKit/ASElementMap.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASLayout.h>
 #import <AsyncDisplayKit/ASLayoutRangeType.h>
 #import <AsyncDisplayKit/ASInsetLayoutSpec.h>
@@ -93,7 +94,7 @@
   CGSize pageSize = context.viewportSize;
   ASScrollDirection scrollableDirections = context.scrollableDirections;
 
-  _ASCollectionGalleryLayoutInfo *info = ASDynamicCast(context.additionalInfo, _ASCollectionGalleryLayoutInfo);
+  _ASCollectionGalleryLayoutInfo *info = AS::DynamicCast<_ASCollectionGalleryLayoutInfo>(context.additionalInfo);
   CGSize itemSize = info.itemSize;
   if (info == nil || CGSizeEqualToSize(CGSizeZero, itemSize)) {
     return [[ASCollectionLayoutState alloc] initWithContext:context];
@@ -129,7 +130,7 @@
   ASLayout *layout = [finalSpec layoutThatFits:ASSizeRangeForCollectionLayoutThatFitsViewportSize(pageSize, scrollableDirections)];
 
   return [[ASCollectionLayoutState alloc] initWithContext:context layout:layout getElementBlock:^ASCollectionElement * _Nullable(ASLayout * _Nonnull sublayout) {
-    _ASGalleryLayoutItem *item = ASDynamicCast(sublayout.layoutElement, _ASGalleryLayoutItem);
+    _ASGalleryLayoutItem *item = AS::DynamicCast<_ASGalleryLayoutItem>(sublayout.layoutElement);
     return item ? item.collectionElement : nil;
   }];
 }

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -21,6 +21,7 @@
 #import <AsyncDisplayKit/ASDispatch.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
 #import <AsyncDisplayKit/ASElementMap.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASLayout.h>
 #import <AsyncDisplayKit/ASLog.h>
 #import <AsyncDisplayKit/ASSignpost.h>
@@ -550,13 +551,13 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   
   if (changeSet.includesReloadData) {
     if (_initialReloadDataHasBeenCalled) {
-      as_log_debug(ASCollectionLog(), "reloadData %@", ASViewToDisplayNode(ASDynamicCast(self.dataSource, UIView)));
+      as_log_debug(ASCollectionLog(), "reloadData %@", ASViewToDisplayNode(AS::DynamicCast<UIView>(self.dataSource)));
     } else {
-      as_log_debug(ASCollectionLog(), "Initial reloadData %@", ASViewToDisplayNode(ASDynamicCast(self.dataSource, UIView)));
+      as_log_debug(ASCollectionLog(), "Initial reloadData %@", ASViewToDisplayNode(AS::DynamicCast<UIView>(self.dataSource)));
       _initialReloadDataHasBeenCalled = YES;
     }
   } else {
-    as_log_debug(ASCollectionLog(), "performBatchUpdates %@ %@", ASViewToDisplayNode(ASDynamicCast(self.dataSource, UIView)), changeSet);
+    as_log_debug(ASCollectionLog(), "performBatchUpdates %@ %@", ASViewToDisplayNode(AS::DynamicCast<UIView>(self.dataSource)), changeSet);
   }
   
   NSTimeInterval transactionQueueFlushDuration = 0.0f;

--- a/Source/Details/ASIntegerMap.mm
+++ b/Source/Details/ASIntegerMap.mm
@@ -11,6 +11,7 @@
 #import <unordered_map>
 #import <AsyncDisplayKit/NSIndexSet+ASHelpers.h>
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 
 /**
  * This is just a friendly Objective-C interface to unordered_map<NSInteger, NSInteger>
@@ -176,7 +177,7 @@
     return YES;
   }
 
-  if (ASIntegerMap *otherMap = ASDynamicCast(object, ASIntegerMap)) {
+  if (ASIntegerMap *otherMap = AS::DynamicCast<ASIntegerMap>(object)) {
     return otherMap->_map == _map;
   }
   return NO;

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -203,7 +203,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
 - (void)_updateVisibleNodeIndexPaths
 {
   as_activity_scope_verbose(as_activity_create("Update range controller", AS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT));
-  as_log_verbose(ASCollectionLog(), "Updating ranges for %@", ASViewToDisplayNode(ASDynamicCast(self.delegate, UIView)));
+  as_log_verbose(ASCollectionLog(), "Updating ranges for %@", ASViewToDisplayNode(AS::DynamicCast(self.delegate, UIView)));
   ASDisplayNodeAssert(_layoutController, @"An ASLayoutController is required by ASRangeController");
   if (!_layoutController || !_dataSource) {
     return;

--- a/Source/Details/UICollectionViewLayout+ASConvenience.mm
+++ b/Source/Details/UICollectionViewLayout+ASConvenience.mm
@@ -12,12 +12,13 @@
 #import <UIKit/UICollectionViewFlowLayout.h>
 
 #import <AsyncDisplayKit/ASCollectionViewFlowLayoutInspector.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 
 @implementation UICollectionViewLayout (ASLayoutInspectorProviding)
 
 - (id<ASCollectionViewLayoutInspecting>)asdk_layoutInspector
 {
-  UICollectionViewFlowLayout *flow = ASDynamicCast(self, UICollectionViewFlowLayout);
+  UICollectionViewFlowLayout *flow = AS::DynamicCast<UICollectionViewFlowLayout>(self);
   if (flow != nil) {
     return [[ASCollectionViewFlowLayoutInspector alloc] initWithFlowLayout:flow];
   } else {

--- a/Source/Details/_ASCollectionReusableView.h
+++ b/Source/Details/_ASCollectionReusableView.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-AS_SUBCLASSING_RESTRICTED // Note: ASDynamicCastStrict is used on instances of this class based on this restriction.
+AS_SUBCLASSING_RESTRICTED // Note: DynamicCastStrict is used on instances of this class based on this restriction.
 @interface _ASCollectionReusableView : UICollectionReusableView
 
 @property (nullable, nonatomic, readonly) ASCellNode *node;

--- a/Source/Details/_ASCollectionViewCell.h
+++ b/Source/Details/_ASCollectionViewCell.h
@@ -15,7 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-AS_SUBCLASSING_RESTRICTED // Note: ASDynamicCastStrict is used on instances of this class based on this restriction.
+AS_SUBCLASSING_RESTRICTED // Note: DynamicCastStrict is used on instances of this class based on this restriction.
 @interface _ASCollectionViewCell : UICollectionViewCell
 
 @property (nonatomic, nullable) ASCollectionElement *element;

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -15,6 +15,7 @@
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASTableNode.h>
 
 #import <queue>
@@ -211,8 +212,8 @@ static void CollectAccessibilityElementsForView(UIView *view, NSMutableArray *el
 
   BOOL anySubNodeIsCollection = (nil != ASDisplayNodeFindFirstNode(node,
       ^BOOL(ASDisplayNode *nodeToCheck) {
-    return ASDynamicCast(nodeToCheck, ASCollectionNode) != nil ||
-           ASDynamicCast(nodeToCheck, ASTableNode) != nil;
+    return AS::DynamicCast<ASCollectionNode>(nodeToCheck) != nil ||
+           AS::DynamicCast<ASTableNode>(nodeToCheck) != nil;
   }));
 
   if (node.isAccessibilityContainer && !anySubNodeIsCollection) {

--- a/Source/Layout/ASLayout.mm
+++ b/Source/Layout/ASLayout.mm
@@ -256,7 +256,7 @@ static std::atomic_bool static_retainsSublayoutLayoutElements = ATOMIC_VAR_INIT(
 {
   if (self == object) return YES;
 
-  ASLayout *layout = ASDynamicCast(object, ASLayout);
+  ASLayout *layout = AS::DynamicCast<ASLayout>(object);
   if (layout == nil) {
     return NO;
   }

--- a/Source/Layout/ASYogaUtilities.mm
+++ b/Source/Layout/ASYogaUtilities.mm
@@ -186,7 +186,7 @@ float ASLayoutElementYogaBaselineFunc(YGNodeRef yogaNode, const float width, con
   ASDisplayNodeCAssert([layoutElement conformsToProtocol:@protocol(ASLayoutElement)],
                        @"Yoga context must be <ASLayoutElement>");
 
-  ASDisplayNode *displayNode = ASDynamicCast(layoutElement, ASDisplayNode);
+  ASDisplayNode *displayNode = AS::DynamicCast(layoutElement, ASDisplayNode);
 
   switch (displayNode.style.parentAlignStyle) {
     case ASStackLayoutAlignItemsBaselineFirst:

--- a/Source/Private/ASInternalHelpers.h
+++ b/Source/Private/ASInternalHelpers.h
@@ -9,8 +9,10 @@
 
 #import "ASAvailability.h"
 
+#import <objc/runtime.h>
 #import <UIKit/UIKit.h>
 
+#import <AsyncDisplayKit/ASAssert.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -98,6 +100,48 @@ ASDISPLAYNODE_INLINE UIEdgeInsets ASConcatInsets(UIEdgeInsets insetsA, UIEdgeIns
 @interface NSIndexPath (ASInverseComparison)
 - (NSComparisonResult)asdk_inverseCompare:(NSIndexPath *)otherIndexPath;
 @end
+
+#ifndef __cplusplus
+#error "Private header should be compiled in C++"
+#else
+
+namespace AS {
+
+template <typename T>
+AS_WARN_UNUSED_RESULT NS_INLINE
+T *_Nullable DynamicCast(id _Nullable value, bool failable = true)
+{
+  if (!value) {
+    return nil;
+  }
+  
+  Class t = [T class];
+  for (Class c = object_getClass(value); c != Nil; c = class_getSuperclass(c)) {
+    if (c == t) {
+      return value;
+    }
+  }
+  ASDisplayNodeCAssert(failable, @"Dynamic cast failed: %@ vs %@", value, t);
+  return nil;
+}
+
+template <typename T>
+AS_WARN_UNUSED_RESULT NS_INLINE
+T *_Nullable DynamicCastStrict(id _Nullable value, bool failable = true)
+{
+  if (!value) {
+    return nil;
+  }
+  if ([T class] == object_getClass(value)) {
+    return value;
+  }
+  ASDisplayNodeCAssert(failable, @"Strict dynamic cast failed: %@ vs %@", value, [T class]);
+  return nil;
+}
+
+}  // namespace AS
+
+#endif  // __cplusplus
 
 NS_ASSUME_NONNULL_END
 

--- a/Source/UIResponder+AsyncDisplayKit.mm
+++ b/Source/UIResponder+AsyncDisplayKit.mm
@@ -12,6 +12,7 @@
 #import <AsyncDisplayKit/ASAssert.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 #import <AsyncDisplayKit/ASResponderChainEnumerator.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 
 @implementation UIResponder (AsyncDisplayKit)
 
@@ -20,7 +21,7 @@
   ASDisplayNodeAssertMainThread();
   
   for (UIResponder *responder in [self asdk_responderChainEnumerator]) {
-    UIViewController *vc = ASDynamicCast(responder, UIViewController);
+    UIViewController *vc = AS::DynamicCast<UIViewController>(responder);
     if (vc) {
       return vc;
     }

--- a/Tests/ASCollectionViewFlowLayoutInspectorTests.mm
+++ b/Tests/ASCollectionViewFlowLayoutInspectorTests.mm
@@ -17,6 +17,9 @@
 #import <AsyncDisplayKit/ASCollectionViewFlowLayoutInspector.h>
 #import <AsyncDisplayKit/ASCellNode.h>
 #import <AsyncDisplayKit/ASCollectionView+Undeprecated.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
+
+using AS::DynamicCast;
 
 @interface ASCollectionView (Private)
 
@@ -142,7 +145,7 @@
   collectionView.asyncDataSource = dataSource;
   collectionView.asyncDelegate = delegate;
   
-  ASCollectionViewFlowLayoutInspector *inspector = ASDynamicCast(collectionView.layoutInspector, ASCollectionViewFlowLayoutInspector);
+  auto inspector = DynamicCast<ASCollectionViewFlowLayoutInspector>(collectionView.layoutInspector);
   ASSizeRange size = [inspector collectionView:collectionView constrainedSizeForSupplementaryNodeOfKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
   ASSizeRange sizeCompare = ASSizeRangeMake(CGSizeMake(collectionView.bounds.size.width, 125.0));
 
@@ -165,7 +168,7 @@
   collectionView.asyncDataSource = dataSource;
   collectionView.asyncDelegate = delegate;
   
-  ASCollectionViewFlowLayoutInspector *inspector = ASDynamicCast(collectionView.layoutInspector, ASCollectionViewFlowLayoutInspector);
+  auto inspector = DynamicCast<ASCollectionViewFlowLayoutInspector>(collectionView.layoutInspector);
   ASSizeRange size = [inspector collectionView:collectionView constrainedSizeForSupplementaryNodeOfKind:UICollectionElementKindSectionFooter atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
   ASSizeRange sizeCompare = ASSizeRangeMake(CGSizeMake(collectionView.bounds.size.width, 125.0));
   ASXCTAssertEqualSizeRanges(size, sizeCompare, @"should have a size constrained by the values returned in the delegate implementation");
@@ -188,7 +191,7 @@
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:rect collectionViewLayout:layout];
   collectionView.asyncDataSource = dataSource;
   
-  ASCollectionViewFlowLayoutInspector *inspector = ASDynamicCast(collectionView.layoutInspector, ASCollectionViewFlowLayoutInspector);
+  auto inspector = DynamicCast<ASCollectionViewFlowLayoutInspector>(collectionView.layoutInspector);
   ASSizeRange size = [inspector collectionView:collectionView constrainedSizeForSupplementaryNodeOfKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
   ASSizeRange sizeCompare = ASSizeRangeMake(CGSizeMake(collectionView.bounds.size.width, 125.0));
   ASXCTAssertEqualSizeRanges(size, sizeCompare, @"should have a size constrained by the size set on the layout");
@@ -209,7 +212,7 @@
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:rect collectionViewLayout:layout];
   collectionView.asyncDataSource = dataSource;
   
-  ASCollectionViewFlowLayoutInspector *inspector = ASDynamicCast(collectionView.layoutInspector, ASCollectionViewFlowLayoutInspector);
+  ASCollectionViewFlowLayoutInspector *inspector = DynamicCast<ASCollectionViewFlowLayoutInspector>(collectionView.layoutInspector);
   ASSizeRange size = [inspector collectionView:collectionView constrainedSizeForSupplementaryNodeOfKind:UICollectionElementKindSectionFooter atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
   ASSizeRange sizeCompare = ASSizeRangeMake(CGSizeMake(collectionView.bounds.size.width, 125.0));
   ASXCTAssertEqualSizeRanges(size, sizeCompare, @"should have a size constrained by the size set on the layout");
@@ -233,7 +236,7 @@
   collectionView.asyncDataSource = dataSource;
   collectionView.asyncDelegate = delegate;
   
-  ASCollectionViewFlowLayoutInspector *inspector = ASDynamicCast(collectionView.layoutInspector, ASCollectionViewFlowLayoutInspector);
+  ASCollectionViewFlowLayoutInspector *inspector = DynamicCast<ASCollectionViewFlowLayoutInspector>(collectionView.layoutInspector);
   ASSizeRange size = [inspector collectionView:collectionView constrainedSizeForSupplementaryNodeOfKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
   ASSizeRange sizeCompare = ASSizeRangeMake(CGSizeMake(125.0, collectionView.bounds.size.height));
   ASXCTAssertEqualSizeRanges(size, sizeCompare, @"should have a size constrained by the values returned in the delegate implementation");
@@ -255,7 +258,7 @@
   collectionView.asyncDataSource = dataSource;
   collectionView.asyncDelegate = delegate;
   
-  ASCollectionViewFlowLayoutInspector *inspector = ASDynamicCast(collectionView.layoutInspector, ASCollectionViewFlowLayoutInspector);
+  auto inspector = DynamicCast<ASCollectionViewFlowLayoutInspector>(collectionView.layoutInspector);
   ASSizeRange size = [inspector collectionView:collectionView constrainedSizeForSupplementaryNodeOfKind:UICollectionElementKindSectionFooter atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
   ASSizeRange sizeCompare = ASSizeRangeMake(CGSizeMake(125.0, collectionView.bounds.size.height));
   ASXCTAssertEqualSizeRanges(size, sizeCompare, @"should have a size constrained by the values returned in the delegate implementation");
@@ -278,7 +281,7 @@
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:rect collectionViewLayout:layout];
   collectionView.asyncDataSource = dataSource;
   
-  ASCollectionViewFlowLayoutInspector *inspector = ASDynamicCast(collectionView.layoutInspector, ASCollectionViewFlowLayoutInspector);
+  ASCollectionViewFlowLayoutInspector *inspector = DynamicCast<ASCollectionViewFlowLayoutInspector>(collectionView.layoutInspector);
   ASSizeRange size = [inspector collectionView:collectionView constrainedSizeForSupplementaryNodeOfKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
   ASSizeRange sizeCompare = ASSizeRangeMake(CGSizeMake(125.0, collectionView.bounds.size.width));
   ASXCTAssertEqualSizeRanges(size, sizeCompare, @"should have a size constrained by the size set on the layout");
@@ -299,7 +302,7 @@
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:rect collectionViewLayout:layout];
   collectionView.asyncDataSource = dataSource;
   
-  ASCollectionViewFlowLayoutInspector *inspector = ASDynamicCast(collectionView.layoutInspector, ASCollectionViewFlowLayoutInspector);
+  auto inspector = AS::DynamicCast<ASCollectionViewFlowLayoutInspector>(collectionView.layoutInspector);
   ASSizeRange size = [inspector collectionView:collectionView constrainedSizeForSupplementaryNodeOfKind:UICollectionElementKindSectionFooter atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
   ASSizeRange sizeCompare = ASSizeRangeMake(CGSizeMake(125.0, collectionView.bounds.size.height));
   ASXCTAssertEqualSizeRanges(size, sizeCompare, @"should have a size constrained by the size set on the layout");
@@ -316,7 +319,7 @@
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
   collectionView.asyncDataSource = dataSource;
   collectionView.asyncDelegate = delegate;
-  ASCollectionViewFlowLayoutInspector *inspector = ASDynamicCast(collectionView.layoutInspector, ASCollectionViewFlowLayoutInspector);
+  ASCollectionViewFlowLayoutInspector *inspector = DynamicCast<ASCollectionViewFlowLayoutInspector>(collectionView.layoutInspector);
   ASSizeRange size = [inspector collectionView:collectionView constrainedSizeForSupplementaryNodeOfKind:UICollectionElementKindSectionFooter atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
   ASSizeRange sizeCompare = ASSizeRangeMake(CGSizeZero, CGSizeZero);
   XCTAssert(CGSizeEqualToSize(size.min, sizeCompare.min) && CGSizeEqualToSize(size.max, sizeCompare.max), @"should have a zero size");
@@ -335,7 +338,7 @@
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
   collectionView.asyncDataSource = dataSource;
   collectionView.asyncDelegate = delegate;
-  ASCollectionViewFlowLayoutInspector *inspector = ASDynamicCast(collectionView.layoutInspector, ASCollectionViewFlowLayoutInspector);
+  auto inspector = DynamicCast<ASCollectionViewFlowLayoutInspector>(collectionView.layoutInspector);
   NSUInteger count = [inspector collectionView:collectionView supplementaryNodesOfKind:UICollectionElementKindSectionHeader inSection:0];
   XCTAssert(count == 1, @"should have a header supplementary view");
   
@@ -352,7 +355,7 @@
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
   collectionView.asyncDataSource = dataSource;
   collectionView.asyncDelegate = delegate;
-  ASCollectionViewFlowLayoutInspector *inspector = ASDynamicCast(collectionView.layoutInspector, ASCollectionViewFlowLayoutInspector);
+  auto inspector = DynamicCast<ASCollectionViewFlowLayoutInspector>(collectionView.layoutInspector);
   NSUInteger count = [inspector collectionView:collectionView supplementaryNodesOfKind:UICollectionElementKindSectionFooter inSection:0];
   XCTAssert(count == 1, @"should have a footer supplementary view");
   
@@ -368,7 +371,7 @@
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
   collectionView.asyncDataSource = dataSource;
   collectionView.asyncDelegate = delegate;
-  ASCollectionViewFlowLayoutInspector *inspector = ASDynamicCast(collectionView.layoutInspector, ASCollectionViewFlowLayoutInspector);
+  auto inspector = DynamicCast<ASCollectionViewFlowLayoutInspector>(collectionView.layoutInspector);
   NSUInteger count = [inspector collectionView:collectionView supplementaryNodesOfKind:UICollectionElementKindSectionFooter inSection:0];
   XCTAssert(count == 0, @"should not have a footer supplementary view");
   


### PR DESCRIPTION
Macros bad, functions good. I've confirmed that when inlined, ARC has full optimization control so it can avoid retains and releases just like in a macro.

The namespace I used for this function is `AS` and not `ASDN` like mutex. #1366 changes mutex to match – I believe that's a better name for our C++ root namespace.