### PR TITLE
Whoops, someone forgot an else!

### DIFF
--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -280,7 +280,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   } else {
     if (emptyDisplayRange == YES) {
       displayElements = [NSHashTable hashTableWithOptions:NSHashTableObjectPointerPersonality];
-    } if (equalDisplayVisible == YES) {
+    } else if (equalDisplayVisible == YES) {
       displayElements = visibleElements;
     } else {
       // Calculating only the Display range means the Preload range is either the same as Display or Visible.


### PR DESCRIPTION
Luckily it seems this didn't cause huge memory bloat because there's
a check below that keeps the display flag from being set in low memory
conditions when the node is off the screen.