### PR TITLE
Make ASImageNodeRoundBorderModificationBlock more flexible

### DIFF
--- a/Source/ASImageNode.h
+++ b/Source/ASImageNode.h
@@ -189,6 +189,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
 /**
  * @abstract Image modification block that rounds (and optionally adds a border to) an image.
  *
+ * @param size The desired final size for the image.
  * @param borderWidth The width of the round border to draw, or zero if no border is desired.
  * @param borderColor What colour border to draw.
  *
@@ -196,7 +197,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  *
  * @return An ASImageNode image modification block.
  */
-AS_EXTERN asimagenode_modification_block_t ASImageNodeRoundBorderModificationBlock(CGFloat borderWidth, UIColor * _Nullable borderColor);
+AS_EXTERN asimagenode_modification_block_t ASImageNodeRoundBorderModificationBlock(CGSize size, CGFloat borderWidth, UIColor * _Nullable borderColor);
 
 /**
  * @abstract Image modification block that applies a tint color à la UIImage configured with

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -732,22 +732,24 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 
 #pragma mark - Extras
 
-asimagenode_modification_block_t ASImageNodeRoundBorderModificationBlock(CGFloat borderWidth, UIColor *borderColor)
+asimagenode_modification_block_t ASImageNodeRoundBorderModificationBlock(CGSize size, CGFloat borderWidth, UIColor *borderColor)
 {
   return ^(UIImage *originalImage) {
-    UIGraphicsBeginImageContextWithOptions(originalImage.size, NO, originalImage.scale);
-    UIBezierPath *roundOutline = [UIBezierPath bezierPathWithOvalInRect:(CGRect){CGPointZero, originalImage.size}];
+
+    CGRect imageRect = (CGRect){CGPointZero, size};
+    UIGraphicsBeginImageContextWithOptions(size, NO, UIScreen.mainScreen.scale);
+    UIBezierPath *roundOutline = [UIBezierPath bezierPathWithOvalInRect:imageRect];
 
     // Make the image round
     [roundOutline addClip];
 
     // Draw the original image
-    [originalImage drawAtPoint:CGPointZero blendMode:kCGBlendModeCopy alpha:1];
-
+    [originalImage drawInRect:imageRect blendMode:kCGBlendModeCopy alpha:1];
     // Draw a border on top.
     if (borderWidth > 0.0) {
       [borderColor setStroke];
-      [roundOutline setLineWidth:borderWidth];
+      CGFloat correctedBorderWidth = borderWidth * 2;
+      [roundOutline setLineWidth:correctedBorderWidth];
       [roundOutline stroke];
     }
 

--- a/Tests/ASImageNodeSnapshotTests.mm
+++ b/Tests/ASImageNodeSnapshotTests.mm
@@ -83,7 +83,7 @@
   UIRectFill(CGRectMake(0, 0, 100, 100));
   UIImage *result = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();
-  UIImage *rounded = ASImageNodeRoundBorderModificationBlock(2, [UIColor redColor])(result);
+  UIImage *rounded = ASImageNodeRoundBorderModificationBlock(CGSizeMake(100, 100), 2, [UIColor redColor])(result);
   ASImageNode *node = [[ASImageNode alloc] init];
   node.image = rounded;
   ASDisplayNodeSizeToFitSize(node, rounded.size);


### PR DESCRIPTION
As it stands the current ASImageNodeRoundBorderModificationBlock has two issues:

1. Will produce a border half the desired size
2. Will produce a border that is visibly different size depending on original size of image

This PR seeks to address this by allowing the caller to specify the desired output size (likely matching the final desired node size), the block will then draw in a rect modified to match the desired size. In addition it will double the size of the border to be that of the desired border width. This will more closely match what you might get when using a CALayer border. 