### PR TITLE
Make sure all ASDisplayNode properties have backing ivars for consistency.

### DIFF
--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -20,6 +20,9 @@
 #import <AsyncDisplayKit/ASLayoutElement.h>
 #import <AsyncDisplayKit/ASLocking.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic error "-Wobjc-missing-property-synthesis"
+
 NS_ASSUME_NONNULL_BEGIN
 
 #define ASDisplayNodeLoggingEnabled 0
@@ -987,3 +990,5 @@ typedef NS_ENUM(NSInteger, ASLayoutEngineType) {
 @end
 
 NS_ASSUME_NONNULL_END
+
+#pragma clang diagnostic pop

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -2635,6 +2635,36 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   return NO;
 }
 
+- (BOOL)placeholderEnabled
+{
+    return _placeholderEnabled;
+}
+
+- (void)setPlaceholderEnabled:(BOOL)placeholderEnabled
+{
+    _placeholderEnabled = placeholderEnabled;
+}
+
+- (NSTimeInterval)placeholderFadeDuration
+{
+    return _placeholderFadeDuration;
+}
+
+- (void)setPlaceholderFadeDuration:(NSTimeInterval)placeholderFadeDuration
+{
+    _placeholderFadeDuration = placeholderFadeDuration;
+}
+
+- (NSInteger)drawingPriority
+{
+    return _drawingPriority;
+}
+
+- (void)setDrawingPriority:(NSInteger)drawingPriority
+{
+    _drawingPriority = drawingPriority;
+}
+
 #pragma mark - Hierarchy State
 
 - (BOOL)isInHierarchy

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -2637,32 +2637,38 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 
 - (BOOL)placeholderEnabled
 {
-    return _placeholderEnabled;
+  MutexLocker l(__instanceLock__);
+  return _placeholderEnabled;
 }
 
 - (void)setPlaceholderEnabled:(BOOL)placeholderEnabled
 {
-    _placeholderEnabled = placeholderEnabled;
+  MutexLocker l(__instanceLock__);
+  _placeholderEnabled = placeholderEnabled;
 }
 
 - (NSTimeInterval)placeholderFadeDuration
 {
-    return _placeholderFadeDuration;
+  MutexLocker l(__instanceLock__);
+  return _placeholderFadeDuration;
 }
 
 - (void)setPlaceholderFadeDuration:(NSTimeInterval)placeholderFadeDuration
 {
-    _placeholderFadeDuration = placeholderFadeDuration;
+  MutexLocker l(__instanceLock__);
+  _placeholderFadeDuration = placeholderFadeDuration;
 }
 
 - (NSInteger)drawingPriority
 {
-    return _drawingPriority;
+  MutexLocker l(__instanceLock__);
+  return _drawingPriority;
 }
 
 - (void)setDrawingPriority:(NSInteger)drawingPriority
 {
-    _drawingPriority = drawingPriority;
+  MutexLocker l(__instanceLock__);
+  _drawingPriority = drawingPriority;
 }
 
 #pragma mark - Hierarchy State

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -204,6 +204,9 @@ static constexpr CACornerMask kASCACornerAllCorners =
   UIImage *_placeholderImage;
   BOOL _placeholderEnabled;
   CALayer *_placeholderLayer;
+  NSTimeInterval _placeholderFadeDuration;
+
+  NSInteger _drawingPriority;
 
   // keeps track of nodes/subnodes that have not finished display, used with placeholders
   ASWeakSet *_pendingDisplayNodes;
@@ -350,20 +353,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
  * Lock is not held during block invocation. Method must not be called with the lock held.
  */
 - (void)enumerateInterfaceStateDelegates:(void(NS_NOESCAPE ^)(id<ASInterfaceStateDelegate> delegate))block;
-
-/**
- * // TODO: NOT YET IMPLEMENTED
- *
- * @abstract Prevents interface state changes from affecting the node, until disabled.
- *
- * @discussion Useful to avoid flashing after removing a node from the hierarchy and re-adding it.
- * Removing a node from the hierarchy will cause it to exit the Display state, clearing its contents.
- * For some animations, it's desirable to be able to remove a node without causing it to re-display.
- * Once re-enabled, the interface state will be updated to the same value it would have been.
- *
- * @see ASInterfaceState
- */
-@property (nonatomic) BOOL interfaceStateSuspended;
 
 /**
  * This method has proven helpful in a few rare scenarios, similar to a category extension on UIView,


### PR DESCRIPTION
Found this by enabling `#pragma clang diagnostic error "-Wobjc-missing-property-synthesis"` for `ASDisplayNode`. One property is unused, saving 8 bytes of heap space per instance on 64-bit builds. Implement setter/getters for these properties, and add appropriate locking. add the warning as error to the build for this file.