### PR TITLE
Launches switching ASNetworkImageNode callbacks to global queue.

### DIFF
--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -18,7 +18,6 @@
                     "exp_interface_state_coalesce",
                     "exp_unfair_lock",
                     "exp_infer_layer_defaults",
-                    "exp_network_image_queue",
                     "exp_collection_teardown",
                     "exp_framesetter_cache",
                     "exp_skip_clear_data",

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -23,15 +23,14 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalInterfaceStateCoalescing = 1 << 2,          // exp_interface_state_coalesce
   ASExperimentalUnfairLock = 1 << 3,                        // exp_unfair_lock
   ASExperimentalLayerDefaults = 1 << 4,                     // exp_infer_layer_defaults
-  ASExperimentalNetworkImageQueue = 1 << 5,                 // exp_network_image_queue
-  ASExperimentalCollectionTeardown = 1 << 6,                // exp_collection_teardown
-  ASExperimentalFramesetterCache = 1 << 7,                  // exp_framesetter_cache
-  ASExperimentalSkipClearData = 1 << 8,                     // exp_skip_clear_data
-  ASExperimentalDidEnterPreloadSkipASMLayout = 1 << 9,      // exp_did_enter_preload_skip_asm_layout
-  ASExperimentalDisableAccessibilityCache = 1 << 10,        // exp_disable_a11y_cache
-  ASExperimentalSkipAccessibilityWait = 1 << 11,            // exp_skip_a11y_wait
-  ASExperimentalNewDefaultCellLayoutMode = 1 << 12,         // exp_new_default_cell_layout_mode
-  ASExperimentalDispatchApply = 1 << 13,                    // exp_dispatch_apply
+  ASExperimentalCollectionTeardown = 1 << 5,                // exp_collection_teardown
+  ASExperimentalFramesetterCache = 1 << 6,                  // exp_framesetter_cache
+  ASExperimentalSkipClearData = 1 << 7,                     // exp_skip_clear_data
+  ASExperimentalDidEnterPreloadSkipASMLayout = 1 << 8,      // exp_did_enter_preload_skip_asm_layout
+  ASExperimentalDisableAccessibilityCache = 1 << 9,        // exp_disable_a11y_cache
+  ASExperimentalSkipAccessibilityWait = 1 << 10,            // exp_skip_a11y_wait
+  ASExperimentalNewDefaultCellLayoutMode = 1 << 11,         // exp_new_default_cell_layout_mode
+  ASExperimentalDispatchApply = 1 << 12,                    // exp_dispatch_apply
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -17,7 +17,6 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_interface_state_coalesce",
                                       @"exp_unfair_lock",
                                       @"exp_infer_layer_defaults",
-                                      @"exp_network_image_queue",
                                       @"exp_collection_teardown",
                                       @"exp_framesetter_cache",
                                       @"exp_skip_clear_data",

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -125,16 +125,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 
 - (dispatch_queue_t)callbackQueue
 {
-    static dispatch_once_t onceToken;
-    static dispatch_queue_t callbackQueue;
-    dispatch_once(&onceToken, ^{
-        if (ASActivateExperimentalFeature(ASExperimentalNetworkImageQueue)) {
-            callbackQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-        } else {
-            callbackQueue = dispatch_get_main_queue();
-        }
-    });
-    return callbackQueue;
+  return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 }
 
 #pragma mark - Public methods -- must lock

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -48,7 +48,6 @@ static ASExperimentalFeatures features[] = {
     @"exp_interface_state_coalesce",
     @"exp_unfair_lock",
     @"exp_infer_layer_defaults",
-    @"exp_network_image_queue",
     @"exp_collection_teardown",
     @"exp_framesetter_cache",
     @"exp_skip_clear_data",

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -23,7 +23,6 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalInterfaceStateCoalescing,
   ASExperimentalUnfairLock,
   ASExperimentalLayerDefaults,
-  ASExperimentalNetworkImageQueue,
   ASExperimentalCollectionTeardown,
   ASExperimentalFramesetterCache,
   ASExperimentalSkipClearData,

--- a/Tests/ASNetworkImageNodeTests.mm
+++ b/Tests/ASNetworkImageNodeTests.mm
@@ -109,7 +109,6 @@
 
 - (void)cachedImageWithURL:(NSURL *)URL callbackQueue:(dispatch_queue_t)callbackQueue completion:(ASImageCacherCompletion)completion
 {
-  ASDisplayNodeAssert(callbackQueue == dispatch_get_main_queue(), @"ASTestImageCache expects main queue for callback.");
   completion(nil);
 }
 


### PR DESCRIPTION
This showed performance gains for us on startup when the main thread was under heavy contention.