### PR TITLE
Fix a bug in ASRangeController that causes cell nodes to render unnecessarily

### DIFF
--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -25,7 +25,8 @@
                     "exp_disable_a11y_cache",
                     "exp_dispatch_apply",
                     "exp_image_downloader_priority",
-                    "exp_text_drawing"
+                    "exp_text_drawing",
+                    "exp_fix_range_controller"
                 ]
     		}
 		}

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -31,6 +31,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalDispatchApply = 1 << 10,                    // exp_dispatch_apply
   ASExperimentalImageDownloaderPriority = 1 << 11,          // exp_image_downloader_priority
   ASExperimentalTextDrawing = 1 << 12,                      // exp_text_drawing
+  ASExperimentalFixRangeController = 1 << 13,               // exp_fix_range_controller
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -24,7 +24,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_disable_a11y_cache",
                                       @"exp_dispatch_apply",
                                       @"exp_image_downloader_priority",
-                                      @"exp_text_drawing"]));
+                                      @"exp_text_drawing",
+                                      @"exp_fix_range_controller"]));
   if (flags == ASExperimentalFeatureAll) {
     return allNames;
   }

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -349,21 +349,25 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
         }
       }
     } else {
-      // If selfInterfaceState isn't visible, then visibleIndexPaths represents what /will/ be immediately visible at the
-      // instant we come onscreen.  So, preload and display all of those things, but don't waste resources preloading yet.
-      // We handle this as a separate case to minimize set operations for offscreen preloading, including containsObject:.
+      // If selfInterfaceState isn't visible, then visibleIndexPaths represents either what /will/ be immediately visible at the
+      // instant we come onscreen, or what /will/ no longer be visible at the instant we come offscreen.
+      // So, preload and display all of those things, but don't waste resources preloading others.
+      // We handle this as a separate case to minimize set operations, including -containsObject:.
+      //
+      // DO NOT set Visible: even though these elements are in the visible range / "viewport",
+      // our overall container object is itself not yet, or no longer, visible.
+      // The moment it becomes visible, we will run the condition above.
+
+      BOOL shouldUpdateInterfaceState = NO;
+      if (ASActivateExperimentalFeature(ASExperimentalFixRangeController)) {
+        shouldUpdateInterfaceState = [visibleIndexPaths containsObject:indexPath];
+      } else {
+        shouldUpdateInterfaceState = [allCurrentIndexPaths containsObject:indexPath];
+      }
       
-      if ([allCurrentIndexPaths containsObject:indexPath]) {
-        // DO NOT set Visible: even though these elements are in the visible range / "viewport",
-        // our overall container object is itself not visible yet.  The moment it becomes visible, we will run the condition above
-        
-        // Set Layout, Preload
+      if (shouldUpdateInterfaceState) {
         interfaceState |= ASInterfaceStatePreload;
-        
         if (rangeMode != ASLayoutRangeModeLowMemory) {
-          // Add Display.
-          // We might be looking at an indexPath that was previously in-range, but now we need to clear it.
-          // In that case we'll just set it back to MeasureLayout.  Only set Display | Preload if in allCurrentIndexPaths.
           interfaceState |= ASInterfaceStateDisplay;
         }
       }

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -30,7 +30,8 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalDisableAccessibilityCache,
   ASExperimentalDispatchApply,
   ASExperimentalImageDownloaderPriority,
-  ASExperimentalTextDrawing
+  ASExperimentalTextDrawing,
+  ASExperimentalFixRangeController
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -55,7 +56,8 @@ static ASExperimentalFeatures features[] = {
     @"exp_disable_a11y_cache",
     @"exp_dispatch_apply",
     @"exp_image_downloader_priority",
-    @"exp_text_drawing"
+    @"exp_text_drawing",
+    @"exp_fix_range_controller"
   ];
 }
 


### PR DESCRIPTION
When a visible collection/table view is about to become invisible, we tell its range controller to update (see https://github.com/TextureGroup/Texture/pull/882). However, [an optimization in ASRangeController](https://github.com/TextureGroup/Texture/commit/90a1bb23469a38820adc681fca4aac23ea5c77ed) doesn't expect that. Instead, it assumes that the view is **invisible** and going to be **visible** soon. As a result, it tells cell nodes in *all* ranges to start preloading and rendering, including nodes that weren't even in the display range. To react to that, those nodes [put themselves into the rendering queue](https://github.com/TextureGroup/Texture/blob/master/Source/ASDisplayNode.mm#L2955) which causes them to load their back store (view/layer).

Since ASRangeController is such a fundamental class, I wrapped this fix in an experiment in case I didn't cover an edge case, and to measure the impact on memory consumption in our app.

Here is what happens in control group - without the fix:
![Screen Shot 2019-03-21 at 5 27 20 PM](https://user-images.githubusercontent.com/587874/54793970-79494000-4c02-11e9-8389-177d56281341.png)
![Screen Shot 2019-03-21 at 5 27 56 PM](https://user-images.githubusercontent.com/587874/54793971-79494000-4c02-11e9-9510-35c156f1722a.png)
![Screen Shot 2019-03-21 at 5 28 09 PM](https://user-images.githubusercontent.com/587874/54793972-79494000-4c02-11e9-9a1d-4abf43b4e30c.png)
![Screen Shot 2019-03-21 at 5 29 06 PM](https://user-images.githubusercontent.com/587874/54794014-a39afd80-4c02-11e9-82a6-5b2e3ff0d356.png)

Here is enabled group - with the fix:
![Screen Shot 2019-03-21 at 5 31 29 PM](https://user-images.githubusercontent.com/587874/54794015-a39afd80-4c02-11e9-800d-89de59d0be25.png)
![Screen Shot 2019-03-21 at 5 32 05 PM](https://user-images.githubusercontent.com/587874/54794016-a39afd80-4c02-11e9-82f4-41589ae369d3.png)

