### PR TITLE
Follow up on the ASRangeController fix in #1418

### DIFF
--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -357,22 +357,28 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
       // our overall container object is itself not yet, or no longer, visible.
       // The moment it becomes visible, we will run the condition above.
 
-      if (ASActivateExperimentalFeature(ASExperimentalFixRangeController)) {
-        if ([visibleIndexPaths containsObject:indexPath]) {
-          interfaceState |= ASInterfaceStatePreload;
-          if (rangeMode != ASLayoutRangeModeLowMemory) {
-            interfaceState |= ASInterfaceStateDisplay;
-          }
-        } else if ([displayIndexPaths containsObject:indexPath]) {
-          interfaceState |= ASInterfaceStatePreload;
+      ASInterfaceState interfaceStateBeforeFix = interfaceState;
+      if ([allCurrentIndexPaths containsObject:indexPath]) {
+        interfaceStateBeforeFix |= ASInterfaceStatePreload;
+        if (rangeMode != ASLayoutRangeModeLowMemory) {
+          interfaceStateBeforeFix |= ASInterfaceStateDisplay;
         }
+      }
+
+      ASInterfaceState interfaceStateAfterFix = interfaceState;
+      if ([visibleIndexPaths containsObject:indexPath]) {
+        interfaceStateAfterFix |= ASInterfaceStatePreload;
+        if (rangeMode != ASLayoutRangeModeLowMemory) {
+          interfaceStateAfterFix |= ASInterfaceStateDisplay;
+        }
+      } else if ([displayIndexPaths containsObject:indexPath]) {
+        interfaceStateAfterFix |= ASInterfaceStatePreload;
+      }
+
+      if (interfaceStateBeforeFix != interfaceStateAfterFix && ASActivateExperimentalFeature(ASExperimentalFixRangeController)) {
+        interfaceState = interfaceStateAfterFix;
       } else {
-        if ([allCurrentIndexPaths containsObject:indexPath]) {
-          interfaceState |= ASInterfaceStatePreload;
-          if (rangeMode != ASLayoutRangeModeLowMemory) {
-            interfaceState |= ASInterfaceStateDisplay;
-          }
-        }
+        interfaceState = interfaceStateBeforeFix;
       }
     }
 

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -351,24 +351,27 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
     } else {
       // If selfInterfaceState isn't visible, then visibleIndexPaths represents either what /will/ be immediately visible at the
       // instant we come onscreen, or what /will/ no longer be visible at the instant we come offscreen.
-      // So, preload and display all of those things, but don't waste resources preloading others.
-      // We handle this as a separate case to minimize set operations, including -containsObject:.
+      // So, preload and display all of those things, but don't waste resources displaying others.
       //
       // DO NOT set Visible: even though these elements are in the visible range / "viewport",
       // our overall container object is itself not yet, or no longer, visible.
       // The moment it becomes visible, we will run the condition above.
 
-      BOOL shouldUpdateInterfaceState = NO;
       if (ASActivateExperimentalFeature(ASExperimentalFixRangeController)) {
-        shouldUpdateInterfaceState = [visibleIndexPaths containsObject:indexPath];
+        if ([visibleIndexPaths containsObject:indexPath]) {
+          interfaceState |= ASInterfaceStatePreload;
+          if (rangeMode != ASLayoutRangeModeLowMemory) {
+            interfaceState |= ASInterfaceStateDisplay;
+          }
+        } else if ([displayIndexPaths containsObject:indexPath]) {
+          interfaceState |= ASInterfaceStatePreload;
+        }
       } else {
-        shouldUpdateInterfaceState = [allCurrentIndexPaths containsObject:indexPath];
-      }
-      
-      if (shouldUpdateInterfaceState) {
-        interfaceState |= ASInterfaceStatePreload;
-        if (rangeMode != ASLayoutRangeModeLowMemory) {
-          interfaceState |= ASInterfaceStateDisplay;
+        if ([allCurrentIndexPaths containsObject:indexPath]) {
+          interfaceState |= ASInterfaceStatePreload;
+          if (rangeMode != ASLayoutRangeModeLowMemory) {
+            interfaceState |= ASInterfaceStateDisplay;
+          }
         }
       }
     }


### PR DESCRIPTION
The changes in #1418 is a bit too aggressive when it comes to nodes that are in display range. It forces those nodes to not preload.

Also update the changes to avoid diluting the experiment data by triggering too broadly (i.e avoid triggering when the old and new implementations yield the same result leading to no behavior change).