### PR TITLE
Naming ivar context can conflict with subclasses

### DIFF
--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -97,11 +97,11 @@ AS_EXTERN NSInteger const ASDefaultDrawingPriority;
 @interface ASDisplayNode : NSObject <ASLocking> {
 @public
   /**
-   * The _context ivar is unused by Texture, but provided to enable advanced clients to make powerful extensions to base class functionality.
-   * For example, _context can be used to implement category methods on ASDisplayNode that add functionality to all node subclass types.
+   * The _displayNodeContext ivar is unused by Texture, but provided to enable advanced clients to make powerful extensions to base class functionality.
+   * For example, _displayNodeContext can be used to implement category methods on ASDisplayNode that add functionality to all node subclass types.
    * Code demonstrating this technique can be found in the CatDealsCollectionView example.
    */
-  void *_context;
+  void *_displayNodeContext;
 }
 
 /** @name Initializing a node object */

--- a/examples/CatDealsCollectionView/Sample/ASDisplayNode+CatDeals.mm
+++ b/examples/CatDealsCollectionView/Sample/ASDisplayNode+CatDeals.mm
@@ -14,16 +14,16 @@ struct CatDealsNodeContext {
   NSString *loggingID = nil;
 };
 
-// Convenience to cast _context into our struct reference.
+// Convenience to cast _displayNodeContext into our struct reference.
 NS_INLINE CatDealsNodeContext &GetNodeContext(ASDisplayNode *node) {
-  return *static_cast<CatDealsNodeContext *>(node->_context);
+  return *static_cast<CatDealsNodeContext *>(node->_displayNodeContext);
 }
 
 @implementation ASDisplayNode (CatDeals)
 
 - (void)baseDidInit
 {
-  _context = new CatDealsNodeContext;
+  _displayNodeContext = new CatDealsNodeContext;
 }
 
 - (void)baseWillDealloc


### PR DESCRIPTION
Naming this context will cause us a bunch of problems. Can we rename before we release this?