### PR TITLE
Suppress documentation warnings when using external libraries

### DIFF
--- a/Tests/ASSnapshotTestCase.h
+++ b/Tests/ASSnapshotTestCase.h
@@ -7,7 +7,11 @@
 //  Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
 //
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
 #import <FBSnapshotTestCase/FBSnapshotTestCase.h>
+#pragma clang diagnostic pop
+
 #import "ASDisplayNodeTestsHelper.h"
 
 @class ASDisplayNode;

--- a/Tests/ASTableViewTests.mm
+++ b/Tests/ASTableViewTests.mm
@@ -8,7 +8,10 @@
 //
 
 #import <XCTest/XCTest.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
 #import <JGMethodSwizzler/JGMethodSwizzler.h>
+#pragma clang diagnostic pop
 
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 #import <AsyncDisplayKit/ASTableView.h>

--- a/Tests/ASTextKitTests.mm
+++ b/Tests/ASTextKitTests.mm
@@ -10,7 +10,10 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
 #import <FBSnapshotTestCase/FBSnapshotTestController.h>
+#pragma clang diagnostic pop
 
 #import <AsyncDisplayKit/ASTextKitAttributes.h>
 


### PR DESCRIPTION
These headers fail `-Wdocumentation`. Only adding local warning supression so the warning remains in the Texture code base. Fixes #1400 