### PR TITLE
Remove lock of ASTextNodeRendererKey

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -119,7 +119,7 @@ id StubLayerActionImplementation(id receiver, SEL _cmd, NSString *key) { return 
  *  @remarks        The instance value is used only if we suspect the class may be dynamic (because it overloads 
  *                  +respondsToSelector: or -respondsToSelector.) In that case we use our "slow path", calling this 
  *                  method on each -init and passing the instance value. While this may seem like an unlikely scenario,
- *                  it turns our our own internal tests use a dynamic class, so it's worth capturing this edge case.
+ *                  it turns out our own internal tests use a dynamic class, so it's worth capturing this edge case.
  *
  *  @return ASDisplayNode flags.
  */

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -95,10 +95,9 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
   if (self == object) {
     return YES;
   }
-  if (!object || ![object isKindOfClass:[self class]]) {
+  if (!object) {
     return NO;
   }
-  
   // NOTE: Skip the class check for this specialized, internal Key object.
   
   return _attributes == object->_attributes && CGSizeEqualToSize(_constrainedSize, object->_constrainedSize);

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -58,7 +58,7 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
 #pragma mark - ASTextKitRenderer
 
 @interface ASTextNodeRendererKey : NSObject
-- (instancetype)initWithAttributes:(ASTextKitAttributes)attributes constrainedSize:(CGSize)constrainedSize;
+- (instancetype)initWithTextKitAttributes:(const ASTextKitAttributes &)attributes constrainedSize:(const CGSize)constrainedSize;
 @end
 
 @implementation ASTextNodeRendererKey {
@@ -66,7 +66,7 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
   CGSize _constrainedSize;
 }
 
-- (instancetype)initWithAttributes:(ASTextKitAttributes)attributes constrainedSize:(CGSize)constrainedSize
+- (instancetype)initWithTextKitAttributes:(const ASTextKitAttributes &)attributes constrainedSize:(const CGSize)constrainedSize
 {
   if (self = [super init]) {
     _attributes = attributes;
@@ -126,7 +126,7 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
 {
   NSCache *cache = sharedRendererCache();
   
-  ASTextNodeRendererKey *key = [[ASTextNodeRendererKey alloc] initWithAttributes:attributes constrainedSize:constrainedSize];
+  ASTextNodeRendererKey *key = [[ASTextNodeRendererKey alloc] initWithTextKitAttributes:attributes constrainedSize:constrainedSize];
 
   ASTextKitRenderer *renderer = [cache objectForKey:key];
   if (renderer == nil) {

--- a/Source/ASVisibilityProtocols.h
+++ b/Source/ASVisibilityProtocols.h
@@ -38,7 +38,7 @@ AS_EXTERN ASLayoutRangeMode ASLayoutRangeModeForVisibilityDepth(NSUInteger visib
  * @discussion Represents the number of user actions necessary to reach the view controller. An increased visibility
  * depth indicates a higher number of user interactions for the view controller to be visible again. For example,
  * an onscreen navigation controller's top view controller should have a visibility depth of 0. The view controller
- * one from the top should have a visibility deptch of 1 as should the root view controller in the stack (because
+ * one from the top should have a visibility depth of 1 as should the root view controller in the stack (because
  * the user can hold the back button to pop to the root view controller).
  *
  * Visibility depth is used to automatically adjust ranges on range controllers (and thus free up memory) and can


### PR DESCRIPTION
1. Remove lock of ASTextNodeRendererKey, don't provide property readwrite for external.
2. Add `nil` and `class kind` check for `isEqual:`.