### PR TITLE
Replace +load initializers with __attribute__((constructor)) functions

### DIFF
--- a/Source/ASConfigurationDelegate.h
+++ b/Source/ASConfigurationDelegate.h
@@ -27,8 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Texture framework initialized. This method is called synchronously
  * on the main thread from ASInitializeFrameworkMainThread if you defined
- * AS_INITIALIZE_FRAMEWORK_MANUALLY or from the default initialization point
- * (currently +load) otherwise.
+ * AS_INITIALIZE_FRAMEWORK_MANUALLY or otherwise from the default initialization point
+ * (currently a static constructor, called before main()).
  */
 - (void)textureDidInitialize;
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -284,7 +284,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 }
 
 #if !AS_INITIALIZE_FRAMEWORK_MANUALLY
-+ (void)load
+__attribute__((constructor)) static void ASLoadFrameworkInitializer(void)
 {
   ASInitializeFrameworkMainThread();
 }

--- a/Source/Private/ASTipsController.mm
+++ b/Source/Private/ASTipsController.mm
@@ -37,9 +37,9 @@
 
 #pragma mark - Singleton
 
-+ (void)load
+__attribute__((constructor)) static void ASLoadTipsControllerNotification(void)
 {
-  [NSNotificationCenter.defaultCenter addObserver:self.shared
+  [NSNotificationCenter.defaultCenter addObserver:ASTipsController.shared
                                          selector:@selector(windowDidBecomeVisibleWithNotification:)
                                              name:UIWindowDidBecomeVisibleNotification
                                            object:nil];


### PR DESCRIPTION
With the latest version of Xcode installed I was getting this dyld error at app launch time:

```Swift class extensions and categories on Swift classes are not allowed to have +load methods```

It looks like it's possible to replace `+load` methods with a static `__attribute__((constructor))` function without making dyld angry.