### PR TITLE
Clean up a clang analyzer cast error

### DIFF
--- a/Source/Private/ASMutableElementMap.mm
+++ b/Source/Private/ASMutableElementMap.mm
@@ -29,7 +29,7 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
 {
   if (self = [super init]) {
     _sections = [sections mutableCopy];
-    _sectionsOfItems = (id)ASTwoDimensionalArrayDeepMutableCopy(items);
+    _sectionsOfItems = (ASMutableCollectionElementTwoDimensionalArray *)ASTwoDimensionalArrayDeepMutableCopy(items);
     _supplementaryElements = [ASMutableElementMap deepMutableCopyOfElementsDictionary:supplementaryElements];
   }
   return self;


### PR DESCRIPTION
Found by Clang Static Analyzer:

```
~/Texture/Source/Private/ASMutableElementMap.mm:32:24: warning: Conversion from value of type 'NSMutableArray<NSMutableArray *> *' to incompatible type 'ASMutableCollectionElementTwoDimensionalArray *'
    _sectionsOfItems = (id)ASTwoDimensionalArrayDeepMutableCopy(items);
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```