### PR TITLE
Avoid an unnecessary lock & unlock pair in ASMainSerialQueue

### DIFF
--- a/Source/Details/ASMainSerialQueue.mm
+++ b/Source/Details/ASMainSerialQueue.mm
@@ -40,14 +40,12 @@
 
 - (void)performBlockOnMainThread:(dispatch_block_t)block
 {
-
-  AS::UniqueLock l(_serialQueueLock);
-  [_blocks addObject:block];
   {
-    l.unlock();
-    [self runBlocks];
-    l.lock();
+    AS::UniqueLock l(_serialQueueLock);
+    [_blocks addObject:block];
   }
+
+  [self runBlocks];
 }
 
 - (void)runBlocks

--- a/Source/Details/ASMainSerialQueue.mm
+++ b/Source/Details/ASMainSerialQueue.mm
@@ -41,7 +41,7 @@
 - (void)performBlockOnMainThread:(dispatch_block_t)block
 {
   {
-    AS::UniqueLock l(_serialQueueLock);
+    AS::MutexLocker l(_serialQueueLock);
     [_blocks addObject:block];
   }
 


### PR DESCRIPTION
There is no point to lock after `runBlocks` only to unlock right afterward.