### PR TITLE
Fix open context bug introduced in #1458

### DIFF
--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -255,6 +255,7 @@ using AS::MutexLocker;
       if (shouldCreateGraphicsContext) {
         CHECK_CANCELLED_AND_RETURN_NIL( UIGraphicsEndImageContext(); );
         image = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
       }
 
       ASDN_DELAY_FOR_DISPLAY();


### PR DESCRIPTION
iOS attempts to automatically close these when the thread exits, but some versions (at least iOS 10, checking others) have a bug which causes it to just keep spinning indefinitely.

cc @garrettmoon @nguyenhuy @ay8s Everyone should cherry-pick this into any branches that include #1458.