### PR TITLE
Fix a bug with Yoga nodes whose position change and don't update.

### DIFF
--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -397,9 +397,19 @@ ASLayoutElementStyleExtensibilityForwarding
     // Use the last known constrainedSize passed from a parent during layout (if never, use bounds).
     NSUInteger version = _layoutVersion;
     ASSizeRange constrainedSize = [self _locked_constrainedSizeForLayoutPass];
+#if YOGA
+    // This flag indicates to the Texture+Yoga code that this next layout is intended to be
+    // displayed (vs. just for measurement). This will cause it to call setNeedsLayout on any nodes
+    // whose layout changes as a result of the Yoga recalculation. This is necessary because a
+    // change in one Yoga node can change the layout for any other node in the tree.
+    self.willApplyNextYogaCalculatedLayout = YES;
+#endif
     ASLayout *layout = [self calculateLayoutThatFits:constrainedSize
                                     restrictedToSize:self.style.size
                                 relativeToParentSize:boundsSizeForLayout];
+#if YOGA
+    self.willApplyNextYogaCalculatedLayout = NO;
+#endif
     nextLayout = ASDisplayNodeLayout(layout, constrainedSize, boundsSizeForLayout, version);
     // Now that the constrained size of pending layout might have been reused, the layout is useless
     // Release it and any orphaned subnodes it retains

--- a/Source/ASDisplayNode+Yoga.h
+++ b/Source/ASDisplayNode+Yoga.h
@@ -29,6 +29,7 @@ AS_EXTERN void ASDisplayNodePerformBlockOnEveryYogaChild(ASDisplayNode * _Nullab
 @property BOOL yogaLayoutInProgress;
 // TODO: Make this atomic (lock).
 @property (nullable, nonatomic) ASLayout *yogaCalculatedLayout;
+@property (nonatomic) BOOL willApplyNextYogaCalculatedLayout;
 
 // Will walk up the Yoga tree and returns the root node
 - (ASDisplayNode *)yogaRoot;
@@ -54,7 +55,7 @@ AS_EXTERN void ASDisplayNodePerformBlockOnEveryYogaChild(ASDisplayNode * _Nullab
 /// For internal usage only
 - (ASLayout *)calculateLayoutYoga:(ASSizeRange)constrainedSize;
 /// For internal usage only
-- (void)calculateLayoutFromYogaRoot:(ASSizeRange)rootConstrainedSize;
+- (void)calculateLayoutFromYogaRoot:(ASSizeRange)rootConstrainedSize willApply:(BOOL)willApply;
 /// For internal usage only
 - (void)invalidateCalculatedYogaLayout;
 /**

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -164,6 +164,7 @@ AS_EXTERN NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimest
   NSMutableArray<ASDisplayNode *> *_yogaChildren;
   __weak ASDisplayNode *_yogaParent;
   ASLayout *_yogaCalculatedLayout;
+  BOOL _willApplyNextYogaCalculatedLayout;
 #endif
 
   // Automatically manages subnodes


### PR DESCRIPTION
Unfortunately I'm unable to add a test easily because Yoga tests aren't setup in the CI yet.

However, this can be reproduced and confirmed fix by the following code:

ASDisplayNode *child1 = [[ASDisplayNode alloc] init];
child1.style.width = ASDimensionMake(ASDimensionUnitPoints, 10);
child1.style.height = ASDimensionMake(ASDimensionUnitPoints, 10);
child1.style.margin = ASEdgeInsetsMake(UIEdgeInsetsMake(5, 5, 5, 5);
ASDisplayNode *child2 = [[ASDisplayNode alloc] init];
child2.style.width = ASDimensionMake(ASDimensionUnitPoints, 10);
child2.style.height = ASDimensionMake(ASDimensionUnitPoints, 10);
ASDisplayNode *canvas = [[ASDisplayNode alloc] init];
canvas.style.width = ASDimensionMake(ASDimensionUnitPoints, 100);
canvas.style.height = ASDimensionMake(ASDimensionUnitPoints, 100);
canvas.style.flexDirection = ASStackLayoutDirectionVertical;
ASDisplayNode *root = [[ASDisplayNode alloc] init];

[canvas addSubnode:child1];
[canvas addYogaChild:child1];
[canvas addSubnode:child2];
[canvas addYogaChild:child2];
[root addSubnode:canvas];
[root addYogaChild:canvas];

[root.style yogaNodeCreateIfNeeded];
root.frame = CGRectMake(0, 0, 100, 100);
[root layoutIfNeeded];

// At this point, frames are as expected:
// child1: 5, 5, 10, 10
// child2: 0, 20, 10, 10
// canvas: 0, 0, 100, 100

// Make a change to a flex property that will affect the position of child2 but nothing else.
child1.style.margin = ASEdgeInsetsMake(UIEdgeInsetsMake(5, 5, 10, 5));
[child1 layoutIfNeeded];
[child2 layoutIfNeeded];
[canvas layoutIfNeeded];
[root layoutIfNeeded];

// At this point, we expect child2's frame to be: 0, 25, 10, 10. But, without this PR, it remains unchanged at: 0, 20, 10, 10