### PR TITLE
Only create activities during debug

### DIFF
--- a/Source/Base/ASLog.h
+++ b/Source/Base/ASLog.h
@@ -79,8 +79,11 @@ AS_EXTERN os_log_t ASLockingLog(void);
  * reflected in the log whereas activities described by the newer
  * os_activity_scope are. So unfortunately we must use these iOS 10
  * APIs to get meaningful logging data.
+ * 
+ * NOTE: Creating and tearing down activities require inter-process communication and can
+ * take dozens of microseconds on an A8. We do it quite often. Enable activities only during debugging.
  */
-#if OS_LOG_TARGET_HAS_10_12_FEATURES
+#if DEBUG && OS_LOG_TARGET_HAS_10_12_FEATURES
 
 #define OS_ACTIVITY_NULLABLE                                              nullable
 #define AS_ACTIVITY_CURRENT                                               OS_ACTIVITY_CURRENT


### PR DESCRIPTION
On an A8 in a large app, creating & tearing these down can take ~80us in some cases. Since using activity data in production hasn't really caught on at all, let's limit this to debug.