### PR TITLE
Fix CTLineRef leaks

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -662,10 +662,12 @@ static NSArray *DefaultLinkAttributeNames() {
       
       CTLineRef truncationTokenLine = CTLineCreateWithAttributedString((CFAttributedStringRef)_truncationAttributedText);
       CFIndex truncationTokenLineGlyphCount = truncationTokenLine ? CTLineGetGlyphCount(truncationTokenLine) : 0;
+      CFRelease(truncationTokenLine);
       
       CTLineRef additionalTruncationTokenLine = CTLineCreateWithAttributedString((CFAttributedStringRef)_additionalTruncationMessage);
       CFIndex additionalTruncationTokenLineGlyphCount = additionalTruncationTokenLine ? CTLineGetGlyphCount(additionalTruncationTokenLine) : 0;   
-      
+      CFRelease(additionalTruncationTokenLine);
+
       switch (_textContainer.truncationType) {
         case ASTextTruncationTypeStart: {
           CFIndex composedTruncationTextLineGlyphCount = truncationTokenLineGlyphCount + additionalTruncationTokenLineGlyphCount;


### PR DESCRIPTION
Found by Clang Static Analyzer:

```
~/Texture/Source/ASTextNode2.mm:663:39: warning: Potential leak of an object stored into 'truncationTokenLine'
      CTLineRef truncationTokenLine = CTLineCreateWithAttributedString((CFAttributedStringRef)_truncationAttributedText);
                                      ^
~/Texture/Source/ASTextNode2.mm:666:49: warning: Potential leak of an object stored into 'additionalTruncationTokenLine'
      CTLineRef additionalTruncationTokenLine = CTLineCreateWithAttributedString((CFAttributedStringRef)_additionalTruncationMessage);
                                                ^
2 warnings generated.
```