### PR TITLE
Broaden UIGraphicsRenderer Experiment to Everywhere

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -432,6 +432,8 @@
 		CCCCCCE41EC3EF060087FE10 /* NSParagraphStyle+ASText.mm in Sources */ = {isa = PBXBuildFile; fileRef = CCCCCCD41EC3EF060087FE10 /* NSParagraphStyle+ASText.mm */; };
 		CCCCCCE71EC3F0FC0087FE10 /* NSAttributedString+ASText.h in Headers */ = {isa = PBXBuildFile; fileRef = CCCCCCE51EC3F0FC0087FE10 /* NSAttributedString+ASText.h */; };
 		CCCCCCE81EC3F0FC0087FE10 /* NSAttributedString+ASText.mm in Sources */ = {isa = PBXBuildFile; fileRef = CCCCCCE61EC3F0FC0087FE10 /* NSAttributedString+ASText.mm */; };
+		CCDC9B4D200991D10063C1F8 /* ASGraphicsContext.h in Headers */ = {isa = PBXBuildFile; fileRef = CCDC9B4B200991D10063C1F8 /* ASGraphicsContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CCDC9B4E200991D10063C1F8 /* ASGraphicsContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = CCDC9B4C200991D10063C1F8 /* ASGraphicsContext.mm */; };
 		CCDD148B1EEDCD9D0020834E /* ASCollectionModernDataSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CCDD148A1EEDCD9D0020834E /* ASCollectionModernDataSourceTests.mm */; };
 		CCE4F9B31F0D60AC00062E4E /* ASIntegerMapTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CCE4F9B21F0D60AC00062E4E /* ASIntegerMapTests.mm */; };
 		CCE4F9B51F0DA4F300062E4E /* ASLayoutEngineTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CCE4F9B41F0DA4F300062E4E /* ASLayoutEngineTests.mm */; };
@@ -962,6 +964,8 @@
 		CCCCCCD41EC3EF060087FE10 /* NSParagraphStyle+ASText.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSParagraphStyle+ASText.mm"; sourceTree = "<group>"; };
 		CCCCCCE51EC3F0FC0087FE10 /* NSAttributedString+ASText.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSAttributedString+ASText.h"; sourceTree = "<group>"; };
 		CCCCCCE61EC3F0FC0087FE10 /* NSAttributedString+ASText.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSAttributedString+ASText.mm"; sourceTree = "<group>"; };
+		CCDC9B4B200991D10063C1F8 /* ASGraphicsContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASGraphicsContext.h; sourceTree = "<group>"; };
+		CCDC9B4C200991D10063C1F8 /* ASGraphicsContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ASGraphicsContext.mm; sourceTree = "<group>"; };
 		CCDD148A1EEDCD9D0020834E /* ASCollectionModernDataSourceTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCollectionModernDataSourceTests.mm; sourceTree = "<group>"; };
 		CCE04B1E1E313EA7006AEBBB /* ASSectionController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASSectionController.h; sourceTree = "<group>"; };
 		CCE04B201E313EB9006AEBBB /* IGListAdapter+AsyncDisplayKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IGListAdapter+AsyncDisplayKit.h"; sourceTree = "<group>"; };
@@ -1425,6 +1429,8 @@
 				68C215571DE10D330019C4BC /* ASCollectionViewLayoutInspector.mm */,
 				E5B225271F1790B5001E1431 /* ASHashing.h */,
 				E5B225261F1790B5001E1431 /* ASHashing.mm */,
+        		CCDC9B4B200991D10063C1F8 /* ASGraphicsContext.h */,
+        		CCDC9B4C200991D10063C1F8 /* ASGraphicsContext.mm */,
 				058D09E6195D050800B7D73C /* ASHighlightOverlayLayer.h */,
 				058D09E7195D050800B7D73C /* ASHighlightOverlayLayer.mm */,
 				68355B371CB57A5A001D4E68 /* ASImageContainerProtocolCategories.h */,
@@ -1980,6 +1986,7 @@
 				68EE0DBE1C1B4ED300BA1B99 /* ASMainSerialQueue.h in Headers */,
 				CCCCCCE11EC3EF060087FE10 /* ASTextUtilities.h in Headers */,
 				B350624B1B010EFD0018CF92 /* _ASPendingState.h in Headers */,
+				CCDC9B4D200991D10063C1F8 /* ASGraphicsContext.h in Headers */,
 				E5C347B11ECB3D9200EC4BE4 /* ASBatchFetchingDelegate.h in Headers */,
 				CC54A81C1D70079800296A24 /* ASDispatch.h in Headers */,
 				B350624D1B010EFD0018CF92 /* _ASScopeTimer.h in Headers */,
@@ -2395,6 +2402,7 @@
 				9C8898BC1C738BA800D6B02E /* ASTextKitFontSizeAdjuster.mm in Sources */,
 				690ED59B1E36D118000627C0 /* ASImageNode+tvOS.mm in Sources */,
 				0FAFDF7620EC1C90003A51C0 /* ASLayout+IGListKit.mm in Sources */,
+				CCDC9B4E200991D10063C1F8 /* ASGraphicsContext.mm in Sources */,
 				CCCCCCD81EC3EF060087FE10 /* ASTextInput.mm in Sources */,
 				34EFC7621B701CA400AD841F /* ASBackgroundLayoutSpec.mm in Sources */,
 				9D9AA56921E23EE200172C09 /* ASDisplayNode+LayoutSpec.mm in Sources */,

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -34,6 +34,7 @@
 #import <AsyncDisplayKit/ASDisplayNode+InterfaceState.h>
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
 #import <AsyncDisplayKit/ASEqualityHelpers.h>
+#import <AsyncDisplayKit/ASGraphicsContext.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASLayoutElementStylePrivate.h>
 #import <AsyncDisplayKit/ASLayoutSpec.h>
@@ -1553,26 +1554,24 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
       BOOL isRight = (idx == 1 || idx == 3);
 
       CGSize size = CGSizeMake(radius + 1, radius + 1);
-      UIGraphicsBeginImageContextWithOptions(size, NO, self.contentsScaleForDisplay);
-
-      CGContextRef ctx = UIGraphicsGetCurrentContext();
-      if (isRight == YES) {
-        CGContextTranslateCTM(ctx, -radius + 1, 0);
-      }
-      if (isTop == NO) {
-        CGContextTranslateCTM(ctx, 0, -radius + 1);
-      }
-
-      UIBezierPath *roundedRect = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, radius * 2, radius * 2) cornerRadius:radius];
-      [roundedRect setUsesEvenOddFillRule:YES];
-      [roundedRect appendPath:[UIBezierPath bezierPathWithRect:CGRectMake(-1, -1, radius * 2 + 1, radius * 2 + 1)]];
-      [backgroundColor setFill];
-      [roundedRect fill];
+      UIImage *newContents = ASGraphicsCreateImageWithOptions(size, NO, self.contentsScaleForDisplay, nil, nil, ^{
+        CGContextRef ctx = UIGraphicsGetCurrentContext();
+        if (isRight == YES) {
+          CGContextTranslateCTM(ctx, -radius + 1, 0);
+        }
+        if (isTop == NO) {
+          CGContextTranslateCTM(ctx, 0, -radius + 1);
+        }
+        UIBezierPath *roundedRect = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, radius * 2, radius * 2) cornerRadius:radius];
+        [roundedRect setUsesEvenOddFillRule:YES];
+        [roundedRect appendPath:[UIBezierPath bezierPathWithRect:CGRectMake(-1, -1, radius * 2 + 1, radius * 2 + 1)]];
+        [backgroundColor setFill];
+        [roundedRect fill];
+      });
 
       // No lock needed, as _clipCornerLayers is only modified on the main thread.
       unowned CALayer *clipCornerLayer = _clipCornerLayers[idx];
-      clipCornerLayer.contents = (id)(UIGraphicsGetImageFromCurrentImageContext().CGImage);
-      UIGraphicsEndImageContext();
+      clipCornerLayer.contents = (id)(newContents.CGImage);
       clipCornerLayer.bounds = CGRectMake(0.0, 0.0, size.width, size.height);
       clipCornerLayer.anchorPoint = CGPointMake(isRight ? 1.0 : 0.0, isTop ? 0.0 : 1.0);
     }

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -33,7 +33,8 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalFixRangeController = 1 << 12,               // exp_fix_range_controller
   ASExperimentalOOMBackgroundDeallocDisable = 1 << 13,      // exp_oom_bg_dealloc_disable
   ASExperimentalTransactionOperationRetainCycle = 1 << 14,  // exp_transaction_operation_retain_cycle
-  ASExperimentalRemoveTextKitInitialisingLock = 1 << 15,  // exp_remove_textkit_initialising_lock
+  ASExperimentalRemoveTextKitInitialisingLock = 1 << 15,    // exp_remove_textkit_initialising_lock
+  ASExperimentalDrawingGlobal = 1 << 16,                    // exp_drawing_global
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -27,7 +27,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_fix_range_controller",
                                       @"exp_oom_bg_dealloc_disable",
                                       @"exp_transaction_operation_retain_cycle",
-                                      @"exp_remove_textkit_initialising_lock"]));
+                                      @"exp_remove_textkit_initialising_lock",
+                                      @"exp_drawing_global"]));
   if (flags == ASExperimentalFeatureAll) {
     return allNames;
   }

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -17,6 +17,7 @@
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
+#import <AsyncDisplayKit/ASGraphicsContext.h>
 #import <AsyncDisplayKit/ASLayout.h>
 #import <AsyncDisplayKit/ASTextNode.h>
 #import <AsyncDisplayKit/ASImageNode+AnimatedImagePrivate.h>
@@ -201,15 +202,11 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
     return nil;
   }
   
-  AS::MutexLocker l(__instanceLock__);
-  
-  UIGraphicsBeginImageContextWithOptions(size, NO, 1);
-  [self.placeholderColor setFill];
-  UIRectFill(CGRectMake(0, 0, size.width, size.height));
-  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
-  
-  return image;
+  return ASGraphicsCreateImageWithOptions(size, NO, 1, nil, nil, ^{
+    AS::MutexLocker l(__instanceLock__);
+    [_placeholderColor setFill];
+    UIRectFill(CGRectMake(0, 0, size.width, size.height));
+  });
 }
 
 #pragma mark - Layout and Sizing
@@ -466,7 +463,7 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 
 + (UIImage *)createContentsForkey:(ASImageNodeContentsKey *)key drawParameters:(id)drawParameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelled
 {
-  // The following `UIGraphicsBeginImageContextWithOptions` call will sometimes take take longer than 5ms on an
+  // The following `ASGraphicsCreateImageWithOptions` call will sometimes take take longer than 5ms on an
   // A5 processor for a 400x800 backingSize.
   // Check for cancellation before we call it.
   if (isCancelled()) {
@@ -475,55 +472,45 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 
   // Use contentsScale of 1.0 and do the contentsScale handling in boundsSizeInPixels so ASCroppedImageBackingSizeAndDrawRectInBounds
   // will do its rounding on pixel instead of point boundaries
-  UIGraphicsBeginImageContextWithOptions(key.backingSize, key.isOpaque, 1.0);
-  
-  BOOL contextIsClean = YES;
-  
-  CGContextRef context = UIGraphicsGetCurrentContext();
-  if (context && key.willDisplayNodeContentWithRenderingContext) {
-    key.willDisplayNodeContentWithRenderingContext(context, drawParameters);
-    contextIsClean = NO;
-  }
-  
-  // if view is opaque, fill the context with background color
-  if (key.isOpaque && key.backgroundColor) {
-    [key.backgroundColor setFill];
-    UIRectFill({ .size = key.backingSize });
-    contextIsClean = NO;
-  }
-  
-  // iOS 9 appears to contain a thread safety regression when drawing the same CGImageRef on
-  // multiple threads concurrently.  In fact, instead of crashing, it appears to deadlock.
-  // The issue is present in Mac OS X El Capitan and has been seen hanging Pro apps like Adobe Premiere,
-  // as well as iOS games, and a small number of ASDK apps that provide the same image reference
-  // to many separate ASImageNodes.  A workaround is to set .displaysAsynchronously = NO for the nodes
-  // that may get the same pointer for a given UI asset image, etc.
-  // FIXME: We should replace @synchronized here, probably using a global, locked NSMutableSet, and
-  // only if the object already exists in the set we should create a semaphore to signal waiting threads
-  // upon removal of the object from the set when the operation completes.
-  // Another option is to have ASDisplayNode+AsyncDisplay coordinate these cases, and share the decoded buffer.
-  // Details tracked in https://github.com/facebook/AsyncDisplayKit/issues/1068
-  
-  UIImage *image = key.image;
-  BOOL canUseCopy = (contextIsClean || ASImageAlphaInfoIsOpaque(CGImageGetAlphaInfo(image.CGImage)));
-  CGBlendMode blendMode = canUseCopy ? kCGBlendModeCopy : kCGBlendModeNormal;
-  
-  @synchronized(image) {
-    [image drawInRect:key.imageDrawRect blendMode:blendMode alpha:1];
-  }
-  
-  if (context && key.didDisplayNodeContentWithRenderingContext) {
-    key.didDisplayNodeContentWithRenderingContext(context, drawParameters);
-  }
+  UIImage *result = ASGraphicsCreateImageWithOptions(key.backingSize, key.isOpaque, 1.0, key.image, isCancelled, ^{
+    BOOL contextIsClean = YES;
 
-  // Check cancellation one last time before forming image.
-  if (isCancelled()) {
-    UIGraphicsEndImageContext();
-    return nil;
-  }
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    if (context && key.willDisplayNodeContentWithRenderingContext) {
+      key.willDisplayNodeContentWithRenderingContext(context, drawParameters);
+      contextIsClean = NO;
+    }
 
-  UIImage *result = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
+    // if view is opaque, fill the context with background color
+    if (key.isOpaque && key.backgroundColor) {
+      [key.backgroundColor setFill];
+      UIRectFill({ .size = key.backingSize });
+      contextIsClean = NO;
+    }
+
+    // iOS 9 appears to contain a thread safety regression when drawing the same CGImageRef on
+    // multiple threads concurrently.  In fact, instead of crashing, it appears to deadlock.
+    // The issue is present in Mac OS X El Capitan and has been seen hanging Pro apps like Adobe Premiere,
+    // as well as iOS games, and a small number of ASDK apps that provide the same image reference
+    // to many separate ASImageNodes.  A workaround is to set .displaysAsynchronously = NO for the nodes
+    // that may get the same pointer for a given UI asset image, etc.
+    // FIXME: We should replace @synchronized here, probably using a global, locked NSMutableSet, and
+    // only if the object already exists in the set we should create a semaphore to signal waiting threads
+    // upon removal of the object from the set when the operation completes.
+    // Another option is to have ASDisplayNode+AsyncDisplay coordinate these cases, and share the decoded buffer.
+    // Details tracked in https://github.com/facebook/AsyncDisplayKit/issues/1068
+
+    BOOL canUseCopy = (contextIsClean || imageIsOpaque);
+    CGBlendMode blendMode = canUseCopy ? kCGBlendModeCopy : kCGBlendModeNormal;
+
+    @synchronized(image) {
+      [image drawInRect:imageDrawRect blendMode:blendMode alpha:1];
+    }
+
+    if (context && key.didDisplayNodeContentWithRenderingContext) {
+      key.didDisplayNodeContentWithRenderingContext(context, drawParameters);
+    }
+  });
   
   if (key.imageModificationBlock) {
     result = key.imageModificationBlock(result);
@@ -735,40 +722,34 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 asimagenode_modification_block_t ASImageNodeRoundBorderModificationBlock(CGFloat borderWidth, UIColor *borderColor)
 {
   return ^(UIImage *originalImage) {
-    UIGraphicsBeginImageContextWithOptions(originalImage.size, NO, originalImage.scale);
-    UIBezierPath *roundOutline = [UIBezierPath bezierPathWithOvalInRect:(CGRect){CGPointZero, originalImage.size}];
+    return ASGraphicsCreateImageWithOptions(originalImage.size, NO, originalImage.scale, originalImage, nil, ^{
+      UIBezierPath *roundOutline = [UIBezierPath bezierPathWithOvalInRect:(CGRect){CGPointZero, originalImage.size}];
 
-    // Make the image round
-    [roundOutline addClip];
+      // Make the image round
+      [roundOutline addClip];
 
-    // Draw the original image
-    [originalImage drawAtPoint:CGPointZero blendMode:kCGBlendModeCopy alpha:1];
+      // Draw the original image
+      [originalImage drawAtPoint:CGPointZero blendMode:kCGBlendModeCopy alpha:1];
 
-    // Draw a border on top.
-    if (borderWidth > 0.0) {
-      [borderColor setStroke];
-      [roundOutline setLineWidth:borderWidth];
-      [roundOutline stroke];
-    }
-
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    return image;
+      // Draw a border on top.
+      if (borderWidth > 0.0) {
+        [borderColor setStroke];
+        [roundOutline setLineWidth:borderWidth];
+        [roundOutline stroke];
+      }
+    });
   };
 }
 
 asimagenode_modification_block_t ASImageNodeTintColorModificationBlock(UIColor *color)
 {
   return ^(UIImage *originalImage) {
-    UIGraphicsBeginImageContextWithOptions(originalImage.size, NO, originalImage.scale);
-    
-    // Set color and render template
-    [color setFill];
-    UIImage *templateImage = [originalImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-    [templateImage drawAtPoint:CGPointZero blendMode:kCGBlendModeCopy alpha:1];
-    
-    UIImage *modifiedImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
+    UIImage *modifiedImage = ASGraphicsCreateImageWithOptions(originalImage.size, NO, originalImage.scale, originalImage, nil, ^{
+      // Set color and render template
+      [color setFill];
+      UIImage *templateImage = [originalImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+      [templateImage drawAtPoint:CGPointZero blendMode:kCGBlendModeCopy alpha:1];
+    });
 
     // if the original image was stretchy, keep it stretchy
     if (!UIEdgeInsetsEqualToEdgeInsets(originalImage.capInsets, UIEdgeInsetsZero)) {

--- a/Source/ASMapNode.mm
+++ b/Source/ASMapNode.mm
@@ -15,6 +15,7 @@
 
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
+#import <AsyncDisplayKit/ASGraphicsContext.h>
 #import <AsyncDisplayKit/ASInsetLayoutSpec.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASLayout.h>
@@ -221,40 +222,38 @@
                     
                     CGRect finalImageRect = CGRectMake(0, 0, image.size.width, image.size.height);
                     
-                    UIGraphicsBeginImageContextWithOptions(image.size, YES, image.scale);
-                    [image drawAtPoint:CGPointZero];
-                    
-                    UIImage *pinImage;
-                    CGPoint pinCenterOffset = CGPointZero;
-                    
-                    // Get a standard annotation view pin if there is no custom annotation block.
-                    if (!strongSelf.imageForStaticMapAnnotationBlock) {
-                      pinImage = [strongSelf.class defaultPinImageWithCenterOffset:&pinCenterOffset];
-                    }
-                    
-                    for (id<MKAnnotation> annotation in annotations) {
-                      if (strongSelf.imageForStaticMapAnnotationBlock) {
-                        // Get custom annotation image from custom annotation block.
-                        pinImage = strongSelf.imageForStaticMapAnnotationBlock(annotation, &pinCenterOffset);
-                        if (!pinImage) {
-                          // just for case block returned nil, which can happen
-                          pinImage = [strongSelf.class defaultPinImageWithCenterOffset:&pinCenterOffset];
+                    image = ASGraphicsCreateImageWithOptions(image.size, YES, image.scale, image, nil, ^{
+                      [image drawAtPoint:CGPointZero];
+
+                      UIImage *pinImage;
+                      CGPoint pinCenterOffset = CGPointZero;
+
+                      // Get a standard annotation view pin if there is no custom annotation block.
+                      if (!strongSelf.imageForStaticMapAnnotationBlock) {
+                        pinImage = [strongSelf.class defaultPinImageWithCenterOffset:&pinCenterOffset];
+                      }
+
+                      for (id<MKAnnotation> annotation in annotations) {
+                        if (strongSelf.imageForStaticMapAnnotationBlock) {
+                          // Get custom annotation image from custom annotation block.
+                          pinImage = strongSelf.imageForStaticMapAnnotationBlock(annotation, &pinCenterOffset);
+                          if (!pinImage) {
+                            // just for case block returned nil, which can happen
+                            pinImage = [strongSelf.class defaultPinImageWithCenterOffset:&pinCenterOffset];
+                          }
+                        }
+
+                        CGPoint point = [snapshot pointForCoordinate:annotation.coordinate];
+                        if (CGRectContainsPoint(finalImageRect, point)) {
+                          CGSize pinSize = pinImage.size;
+                          point.x -= pinSize.width / 2.0;
+                          point.y -= pinSize.height / 2.0;
+                          point.x += pinCenterOffset.x;
+                          point.y += pinCenterOffset.y;
+                          [pinImage drawAtPoint:point];
                         }
                       }
-                      
-                      CGPoint point = [snapshot pointForCoordinate:annotation.coordinate];
-                      if (CGRectContainsPoint(finalImageRect, point)) {
-                        CGSize pinSize = pinImage.size;
-                        point.x -= pinSize.width / 2.0;
-                        point.y -= pinSize.height / 2.0;
-                        point.x += pinCenterOffset.x;
-                        point.y += pinCenterOffset.y;
-                        [pinImage drawAtPoint:point];
-                      }
-                    }
-                    
-                    image = UIGraphicsGetImageFromCurrentImageContext();
-                    UIGraphicsEndImageContext();
+                    });
                   }
                   
                   strongSelf.image = image;

--- a/Source/Debug/AsyncDisplayKit+Debug.mm
+++ b/Source/Debug/AsyncDisplayKit+Debug.mm
@@ -13,6 +13,7 @@
 #import <AsyncDisplayKit/ASWeakSet.h>
 #import <AsyncDisplayKit/UIImage+ASConvenience.h>
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
+#import <AsyncDisplayKit/ASGraphicsContext.h>
 #import <AsyncDisplayKit/CoreGraphics+ASConvenience.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
 #import <AsyncDisplayKit/ASTextNode.h>
@@ -139,17 +140,14 @@ static BOOL __enableHitTestDebug = NO;
       UIColor *borderColor      = [[UIColor orangeColor] colorWithAlphaComponent:0.8];
       UIColor *clipsBorderColor = [UIColor colorWithRed:30/255.0 green:90/255.0 blue:50/255.0 alpha:0.7];
       CGRect imgRect            = CGRectMake(0, 0, 2.0 * borderWidth + 1.0, 2.0 * borderWidth + 1.0);
-      
-      UIGraphicsBeginImageContextWithOptions(imgRect.size, NO, 1);
-      
-      [fillColor setFill];
-      UIRectFill(imgRect);
-      
-      [self drawEdgeIfClippedWithEdges:clippedEdges color:clipsBorderColor borderWidth:borderWidth imgRect:imgRect];
-      [self drawEdgeIfClippedWithEdges:clipsToBoundsClippedEdges color:borderColor borderWidth:borderWidth imgRect:imgRect];
-      
-      UIImage *debugHighlightImage = UIGraphicsGetImageFromCurrentImageContext();
-      UIGraphicsEndImageContext();
+
+      UIImage *debugHighlightImage = ASGraphicsCreateImageWithOptions(imgRect.size, NO, 1, nil, nil, ^{
+        [fillColor setFill];
+        UIRectFill(imgRect);
+
+        [self drawEdgeIfClippedWithEdges:clippedEdges color:clipsBorderColor borderWidth:borderWidth imgRect:imgRect];
+        [self drawEdgeIfClippedWithEdges:clipsToBoundsClippedEdges color:borderColor borderWidth:borderWidth imgRect:imgRect];
+      });
       
       UIEdgeInsets edgeInsets = UIEdgeInsetsMake(borderWidth, borderWidth, borderWidth, borderWidth);
       debugOverlay.image = [debugHighlightImage resizableImageWithCapInsets:edgeInsets resizingMode:UIImageResizingModeStretch];

--- a/Source/Details/ASGraphicsContext.h
+++ b/Source/Details/ASGraphicsContext.h
@@ -1,0 +1,32 @@
+//
+//  ASGraphicsContext.h
+//  Texture
+//
+//  Copyright (c) Pinterest, Inc.  All rights reserved.
+//  Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <UIKit/UIKit.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+#import <AsyncDisplayKit/ASBlockTypes.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A wrapper for the UIKit drawing APIs. If you are in ASExperimentalDrawingGlobal, and you have iOS >= 10, we will create
+ * a UIGraphicsRenderer with an appropriate format. Otherwise, we will use UIGraphicsBeginImageContext et al.
+ *
+ * @param size The size of the context.
+ * @param opaque Whether the context should be opaque or not.
+ * @param scale The scale of the context. 0 uses main screen scale.
+ * @param sourceImage If you are planning to render a UIImage into this context, provide it here and we will use its
+ *   preferred renderer format if we are using UIGraphicsImageRenderer.
+ * @param isCancelled An optional block for canceling the drawing before forming the image. Only takes effect under
+ *   the legacy code path, as UIGraphicsRenderer does not support cancellation.
+ * @param work A block, wherein the current UIGraphics context is set based on the arguments.
+ *
+ * @return The rendered image. You can also render intermediary images using UIGraphicsGetImageFromCurrentImageContext.
+ */
+AS_EXTERN UIImage *ASGraphicsCreateImageWithOptions(CGSize size, BOOL opaque, CGFloat scale, UIImage * _Nullable sourceImage, asdisplaynode_iscancelled_block_t NS_NOESCAPE _Nullable isCancelled, void (NS_NOESCAPE ^work)());
+
+NS_ASSUME_NONNULL_END

--- a/Source/Details/ASGraphicsContext.mm
+++ b/Source/Details/ASGraphicsContext.mm
@@ -1,0 +1,75 @@
+//
+//  ASGraphicsContext.mm
+//  Texture
+//
+//  Copyright (c) Pinterest, Inc.  All rights reserved.
+//  Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASGraphicsContext.h>
+#import <AsyncDisplayKit/ASAssert.h>
+#import <AsyncDisplayKit/ASConfigurationInternal.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
+
+NS_AVAILABLE_IOS(10)
+NS_INLINE void ASConfigureExtendedRange(UIGraphicsImageRendererFormat *format)
+{
+  if (AS_AVAILABLE_IOS_TVOS(12, 12)) {
+    // nop. We always use automatic range on iOS >= 12.
+  } else {
+    // Currently we never do wide color. One day we could pipe this information through from the ASImageNode if it was worth it.
+    format.prefersExtendedRange = NO;
+  }
+}
+
+UIImage *ASGraphicsCreateImageWithOptions(CGSize size, BOOL opaque, CGFloat scale, UIImage *sourceImage,
+                                          asdisplaynode_iscancelled_block_t NS_NOESCAPE isCancelled,
+                                          void (^NS_NOESCAPE work)())
+{
+  if (AS_AVAILABLE_IOS_TVOS(10, 10)) {
+    if (ASActivateExperimentalFeature(ASExperimentalDrawingGlobal)) {
+      // If they used default scale, reuse one of two default formats.
+      static UIGraphicsImageRendererFormat *defaultFormat;
+      static UIGraphicsImageRendererFormat *opaqueFormat;
+      static dispatch_once_t onceToken;
+      dispatch_once(&onceToken, ^{
+        defaultFormat = [[UIGraphicsImageRendererFormat alloc] init];
+        opaqueFormat = [[UIGraphicsImageRendererFormat alloc] init];
+        opaqueFormat.opaque = YES;
+        ASConfigureExtendedRange(defaultFormat);
+        ASConfigureExtendedRange(opaqueFormat);
+      });
+
+      UIGraphicsImageRendererFormat *format;
+      if (sourceImage) {
+        format = sourceImage.imageRendererFormat;
+        // We only want the private bits (color space and bits per component) from the image.
+        // We have our own ideas about opacity and scale.
+        format.opaque = opaque;
+        format.scale = scale;
+      } else if (scale == 0 || scale == ASScreenScale()) {
+        format = opaque ? opaqueFormat : defaultFormat;
+      } else {
+        format = [[UIGraphicsImageRendererFormat alloc] init];
+        if (opaque) format.opaque = YES;
+        format.scale = scale;
+        ASConfigureExtendedRange(format);
+      }
+
+      return [[[UIGraphicsImageRenderer alloc] initWithSize:size format:format] imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
+        ASDisplayNodeCAssert(UIGraphicsGetCurrentContext(), @"Should have a context!");
+        work();
+      }];
+    }
+  }
+
+  // Bad OS or experiment flag. Use UIGraphics* API.
+  UIGraphicsBeginImageContextWithOptions(size, opaque, scale);
+  work();
+  UIImage *image = nil;
+  if (isCancelled && !isCancelled()) {
+    image = UIGraphicsGetImageFromCurrentImageContext();
+  }
+  UIGraphicsEndImageContext();
+  return image;
+}

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -13,6 +13,7 @@
 #import <AsyncDisplayKit/ASAssert.h>
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h>
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
+#import <AsyncDisplayKit/ASGraphicsContext.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASSignpost.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
@@ -210,16 +211,13 @@ using AS::MutexLocker;
 
     displayBlock = ^id{
       CHECK_CANCELLED_AND_RETURN_NIL();
-      
-      UIGraphicsBeginImageContextWithOptions(bounds.size, opaque, contentsScaleForDisplay);
 
-      for (dispatch_block_t block in displayBlocks) {
-        CHECK_CANCELLED_AND_RETURN_NIL(UIGraphicsEndImageContext());
-        block();
-      }
-      
-      UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-      UIGraphicsEndImageContext();
+      UIImage *image = ASGraphicsCreateImageWithOptions(bounds.size, opaque, contentsScaleForDisplay, nil, isCancelledBlock, ^{
+        for (dispatch_block_t block in displayBlocks) {
+          if (isCancelledBlock()) return;
+          block();
+        }
+      });
 
       ASDN_DELAY_FOR_DISPLAY();
       return image;
@@ -228,37 +226,35 @@ using AS::MutexLocker;
     displayBlock = ^id{
       CHECK_CANCELLED_AND_RETURN_NIL();
 
+      __block UIImage *image = nil;
+      void (^workWithContext)() = ^{
+        CGContextRef currentContext = UIGraphicsGetCurrentContext();
+
+        if (shouldCreateGraphicsContext && !currentContext) {
+          ASDisplayNodeAssert(NO, @"Failed to create a CGContext (size: %@)", NSStringFromCGSize(bounds.size));
+          return;
+        }
+
+        // For -display methods, we don't have a context, and thus will not call the _willDisplayNodeContentWithRenderingContext or
+        // _didDisplayNodeContentWithRenderingContext blocks. It's up to the implementation of -display... to do what it needs.
+        [self __willDisplayNodeContentWithRenderingContext:currentContext drawParameters:drawParameters];
+
+        if (usesImageDisplay) {                                   // If we are using a display method, we'll get an image back directly.
+          image = [self.class displayWithParameters:drawParameters isCancelled:isCancelledBlock];
+        } else if (usesDrawRect) {                                // If we're using a draw method, this will operate on the currentContext.
+          [self.class drawRect:bounds withParameters:drawParameters isCancelled:isCancelledBlock isRasterizing:rasterizing];
+        }
+
+        [self __didDisplayNodeContentWithRenderingContext:currentContext image:&image drawParameters:drawParameters backgroundColor:backgroundColor borderWidth:borderWidth borderColor:borderColor];
+        ASDN_DELAY_FOR_DISPLAY();
+      };
+
       if (shouldCreateGraphicsContext) {
-        UIGraphicsBeginImageContextWithOptions(bounds.size, opaque, contentsScaleForDisplay);
+        return ASGraphicsCreateImageWithOptions(bounds.size, opaque, contentsScaleForDisplay, nil, isCancelledBlock, workWithContext);
+      } else {
+        workWithContext();
+        return image;
       }
-
-      CGContextRef currentContext = UIGraphicsGetCurrentContext();
-      UIImage *image = nil;
-
-      if (shouldCreateGraphicsContext && !currentContext) {
-        ASDisplayNodeAssert(NO, @"Failed to create a CGContext (size: %@)", NSStringFromCGSize(bounds.size));
-        return nil;
-      }
-
-      // For -display methods, we don't have a context, and thus will not call the _willDisplayNodeContentWithRenderingContext or
-      // _didDisplayNodeContentWithRenderingContext blocks. It's up to the implementation of -display... to do what it needs.
-      [self __willDisplayNodeContentWithRenderingContext:currentContext drawParameters:drawParameters];
-      
-      if (usesImageDisplay) {                                   // If we are using a display method, we'll get an image back directly.
-        image = [self.class displayWithParameters:drawParameters isCancelled:isCancelledBlock];
-      } else if (usesDrawRect) {                                // If we're using a draw method, this will operate on the currentContext.
-        [self.class drawRect:bounds withParameters:drawParameters isCancelled:isCancelledBlock isRasterizing:rasterizing];
-      }
-      
-      [self __didDisplayNodeContentWithRenderingContext:currentContext image:&image drawParameters:drawParameters backgroundColor:backgroundColor borderWidth:borderWidth borderColor:borderColor];
-      
-      if (shouldCreateGraphicsContext) {
-        CHECK_CANCELLED_AND_RETURN_NIL( UIGraphicsEndImageContext(); );
-        image = UIGraphicsGetImageFromCurrentImageContext();
-      }
-
-      ASDN_DELAY_FOR_DISPLAY();
-      return image;
     };
   }
 
@@ -365,6 +361,8 @@ using AS::MutexLocker;
     
     if (*image) {
       *image = UIGraphicsGetImageFromCurrentImageContext();
+    }
+    if (context == NULL) {
       UIGraphicsEndImageContext();
     }
   }

--- a/Source/UIImage+ASConvenience.mm
+++ b/Source/UIImage+ASConvenience.mm
@@ -8,6 +8,7 @@
 //
 
 #import <AsyncDisplayKit/UIImage+ASConvenience.h>
+#import <AsyncDisplayKit/ASGraphicsContext.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASAssert.h>
 
@@ -130,38 +131,35 @@ UIImage *cachedImageNamed(NSString *imageName, UITraitCollection *traitCollectio
   
   // We should probably check if the background color has any alpha component but that
   // might be expensive due to needing to check mulitple color spaces.
-  UIGraphicsBeginImageContextWithOptions(bounds.size, cornerColor != nil, scale);
-  
-  BOOL contextIsClean = YES;
-  if (cornerColor) {
-    contextIsClean = NO;
-    [cornerColor setFill];
-    // Copy "blend" mode is extra fast because it disregards any value currently in the buffer and overrides directly.
-    UIRectFillUsingBlendMode(bounds, kCGBlendModeCopy);
-  }
-  
-  BOOL canUseCopy = contextIsClean || (CGColorGetAlpha(fillColor.CGColor) == 1);
-  [fillColor setFill];
-  [path fillWithBlendMode:(canUseCopy ? kCGBlendModeCopy : kCGBlendModeNormal) alpha:1];
-  
-  if (borderColor) {
-    [borderColor setStroke];
-    
-    // Inset border fully inside filled path (not halfway on each side of path)
-    CGRect strokeRect = CGRectInset(bounds, borderWidth / 2.0, borderWidth / 2.0);
-    
-    // It is rarer to have a stroke path, and our cache key only handles rounded rects for the exact-stretchable
-    // size calculated by cornerRadius, so we won't bother caching this path.  Profiling validates this decision.
-    UIBezierPath *strokePath = [UIBezierPath bezierPathWithRoundedRect:strokeRect
-                                                     byRoundingCorners:roundedCorners
-                                                           cornerRadii:cornerRadii];
-    [strokePath setLineWidth:borderWidth];
-    BOOL canUseCopy = (CGColorGetAlpha(borderColor.CGColor) == 1);
-    [strokePath strokeWithBlendMode:(canUseCopy ? kCGBlendModeCopy : kCGBlendModeNormal) alpha:1];
-  }
-  
-  UIImage *result = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
+  UIImage *result = ASGraphicsCreateImageWithOptions(bounds.size, cornerColor != nil, scale, nil, nil, ^{
+    BOOL contextIsClean = YES;
+    if (cornerColor) {
+      contextIsClean = NO;
+      [cornerColor setFill];
+      // Copy "blend" mode is extra fast because it disregards any value currently in the buffer and overrides directly.
+      UIRectFillUsingBlendMode(bounds, kCGBlendModeCopy);
+    }
+
+    BOOL canUseCopy = contextIsClean || (CGColorGetAlpha(fillColor.CGColor) == 1);
+    [fillColor setFill];
+    [path fillWithBlendMode:(canUseCopy ? kCGBlendModeCopy : kCGBlendModeNormal) alpha:1];
+
+    if (borderColor) {
+      [borderColor setStroke];
+
+      // Inset border fully inside filled path (not halfway on each side of path)
+      CGRect strokeRect = CGRectInset(bounds, borderWidth / 2.0, borderWidth / 2.0);
+
+      // It is rarer to have a stroke path, and our cache key only handles rounded rects for the exact-stretchable
+      // size calculated by cornerRadius, so we won't bother caching this path.  Profiling validates this decision.
+      UIBezierPath *strokePath = [UIBezierPath bezierPathWithRoundedRect:strokeRect
+                                                       byRoundingCorners:roundedCorners
+                                                             cornerRadii:cornerRadii];
+      [strokePath setLineWidth:borderWidth];
+      BOOL canUseCopy = (CGColorGetAlpha(borderColor.CGColor) == 1);
+      [strokePath strokeWithBlendMode:(canUseCopy ? kCGBlendModeCopy : kCGBlendModeNormal) alpha:1];
+    }
+  });
   
   UIEdgeInsets capInsets = UIEdgeInsetsMake(cornerRadius, cornerRadius, cornerRadius, cornerRadius);
   result = [result resizableImageWithCapInsets:capInsets resizingMode:UIImageResizingModeStretch];

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -34,6 +34,7 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalOOMBackgroundDeallocDisable,
   ASExperimentalTransactionOperationRetainCycle,
   ASExperimentalRemoveTextKitInitialisingLock,
+  ASExperimentalDrawingGlobal
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -61,7 +62,8 @@ static ASExperimentalFeatures features[] = {
     @"exp_fix_range_controller",
     @"exp_oom_bg_dealloc_disable",
     @"exp_transaction_operation_retain_cycle",
-    @"exp_remove_textkit_initialising_lock"
+    @"exp_remove_textkit_initialising_lock",
+    @"exp_drawing_global"
   ];
 }
 


### PR DESCRIPTION
This gets rid of the ASExperimentalGraphicsContext experiment that was a dud, and replaces ASGraphicsContexts.h with a wrapper. The wrapper calls into either UIGraphicsBeginImageContext or UIGraphicsImageRenderer to build an image.

These graphics renderers seem pretty awesome. https://gist.github.com/NSProgrammer/38f1b4f9b29c3077af3f39a7e98092b1

Want multiple core-team reviews on this since it touches such core code. It's pretty straightforward though. The one case where it wasn't straightforward (`__didDisplay…`) I just left with UIGraphics.