### PR TITLE
Experiment with disabling background dealloc for ASViewController

### DIFF
--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -26,7 +26,8 @@
                     "exp_dispatch_apply",
                     "exp_image_downloader_priority",
                     "exp_text_drawing",
-                    "exp_fix_range_controller"
+                    "exp_fix_range_controller",
+                    "exp_oom_bg_dealloc_disable"
                 ]
     		}
 		}

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -32,6 +32,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalImageDownloaderPriority = 1 << 11,          // exp_image_downloader_priority
   ASExperimentalTextDrawing = 1 << 12,                      // exp_text_drawing
   ASExperimentalFixRangeController = 1 << 13,               // exp_fix_range_controller
+  ASExperimentalOOMBackgroundDeallocDisable = 1 << 14,      // exp_oom_bg_dealloc_disable
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -25,7 +25,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_dispatch_apply",
                                       @"exp_image_downloader_priority",
                                       @"exp_text_drawing",
-                                      @"exp_fix_range_controller"]));
+                                      @"exp_fix_range_controller",
+                                      @"exp_oom_bg_dealloc_disable"]));
   if (flags == ASExperimentalFeatureAll) {
     return allNames;
   }

--- a/Source/ASViewController.mm
+++ b/Source/ASViewController.mm
@@ -15,6 +15,8 @@
 #import <AsyncDisplayKit/ASTraitCollection.h>
 #import <AsyncDisplayKit/ASRangeControllerUpdateRangeProtocol+Beta.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
+#import <AsyncDisplayKit/ASConfigurationInternal.h>
+#import <AsyncDisplayKit/ASExperimentalFeatures.h>
 
 @implementation ASViewController
 {
@@ -98,6 +100,9 @@
 
 - (void)dealloc
 {
+  if (ASActivateExperimentalFeature(ASExperimentalOOMBackgroundDeallocDisable)) {
+    return;
+  }
   ASPerformBackgroundDeallocation(&_node);
 }
 

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -31,7 +31,8 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalDispatchApply,
   ASExperimentalImageDownloaderPriority,
   ASExperimentalTextDrawing,
-  ASExperimentalFixRangeController
+  ASExperimentalFixRangeController,
+  ASExperimentalOOMBackgroundDeallocDisable
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -57,7 +58,8 @@ static ASExperimentalFeatures features[] = {
     @"exp_dispatch_apply",
     @"exp_image_downloader_priority",
     @"exp_text_drawing",
-    @"exp_fix_range_controller"
+    @"exp_fix_range_controller",
+    @"exp_oom_bg_dealloc_disable"
   ];
 }
 


### PR DESCRIPTION
The release in `-[ASRunLoopQueue releaseObjectInBackground]` might not actually be doing everything necessary to free memory.