### PR TITLE
Fix the stub for layerActionForKey: to let CA continue the search

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -107,7 +107,7 @@ void StubImplementationWithNoArgs(id receiver, SEL _cmd) {}
 void StubImplementationWithSizeRange(id receiver, SEL _cmd, ASSizeRange sr) {}
 void StubImplementationWithTwoInterfaceStates(id receiver, SEL _cmd, ASInterfaceState s0, ASInterfaceState s1) {}
 
-/// Returning nil won't trigger unwanted default actions, because we override
+/// Returning nil here won't trigger unwanted default actions, because we override
 /// +defaultActionForKey: to return kCFNull.
 id StubLayerActionImplementation(id receiver, SEL _cmd, NSString *key) { return nil; }
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -106,7 +106,10 @@ _ASPendingState *ASDisplayNodeGetPendingState(ASDisplayNode *node)
 void StubImplementationWithNoArgs(id receiver, SEL _cmd) {}
 void StubImplementationWithSizeRange(id receiver, SEL _cmd, ASSizeRange sr) {}
 void StubImplementationWithTwoInterfaceStates(id receiver, SEL _cmd, ASInterfaceState s0, ASInterfaceState s1) {}
-id StubLayerActionImplementation(id receiver, SEL _cmd, NSString *key) { return (id)kCFNull; }
+
+/// Returning nil won't trigger unwanted default actions, because we override
+/// +defaultActionForKey: to return kCFNull.
+id StubLayerActionImplementation(id receiver, SEL _cmd, NSString *key) { return nil; }
 
 /**
  *  Returns ASDisplayNodeFlags for the given class/instance. instance MAY BE NIL.


### PR DESCRIPTION
As the comment says, we return kCFNull from +defaultActionForKey:. Stubbing this to nil is important so that CA will search the actions and style.actions dictionaries for layer actions.