### PR TITLE
Perform relayoutAllNodes (rotation, window resize) concurrently

### DIFF
--- a/Source/Details/ASCollectionElement.h
+++ b/Source/Details/ASCollectionElement.h
@@ -15,8 +15,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Copy returns self. Only here for dictionary use.
 AS_SUBCLASSING_RESTRICTED
-@interface ASCollectionElement : NSObject
+@interface ASCollectionElement : NSObject <NSCopying>
 
 @property (nullable, nonatomic, copy, readonly) NSString *supplementaryElementKind;
 @property (nonatomic) ASSizeRange constrainedSize;

--- a/Source/Details/ASCollectionElement.mm
+++ b/Source/Details/ASCollectionElement.mm
@@ -85,4 +85,9 @@
   }
 }
 
+- (id)copyWithZone:(NSZone *)zone
+{
+  return self;
+}
+
 @end

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -891,8 +891,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   _visibleMap = _pendingMap;
 
   // First update size constraints on the main thread.
-  NSDictionary<ASCollectionElement *, NSIndexPath *> *elementToIndexPath =
-  _visibleMap.elementToIndexPath;
+  NSDictionary<ASCollectionElement *, NSIndexPath *> *elementToIndexPath = _visibleMap.elementToIndexPath;
   [elementToIndexPath
    enumerateKeysAndObjectsUsingBlock:^(ASCollectionElement *element, NSIndexPath *indexPath,
                                        __unused BOOL *stop) {

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -890,27 +890,30 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   _pendingMap = [newMap copy];
   _visibleMap = _pendingMap;
 
-  for (ASCollectionElement *element in _visibleMap) {
-    // Ignore this element if it is no longer in the latest data. It is still recognized in the UIKit world but will be deleted soon.
-    NSIndexPath *indexPathInPendingMap = [_pendingMap indexPathForElement:element];
-    if (indexPathInPendingMap == nil) {
-      continue;
-    }
-
-    NSString *kind = element.supplementaryElementKind ?: ASDataControllerRowNodeKind;
-    ASSizeRange newConstrainedSize = [self constrainedSizeForNodeOfKind:kind atIndexPath:indexPathInPendingMap];
-
-    if (ASSizeRangeHasSignificantArea(newConstrainedSize)) {
-      element.constrainedSize = newConstrainedSize;
-
-      // Node may not be allocated yet (e.g node virtualization or same size optimization)
-      // Call context.nodeIfAllocated here to avoid premature node allocation and layout
-      ASCellNode *node = element.nodeIfAllocated;
-      if (node) {
-        [self _layoutNode:node withConstrainedSize:newConstrainedSize];
-      }
-    }
-  }
+  // First update size constraints on the main thread.
+  NSDictionary<ASCollectionElement *, NSIndexPath *> *elementToIndexPath =
+  _visibleMap.elementToIndexPath;
+  [elementToIndexPath
+   enumerateKeysAndObjectsUsingBlock:^(ASCollectionElement *element, NSIndexPath *indexPath,
+                                       __unused BOOL *stop) {
+     element.constrainedSize =
+     [self constrainedSizeForNodeOfKind:(element.supplementaryElementKind
+                                         ?: ASDataControllerRowNodeKind)
+                            atIndexPath:indexPath];
+   }];
+  
+  // Then concurrently synchronously ensure every node is measured against new constraints.
+  [elementToIndexPath
+   enumerateKeysAndObjectsWithOptions:NSEnumerationConcurrent
+   usingBlock:^(ASCollectionElement *element, NSIndexPath *indexPath,
+                __unused BOOL *stop) {
+     const ASSizeRange sizeRange = element.constrainedSize;
+     if (ASSizeRangeHasSignificantArea(sizeRange)) {
+       if (ASCellNode *node = element.nodeIfAllocated) {
+         [self _layoutNode:node withConstrainedSize:sizeRange];
+       }
+     }
+   }];
 }
 
 # pragma mark - ASPrimitiveTraitCollection

--- a/Source/Details/ASElementMap.h
+++ b/Source/Details/ASElementMap.h
@@ -61,6 +61,11 @@ AS_SUBCLASSING_RESTRICTED
 @property (copy, readonly) NSArray<ASCollectionElement *> *itemElements;
 
 /**
+ * All the elements in the map, in NSDictionary form. O(1)
+ */
+@property (readonly) NSDictionary<ASCollectionElement *, NSIndexPath *> *elementToIndexPath;
+
+/**
  * Returns the index path that corresponds to the same element in @c map at the given @c indexPath.
  * O(1) for items, fast O(N) for sections.
  *

--- a/Source/Details/ASElementMap.mm
+++ b/Source/Details/ASElementMap.mm
@@ -20,9 +20,6 @@
 
 @property (nonatomic, readonly) NSArray<ASSection *> *sections;
 
-// Element -> IndexPath
-@property (nonatomic, readonly) NSMapTable<ASCollectionElement *, NSIndexPath *> *elementToIndexPathMap;
-
 // The items, in a 2D array
 @property (nonatomic, readonly) ASCollectionElementTwoDimensionalArray *sectionsOfItems;
 
@@ -47,20 +44,20 @@
     _supplementaryElements = [[NSDictionary alloc] initWithDictionary:supplementaryElements copyItems:YES];
 
     // Setup our index path map
-    _elementToIndexPathMap = [NSMapTable mapTableWithKeyOptions:(NSMapTableStrongMemory | NSMapTableObjectPointerPersonality) valueOptions:NSMapTableCopyIn];
+    auto mElementToIndexPath = [[NSMutableDictionary<ASCollectionElement *, NSIndexPath *> alloc] init];
     NSInteger s = 0;
     for (NSArray *section in _sectionsOfItems) {
       NSInteger i = 0;
       for (ASCollectionElement *element in section) {
         NSIndexPath *indexPath = [NSIndexPath indexPathForItem:i inSection:s];
-        [_elementToIndexPathMap setObject:indexPath forKey:element];
+        [mElementToIndexPath setObject:indexPath forKey:element];
         i++;
       }
       s++;
     }
     for (NSDictionary *supplementariesForKind in [_supplementaryElements objectEnumerator]) {
       [supplementariesForKind enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *_Nonnull indexPath, ASCollectionElement * _Nonnull element, BOOL * _Nonnull stop) {
-        [_elementToIndexPathMap setObject:indexPath forKey:element];
+        [mElementToIndexPath setObject:indexPath forKey:element];
       }];
     }
   }
@@ -69,7 +66,7 @@
 
 - (NSUInteger)count
 {
-  return _elementToIndexPathMap.count;
+  return _elementToIndexPath.count;
 }
 
 - (NSArray<NSIndexPath *> *)itemIndexPaths
@@ -112,7 +109,7 @@
 
 - (nullable NSIndexPath *)indexPathForElement:(ASCollectionElement *)element
 {
-  return element ? [_elementToIndexPathMap objectForKey:element] : nil;
+  return element ? [_elementToIndexPath objectForKey:element] : nil;
 }
 
 - (nullable NSIndexPath *)indexPathForElementIfCell:(ASCollectionElement *)element
@@ -196,7 +193,7 @@
 
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id  _Nullable __unsafe_unretained [])buffer count:(NSUInteger)len
 {
-  return [_elementToIndexPathMap countByEnumeratingWithState:state objects:buffer count:len];
+  return [_elementToIndexPath countByEnumeratingWithState:state objects:buffer count:len];
 }
 
 - (NSString *)smallDescription


### PR DESCRIPTION
This makes those operations run a lot faster.

Switching ASElementMap from NSMapTable to NSDictionary is necessary for this, but probably more efficient too. NSMapTable is pretty horrible (tons of extra memory allocations).