### PR TITLE
Make shared CA transaction queue variable extern so it's actually shared

### DIFF
--- a/Source/ASRunLoopQueue.h
+++ b/Source/ASRunLoopQueue.h
@@ -68,13 +68,14 @@ AS_SUBCLASSING_RESTRICTED
 
 @end
 
+extern ASCATransactionQueue *_ASSharedCATransactionQueue;
+extern dispatch_once_t _ASSharedCATransactionQueueOnceToken;
+
 NS_INLINE ASCATransactionQueue *ASCATransactionQueueGet(void) {
-  static ASCATransactionQueue *q;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    q = [[ASCATransactionQueue alloc] init];
+  dispatch_once(&_ASSharedCATransactionQueueOnceToken, ^{
+    _ASSharedCATransactionQueue = [[ASCATransactionQueue alloc] init];
   });
-  return q;
+  return _ASSharedCATransactionQueue;
 }
 
 @interface ASDeallocQueue : NSObject

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -354,6 +354,9 @@ ASSynthesizeLockingMethodsWithMutex(_internalQueueLock)
 // but after most other scheduled work on the runloop has processed.
 static int const kASASCATransactionQueueOrder = 1000000;
 
+ASCATransactionQueue *_ASSharedCATransactionQueue;
+dispatch_once_t _ASSharedCATransactionQueueOnceToken;
+
 - (instancetype)init
 {
   if (self = [super init]) {


### PR DESCRIPTION
Basically NS_INLINE means "static inline" and the static part means each call site of this function got its own copy. Using just plain inline isn't really an option either because it would mean that each module would get its own. In practice that's OK since it's private to Texture but better just to make it extern.

Fixes the unit tests when running with interface coalescing on. The unit tests wait on this queue, and they were waiting on the wrong queue!