### PR TITLE
Make experiment checks faster

### DIFF
--- a/Source/ASConfigurationInternal.h
+++ b/Source/ASConfigurationInternal.h
@@ -20,7 +20,21 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * The delegate will be notified asynchronously.
  */
-AS_EXTERN BOOL ASActivateExperimentalFeature(ASExperimentalFeatures option);
+#if DEBUG
+#define ASActivateExperimentalFeature(opt) _ASActivateExperimentalFeature(opt)
+#else
+#define ASActivateExperimentalFeature(opt) ({\
+  static BOOL result;\
+  static dispatch_once_t onceToken;\
+  dispatch_once(&onceToken, ^{ result = _ASActivateExperimentalFeature(opt); });\
+  result;\
+})
+#endif
+
+/**
+ * Internal function. Use the macro without the underbar.
+ */
+AS_EXTERN BOOL _ASActivateExperimentalFeature(ASExperimentalFeatures option);
 
 /**
  * Notify the configuration delegate that the framework initialized, if needed.

--- a/Source/ASConfigurationInternal.mm
+++ b/Source/ASConfigurationInternal.mm
@@ -12,13 +12,14 @@
 #import <AsyncDisplayKit/ASConfigurationDelegate.h>
 #import <stdatomic.h>
 
+static ASConfigurationManager *ASSharedConfigurationManager;
+static dispatch_once_t ASSharedConfigurationManagerOnceToken;
+
 NS_INLINE ASConfigurationManager *ASConfigurationManagerGet() {
-  static ASConfigurationManager *inst;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    inst = [[ASConfigurationManager alloc] init];
+  dispatch_once(&ASSharedConfigurationManagerOnceToken, ^{
+    ASSharedConfigurationManager = [[ASConfigurationManager alloc] init];
   });
-  return inst;
+  return ASSharedConfigurationManager;
 }
 
 @implementation ASConfigurationManager {

--- a/Source/ASConfigurationInternal.mm
+++ b/Source/ASConfigurationInternal.mm
@@ -92,7 +92,7 @@ NS_INLINE ASConfigurationManager *ASConfigurationManagerGet() {
 // Define this even when !DEBUG, since we may run our tests in release mode.
 + (void)test_resetWithConfiguration:(ASConfiguration *)configuration
 {
-  ASConfigurationManager *inst = ASGetSharedConfigMgr();
+  ASConfigurationManager *inst = ASConfigurationManagerGet();
   inst->_config = configuration ?: [self defaultConfiguration];
   atomic_store(&inst->_activatedExperiments, 0);
 }

--- a/Source/ASConfigurationInternal.mm
+++ b/Source/ASConfigurationInternal.mm
@@ -12,24 +12,20 @@
 #import <AsyncDisplayKit/ASConfigurationDelegate.h>
 #import <stdatomic.h>
 
-#define ASGetSharedConfigMgr() (__bridge ASConfigurationManager *)ASConfigurationManager.sharedInstance
+NS_INLINE ASConfigurationManager *ASConfigurationManagerGet() {
+  static ASConfigurationManager *inst;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    inst = [[ASConfigurationManager alloc] init];
+  });
+  return inst;
+}
 
 @implementation ASConfigurationManager {
   ASConfiguration *_config;
   dispatch_queue_t _delegateQueue;
   BOOL _frameworkInitialized;
   _Atomic(ASExperimentalFeatures) _activatedExperiments;
-}
-
-/// Return CFTypeRef to avoid retain/release on this singleton.
-+ (CFTypeRef)sharedInstance
-{
-  static CFTypeRef inst;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    inst = (__bridge_retained CFTypeRef)[[ASConfigurationManager alloc] init];
-  });
-  return inst;
 }
 
 + (ASConfiguration *)defaultConfiguration NS_RETURNS_RETAINED
@@ -103,12 +99,12 @@
 
 @end
 
-BOOL ASActivateExperimentalFeature(ASExperimentalFeatures feature)
+BOOL _ASActivateExperimentalFeature(ASExperimentalFeatures feature)
 {
-  return [ASGetSharedConfigMgr() activateExperimentalFeature:feature];
+  return [ASConfigurationManagerGet() activateExperimentalFeature:feature];
 }
 
 void ASNotifyInitialized()
 {
-  [ASGetSharedConfigMgr() frameworkDidInitialize];
+  [ASConfigurationManagerGet() frameworkDidInitialize];
 }


### PR DESCRIPTION
- Use `dispatch_once` when not debugging.
- Clean up the singleton – replace the method + macro with an inline function.