### PR TITLE
Make ASTextNode2 more forgiving when searching for links

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -615,7 +615,6 @@ static NSArray *DefaultLinkAttributeNames() {
   for (const CGSize &offset : kRectOffsets) {
     const CGPoint testPoint = CGPointMake(point.x + offset.width,
                                           point.y + offset.height);
-    
     ASTextPosition *pos = [layout closestPositionToPoint:testPoint];
     for (NSString *attributeName in _linkAttributeNames) {
       NSRange effectiveRange = NSMakeRange(0, 0);
@@ -625,7 +624,7 @@ static NSArray *DefaultLinkAttributeNames() {
         // Didn't find any links specified with this attribute.
         continue;
       }
-      
+
       // If highlighting, check with delegate first. If not implemented, assume YES.
       if (highlighting
           && [_delegate respondsToSelector:@selector(textNode:shouldHighlightLinkAttribute:value:atPoint:)]
@@ -633,13 +632,13 @@ static NSArray *DefaultLinkAttributeNames() {
                             value:value atPoint:point]) {
         continue;
       }
-      
+
       *rangeOut = NSIntersectionRange(visibleRange, effectiveRange);
-      
+
       if (attributeNameOut != NULL) {
         *attributeNameOut = attributeName;
       }
-      
+
       return value;
     }
   }

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -607,7 +607,7 @@ static NSArray *DefaultLinkAttributeNames() {
   static constexpr CGSize kRectOffsets[9] = {
     { 0, 0 },
     { -22, 0 }, { 22, 0 },
-    { 0, -22 } , { 0, 22 },
+    { 0, -22 }, { 0, 22 },
     { -22, -22 }, { -22, 22 },
     { 22, -22 }, { 22, 22 }
   };
@@ -616,6 +616,9 @@ static NSArray *DefaultLinkAttributeNames() {
     const CGPoint testPoint = CGPointMake(point.x + offset.width,
                                           point.y + offset.height);
     ASTextPosition *pos = [layout closestPositionToPoint:testPoint];
+    if (!pos || !NSLocationInRange(pos.offset, clampedRange)) {
+      continue;
+    }
     for (NSString *attributeName in _linkAttributeNames) {
       NSRange effectiveRange = NSMakeRange(0, 0);
       id value = [_attributedText attribute:attributeName atIndex:pos.offset
@@ -642,7 +645,6 @@ static NSArray *DefaultLinkAttributeNames() {
       return value;
     }
   }
-  
 
   return nil;
 }


### PR DESCRIPTION
Instead of only looking at the point you actually touched, this searches in a 44x44 rect around the touch to find any links you might have hit. Similar behavior from ASTextNode1.