### PR TITLE
Make ASCollectionNode's pan gesture customizable

### DIFF
--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  * ASCollectionNode is a node based class that wraps an ASCollectionView. It can be used
  * as a subnode of another node, and provide room for many (great) features and improvements later on.
  */
-@interface ASCollectionNode : ASDisplayNode <ASRangeControllerUpdateRangeProtocol, ASRangeManagingNode>
+@interface ASCollectionNode : ASDisplayNode <ASRangeControllerUpdateRangeProtocol, ASRangeManagingNode, UIGestureRecognizerDelegate>
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -1040,6 +1040,28 @@ ASLayoutElementCollectionTableSetTraitCollection(_environmentStateLock)
   return result;
 }
 
+#pragma mark - UIGestureRecognizerDelegate Methods
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+    return YES;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return NO;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return NO;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return NO;
+}
+
 #pragma mark - Private methods
 
 - (void)_configureCollectionViewLayout:(UICollectionViewLayout *)layout

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -1041,8 +1041,18 @@ ASLayoutElementCollectionTableSetTraitCollection(_environmentStateLock)
 }
 
 #pragma mark - UIGestureRecognizerDelegate Methods
-
+// The value returned below are default implementation of UIKit's UIGestureRecognizerDelegate
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+    return YES;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+    return YES;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceivePress:(UIPress *)press
 {
     return YES;
 }

--- a/Source/ASCollectionView.h
+++ b/Source/ASCollectionView.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @note ASCollectionNode is strongly recommended over ASCollectionView.  This class exists for adoption convenience.
  */
-@interface ASCollectionView : UICollectionView
+@interface ASCollectionView : UICollectionView <UIGestureRecognizerDelegate>
 
 /**
  * Returns the corresponding ASCollectionNode

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -317,7 +317,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   [self registerClass:[_ASCollectionViewCell class] forCellWithReuseIdentifier:kReuseIdentifier];
   
   [self _configureCollectionViewLayout:layout];
-  
+
+  self.panGestureRecognizer.delegate = self;
   return self;
 }
 
@@ -2516,6 +2517,27 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 {
   [self waitUntilAllUpdatesAreCommitted];
   return [super accessibilityElements];
+}
+
+#pragma mark - UIGestureRecognizerDelegate Method
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return [self.collectionNode gestureRecognizer:gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:otherGestureRecognizer];
+}
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+    return [self.collectionNode gestureRecognizerShouldBegin:gestureRecognizer];
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return [self.collectionNode gestureRecognizer:gestureRecognizer shouldRequireFailureOfGestureRecognizer:otherGestureRecognizer];
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return [self.collectionNode gestureRecognizer:gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:otherGestureRecognizer];
 }
 
 @end

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -2520,14 +2520,24 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 }
 
 #pragma mark - UIGestureRecognizerDelegate Method
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
-{
-    return [self.collectionNode gestureRecognizer:gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:otherGestureRecognizer];
-}
-
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
     return [self.collectionNode gestureRecognizerShouldBegin:gestureRecognizer];
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+    return [self.collectionNode gestureRecognizer:gestureRecognizer shouldReceiveTouch:touch];
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceivePress:(UIPress *)press
+{
+    return [self.collectionNode gestureRecognizer:gestureRecognizer shouldReceivePress:press];
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return [self.collectionNode gestureRecognizer:gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:otherGestureRecognizer];
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer


### PR DESCRIPTION
Adding the ability for ASCollectionNode’s subclasses to customize the behavior of its default panGestureRecognizer.

With texture and UIKit, you can't assign a collection's default pan gesture delegate to an instance other than the collectionView itself, so for code like this `self.pagerNode.view.panGestureRecognizer.delegate = self;`, UIKit would raise the following exception:
`Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'UIScrollView's built-in pan gesture recognizer must have its scroll view as its delegate.'`

I don't see any other way to do this since Texture's collectionNode wraps its underlying view and users of this class would not be able to subclass the view.

