### PR TITLE
Add layer-action support to nodes

### DIFF
--- a/Source/ASDisplayNode+Subclasses.h
+++ b/Source/ASDisplayNode+Subclasses.h
@@ -376,6 +376,13 @@ AS_CATEGORY_IMPLEMENTABLE
  */
 @property (readonly) CGFloat contentsScaleForDisplay;
 
+/**
+ * Called as part of actionForLayer:forKey:. Gives the node a chance to provide a custom action for its layer.
+ *
+ * The default implementation returns NSNull, indicating that no action should be taken.
+ */
+AS_CATEGORY_IMPLEMENTABLE
+- (nullable id<CAAction>)layerActionForKey:(NSString *)event;
 
 #pragma mark - Touch handling
 /** @name Touch handling */

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -686,6 +686,8 @@ AS_EXTERN NSInteger const ASDefaultDrawingPriority;
 @property (getter=isExclusiveTouch) BOOL exclusiveTouch;      // default=NO
 #endif
 
+@property (nullable, copy) NSDictionary<NSString *, id<CAAction>> *actions; // default = nil
+
 /**
  * @abstract The node view's background color.
  *

--- a/Source/Details/UIView+ASConvenience.h
+++ b/Source/Details/UIView+ASConvenience.h
@@ -42,6 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL allowsGroupOpacity;
 @property (nonatomic) BOOL allowsEdgeAntialiasing;
 @property (nonatomic) unsigned int edgeAntialiasingMask;
+@property (nonatomic, nullable, copy) NSDictionary<NSString *, id<CAAction>> *actions;
 
 - (void)setNeedsDisplay;
 - (void)setNeedsLayout;

--- a/Source/Details/_ASDisplayLayer.mm
+++ b/Source/Details/_ASDisplayLayer.mm
@@ -115,6 +115,13 @@
 
 #pragma mark -
 
++ (id<CAAction>)defaultActionForKey:(NSString *)event
+{
+  // We never want to run one of CA's root default actions. So if we return nil from actionForLayer:forKey:, and let CA
+  // dig into the actions dictionary, and it doesn't find it there, it will check here and we need to stop the search.
+  return (id)kCFNull;
+}
+
 + (dispatch_queue_t)displayQueue
 {
   static dispatch_queue_t displayQueue = NULL;

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -159,10 +159,7 @@ static _ASDisplayViewMethodOverrides GetASDisplayViewMethodOverrides(Class c)
 
   // Even though the UIKit action will take precedence, we still unconditionally forward to the node so that it can
   // track events like kCAOnOrderIn.
-  id<CAAction> nodeAction = (id)kCFNull;
-  if (ASDisplayNode *node = _asyncdisplaykit_node) {
-    nodeAction = [node actionForLayer:layer forKey:event];
-  }
+  id<CAAction> nodeAction = [_asyncdisplaykit_node actionForLayer:layer forKey:event];
 
   // If UIKit specifies an action, that takes precedence. That's an animation block so it's explicit.
   if (uikitAction && uikitAction != (id)kCFNull) {

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -153,22 +153,22 @@ static _ASDisplayViewMethodOverrides GetASDisplayViewMethodOverrides(Class c)
 
 #pragma mark - UIView Overrides
 
-- (void)willMoveToWindow:(UIWindow *)newWindow
+- (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event
 {
-  ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  BOOL visible = (newWindow != nil);
-  if (visible && !node.inHierarchy) {
-    [node __enterHierarchy];
-  }
-}
+  id<CAAction> uikitAction = [super actionForLayer:layer forKey:event];
 
-- (void)didMoveToWindow
-{
-  ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  BOOL visible = (self.window != nil);
-  if (!visible && node.inHierarchy) {
-    [node __exitHierarchy];
+  // Even though the UIKit action will take precedence, we still unconditionally forward to the node so that it can
+  // track events like kCAOnOrderIn.
+  id<CAAction> nodeAction = (id)kCFNull;
+  if (ASDisplayNode *node = _asyncdisplaykit_node) {
+    nodeAction = [node actionForLayer:layer forKey:event];
   }
+
+  // If UIKit specifies an action, that takes precedence. That's an animation block so it's explicit.
+  if (uikitAction && uikitAction != (id)kCFNull) {
+    return uikitAction;
+  }
+  return nodeAction;
 }
 
 - (void)willMoveToSuperview:(UIView *)newSuperview

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -953,7 +953,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
 - (void)setActions:(NSDictionary<NSString *,id<CAAction>> *)actions
 {
   _bridge_prologue_write;
-  _setToLayer(actions, [actions copy]);
+  _setToLayer(actions, actions);
 }
 
 - (void)safeAreaInsetsDidChange

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -944,6 +944,18 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
   }
 }
 
+- (NSDictionary<NSString *,id<CAAction>> *)actions
+{
+  _bridge_prologue_read;
+  return _getFromLayer(actions);
+}
+
+- (void)setActions:(NSDictionary<NSString *,id<CAAction>> *)actions
+{
+  _bridge_prologue_write;
+  _setToLayer(actions, [actions copy]);
+}
+
 - (void)safeAreaInsetsDidChange
 {
   ASDisplayNodeAssertMainThread();

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -76,7 +76,7 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
 
 #define NUM_CLIP_CORNER_LAYERS 4
 
-@interface ASDisplayNode () <_ASTransitionContextCompletionDelegate>
+@interface ASDisplayNode () <_ASTransitionContextCompletionDelegate, CALayerDelegate>
 {
 @package
   AS::RecursiveMutex __instanceLock__;

--- a/Source/Private/_ASPendingState.mm
+++ b/Source/Private/_ASPendingState.mm
@@ -1305,7 +1305,7 @@ static UIColor *defaultTintColor = nil;
 
 - (BOOL)hasChanges
 {
-  return !memcmp(&_flags, &kZeroFlags, sizeof(ASPendingStateFlags));
+  return memcmp(&_flags, &kZeroFlags, sizeof(ASPendingStateFlags));
 }
 
 - (void)dealloc

--- a/Source/Private/_ASPendingState.mm
+++ b/Source/Private/_ASPendingState.mm
@@ -86,6 +86,7 @@ typedef struct {
   int setLayoutMargins:1;
   int setPreservesSuperviewLayoutMargins:1;
   int setInsetsLayoutMarginsFromSafeArea:1;
+  int setActions:1;
 } ASPendingStateFlags;
 
 @implementation _ASPendingState
@@ -140,6 +141,7 @@ typedef struct {
   CGPoint accessibilityActivationPoint;
   UIBezierPath *accessibilityPath;
   UISemanticContentAttribute semanticContentAttribute API_AVAILABLE(ios(9.0), tvos(9.0));
+  NSDictionary<NSString *, id<CAAction>> *actions;
 
   ASPendingStateFlags _flags;
 }
@@ -209,6 +211,7 @@ ASDISPLAYNODE_INLINE void ASPendingStateApplyMetricsToLayer(_ASPendingState *sta
 @synthesize layoutMargins=layoutMargins;
 @synthesize preservesSuperviewLayoutMargins=preservesSuperviewLayoutMargins;
 @synthesize insetsLayoutMarginsFromSafeArea=insetsLayoutMarginsFromSafeArea;
+@synthesize actions=actions;
 
 static CGColorRef blackColorRef = NULL;
 static UIColor *defaultTintColor = nil;
@@ -586,6 +589,12 @@ static UIColor *defaultTintColor = nil;
   _flags.setSemanticContentAttribute = YES;
 }
 
+- (void)setActions:(NSDictionary<NSString *,id<CAAction>> *)actionsArg
+{
+  actions = [actionsArg copy];
+  _flags.setActions = YES;
+}
+
 - (BOOL)isAccessibilityElement
 {
   return isAccessibilityElement;
@@ -916,6 +925,9 @@ static UIColor *defaultTintColor = nil;
 
   if (flags.setOpaque)
     ASDisplayNodeAssert(layer.opaque == opaque, @"Didn't set opaque as desired");
+
+  if (flags.setActions)
+    layer.actions = actions;
 
   ASPendingStateApplyMetricsToLayer(self, layer);
   

--- a/Source/Private/_ASPendingState.mm
+++ b/Source/Private/_ASPendingState.mm
@@ -89,6 +89,9 @@ typedef struct {
   int setActions:1;
 } ASPendingStateFlags;
 
+
+static constexpr ASPendingStateFlags kZeroFlags = {0};
+
 @implementation _ASPendingState
 {
   @package //Expose all ivars for ASDisplayNode to bypass getters for efficiency
@@ -948,7 +951,7 @@ static UIColor *defaultTintColor = nil;
    because a different setter would be called.
    */
 
-  CALayer *layer = view.layer;
+  unowned CALayer *layer = view.layer;
 
   ASPendingStateFlags flags = _flags;
   if (__shouldSetNeedsDisplay(layer)) {
@@ -990,6 +993,9 @@ static UIColor *defaultTintColor = nil;
 
   if (flags.setRasterizationScale)
     layer.rasterizationScale = rasterizationScale;
+
+  if (flags.setActions)
+    layer.actions = actions;
 
   if (flags.setClipsToBounds)
     view.clipsToBounds = clipsToBounds;
@@ -1284,7 +1290,7 @@ static UIColor *defaultTintColor = nil;
 
 - (void)clearChanges
 {
-  _flags = (ASPendingStateFlags){ 0 };
+  _flags = kZeroFlags;
 }
 
 - (BOOL)hasSetNeedsLayout
@@ -1299,69 +1305,7 @@ static UIColor *defaultTintColor = nil;
 
 - (BOOL)hasChanges
 {
-  ASPendingStateFlags flags = _flags;
-
-  return (flags.setAnchorPoint
-  || flags.setPosition
-  || flags.setZPosition
-  || flags.setFrame
-  || flags.setBounds
-  || flags.setPosition
-  || flags.setTransform
-  || flags.setSublayerTransform
-  || flags.setContents
-  || flags.setContentsGravity
-  || flags.setContentsRect
-  || flags.setContentsCenter
-  || flags.setContentsScale
-  || flags.setRasterizationScale
-  || flags.setClipsToBounds
-  || flags.setBackgroundColor
-  || flags.setTintColor
-  || flags.setHidden
-  || flags.setAlpha
-  || flags.setCornerRadius
-  || flags.setContentMode
-  || flags.setUserInteractionEnabled
-  || flags.setExclusiveTouch
-  || flags.setShadowOpacity
-  || flags.setShadowOffset
-  || flags.setShadowRadius
-  || flags.setShadowColor
-  || flags.setBorderWidth
-  || flags.setBorderColor
-  || flags.setAutoresizingMask
-  || flags.setAutoresizesSubviews
-  || flags.setNeedsDisplayOnBoundsChange
-  || flags.setAllowsGroupOpacity
-  || flags.setAllowsEdgeAntialiasing
-  || flags.setEdgeAntialiasingMask
-  || flags.needsDisplay
-  || flags.needsLayout
-  || flags.setAsyncTransactionContainer
-  || flags.setOpaque
-  || flags.setSemanticContentAttribute
-  || flags.setLayoutMargins
-  || flags.setPreservesSuperviewLayoutMargins
-  || flags.setInsetsLayoutMarginsFromSafeArea
-  || flags.setIsAccessibilityElement
-  || flags.setAccessibilityLabel
-  || flags.setAccessibilityAttributedLabel
-  || flags.setAccessibilityHint
-  || flags.setAccessibilityAttributedHint
-  || flags.setAccessibilityValue
-  || flags.setAccessibilityAttributedValue
-  || flags.setAccessibilityTraits
-  || flags.setAccessibilityFrame
-  || flags.setAccessibilityLanguage
-  || flags.setAccessibilityElementsHidden
-  || flags.setAccessibilityViewIsModal
-  || flags.setShouldGroupAccessibilityChildren
-  || flags.setAccessibilityIdentifier
-  || flags.setAccessibilityNavigationStyle
-  || flags.setAccessibilityHeaderElements
-  || flags.setAccessibilityActivationPoint
-  || flags.setAccessibilityPath);
+  return !memcmp(&_flags, &kZeroFlags, sizeof(ASPendingStateFlags));
 }
 
 - (void)dealloc

--- a/Tests/ASDisplayNodeTests.mm
+++ b/Tests/ASDisplayNodeTests.mm
@@ -9,6 +9,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 #import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
 
 #import <AsyncDisplayKit/_ASDisplayLayer.h>
 #import <AsyncDisplayKit/_ASDisplayView.h>
@@ -2695,6 +2696,19 @@ static bool stringContainsPointer(NSString *description, id p) {
     CALayer *cornerLayer = (*l)[i];
     XCTAssertTrue([cornerLayer.delegate isKindOfClass:[ASDisplayNodeCornerLayerDelegate class]], @"");
   }
+}
+
+- (void)testLayerActionForKeyIsCalled
+{
+  UIWindow *window = [[UIWindow alloc] init];
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+
+  id mockNode = OCMPartialMock(node);
+  OCMExpect([mockNode layerActionForKey:kCAOnOrderIn]);
+  [window.layer addSublayer:node.layer];
+  OCMExpect([mockNode layerActionForKey:@"position"]);
+  node.layer.position = CGPointMake(10, 10);
+  OCMVerifyAll(mockNode);
 }
 
 @end


### PR DESCRIPTION
- Make `_ASDisplayView` forward `actionForLayer:forKey:` to the node, so now nodes get that call for view and layer backed nodes.
- Remove `_ASDisplayView will/didMoveToWindow` since we can derive that information from `actionForLayer:` just like layer-backed nodes do.
- Add a base-implementable node method `layerActionForKey:` that the node will call.
- Add bridging for the `CALayer.actions` property so you can set up your actions off-main.

This makes it possible to add pretty broad animation support outside of the `transitionLayoutWithSizeRange:` pipeline.