### PR TITLE
Experiment with releasing pending state of all nodes

### DIFF
--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -25,7 +25,8 @@
                     "exp_disable_a11y_cache",
                     "exp_dispatch_apply",
                     "exp_image_downloader_priority",
-                    "exp_text_drawing"
+                    "exp_text_drawing",
+                    "exp_release_pending_state"
                 ]
     		}
 		}

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3465,7 +3465,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   // and table views. This needs to be weighed against the cost of
   // reallocing a _ASPendingState. So in range managed nodes we
   // delete the pending state, otherwise we just clear it.
-  if (ASHierarchyStateIncludesRangeManaged(_hierarchyState)) {
+  if (ASHierarchyStateIncludesRangeManaged(_hierarchyState) || ASActivateExperimentalFeature(ASExperimentalReleasePendingState)) {
     _pendingViewState = nil;
   } else {
     [_pendingViewState clearChanges];

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -31,6 +31,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalDispatchApply = 1 << 10,                    // exp_dispatch_apply
   ASExperimentalImageDownloaderPriority = 1 << 11,          // exp_image_downloader_priority
   ASExperimentalTextDrawing = 1 << 12,                      // exp_text_drawing
+  ASExperimentalReleasePendingState = 1 << 13,              // exp_release_pending_state
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -24,7 +24,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_disable_a11y_cache",
                                       @"exp_dispatch_apply",
                                       @"exp_image_downloader_priority",
-                                      @"exp_text_drawing"]));
+                                      @"exp_text_drawing",
+                                      @"exp_release_pending_state"]));
   if (flags == ASExperimentalFeatureAll) {
     return allNames;
   }

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -30,7 +30,8 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalDisableAccessibilityCache,
   ASExperimentalDispatchApply,
   ASExperimentalImageDownloaderPriority,
-  ASExperimentalTextDrawing
+  ASExperimentalTextDrawing,
+  ASExperimentalReleasePendingState
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -55,7 +56,8 @@ static ASExperimentalFeatures features[] = {
     @"exp_disable_a11y_cache",
     @"exp_dispatch_apply",
     @"exp_image_downloader_priority",
-    @"exp_text_drawing"
+    @"exp_text_drawing",
+    @"exp_release_pending_state"
   ];
 }
 


### PR DESCRIPTION
Instead of specifically just range managed. We're seeing ASPendingState become a large portion of our memory footprint when digging deep into view controller stacks. If this significantly reduces our OOM we may want to look at how we can more effectively choose when to clear these out vs when to release them entirely.

If we're lucky we'll also be able to check if this regresses scroll performance. If it doesn't we may even just want to ship this as is.