### PR TITLE
Shrink Texture Node's in-memory size by 9% on average.

### DIFF
--- a/Source/ASButtonNode+Private.h
+++ b/Source/ASButtonNode+Private.h
@@ -31,14 +31,15 @@
   UIImage *_disabledBackgroundImage;
   
   CGFloat _contentSpacing;
-  BOOL  _laysOutHorizontally;
-  ASVerticalAlignment _contentVerticalAlignment;
-  ASHorizontalAlignment _contentHorizontalAlignment;
   UIEdgeInsets _contentEdgeInsets;
-  ASButtonNodeImageAlignment _imageAlignment;
   ASTextNode *_titleNode;
   ASImageNode *_imageNode;
   ASImageNode *_backgroundImageNode;
+
+    BOOL  _laysOutHorizontally;
+    ASVerticalAlignment _contentVerticalAlignment;
+    ASHorizontalAlignment _contentHorizontalAlignment;
+    ASButtonNodeImageAlignment _imageAlignment;
 }
 
 @end

--- a/Source/ASButtonNode.h
+++ b/Source/ASButtonNode.h
@@ -10,6 +10,9 @@
 #import <AsyncDisplayKit/ASControlNode.h>
 #import <UIKit/UIKit.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic error "-Wobjc-missing-property-synthesis"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class ASImageNode, ASTextNode;
@@ -17,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Image alignment defines where the image will be placed relative to the text.
  */
-typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
+typedef NS_ENUM(unsigned char, ASButtonNodeImageAlignment) {
   /** Places the image before the text. */
   ASButtonNodeImageAlignmentBeginning,
   /** Places the image after the text. */
@@ -128,3 +131,5 @@ typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
 @end
 
 NS_ASSUME_NONNULL_END
+
+#pragma clang diagnostic pop

--- a/Source/ASCellNode.h
+++ b/Source/ASCellNode.h
@@ -9,6 +9,9 @@
 
 #import <AsyncDisplayKit/ASDisplayNode.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic error "-Wobjc-missing-property-synthesis"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class ASCellNode, ASTextNode;
@@ -257,3 +260,5 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
 @end
 
 NS_ASSUME_NONNULL_END
+
+#pragma clang diagnostic pop

--- a/Source/ASCellNode.mm
+++ b/Source/ASCellNode.mm
@@ -38,6 +38,16 @@
   BOOL _selected;
   BOOL _highlighted;
   UICollectionViewLayoutAttributes *_layoutAttributes;
+
+  BOOL _neverShowPlaceholders;
+  id _nodeModel;
+  __weak id<ASRangeManagingNode> _owningNode;
+  UITableViewCellSelectionStyle _selectionStyle;
+  UITableViewCellFocusStyle _focusStyle;
+  UIView *_selectedBackgroundView;
+  UIView *_backgroundView;
+  UITableViewCellAccessoryType _accessoryType;
+  UIEdgeInsets _separatorInset;
 }
 
 @end
@@ -157,6 +167,96 @@
       });
     }
   }
+}
+
+- (BOOL)neverShowPlaceholders
+{
+  return ASLockedSelf(_neverShowPlaceholders);
+}
+
+- (void)setNeverShowPlaceholders:(BOOL)neverShowPlaceholders
+{
+  ASLockedSelfCompareAssign(_neverShowPlaceholders, neverShowPlaceholders);
+}
+
+- (id)nodeModel
+{
+  return ASLockedSelf(_nodeModel);
+}
+
+- (void)setNodeModel:(id)nodeModel
+{
+  ASLockedSelfCompareAssign(_nodeModel, nodeModel);
+}
+
+- (id)owningNode
+{
+  return ASLockedSelf(_owningNode);
+}
+
+- (void)setOwningNode:(id<ASRangeManagingNode>)owningNode
+{
+  ASLockedSelfCompareAssign(_owningNode, owningNode);
+}
+
+- (UITableViewCellSelectionStyle)selectionStyle
+{
+  return ASLockedSelf(_selectionStyle);
+}
+
+- (void)setSelectionStyle:(UITableViewCellSelectionStyle)selectionStyle
+{
+  ASLockedSelfCompareAssign(_selectionStyle, selectionStyle);
+}
+
+- (UITableViewCellFocusStyle)focusStyle
+{
+  return ASLockedSelf(_focusStyle);
+}
+
+- (void)setFocusStyle:(UITableViewCellFocusStyle)focusStyle
+{
+  ASLockedSelfCompareAssign(_focusStyle, focusStyle);
+}
+
+- (UIView *)selectedBackgroundView
+{
+  return ASLockedSelf(_selectedBackgroundView);
+}
+
+- (void)setSelectedBackgroundView:(UIView *)selectedBackgroundView
+{
+  ASLockedSelfCompareAssign(_selectedBackgroundView, selectedBackgroundView);
+}
+
+- (UIView *)backgroundView
+{
+  return ASLockedSelf(_backgroundView);
+}
+
+- (void)setBackgroundView:(UIView *)backgroundView
+{
+  ASLockedSelfCompareAssign(_backgroundView, backgroundView);
+}
+
+- (UITableViewCellAccessoryType)accessoryType
+{
+  return ASLockedSelf(_accessoryType);
+}
+
+- (void)setAccessoryType:(UITableViewCellAccessoryType)accessoryType
+{
+  ASLockedSelfCompareAssign(_accessoryType, accessoryType);
+}
+
+- (UIEdgeInsets)separatorInset
+{
+  return ASLockedSelf(_separatorInset);
+}
+
+- (void)setSeparatorInset:(UIEdgeInsets)separatorInset
+{
+  ASLockedSelfCompareAssignCustom(_separatorInset, separatorInset, UIEdgeInsetsEqualToEdgeInsets);
 }
 
 - (void)__setSelectedFromUIKit:(BOOL)selected;
@@ -393,6 +493,7 @@
   NSDictionary<NSAttributedStringKey, id> *_textAttributes;
   UIEdgeInsets _textInsets;
   NSString *_text;
+  ASTextNode *_textNode;
 }
 
 static const CGFloat kASTextCellNodeDefaultFontSize = 18.0f;
@@ -468,6 +569,11 @@ static const CGFloat kASTextCellNodeDefaultVerticalPadding = 11.0f;
   if (ASCompareAssignCopy(_text, text)) {
     [self locked_updateAttributedText];
   }
+}
+
+- (ASTextNode *)textNode
+{
+  return ASLockedSelf(_textNode);
 }
 
 - (void)locked_updateAttributedText

--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -14,6 +14,9 @@
 #import <AsyncDisplayKit/ASBlockTypes.h>
 #import <AsyncDisplayKit/ASRangeManagingNode.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic error "-Wobjc-missing-property-synthesis"
+
 @protocol ASCollectionViewLayoutFacilitatorProtocol;
 @protocol ASCollectionDelegate;
 @protocol ASCollectionDataSource;
@@ -954,3 +957,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#pragma clang diagnostic pop

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -29,11 +29,28 @@
 #import <AsyncDisplayKit/ASRangeController.h>
 #import <AsyncDisplayKit/ASAbstractLayoutController+FrameworkPrivate.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic error "-Wobjc-missing-property-synthesis"
+
 #pragma mark - _ASCollectionPendingState
 
 @interface _ASCollectionPendingState : NSObject {
 @public
   std::vector<std::vector<ASRangeTuningParameters>> _tuningParameters;
+
+  struct {
+    ASLayoutRangeMode rangeMode;
+    ASCellLayoutMode cellLayoutMode;
+    unsigned int allowsSelection:1; // default is YES
+    unsigned int allowsMultipleSelection:1; // default is NO
+    unsigned int inverted:1; //default is NO
+    unsigned int alwaysBounceVertical:1;
+    unsigned int alwaysBounceHorizontal:1;
+    unsigned int animatesContentOffset:1;
+    unsigned int showsVerticalScrollIndicator:1;
+    unsigned int showsHorizontalScrollIndicator:1;
+    unsigned int pagingEnabled:1;
+  } _fields;
 }
 @property (nonatomic, weak) id <ASCollectionDelegate>   delegate;
 @property (nonatomic, weak) id <ASCollectionDataSource> dataSource;
@@ -57,25 +74,145 @@
 
 @implementation _ASCollectionPendingState
 
+@synthesize delegate;
+@synthesize dataSource;
+@synthesize collectionViewLayout;
+@synthesize leadingScreensForBatching;
+@synthesize layoutInspector;
+@synthesize contentInset = _contentInset;
+@synthesize contentOffset = _contentOffset;
+
 #pragma mark Lifecycle
 
 - (instancetype)init
 {
   self = [super init];
   if (self) {
-    _rangeMode = ASLayoutRangeModeUnspecified;
+    _fields.rangeMode = ASLayoutRangeModeUnspecified;
     _tuningParameters = [ASAbstractLayoutController defaultTuningParameters];
-    _allowsSelection = YES;
-    _allowsMultipleSelection = NO;
-    _inverted = NO;
+    _fields.allowsSelection = YES;
+    _fields.allowsMultipleSelection = NO;
+    _fields.inverted = NO;
     _contentInset = UIEdgeInsetsZero;
     _contentOffset = CGPointZero;
-    _animatesContentOffset = NO;
-    _showsVerticalScrollIndicator = YES;
-    _showsHorizontalScrollIndicator = YES;
-    _pagingEnabled = NO;
+    _fields.animatesContentOffset = NO;
+    _fields.showsVerticalScrollIndicator = YES;
+    _fields.showsHorizontalScrollIndicator = YES;
+    _fields.pagingEnabled = NO;
   }
   return self;
+}
+
+#pragma mark Properties
+
+- (ASLayoutRangeMode)rangeMode
+{
+  return _fields.rangeMode;
+}
+
+- (void)setRangeMode:(ASLayoutRangeMode)rangeMode
+{
+  _fields.rangeMode = rangeMode;
+}
+
+- (ASCellLayoutMode)cellLayoutMode
+{
+  return _fields.cellLayoutMode;
+}
+
+- (void)setCellLayoutMode:(ASCellLayoutMode)cellLayoutMode
+{
+  _fields.cellLayoutMode = cellLayoutMode;
+}
+
+- (BOOL)allowsSelection
+{
+  return _fields.allowsSelection;
+}
+
+- (void)setAllowsSelection:(BOOL)allowsSelection
+{
+  _fields.allowsSelection = allowsSelection;
+}
+
+- (BOOL)allowsMultipleSelection
+{
+  return _fields.allowsMultipleSelection;
+}
+
+- (void)setAllowsMultipleSelection:(BOOL)allowsMultipleSelection
+{
+  _fields.allowsMultipleSelection = allowsMultipleSelection;
+}
+
+- (BOOL)inverted
+{
+  return _fields.inverted;
+}
+
+-(void)setInverted:(BOOL)inverted
+{
+  _fields.inverted = inverted;
+}
+
+-(BOOL)alwaysBounceVertical
+{
+  return _fields.alwaysBounceVertical;
+}
+
+-(void)setAlwaysBounceVertical:(BOOL)alwaysBounceVertical
+{
+  _fields.alwaysBounceVertical = alwaysBounceVertical;
+}
+
+-(BOOL)alwaysBounceHorizontal
+{
+  return _fields.alwaysBounceHorizontal;
+}
+
+-(void)setAlwaysBounceHorizontal:(BOOL)alwaysBounceHorizontal
+{
+  _fields.alwaysBounceHorizontal = alwaysBounceHorizontal;
+}
+
+- (BOOL)animatesContentOffset
+{
+  return _fields.animatesContentOffset;
+}
+
+-(void)setAnimatesContentOffset:(BOOL)animatesContentOffset
+{
+  _fields.animatesContentOffset = animatesContentOffset;
+}
+
+- (BOOL)showsVerticalScrollIndicator
+{
+  return _fields.showsVerticalScrollIndicator;
+}
+
+- (void)setShowsVerticalScrollIndicator:(BOOL)showsVerticalScrollIndicator
+{
+  _fields.showsVerticalScrollIndicator = showsVerticalScrollIndicator;
+}
+
+-(BOOL)showsHorizontalScrollIndicator
+{
+  return _fields.showsHorizontalScrollIndicator;
+}
+
+- (void)setShowsHorizontalScrollIndicator:(BOOL)showsHorizontalScrollIndicator
+{
+  _fields.showsHorizontalScrollIndicator = showsHorizontalScrollIndicator;
+}
+
+-(BOOL)pagingEnabled
+{
+  return _fields.pagingEnabled;
+}
+
+- (void)setPagingEnabled:(BOOL)pagingEnabled
+{
+  _fields.pagingEnabled = pagingEnabled;
 }
 
 #pragma mark Tuning Parameters
@@ -117,6 +254,9 @@
 @end
 
 @implementation ASCollectionNode
+
+@synthesize pendingState = _pendingState;
+@synthesize rangeController = _rangeController;
 
 #pragma mark Lifecycle
 
@@ -1110,3 +1250,5 @@ ASLayoutElementCollectionTableSetTraitCollection(_environmentStateLock)
 }
 
 @end
+
+#pragma clang diagnostic pop

--- a/Source/ASCollectionViewProtocols.h
+++ b/Source/ASCollectionViewProtocols.h
@@ -10,7 +10,7 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
-typedef NS_OPTIONS(NSUInteger, ASCellLayoutMode) {
+typedef NS_OPTIONS(unsigned short, ASCellLayoutMode) {
   /**
    * No options set. If cell layout mode is set to ASCellLayoutModeNone, the default values for
    * each flag listed below is used.

--- a/Source/ASControlNode.mm
+++ b/Source/ASControlNode.mm
@@ -30,14 +30,16 @@
 @interface ASControlNode ()
 {
 @private
-  // Control Attributes
-  BOOL _enabled;
-  BOOL _highlighted;
-  BOOL _selected;
+  struct {
+    // Control Attributes
+    unsigned int enabled:1;
+    unsigned int highlighted:1;
+    unsigned int selected:1;
 
-  // Tracking
-  BOOL _tracking;
-  BOOL _touchInside;
+    // Tracking
+    unsigned int tracking:1;
+    unsigned int touchInside:1;
+  } _controlNodeFlags;
 
   // Target action pairs stored in an array for each event type
   // ASControlEvent -> [ASTargetAction0, ASTargetAction1]
@@ -84,7 +86,7 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
   if (!(self = [super init]))
     return nil;
 
-  _enabled = YES;
+  _controlNodeFlags.enabled = YES;
 
   // As we have no targets yet, we start off with user interaction off. When a target is added, it'll get turned back on.
   self.userInteractionEnabled = NO;
@@ -127,61 +129,61 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
 - (BOOL)isEnabled
 {
   ASLockScopeSelf();
-  return _enabled;
+  return _controlNodeFlags.enabled;
 }
 
 - (void)setEnabled:(BOOL)enabled
 {
   ASLockScopeSelf();
-  _enabled = enabled;
+  _controlNodeFlags.enabled = enabled;
 }
 
 - (BOOL)isHighlighted
 {
   ASLockScopeSelf();
-  return _highlighted;
+  return _controlNodeFlags.highlighted;
 }
 
 - (void)setHighlighted:(BOOL)highlighted
 {
   ASLockScopeSelf();
-  _highlighted = highlighted;
+  _controlNodeFlags.highlighted = highlighted;
 }
 
 - (void)setSelected:(BOOL)selected
 {
   ASLockScopeSelf();
-  _selected = selected;
+  _controlNodeFlags.selected = selected;
 }
 
 - (BOOL)isSelected
 {
   ASLockScopeSelf();
-  return _selected;
+  return _controlNodeFlags.selected;
 }
 
 - (void)setTracking:(BOOL)tracking
 {
   ASLockScopeSelf();
-  _tracking = tracking;
+  _controlNodeFlags.tracking = tracking;
 }
 
 - (BOOL)isTracking
 {
   ASLockScopeSelf();
-  return _tracking;
+  return _controlNodeFlags.tracking;
 }
 
 - (void)setTouchInside:(BOOL)touchInside
 {
   ASLockScopeSelf();
-  _touchInside = touchInside;
+  _controlNodeFlags.touchInside = touchInside;
 }
 
 - (BOOL)isTouchInside
 {
   ASLockScopeSelf();
-  return _touchInside;
+  return _controlNodeFlags.touchInside;
 }
 
 #pragma clang diagnostic push

--- a/Source/ASDisplayNode+Beta.h
+++ b/Source/ASDisplayNode+Beta.h
@@ -25,7 +25,7 @@ AS_EXTERN void ASPerformBlockOnBackgroundThread(void (^block)(void)); // DISPATC
 /**
  * Bitmask to indicate what performance measurements the cell should record.
  */
-typedef NS_OPTIONS(NSUInteger, ASDisplayNodePerformanceMeasurementOptions) {
+typedef NS_OPTIONS(unsigned char, ASDisplayNodePerformanceMeasurementOptions) {
   ASDisplayNodePerformanceMeasurementOptionLayoutSpec = 1 << 0,
   ASDisplayNodePerformanceMeasurementOptionLayoutComputation = 1 << 1
 };

--- a/Source/ASDisplayNode+InterfaceState.h
+++ b/Source/ASDisplayNode+InterfaceState.h
@@ -16,7 +16,7 @@
  * The defualt state, ASInterfaceStateNone, means that the element is not predicted to be onscreen soon and
  * preloading should not be performed. Swift: use [] for the default behavior.
  */
-typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
+typedef NS_OPTIONS(unsigned char, ASInterfaceState)
 {
     /** The element is not predicted to be onscreen soon and preloading should not be performed */
     ASInterfaceStateNone          = 0,

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -547,13 +547,13 @@ ASLayoutElementStyleExtensibilityForwarding
 - (BOOL)automaticallyManagesSubnodes
 {
   MutexLocker l(__instanceLock__);
-  return _automaticallyManagesSubnodes;
+  return _flags.automaticallyManagesSubnodes;
 }
 
 - (void)setAutomaticallyManagesSubnodes:(BOOL)automaticallyManagesSubnodes
 {
   MutexLocker l(__instanceLock__);
-  _automaticallyManagesSubnodes = automaticallyManagesSubnodes;
+  _flags.automaticallyManagesSubnodes = automaticallyManagesSubnodes;
 }
 
 @end
@@ -1027,7 +1027,7 @@ ASLayoutElementStyleExtensibilityForwarding
   // We generate placeholders at -layoutThatFits: time so that a node is guaranteed to have a placeholder ready to go.
   // This is also because measurement is usually asynchronous, but placeholders need to be set up synchronously.
   // First measurement is guaranteed to be before the node is onscreen, so we can create the image async. but still have it appear sync.
-  if (_placeholderEnabled && !_placeholderImage && [self _locked_displaysAsynchronously]) {
+  if (_flags.placeholderEnabled && !_placeholderImage && [self _locked_displaysAsynchronously]) {
     
     // Zero-sized nodes do not require a placeholder.
     CGSize layoutSize = _calculatedDisplayNodeLayout.layout.size;

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -167,11 +167,11 @@
 }
 
 - (BOOL)willApplyNextYogaCalculatedLayout {
-  return _willApplyNextYogaCalculatedLayout;
+  return _flags.willApplyNextYogaCalculatedLayout;
 }
 
 - (void)setWillApplyNextYogaCalculatedLayout:(BOOL)willApplyNextYogaCalculatedLayout {
-  _willApplyNextYogaCalculatedLayout = willApplyNextYogaCalculatedLayout;
+  _flags.willApplyNextYogaCalculatedLayout = willApplyNextYogaCalculatedLayout;
 }
 
 - (void)setYogaLayoutInProgress:(BOOL)yogaLayoutInProgress

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -70,7 +70,7 @@ typedef ASLayoutSpec * _Nonnull(^ASLayoutSpecBlock)(__kindof ASDisplayNode *node
  */
 typedef void (^ASDisplayNodeNonFatalErrorBlock)(NSError *error);
 
-typedef NS_ENUM(NSInteger, ASCornerRoundingType) {
+typedef NS_ENUM(unsigned char, ASCornerRoundingType) {
   ASCornerRoundingTypeDefaultSlowCALayer,
   ASCornerRoundingTypePrecomposited,
   ASCornerRoundingTypeClipping

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -337,11 +337,11 @@ __attribute__((constructor)) static void ASLoadFrameworkInitializer(void)
   _flags.canCallSetNeedsDisplayOfLayer = YES;
 
   _fallbackSafeAreaInsets = UIEdgeInsetsZero;
-  _fallbackInsetsLayoutMarginsFromSafeArea = YES;
-  _isViewControllerRoot = NO;
+  _flags.fallbackInsetsLayoutMarginsFromSafeArea = YES;
+  _flags.isViewControllerRoot = NO;
 
-  _automaticallyRelayoutOnSafeAreaChanges = NO;
-  _automaticallyRelayoutOnLayoutMarginsChanges = NO;
+  _flags.automaticallyRelayoutOnSafeAreaChanges = NO;
+  _flags.automaticallyRelayoutOnLayoutMarginsChanges = NO;
 
   [self baseDidInit];
 }
@@ -861,37 +861,37 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
 - (BOOL)isViewControllerRoot
 {
   MutexLocker l(__instanceLock__);
-  return _isViewControllerRoot;
+  return _flags.isViewControllerRoot;
 }
 
 - (void)setViewControllerRoot:(BOOL)flag
 {
   MutexLocker l(__instanceLock__);
-  _isViewControllerRoot = flag;
+  _flags.isViewControllerRoot = flag;
 }
 
 - (BOOL)automaticallyRelayoutOnSafeAreaChanges
 {
   MutexLocker l(__instanceLock__);
-  return _automaticallyRelayoutOnSafeAreaChanges;
+  return _flags.automaticallyRelayoutOnSafeAreaChanges;
 }
 
 - (void)setAutomaticallyRelayoutOnSafeAreaChanges:(BOOL)flag
 {
   MutexLocker l(__instanceLock__);
-  _automaticallyRelayoutOnSafeAreaChanges = flag;
+  _flags.automaticallyRelayoutOnSafeAreaChanges = flag;
 }
 
 - (BOOL)automaticallyRelayoutOnLayoutMarginsChanges
 {
   MutexLocker l(__instanceLock__);
-  return _automaticallyRelayoutOnLayoutMarginsChanges;
+  return _flags.automaticallyRelayoutOnLayoutMarginsChanges;
 }
 
 - (void)setAutomaticallyRelayoutOnLayoutMarginsChanges:(BOOL)flag
 {
   MutexLocker l(__instanceLock__);
-  _automaticallyRelayoutOnLayoutMarginsChanges = flag;
+  _flags.automaticallyRelayoutOnLayoutMarginsChanges = flag;
 }
 
 - (void)__setNodeController:(ASNodeController *)controller
@@ -2593,7 +2593,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (BOOL)_locked_shouldHavePlaceholderLayer
 {
   DISABLED_ASAssertLocked(__instanceLock__);
-  return (_placeholderEnabled && [self _implementsDisplay]);
+  return (_flags.placeholderEnabled && [self _implementsDisplay]);
 }
 
 - (void)_locked_setupPlaceholderLayerIfNeeded
@@ -2638,13 +2638,13 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (BOOL)placeholderEnabled
 {
   MutexLocker l(__instanceLock__);
-  return _placeholderEnabled;
+  return _flags.placeholderEnabled;
 }
 
 - (void)setPlaceholderEnabled:(BOOL)placeholderEnabled
 {
   MutexLocker l(__instanceLock__);
-  _placeholderEnabled = placeholderEnabled;
+  _flags.placeholderEnabled = placeholderEnabled;
 }
 
 - (NSTimeInterval)placeholderFadeDuration
@@ -3144,7 +3144,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (void)addInterfaceStateDelegate:(id <ASInterfaceStateDelegate>)interfaceStateDelegate
 {
   MutexLocker l(__instanceLock__);
-  _hasHadInterfaceStateDelegates = YES;
+  _flags.hasHadInterfaceStateDelegates = YES;
   for (int i = 0; i < AS_MAX_INTERFACE_STATE_DELEGATES; i++) {
     if (_interfaceStateDelegates[i] == nil) {
       _interfaceStateDelegates[i] = interfaceStateDelegate;
@@ -3326,7 +3326,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   {
     ASLockScopeSelf();
     // Fast path for non-delegating nodes.
-    if (!_hasHadInterfaceStateDelegates) {
+    if (!_flags.hasHadInterfaceStateDelegates) {
       return;
     }
 
@@ -3538,13 +3538,13 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (void)setIsAccessibilityContainer:(BOOL)isAccessibilityContainer
 {
   MutexLocker l(__instanceLock__);
-  _isAccessibilityContainer = isAccessibilityContainer;
+  _flags.isAccessibilityContainer = isAccessibilityContainer;
 }
 
 - (BOOL)isAccessibilityContainer
 {
   MutexLocker l(__instanceLock__);
-  return _isAccessibilityContainer;
+  return _flags.isAccessibilityContainer;
 }
 
 - (NSString *)defaultAccessibilityLabel

--- a/Source/ASImageNode+AnimatedImage.mm
+++ b/Source/ASImageNode+AnimatedImage.mm
@@ -110,7 +110,7 @@
 {
   ASLockScopeSelf();
 
-  _animatedImagePaused = animatedImagePaused;
+  _imageNodeFlags.animatedImagePaused = animatedImagePaused;
 
   [self _locked_setShouldAnimate:!animatedImagePaused];
 }
@@ -118,7 +118,7 @@
 - (BOOL)animatedImagePaused
 {
   ASLockScopeSelf();
-  return _animatedImagePaused;
+  return _imageNodeFlags.animatedImagePaused;
 }
 
 - (void)setCoverImageCompleted:(UIImage *)coverImage
@@ -235,7 +235,7 @@
     return;
   }
   
-  if (_animatedImagePaused) {
+  if (_imageNodeFlags.animatedImagePaused) {
     return;
   }
   

--- a/Source/ASImageNode.h
+++ b/Source/ASImageNode.h
@@ -10,6 +10,9 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASControlNode.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic error "-Wobjc-missing-property-synthesis"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol ASAnimatedImageProtocol;
@@ -211,3 +214,5 @@ AS_EXTERN asimagenode_modification_block_t ASImageNodeRoundBorderModificationBlo
 AS_EXTERN asimagenode_modification_block_t ASImageNodeTintColorModificationBlock(UIColor *color);
 
 NS_ASSUME_NONNULL_END
+
+#pragma clang diagnostic pop

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -146,8 +146,6 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
   ASTextNode *_debugLabelNode;
   
   // Cropping.
-  BOOL _cropEnabled; // Defaults to YES.
-  BOOL _forceUpscaling; //Defaults to NO.
   CGSize _forcedSize; //Defaults to CGSizeZero, indicating no forced size.
   CGRect _cropRect; // Defaults to CGRectMake(0.5, 0.5, 0, 0)
   CGRect _cropDisplayBounds; // Defaults to CGRectNull
@@ -174,8 +172,8 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
   // initial value. With setting a explicit backgroundColor we can prevent that change.
   self.backgroundColor = [UIColor clearColor];
 
-  _cropEnabled = YES;
-  _forceUpscaling = NO;
+  _imageNodeFlags.cropEnabled = YES;
+  _imageNodeFlags.forceUpscaling = NO;
   _cropRect = CGRectMake(0.5, 0.5, 0, 0);
   _cropDisplayBounds = CGRectNull;
   _placeholderColor = ASDisplayNodeDefaultPlaceholderColor();
@@ -287,7 +285,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 {
   ASLockScopeSelf();
   if (ASCompareAssignCopy(_placeholderColor, placeholderColor)) {
-    _placeholderEnabled = (placeholderColor != nil);
+    _flags.placeholderEnabled = (placeholderColor != nil);
   }
 }
 
@@ -304,8 +302,8 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
   drawParameters->_contentsScale = _contentsScaleForDisplay;
   drawParameters->_backgroundColor = self.backgroundColor;
   drawParameters->_contentMode = self.contentMode;
-  drawParameters->_cropEnabled = _cropEnabled;
-  drawParameters->_forceUpscaling = _forceUpscaling;
+  drawParameters->_cropEnabled = self.cropEnabled;
+  drawParameters->_forceUpscaling = self.forceUpscaling;
   drawParameters->_forcedSize = _forcedSize;
   drawParameters->_cropRect = _cropRect;
   drawParameters->_cropDisplayBounds = _cropDisplayBounds;
@@ -606,7 +604,7 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 - (BOOL)isCropEnabled
 {
   AS::MutexLocker l(__instanceLock__);
-  return _cropEnabled;
+  return _imageNodeFlags.cropEnabled;
 }
 
 - (void)setCropEnabled:(BOOL)cropEnabled
@@ -617,12 +615,12 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 - (void)setCropEnabled:(BOOL)cropEnabled recropImmediately:(BOOL)recropImmediately inBounds:(CGRect)cropBounds
 {
   __instanceLock__.lock();
-  if (_cropEnabled == cropEnabled) {
+  if (_imageNodeFlags.cropEnabled == cropEnabled) {
     __instanceLock__.unlock();
     return;
   }
 
-  _cropEnabled = cropEnabled;
+  _imageNodeFlags.cropEnabled = cropEnabled;
   _cropDisplayBounds = cropBounds;
   
   UIImage *image = _image;
@@ -672,13 +670,13 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 - (BOOL)forceUpscaling
 {
   AS::MutexLocker l(__instanceLock__);
-  return _forceUpscaling;
+  return _imageNodeFlags.forceUpscaling;
 }
 
 - (void)setForceUpscaling:(BOOL)forceUpscaling
 {
   AS::MutexLocker l(__instanceLock__);
-  _forceUpscaling = forceUpscaling;
+  _imageNodeFlags.forceUpscaling = forceUpscaling;
 }
 
 - (CGSize)forcedSize

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -42,41 +42,39 @@
   // The download identifier that we have set a progress block on, if any.
   id _downloadIdentifierForProgressBlock;
 
-  BOOL _imageLoaded;
-  BOOL _imageWasSetExternally;
   CGFloat _currentImageQuality;
   CGFloat _renderedImageQuality;
-  BOOL _shouldRenderProgressImages;
 
-  struct {
-    unsigned int delegateWillStartDisplayAsynchronously:1;
-    unsigned int delegateWillLoadImageFromCache:1;
-    unsigned int delegateWillLoadImageFromNetwork:1;
-    unsigned int delegateDidStartFetchingData:1;
-    unsigned int delegateDidFailWithError:1;
-    unsigned int delegateDidFinishDecoding:1;
-    unsigned int delegateDidLoadImage:1;
-    unsigned int delegateDidLoadImageFromCache:1;
-    unsigned int delegateDidLoadImageWithInfo:1;
-  } _delegateFlags;
-
-  
-  // Immutable and set on init only. We don't need to lock in this case.
+    // Immutable and set on init only. We don't need to lock in this case.
   __weak id<ASImageDownloaderProtocol> _downloader;
-  struct {
-    unsigned int downloaderImplementsSetProgress:1;
-    unsigned int downloaderImplementsSetPriority:1;
-    unsigned int downloaderImplementsAnimatedImage:1;
-    unsigned int downloaderImplementsCancelWithResume:1;
-    unsigned int downloaderImplementsDownloadWithPriority:1;
-  } _downloaderFlags;
 
   // Immutable and set on init only. We don't need to lock in this case.
   __weak id<ASImageCacheProtocol> _cache;
   struct {
-    unsigned int cacheSupportsClearing:1;
-    unsigned int cacheSupportsSynchronousFetch:1;
-  } _cacheFlags;
+      unsigned int delegateWillStartDisplayAsynchronously:1;
+      unsigned int delegateWillLoadImageFromCache:1;
+      unsigned int delegateWillLoadImageFromNetwork:1;
+      unsigned int delegateDidStartFetchingData:1;
+      unsigned int delegateDidFailWithError:1;
+      unsigned int delegateDidFinishDecoding:1;
+      unsigned int delegateDidLoadImage:1;
+      unsigned int delegateDidLoadImageFromCache:1;
+      unsigned int delegateDidLoadImageWithInfo:1;
+
+      unsigned int downloaderImplementsSetProgress:1;
+      unsigned int downloaderImplementsSetPriority:1;
+      unsigned int downloaderImplementsAnimatedImage:1;
+      unsigned int downloaderImplementsCancelWithResume:1;
+      unsigned int downloaderImplementsDownloadWithPriority:1;
+
+      unsigned int cacheSupportsClearing:1;
+      unsigned int cacheSupportsSynchronousFetch:1;
+
+      unsigned int imageLoaded:1;
+      unsigned int imageWasSetExternally:1;
+      unsigned int shouldRenderProgressImages:1;
+      unsigned int shouldCacheImage:1;
+  } _networkImageNodeFlags;
 }
 
 @end
@@ -95,17 +93,17 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
   _cache = (id<ASImageCacheProtocol>)cache;
   _downloader = (id<ASImageDownloaderProtocol>)downloader;
   
-  _downloaderFlags.downloaderImplementsSetProgress = [downloader respondsToSelector:@selector(setProgressImageBlock:callbackQueue:withDownloadIdentifier:)];
-  _downloaderFlags.downloaderImplementsSetPriority = [downloader respondsToSelector:@selector(setPriority:withDownloadIdentifier:)];
-  _downloaderFlags.downloaderImplementsAnimatedImage = [downloader respondsToSelector:@selector(animatedImageWithData:)];
-  _downloaderFlags.downloaderImplementsCancelWithResume = [downloader respondsToSelector:@selector(cancelImageDownloadWithResumePossibilityForIdentifier:)];
-  _downloaderFlags.downloaderImplementsDownloadWithPriority = [downloader respondsToSelector:@selector(downloadImageWithURL:priority:callbackQueue:downloadProgress:completion:)];
+  _networkImageNodeFlags.downloaderImplementsSetProgress = [downloader respondsToSelector:@selector(setProgressImageBlock:callbackQueue:withDownloadIdentifier:)];
+  _networkImageNodeFlags.downloaderImplementsSetPriority = [downloader respondsToSelector:@selector(setPriority:withDownloadIdentifier:)];
+  _networkImageNodeFlags.downloaderImplementsAnimatedImage = [downloader respondsToSelector:@selector(animatedImageWithData:)];
+  _networkImageNodeFlags.downloaderImplementsCancelWithResume = [downloader respondsToSelector:@selector(cancelImageDownloadWithResumePossibilityForIdentifier:)];
+  _networkImageNodeFlags.downloaderImplementsDownloadWithPriority = [downloader respondsToSelector:@selector(downloadImageWithURL:priority:callbackQueue:downloadProgress:completion:)];
 
-  _cacheFlags.cacheSupportsClearing = [cache respondsToSelector:@selector(clearFetchedImageFromCacheWithURL:)];
-  _cacheFlags.cacheSupportsSynchronousFetch = [cache respondsToSelector:@selector(synchronouslyFetchedCachedImageWithURL:)];
+  _networkImageNodeFlags.cacheSupportsClearing = [cache respondsToSelector:@selector(clearFetchedImageFromCacheWithURL:)];
+  _networkImageNodeFlags.cacheSupportsSynchronousFetch = [cache respondsToSelector:@selector(synchronouslyFetchedCachedImageWithURL:)];
   
-  _shouldCacheImage = YES;
-  _shouldRenderProgressImages = YES;
+  _networkImageNodeFlags.shouldCacheImage = YES;
+  _networkImageNodeFlags.shouldRenderProgressImages = YES;
   self.shouldBypassEnsureDisplay = YES;
 
   return self;
@@ -132,7 +130,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 
 #pragma mark - Public methods -- must lock
 
-/// Setter for public image property. It has the side effect of setting an internal _imageWasSetExternally that prevents setting an image internally. Setting an image internally should happen with the _setImage: method
+/// Setter for public image property. It has the side effect of setting an internal _networkImageNodeFlags.imageWasSetExternally that prevents setting an image internally. Setting an image internally should happen with the _setImage: method
 - (void)setImage:(UIImage *)image
 {
   ASLockScopeSelf();
@@ -144,8 +142,8 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
   DISABLED_ASAssertLocked(__instanceLock__);
   
   BOOL imageWasSetExternally = (image != nil);
-  BOOL shouldCancelAndClear = imageWasSetExternally && (imageWasSetExternally != _imageWasSetExternally);
-  _imageWasSetExternally = imageWasSetExternally;
+  BOOL shouldCancelAndClear = imageWasSetExternally && (imageWasSetExternally != _networkImageNodeFlags.imageWasSetExternally);
+  _networkImageNodeFlags.imageWasSetExternally = imageWasSetExternally;
   if (shouldCancelAndClear) {
     ASDisplayNodeAssertNil(_URL, @"Directly setting an image on an ASNetworkImageNode causes it to behave like an ASImageNode instead of an ASNetworkImageNode. If this is what you want, set the URL to nil first.");
     _URL = nil;
@@ -201,13 +199,13 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
     
     URL = [URL copy];
     
-    ASDisplayNodeAssert(_imageWasSetExternally == NO, @"Setting a URL to an ASNetworkImageNode after setting an image changes its behavior from an ASImageNode to an ASNetworkImageNode. If this is what you want, set the image to nil first.");
+    ASDisplayNodeAssert(_networkImageNodeFlags.imageWasSetExternally == NO, @"Setting a URL to an ASNetworkImageNode after setting an image changes its behavior from an ASImageNode to an ASNetworkImageNode. If this is what you want, set the image to nil first.");
     
-    _imageWasSetExternally = NO;
+    _networkImageNodeFlags.imageWasSetExternally = NO;
     
     [self _locked_cancelImageDownloadWithResumePossibility:NO];
 
-    _imageLoaded = NO;
+    _networkImageNodeFlags.imageLoaded = NO;
     
     _URL = URL;
     
@@ -242,7 +240,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 
   _defaultImage = defaultImage;
 
-  if (!_imageLoaded) {
+  if (!_networkImageNodeFlags.imageLoaded) {
     [self _setCurrentImageQuality:((_URL == nil) ? 0.0 : 1.0)];
     [self _locked__setImage:defaultImage];
   }
@@ -294,15 +292,15 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
   ASLockScopeSelf();
   _delegate = delegate;
   
-  _delegateFlags.delegateWillStartDisplayAsynchronously = [delegate respondsToSelector:@selector(imageNodeWillStartDisplayAsynchronously:)];
-  _delegateFlags.delegateWillLoadImageFromCache = [delegate respondsToSelector:@selector(imageNodeWillLoadImageFromCache:)];
-  _delegateFlags.delegateWillLoadImageFromNetwork = [delegate respondsToSelector:@selector(imageNodeWillLoadImageFromNetwork:)];
-  _delegateFlags.delegateDidStartFetchingData = [delegate respondsToSelector:@selector(imageNodeDidStartFetchingData:)];
-  _delegateFlags.delegateDidFailWithError = [delegate respondsToSelector:@selector(imageNode:didFailWithError:)];
-  _delegateFlags.delegateDidFinishDecoding = [delegate respondsToSelector:@selector(imageNodeDidFinishDecoding:)];
-  _delegateFlags.delegateDidLoadImage = [delegate respondsToSelector:@selector(imageNode:didLoadImage:)];
-  _delegateFlags.delegateDidLoadImageFromCache = [delegate respondsToSelector:@selector(imageNodeDidLoadImageFromCache:)];
-  _delegateFlags.delegateDidLoadImageWithInfo = [delegate respondsToSelector:@selector(imageNode:didLoadImage:info:)];
+  _networkImageNodeFlags.delegateWillStartDisplayAsynchronously = [delegate respondsToSelector:@selector(imageNodeWillStartDisplayAsynchronously:)];
+  _networkImageNodeFlags.delegateWillLoadImageFromCache = [delegate respondsToSelector:@selector(imageNodeWillLoadImageFromCache:)];
+  _networkImageNodeFlags.delegateWillLoadImageFromNetwork = [delegate respondsToSelector:@selector(imageNodeWillLoadImageFromNetwork:)];
+  _networkImageNodeFlags.delegateDidStartFetchingData = [delegate respondsToSelector:@selector(imageNodeDidStartFetchingData:)];
+  _networkImageNodeFlags.delegateDidFailWithError = [delegate respondsToSelector:@selector(imageNode:didFailWithError:)];
+  _networkImageNodeFlags.delegateDidFinishDecoding = [delegate respondsToSelector:@selector(imageNodeDidFinishDecoding:)];
+  _networkImageNodeFlags.delegateDidLoadImage = [delegate respondsToSelector:@selector(imageNode:didLoadImage:)];
+  _networkImageNodeFlags.delegateDidLoadImageFromCache = [delegate respondsToSelector:@selector(imageNodeDidLoadImageFromCache:)];
+  _networkImageNodeFlags.delegateDidLoadImageWithInfo = [delegate respondsToSelector:@selector(imageNode:didLoadImage:info:)];
 }
 
 - (id<ASNetworkImageNodeDelegate>)delegate
@@ -313,7 +311,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 
 - (void)setShouldRenderProgressImages:(BOOL)shouldRenderProgressImages
 {
-  if (ASLockedSelfCompareAssign(_shouldRenderProgressImages, shouldRenderProgressImages)) {
+  if (ASLockedSelfCompareAssign(_networkImageNodeFlags.shouldRenderProgressImages, shouldRenderProgressImages)) {
     [self _updateProgressImageBlockOnDownloaderIfNeeded];
   }
 }
@@ -321,7 +319,18 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 - (BOOL)shouldRenderProgressImages
 {
   ASLockScopeSelf();
-  return _shouldRenderProgressImages;
+  return _networkImageNodeFlags.shouldRenderProgressImages;
+}
+
+- (void)setShouldCacheImage:(BOOL)shouldCacheImage
+{
+    ASLockedSelfCompareAssign(_networkImageNodeFlags.shouldCacheImage, shouldCacheImage);
+}
+
+- (BOOL)shouldCacheImage
+{
+    ASLockScopeSelf();
+    return _networkImageNodeFlags.shouldCacheImage;
 }
 
 - (BOOL)placeholderShouldPersist
@@ -340,30 +349,30 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
   BOOL notifyDelegate;
   {
     ASLockScopeSelf();
-    notifyDelegate = _delegateFlags.delegateWillStartDisplayAsynchronously;
+    notifyDelegate = _networkImageNodeFlags.delegateWillStartDisplayAsynchronously;
     delegate = _delegate;
   }
   if (notifyDelegate) {
     [delegate imageNodeWillStartDisplayAsynchronously:self];
   }
   
-  if (asynchronously == NO && _cacheFlags.cacheSupportsSynchronousFetch) {
+  if (asynchronously == NO && _networkImageNodeFlags.cacheSupportsSynchronousFetch) {
     ASLockScopeSelf();
 
     NSURL *url = _URL;
-    if (_imageLoaded == NO && url && _downloadIdentifier == nil) {
+    if (_networkImageNodeFlags.imageLoaded == NO && url && _downloadIdentifier == nil) {
       UIImage *result = [[_cache synchronouslyFetchedCachedImageWithURL:url] asdk_image];
       if (result) {
         [self _setCurrentImageQuality:1.0];
         [self _locked__setImage:result];
-        _imageLoaded = YES;
+        _networkImageNodeFlags.imageLoaded = YES;
         
         // Call out to the delegate.
-        if (_delegateFlags.delegateDidLoadImageWithInfo) {
+        if (_networkImageNodeFlags.delegateDidLoadImageWithInfo) {
           ASUnlockScope(self);
           const auto info = [[ASNetworkImageLoadInfo alloc] initWithURL:url sourceType:ASNetworkImageSourceSynchronousCache downloadIdentifier:nil userInfo:nil];
           [delegate imageNode:self didLoadImage:result info:info];
-        } else if (_delegateFlags.delegateDidLoadImage) {
+        } else if (_networkImageNodeFlags.delegateDidLoadImage) {
           ASUnlockScope(self);
           [delegate imageNode:self didLoadImage:result];
         }
@@ -405,7 +414,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
   [super didExitPreloadState];
 
   // If the image was set explicitly we don't want to remove it while exiting the preload state
-  if (ASLockedSelf(_imageWasSetExternally)) {
+  if (ASLockedSelf(_networkImageNodeFlags.imageWasSetExternally)) {
     return;
   }
 
@@ -448,7 +457,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 
 - (void)_updatePriorityOnDownloaderIfNeededWithDefaultPriority:(ASImageDownloaderPriority)defaultPriority
 {
-  if (_downloaderFlags.downloaderImplementsSetPriority) {
+  if (_networkImageNodeFlags.downloaderImplementsSetPriority) {
     ASLockScopeSelf();
 
     if (_downloadIdentifier != nil) {
@@ -465,13 +474,13 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 - (void)_updateProgressImageBlockOnDownloaderIfNeeded
 {
   // If the downloader doesn't do progress, we are done.
-  if (_downloaderFlags.downloaderImplementsSetProgress == NO) {
+  if (_networkImageNodeFlags.downloaderImplementsSetProgress == NO) {
     return;
   }
 
   // Read state.
   [self lock];
-    BOOL shouldRender = _shouldRenderProgressImages && ASInterfaceStateIncludesVisible(_interfaceState);
+    BOOL shouldRender = _networkImageNodeFlags.shouldRenderProgressImages && ASInterfaceStateIncludesVisible(_interfaceState);
     id oldDownloadIDForProgressBlock = _downloadIdentifierForProgressBlock;
     id newDownloadIDForProgressBlock = shouldRender ? _downloadIdentifier : nil;
     BOOL clearAndReattempt = NO;
@@ -536,9 +545,9 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
   [self _setCurrentImageQuality:0.0];
   [self _locked__setImage:_defaultImage];
 
-  _imageLoaded = NO;
+  _networkImageNodeFlags.imageLoaded = NO;
 
-  if (_cacheFlags.cacheSupportsClearing) {
+  if (_networkImageNodeFlags.cacheSupportsClearing) {
     if (_URL != nil) {
       as_log_verbose(ASImageLoadingLog(), "Clearing cached image for %@ url: %@", self, _URL);
       [_cache clearFetchedImageFromCacheWithURL:_URL];
@@ -561,7 +570,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
   }
 
   if (_downloadIdentifier) {
-    if (storeResume && _downloaderFlags.downloaderImplementsCancelWithResume) {
+    if (storeResume && _networkImageNodeFlags.downloaderImplementsCancelWithResume) {
       as_log_verbose(ASImageLoadingLog(), "Canceling image download w resume for %@ id: %@", self, _downloadIdentifier);
       [_downloader cancelImageDownloadWithResumePossibilityForIdentifier:_downloadIdentifier];
     } else {
@@ -598,7 +607,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
       }
     };
 
-    if (self->_downloaderFlags.downloaderImplementsDownloadWithPriority
+    if (self->_networkImageNodeFlags.downloaderImplementsDownloadWithPriority
         && ASActivateExperimentalFeature(ASExperimentalImageDownloaderPriority)) {
       /*
         Decide a priority based on the current interface state of this node.
@@ -661,11 +670,11 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 
   [self lock];
     __weak id<ASNetworkImageNodeDelegate> delegate = _delegate;
-    BOOL delegateDidStartFetchingData = _delegateFlags.delegateDidStartFetchingData;
-    BOOL delegateWillLoadImageFromCache = _delegateFlags.delegateWillLoadImageFromCache;
-    BOOL delegateWillLoadImageFromNetwork = _delegateFlags.delegateWillLoadImageFromNetwork;
-    BOOL delegateDidLoadImageFromCache = _delegateFlags.delegateDidLoadImageFromCache;
-    BOOL isImageLoaded = _imageLoaded;
+    BOOL delegateDidStartFetchingData = _networkImageNodeFlags.delegateDidStartFetchingData;
+    BOOL delegateWillLoadImageFromCache = _networkImageNodeFlags.delegateWillLoadImageFromCache;
+    BOOL delegateWillLoadImageFromNetwork = _networkImageNodeFlags.delegateWillLoadImageFromNetwork;
+    BOOL delegateDidLoadImageFromCache = _networkImageNodeFlags.delegateDidLoadImageFromCache;
+    BOOL isImageLoaded = _networkImageNodeFlags.imageLoaded;
     NSURL *URL = _URL;
     id currentDownloadIdentifier = _downloadIdentifier;
   [self unlock];
@@ -684,7 +693,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
           return;
         }
         
-        if (self->_shouldCacheImage) {
+        if (self->_networkImageNodeFlags.shouldCacheImage) {
           [self _locked__setImage:[UIImage imageNamed:URL.path.lastPathComponent]];
         } else {
           // First try to load the path directly, for efficiency assuming a developer who
@@ -701,7 +710,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 
           // If the file may be an animated gif and then created an animated image.
           id<ASAnimatedImageProtocol> animatedImage = nil;
-          if (self->_downloaderFlags.downloaderImplementsAnimatedImage) {
+          if (self->_networkImageNodeFlags.downloaderImplementsAnimatedImage) {
             const auto data = [[NSData alloc] initWithContentsOfURL:URL];
             if (data != nil) {
               animatedImage = [self->_downloader animatedImageWithData:data];
@@ -719,15 +728,15 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
           }
         }
 
-        self->_imageLoaded = YES;
+        self->_networkImageNodeFlags.imageLoaded = YES;
 
         [self _setCurrentImageQuality:1.0];
 
-        if (self->_delegateFlags.delegateDidLoadImageWithInfo) {
+        if (self->_networkImageNodeFlags.delegateDidLoadImageWithInfo) {
           ASUnlockScope(self);
           const auto info = [[ASNetworkImageLoadInfo alloc] initWithURL:URL sourceType:ASNetworkImageSourceFileURL downloadIdentifier:nil userInfo:nil];
           [delegate imageNode:self didLoadImage:self.image info:info];
-        } else if (self->_delegateFlags.delegateDidLoadImage) {
+        } else if (self->_networkImageNodeFlags.delegateDidLoadImage) {
           ASUnlockScope(self);
           [delegate imageNode:self didLoadImage:self.image];
         }
@@ -762,14 +771,14 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
           if (imageContainer != nil) {
             [strongSelf _setCurrentImageQuality:1.0];
             NSData *animatedImageData = [imageContainer asdk_animatedImageData];
-            if (animatedImageData && strongSelf->_downloaderFlags.downloaderImplementsAnimatedImage) {
+            if (animatedImageData && strongSelf->_networkImageNodeFlags.downloaderImplementsAnimatedImage) {
               id animatedImage = [strongSelf->_downloader animatedImageWithData:animatedImageData];
               [strongSelf _locked_setAnimatedImage:animatedImage];
             } else {
               newImage = [imageContainer asdk_image];
               [strongSelf _locked__setImage:newImage];
             }
-            strongSelf->_imageLoaded = YES;
+            strongSelf->_networkImageNodeFlags.imageLoaded = YES;
           }
           
           strongSelf->_downloadIdentifier = nil;
@@ -778,17 +787,17 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
           void (^calloutBlock)(ASNetworkImageNode *inst);
           
           if (newImage) {
-            if (strongSelf->_delegateFlags.delegateDidLoadImageWithInfo) {
+            if (strongSelf->_networkImageNodeFlags.delegateDidLoadImageWithInfo) {
               calloutBlock = ^(ASNetworkImageNode *strongSelf) {
                 const auto info = [[ASNetworkImageLoadInfo alloc] initWithURL:URL sourceType:imageSource downloadIdentifier:downloadIdentifier userInfo:userInfo];
                 [delegate imageNode:strongSelf didLoadImage:newImage info:info];
               };
-            } else if (strongSelf->_delegateFlags.delegateDidLoadImage) {
+            } else if (strongSelf->_networkImageNodeFlags.delegateDidLoadImage) {
               calloutBlock = ^(ASNetworkImageNode *strongSelf) {
                 [delegate imageNode:strongSelf didLoadImage:newImage];
               };
             }
-          } else if (error && strongSelf->_delegateFlags.delegateDidFailWithError) {
+          } else if (error && strongSelf->_networkImageNodeFlags.delegateDidFailWithError) {
             calloutBlock = ^(ASNetworkImageNode *strongSelf) {
               [delegate imageNode:strongSelf didFailWithError:error];
             };
@@ -865,7 +874,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
   
   {
     ASLockScopeSelf();
-    if (_delegateFlags.delegateDidFinishDecoding && self.layer.contents != nil) {
+    if (_networkImageNodeFlags.delegateDidFinishDecoding && self.layer.contents != nil) {
       /* We store the image quality in _currentImageQuality whenever _image is set. On the following displayDidFinish, we'll know that
        _currentImageQuality is the quality of the image that has just finished rendering. In order for this to be accurate, we
        need to be sure we are on main thread when we set _currentImageQuality. Otherwise, it is possible for _currentImageQuality

--- a/Source/ASPagerNode.mm
+++ b/Source/ASPagerNode.mm
@@ -29,6 +29,7 @@
     unsigned nodeBlockAtIndex:1;
     unsigned nodeAtIndex:1;
   } _pagerDataSourceFlags;
+    BOOL _allowsAutomaticInsetsAdjustment;
 
   __weak id <ASPagerDelegate> _pagerDelegate;
   ASPagerNodeProxy *_proxyDelegate;

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -208,11 +208,13 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
 
   NSString *_highlightedLinkAttributeName;
   id _highlightedLinkAttributeValue;
-  ASTextNodeHighlightStyle _highlightStyle;
   NSRange _highlightRange;
   ASHighlightOverlayLayer *_activeHighlightLayer;
 
   UILongPressGestureRecognizer *_longPressGestureRecognizer;
+    ASTextNodeHighlightStyle _highlightStyle;
+    BOOL _longPressCancelsTouches;
+    BOOL _passthroughNonlinkTouches;
 }
 @dynamic placeholderEnabled;
 
@@ -263,6 +265,11 @@ static NSArray *DefaultLinkAttributeNames() {
 - (void)dealloc
 {
   CGColorRelease(_shadowColor);
+}
+
+- (BOOL)usingExperiment
+{
+    return NO;
 }
 
 #pragma mark - Description

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -170,12 +170,14 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
   
   NSString *_highlightedLinkAttributeName;
   id _highlightedLinkAttributeValue;
-  ASTextNodeHighlightStyle _highlightStyle;
   NSRange _highlightRange;
   ASHighlightOverlayLayer *_activeHighlightLayer;
   UIColor *_placeholderColor;
   
   UILongPressGestureRecognizer *_longPressGestureRecognizer;
+    ASTextNodeHighlightStyle _highlightStyle;
+    BOOL _longPressCancelsTouches;
+    BOOL _passthroughNonlinkTouches;
 }
 @dynamic placeholderEnabled;
 

--- a/Source/ASTextNodeCommon.h
+++ b/Source/ASTextNodeCommon.h
@@ -22,7 +22,7 @@
 /**
  * Highlight styles.
  */
-typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
+typedef NS_ENUM(unsigned char, ASTextNodeHighlightStyle) {
   /**
    * Highlight style for text on a light background.
    */

--- a/Source/Details/ASLayoutRangeType.h
+++ b/Source/Details/ASLayoutRangeType.h
@@ -24,7 +24,7 @@ AS_EXTERN BOOL ASRangeTuningParametersEqualToRangeTuningParameters(ASRangeTuning
  * Depending on some conditions (including interface state and direction of the scroll view, state of rendering engine, etc),
  * a range controller can choose which mode it should use at a given time.
  */
-typedef NS_ENUM(NSInteger, ASLayoutRangeMode) {
+typedef NS_ENUM(char, ASLayoutRangeMode) {
   ASLayoutRangeModeUnspecified = -1,
   
   /**

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -13,6 +13,7 @@
 #import <AsyncDisplayKit/ASAssert.h>
 #import <AsyncDisplayKit/ASCellNode+Internal.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>
+#import <AsyncDisplayKit/ASCollectionView.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h> // Required for interfaceState and hierarchyState setter methods.
 #import <AsyncDisplayKit/ASElementMap.h>
@@ -413,10 +414,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   if (ASDisplayNode.shouldShowRangeDebugOverlay) {
     ASScrollDirection scrollableDirections = ASScrollDirectionUp | ASScrollDirectionDown;
     if ([_dataSource isKindOfClass:NSClassFromString(@"ASCollectionView")]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
-      scrollableDirections = (ASScrollDirection)[_dataSource performSelector:@selector(scrollableDirections)];
-#pragma clang diagnostic pop
+        scrollableDirections = ((ASCollectionView *)_dataSource).scrollableDirections;
     }
     
     [self updateRangeController:self

--- a/Source/Details/ASScrollDirection.h
+++ b/Source/Details/ASScrollDirection.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_OPTIONS(NSInteger, ASScrollDirection) {
+typedef NS_OPTIONS(unsigned char, ASScrollDirection) {
   ASScrollDirectionNone  = 0,
   ASScrollDirectionRight = 1 << 0,
   ASScrollDirectionLeft  = 1 << 1,

--- a/Source/Layout/ASStackLayoutDefines.h
+++ b/Source/Layout/ASStackLayoutDefines.h
@@ -108,7 +108,7 @@ typedef NS_ENUM(NSUInteger, ASStackLayoutAlignContent) {
 };
 
 /** Orientation of children along horizontal axis */
-typedef NS_ENUM(NSUInteger, ASHorizontalAlignment) {
+typedef NS_ENUM(unsigned char, ASHorizontalAlignment) {
   /** No alignment specified. Default value */
   ASHorizontalAlignmentNone,
   /** Left aligned */
@@ -128,7 +128,7 @@ typedef NS_ENUM(NSUInteger, ASHorizontalAlignment) {
 };
 
 /** Orientation of children along vertical axis */
-typedef NS_ENUM(NSUInteger, ASVerticalAlignment) {
+typedef NS_ENUM(unsigned char, ASVerticalAlignment) {
   /** No alignment specified. Default value */
   ASVerticalAlignmentNone,
   /** Top aligned */

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -943,7 +943,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
   {
     _bridge_prologue_write;
 
-    _fallbackInsetsLayoutMarginsFromSafeArea = insetsLayoutMarginsFromSafeArea;
+    _flags.fallbackInsetsLayoutMarginsFromSafeArea = insetsLayoutMarginsFromSafeArea;
 
     if (AS_AVAILABLE_IOS(11.0)) {
       if (!_flags.layerBacked) {
@@ -1027,7 +1027,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
       return _getFromViewOnly(insetsLayoutMarginsFromSafeArea);
     }
   }
-  return _fallbackInsetsLayoutMarginsFromSafeArea;
+  return _flags.fallbackInsetsLayoutMarginsFromSafeArea;
 }
 
 @end
@@ -1056,13 +1056,13 @@ nodeProperty = nodeValueExpr; _setToViewOnly(viewAndPendingViewStateProperty, vi
 - (BOOL)isAccessibilityElement
 {
   _bridge_prologue_read;
-  return _getAccessibilityFromViewOrProperty(_isAccessibilityElement, isAccessibilityElement);
+  return _getAccessibilityFromViewOrProperty(_flags.isAccessibilityElement, isAccessibilityElement);
 }
 
 - (void)setIsAccessibilityElement:(BOOL)isAccessibilityElement
 {
   _bridge_prologue_write;
-  _setAccessibilityToViewAndProperty(_isAccessibilityElement, isAccessibilityElement, isAccessibilityElement, isAccessibilityElement);
+  _setAccessibilityToViewAndProperty(_flags.isAccessibilityElement, isAccessibilityElement, isAccessibilityElement, isAccessibilityElement);
 }
 
 - (NSString *)accessibilityLabel
@@ -1192,37 +1192,37 @@ nodeProperty = nodeValueExpr; _setToViewOnly(viewAndPendingViewStateProperty, vi
 - (BOOL)accessibilityElementsHidden
 {
   _bridge_prologue_read;
-  return _getAccessibilityFromViewOrProperty(_accessibilityElementsHidden, accessibilityElementsHidden);
+  return _getAccessibilityFromViewOrProperty(_flags.accessibilityElementsHidden, accessibilityElementsHidden);
 }
 
 - (void)setAccessibilityElementsHidden:(BOOL)accessibilityElementsHidden
 {
   _bridge_prologue_write;
-  _setAccessibilityToViewAndProperty(_accessibilityElementsHidden, accessibilityElementsHidden, accessibilityElementsHidden, accessibilityElementsHidden);
+  _setAccessibilityToViewAndProperty(_flags.accessibilityElementsHidden, accessibilityElementsHidden, accessibilityElementsHidden, accessibilityElementsHidden);
 }
 
 - (BOOL)accessibilityViewIsModal
 {
   _bridge_prologue_read;
-  return _getAccessibilityFromViewOrProperty(_accessibilityViewIsModal, accessibilityViewIsModal);
+  return _getAccessibilityFromViewOrProperty(_flags.accessibilityViewIsModal, accessibilityViewIsModal);
 }
 
 - (void)setAccessibilityViewIsModal:(BOOL)accessibilityViewIsModal
 {
   _bridge_prologue_write;
-  _setAccessibilityToViewAndProperty(_accessibilityViewIsModal, accessibilityViewIsModal, accessibilityViewIsModal, accessibilityViewIsModal);
+  _setAccessibilityToViewAndProperty(_flags.accessibilityViewIsModal, accessibilityViewIsModal, accessibilityViewIsModal, accessibilityViewIsModal);
 }
 
 - (BOOL)shouldGroupAccessibilityChildren
 {
   _bridge_prologue_read;
-  return _getAccessibilityFromViewOrProperty(_shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren);
+  return _getAccessibilityFromViewOrProperty(_flags.shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren);
 }
 
 - (void)setShouldGroupAccessibilityChildren:(BOOL)shouldGroupAccessibilityChildren
 {
   _bridge_prologue_write;
-  _setAccessibilityToViewAndProperty(_shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren);
+  _setAccessibilityToViewAndProperty(_flags.shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren);
 }
 
 - (NSString *)accessibilityIdentifier

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -35,7 +35,7 @@ BOOL ASDisplayNodeNeedsSpecialPropertiesHandling(BOOL isSynchronous, BOOL isLaye
 /// Get the pending view state for the node, creating one if needed.
 _ASPendingState * ASDisplayNodeGetPendingState(ASDisplayNode * node);
 
-typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
+typedef NS_OPTIONS(unsigned short, ASDisplayNodeMethodOverrides)
 {
   ASDisplayNodeMethodOverrideNone                   = 0,
   ASDisplayNodeMethodOverrideTouchesBegan           = 1 << 0,
@@ -86,7 +86,10 @@ static constexpr CACornerMask kASCACornerAllCorners =
   _ASPendingState *_pendingViewState;
   ASInterfaceState _pendingInterfaceState;
   ASInterfaceState _preExitingInterfaceState;
-  
+    ASCornerRoundingType _cornerRoundingType;
+    ASDisplayNodePerformanceMeasurementOptions _measurementOptions;
+    ASDisplayNodeMethodOverrides _methodOverrides;
+
   UIView *_view;
   CALayer *_layer;
 
@@ -126,6 +129,24 @@ static constexpr CACornerMask kASCACornerAllCorners =
     unsigned isInHierarchy:1;
     unsigned visibilityNotificationsDisabled:VISIBILITY_NOTIFICATIONS_DISABLED_BITS;
     unsigned isDeallocating:1;
+
+#if YOGA
+      unsigned willApplyNextYogaCalculatedLayout:1;
+#endif
+      // Automatically manages subnodes
+      unsigned automaticallyManagesSubnodes:1; // Main thread only
+      unsigned placeholderEnabled:1;
+      // Accessibility support
+      unsigned isAccessibilityElement:1;
+      unsigned accessibilityElementsHidden:1;
+      unsigned accessibilityViewIsModal:1;
+      unsigned shouldGroupAccessibilityChildren:1;
+      unsigned isAccessibilityContainer:1;
+      unsigned fallbackInsetsLayoutMarginsFromSafeArea:1;
+      unsigned automaticallyRelayoutOnSafeAreaChanges:1;
+      unsigned automaticallyRelayoutOnLayoutMarginsChanges:1;
+      unsigned isViewControllerRoot:1;
+      unsigned hasHadInterfaceStateDelegates:1;
   } _flags;
   
 @protected
@@ -142,7 +163,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
 
   // This is the desired contentsScale, not the scale at which the layer's contents should be displayed
   CGFloat _contentsScaleForDisplay;
-  ASDisplayNodeMethodOverrides _methodOverrides;
 
   UIEdgeInsets _hitTestSlop;
 
@@ -161,11 +181,7 @@ static constexpr CACornerMask kASCACornerAllCorners =
   NSMutableArray<ASDisplayNode *> *_yogaChildren;
   __weak ASDisplayNode *_yogaParent;
   ASLayout *_yogaCalculatedLayout;
-  BOOL _willApplyNextYogaCalculatedLayout;
 #endif
-
-  // Automatically manages subnodes
-  BOOL _automaticallyManagesSubnodes; // Main thread only
 
   // Layout Transition
   _ASTransitionContext *_pendingLayoutTransitionContext;
@@ -185,7 +201,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
 
 
   // Layout Spec performance measurement
-  ASDisplayNodePerformanceMeasurementOptions _measurementOptions;
   NSTimeInterval _layoutSpecTotalTime;
   NSInteger _layoutSpecNumberOfPasses;
   NSTimeInterval _layoutComputationTotalTime;
@@ -214,7 +229,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
 
   // Corner Radius support
   CGFloat _cornerRadius;
-  ASCornerRoundingType _cornerRoundingType;
   CALayer *_clipCornerLayers[NUM_CLIP_CORNER_LAYERS];
   CACornerMask _maskedCorners;
 
@@ -223,7 +237,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
 
 
   // Accessibility support
-  BOOL _isAccessibilityElement;
   NSString *_accessibilityLabel;
   NSAttributedString *_accessibilityAttributedLabel;
   NSString *_accessibilityHint;
@@ -233,28 +246,17 @@ static constexpr CACornerMask kASCACornerAllCorners =
   UIAccessibilityTraits _accessibilityTraits;
   CGRect _accessibilityFrame;
   NSString *_accessibilityLanguage;
-  BOOL _accessibilityElementsHidden;
-  BOOL _accessibilityViewIsModal;
-  BOOL _shouldGroupAccessibilityChildren;
   NSString *_accessibilityIdentifier;
   UIAccessibilityNavigationStyle _accessibilityNavigationStyle;
   NSArray *_accessibilityCustomActions;
   NSArray *_accessibilityHeaderElements;
   CGPoint _accessibilityActivationPoint;
   UIBezierPath *_accessibilityPath;
-  BOOL _isAccessibilityContainer;
 
 
   // Safe Area support
   // These properties are used on iOS 10 and lower, where safe area is not supported by UIKit.
   UIEdgeInsets _fallbackSafeAreaInsets;
-  BOOL _fallbackInsetsLayoutMarginsFromSafeArea;
-
-  BOOL _automaticallyRelayoutOnSafeAreaChanges;
-  BOOL _automaticallyRelayoutOnLayoutMarginsChanges;
-
-  BOOL _isViewControllerRoot;
-
 
 #pragma mark - ASDisplayNode (Debugging)
   ASLayout *_unflattenedLayout;
@@ -268,7 +270,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
 #endif
 
   /// Fast path: tells whether we've ever had an interface state delegate before.
-  BOOL _hasHadInterfaceStateDelegates;
   __weak id<ASInterfaceStateDelegate> _interfaceStateDelegates[AS_MAX_INTERFACE_STATE_DELEGATES];
 }
 

--- a/Source/Private/ASImageNode+AnimatedImagePrivate.h
+++ b/Source/Private/ASImageNode+AnimatedImagePrivate.h
@@ -15,7 +15,6 @@
 {
   AS::Mutex _displayLinkLock;
   id <ASAnimatedImageProtocol> _animatedImage;
-  BOOL _animatedImagePaused;
   NSString *_animatedImageRunLoopMode;
   CADisplayLink *_displayLink;
   NSUInteger _lastSuccessfulFrameIndex;
@@ -23,6 +22,12 @@
   //accessed on main thread only
   CFTimeInterval _playHead;
   NSUInteger _playedLoops;
+
+    struct {
+        unsigned int animatedImagePaused:1;
+        unsigned int cropEnabled:1; // Defaults to YES.
+        unsigned int forceUpscaling:1; //Defaults to NO.
+    } _imageNodeFlags;
 }
 
 @property (nonatomic) CFTimeInterval lastDisplayLinkFire;

--- a/Source/Private/_ASHierarchyChangeSet.h
+++ b/Source/Private/_ASHierarchyChangeSet.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NSUInteger ASDataControllerAnimationOptions;
 
-typedef NS_ENUM(NSInteger, _ASHierarchyChangeType) {
+typedef NS_ENUM(unsigned char, _ASHierarchyChangeType) {
   /**
    * A reload change, as submitted by the user. When a change set is
    * completed, these changes are decomposed into delete-insert pairs

--- a/Source/Private/_ASPendingState.h
+++ b/Source/Private/_ASPendingState.h
@@ -11,6 +11,9 @@
 
 #import <AsyncDisplayKit/UIView+ASConvenience.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic error "-Wobjc-missing-property-synthesis"
+
 /**
 
  Private header for ASDisplayNode.mm
@@ -39,3 +42,6 @@
 - (void)clearChanges;
 
 @end
+
+#pragma clang diagnostic pop
+

--- a/Source/Private/_ASPendingState.mm
+++ b/Source/Private/_ASPendingState.mm
@@ -17,78 +17,95 @@
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 
 #define __shouldSetNeedsDisplay(layer) (flags.needsDisplay \
-  || (flags.setOpaque && opaque != (layer).opaque)\
+  || (flags.setOpaque && flags.opaque != (layer).opaque)\
   || (flags.setBackgroundColor && !CGColorEqualToColor(backgroundColor, (layer).backgroundColor)))
 
 typedef struct {
   // Properties
-  int needsDisplay:1;
-  int needsLayout:1;
-  int layoutIfNeeded:1;
+  unsigned int needsDisplay:1;
+  unsigned int needsLayout:1;
+  unsigned int layoutIfNeeded:1;
   
+  unsigned int asyncTransactionContainer:1;
+  unsigned int preservesSuperviewLayoutMargins:1;
+  unsigned int insetsLayoutMarginsFromSafeArea:1;
+  unsigned int isAccessibilityElement:1;
+  unsigned int accessibilityElementsHidden:1;
+  unsigned int accessibilityViewIsModal:1;
+  unsigned int shouldGroupAccessibilityChildren:1;
+  unsigned int clipsToBounds:1;
+  unsigned int opaque:1;
+  unsigned int hidden:1;
+  unsigned int needsDisplayOnBoundsChange:1;
+  unsigned int allowsGroupOpacity:1;
+  unsigned int allowsEdgeAntialiasing:1;
+  unsigned int autoresizesSubviews:1;
+  unsigned int userInteractionEnabled:1;
+  unsigned int exclusiveTouch:1;
+
   // Flags indicating that a given property should be applied to the view at creation
-  int setClipsToBounds:1;
-  int setOpaque:1;
-  int setNeedsDisplayOnBoundsChange:1;
-  int setAutoresizesSubviews:1;
-  int setAutoresizingMask:1;
-  int setFrame:1;
-  int setBounds:1;
-  int setBackgroundColor:1;
-  int setTintColor:1;
-  int setHidden:1;
-  int setAlpha:1;
-  int setCornerRadius:1;
-  int setContentMode:1;
-  int setNeedsDisplay:1;
-  int setAnchorPoint:1;
-  int setPosition:1;
-  int setZPosition:1;
-  int setTransform:1;
-  int setSublayerTransform:1;
-  int setContents:1;
-  int setContentsGravity:1;
-  int setContentsRect:1;
-  int setContentsCenter:1;
-  int setContentsScale:1;
-  int setRasterizationScale:1;
-  int setUserInteractionEnabled:1;
-  int setExclusiveTouch:1;
-  int setShadowColor:1;
-  int setShadowOpacity:1;
-  int setShadowOffset:1;
-  int setShadowRadius:1;
-  int setBorderWidth:1;
-  int setBorderColor:1;
-  int setAsyncTransactionContainer:1;
-  int setAllowsGroupOpacity:1;
-  int setAllowsEdgeAntialiasing:1;
-  int setEdgeAntialiasingMask:1;
-  int setIsAccessibilityElement:1;
-  int setAccessibilityLabel:1;
-  int setAccessibilityAttributedLabel:1;
-  int setAccessibilityHint:1;
-  int setAccessibilityAttributedHint:1;
-  int setAccessibilityValue:1;
-  int setAccessibilityAttributedValue:1;
-  int setAccessibilityTraits:1;
-  int setAccessibilityFrame:1;
-  int setAccessibilityLanguage:1;
-  int setAccessibilityElementsHidden:1;
-  int setAccessibilityViewIsModal:1;
-  int setShouldGroupAccessibilityChildren:1;
-  int setAccessibilityIdentifier:1;
-  int setAccessibilityNavigationStyle:1;
-  int setAccessibilityCustomActions:1;
-  int setAccessibilityHeaderElements:1;
-  int setAccessibilityActivationPoint:1;
-  int setAccessibilityPath:1;
-  int setSemanticContentAttribute:1;
-  int setLayoutMargins:1;
-  int setPreservesSuperviewLayoutMargins:1;
-  int setInsetsLayoutMarginsFromSafeArea:1;
-  int setActions:1;
-  int setMaskedCorners : 1;
+  unsigned int setClipsToBounds:1;
+  unsigned int setOpaque:1;
+  unsigned int setNeedsDisplayOnBoundsChange:1;
+  unsigned int setAutoresizesSubviews:1;
+  unsigned int setAutoresizingMask:1;
+  unsigned int setFrame:1;
+  unsigned int setBounds:1;
+  unsigned int setBackgroundColor:1;
+  unsigned int setTintColor:1;
+  unsigned int setHidden:1;
+  unsigned int setAlpha:1;
+  unsigned int setCornerRadius:1;
+  unsigned int setContentMode:1;
+  unsigned int setNeedsDisplay:1;
+  unsigned int setAnchorPoint:1;
+  unsigned int setPosition:1;
+  unsigned int setZPosition:1;
+  unsigned int setTransform:1;
+  unsigned int setSublayerTransform:1;
+  unsigned int setContents:1;
+  unsigned int setContentsGravity:1;
+  unsigned int setContentsRect:1;
+  unsigned int setContentsCenter:1;
+  unsigned int setContentsScale:1;
+  unsigned int setRasterizationScale:1;
+  unsigned int setUserInteractionEnabled:1;
+  unsigned int setExclusiveTouch:1;
+  unsigned int setShadowColor:1;
+  unsigned int setShadowOpacity:1;
+  unsigned int setShadowOffset:1;
+  unsigned int setShadowRadius:1;
+  unsigned int setBorderWidth:1;
+  unsigned int setBorderColor:1;
+  unsigned int setAsyncTransactionContainer:1;
+  unsigned int setAllowsGroupOpacity:1;
+  unsigned int setAllowsEdgeAntialiasing:1;
+  unsigned int setEdgeAntialiasingMask:1;
+  unsigned int setIsAccessibilityElement:1;
+  unsigned int setAccessibilityLabel:1;
+  unsigned int setAccessibilityAttributedLabel:1;
+  unsigned int setAccessibilityHint:1;
+  unsigned int setAccessibilityAttributedHint:1;
+  unsigned int setAccessibilityValue:1;
+  unsigned int setAccessibilityAttributedValue:1;
+  unsigned int setAccessibilityTraits:1;
+  unsigned int setAccessibilityFrame:1;
+  unsigned int setAccessibilityLanguage:1;
+  unsigned int setAccessibilityElementsHidden:1;
+  unsigned int setAccessibilityViewIsModal:1;
+  unsigned int setShouldGroupAccessibilityChildren:1;
+  unsigned int setAccessibilityIdentifier:1;
+  unsigned int setAccessibilityNavigationStyle:1;
+  unsigned int setAccessibilityCustomActions:1;
+  unsigned int setAccessibilityHeaderElements:1;
+  unsigned int setAccessibilityActivationPoint:1;
+  unsigned int setAccessibilityPath:1;
+  unsigned int setSemanticContentAttribute:1;
+  unsigned int setLayoutMargins:1;
+  unsigned int setPreservesSuperviewLayoutMargins:1;
+  unsigned int setInsetsLayoutMarginsFromSafeArea:1;
+  unsigned int setActions:1;
+  unsigned int setMaskedCorners : 1;
 } ASPendingStateFlags;
 
 
@@ -123,11 +140,7 @@ static constexpr ASPendingStateFlags kZeroFlags = {0};
   CGFloat shadowRadius;
   CGFloat borderWidth;
   CGColorRef borderColor;
-  BOOL asyncTransactionContainer;
   UIEdgeInsets layoutMargins;
-  BOOL preservesSuperviewLayoutMargins;
-  BOOL insetsLayoutMarginsFromSafeArea;
-  BOOL isAccessibilityElement;
   NSString *accessibilityLabel;
   NSAttributedString *accessibilityAttributedLabel;
   NSString *accessibilityHint;
@@ -137,9 +150,6 @@ static constexpr ASPendingStateFlags kZeroFlags = {0};
   UIAccessibilityTraits accessibilityTraits;
   CGRect accessibilityFrame;
   NSString *accessibilityLanguage;
-  BOOL accessibilityElementsHidden;
-  BOOL accessibilityViewIsModal;
-  BOOL shouldGroupAccessibilityChildren;
   NSString *accessibilityIdentifier;
   UIAccessibilityNavigationStyle accessibilityNavigationStyle;
   NSArray *accessibilityCustomActions;
@@ -177,17 +187,10 @@ ASDISPLAYNODE_INLINE void ASPendingStateApplyMetricsToLayer(_ASPendingState *sta
   }
 }
 
-@synthesize clipsToBounds=clipsToBounds;
-@synthesize opaque=opaque;
 @synthesize frame=frame;
 @synthesize bounds=bounds;
 @synthesize backgroundColor=backgroundColor;
-@synthesize hidden=isHidden;
-@synthesize needsDisplayOnBoundsChange=needsDisplayOnBoundsChange;
-@synthesize allowsGroupOpacity=allowsGroupOpacity;
-@synthesize allowsEdgeAntialiasing=allowsEdgeAntialiasing;
 @synthesize edgeAntialiasingMask=edgeAntialiasingMask;
-@synthesize autoresizesSubviews=autoresizesSubviews;
 @synthesize autoresizingMask=autoresizingMask;
 @synthesize tintColor=tintColor;
 @synthesize alpha=alpha;
@@ -240,17 +243,17 @@ static UIColor *defaultTintColor = nil;
   });
 
   // Set defaults, these come from the defaults specified in CALayer and UIView
-  clipsToBounds = NO;
-  opaque = YES;
+  _flags.clipsToBounds = NO;
+  _flags.opaque = YES;
   frame = CGRectZero;
   bounds = CGRectZero;
   backgroundColor = nil;
   tintColor = defaultTintColor;
-  isHidden = NO;
-  needsDisplayOnBoundsChange = NO;
-  allowsGroupOpacity = ASDefaultAllowsGroupOpacity();
-  allowsEdgeAntialiasing = ASDefaultAllowsEdgeAntialiasing();
-  autoresizesSubviews = YES;
+  _flags.hidden = NO;
+  _flags.needsDisplayOnBoundsChange = NO;
+  _flags.allowsGroupOpacity = ASDefaultAllowsGroupOpacity();
+  _flags.allowsEdgeAntialiasing = ASDefaultAllowsEdgeAntialiasing();
+  _flags.autoresizesSubviews = YES;
   alpha = 1.0f;
   cornerRadius = 0.0f;
   contentMode = UIViewContentModeScaleToFill;
@@ -266,7 +269,7 @@ static UIColor *defaultTintColor = nil;
   contentsCenter = CGRectMake(0.0f, 0.0f, 1.0f, 1.0f);
   contentsScale = 1.0f;
   rasterizationScale = 1.0f;
-  userInteractionEnabled = YES;
+  _flags.userInteractionEnabled = YES;
   shadowColor = blackColorRef;
   shadowOpacity = 0.0;
   shadowOffset = CGSizeMake(0, -3);
@@ -274,9 +277,9 @@ static UIColor *defaultTintColor = nil;
   borderWidth = 0;
   borderColor = blackColorRef;
   layoutMargins = UIEdgeInsetsMake(8, 8, 8, 8);
-  preservesSuperviewLayoutMargins = NO;
-  insetsLayoutMarginsFromSafeArea = YES;
-  isAccessibilityElement = NO;
+  _flags.preservesSuperviewLayoutMargins = NO;
+  _flags.insetsLayoutMarginsFromSafeArea = YES;
+  _flags.isAccessibilityElement = NO;
   accessibilityLabel = nil;
   accessibilityAttributedLabel = nil;
   accessibilityHint = nil;
@@ -286,9 +289,9 @@ static UIColor *defaultTintColor = nil;
   accessibilityTraits = UIAccessibilityTraitNone;
   accessibilityFrame = CGRectZero;
   accessibilityLanguage = nil;
-  accessibilityElementsHidden = NO;
-  accessibilityViewIsModal = NO;
-  shouldGroupAccessibilityChildren = NO;
+  _flags.accessibilityElementsHidden = NO;
+  _flags.accessibilityViewIsModal = NO;
+  _flags.shouldGroupAccessibilityChildren = NO;
   accessibilityIdentifier = nil;
   accessibilityNavigationStyle = UIAccessibilityNavigationStyleAutomatic;
   accessibilityCustomActions = nil;
@@ -318,32 +321,57 @@ static UIColor *defaultTintColor = nil;
 
 - (void)setClipsToBounds:(BOOL)flag
 {
-  clipsToBounds = flag;
+  _flags.clipsToBounds = flag;
   _flags.setClipsToBounds = YES;
+}
+
+- (BOOL)clipsToBounds
+{
+    return _flags.clipsToBounds;
 }
 
 - (void)setOpaque:(BOOL)flag
 {
-  opaque = flag;
+  _flags.opaque = flag;
   _flags.setOpaque = YES;
+}
+
+- (BOOL)isOpaque
+{
+    return _flags.opaque;
 }
 
 - (void)setNeedsDisplayOnBoundsChange:(BOOL)flag
 {
-  needsDisplayOnBoundsChange = flag;
+  _flags.needsDisplayOnBoundsChange = flag;
   _flags.setNeedsDisplayOnBoundsChange = YES;
+}
+
+- (BOOL)needsDisplayOnBoundsChange
+{
+    return _flags.needsDisplayOnBoundsChange;
 }
 
 - (void)setAllowsGroupOpacity:(BOOL)flag
 {
-  allowsGroupOpacity = flag;
+  _flags.allowsGroupOpacity = flag;
   _flags.setAllowsGroupOpacity = YES;
+}
+
+- (BOOL)allowsGroupOpacity
+{
+    return _flags.allowsGroupOpacity;
 }
 
 - (void)setAllowsEdgeAntialiasing:(BOOL)flag
 {
-  allowsEdgeAntialiasing = flag;
+  _flags.allowsEdgeAntialiasing = flag;
   _flags.setAllowsEdgeAntialiasing = YES;
+}
+
+- (BOOL)allowsEdgeAntialiasing
+{
+    return _flags.allowsEdgeAntialiasing;
 }
 
 - (void)setEdgeAntialiasingMask:(unsigned int)mask
@@ -354,8 +382,13 @@ static UIColor *defaultTintColor = nil;
 
 - (void)setAutoresizesSubviews:(BOOL)flag
 {
-  autoresizesSubviews = flag;
+  _flags.autoresizesSubviews = flag;
   _flags.setAutoresizesSubviews = YES;
+}
+
+- (BOOL)autoresizesSubviews
+{
+    return _flags.autoresizesSubviews;
 }
 
 - (void)setAutoresizingMask:(UIViewAutoresizing)mask
@@ -405,8 +438,13 @@ static UIColor *defaultTintColor = nil;
 
 - (void)setHidden:(BOOL)flag
 {
-  isHidden = flag;
+  _flags.hidden = flag;
   _flags.setHidden = YES;
+}
+
+- (BOOL)isHidden
+{
+    return _flags.hidden;
 }
 
 - (void)setAlpha:(CGFloat)newAlpha
@@ -510,14 +548,24 @@ static UIColor *defaultTintColor = nil;
 
 - (void)setUserInteractionEnabled:(BOOL)flag
 {
-  userInteractionEnabled = flag;
+  _flags.userInteractionEnabled = flag;
   _flags.setUserInteractionEnabled = YES;
+}
+
+- (BOOL)isUserInteractionEnabled
+{
+    return _flags.userInteractionEnabled;
 }
 
 - (void)setExclusiveTouch:(BOOL)flag
 {
-  exclusiveTouch = flag;
+  _flags.exclusiveTouch = flag;
   _flags.setExclusiveTouch = YES;
+}
+
+- (BOOL)isExclusiveTouch
+{
+    return _flags.exclusiveTouch;
 }
 
 - (void)setShadowColor:(CGColorRef)color
@@ -576,8 +624,13 @@ static UIColor *defaultTintColor = nil;
 
 - (void)asyncdisplaykit_setAsyncTransactionContainer:(BOOL)flag
 {
-  asyncTransactionContainer = flag;
+  _flags.asyncTransactionContainer = flag;
   _flags.setAsyncTransactionContainer = YES;
+}
+
+- (BOOL)asyncdisplaykit_isAsyncTransactionContainer
+{
+    return _flags.asyncTransactionContainer;
 }
 
 - (void)setLayoutMargins:(UIEdgeInsets)margins
@@ -588,14 +641,24 @@ static UIColor *defaultTintColor = nil;
 
 - (void)setPreservesSuperviewLayoutMargins:(BOOL)flag
 {
-  preservesSuperviewLayoutMargins = flag;
+  _flags.preservesSuperviewLayoutMargins = flag;
   _flags.setPreservesSuperviewLayoutMargins = YES;
+}
+
+- (BOOL)preservesSuperviewLayoutMargins
+{
+    return _flags.preservesSuperviewLayoutMargins;
 }
 
 - (void)setInsetsLayoutMarginsFromSafeArea:(BOOL)flag
 {
-  insetsLayoutMarginsFromSafeArea = flag;
+  _flags.insetsLayoutMarginsFromSafeArea = flag;
   _flags.setInsetsLayoutMarginsFromSafeArea = YES;
+}
+
+- (BOOL)insetsLayoutMarginsFromSafeArea
+{
+    return _flags.insetsLayoutMarginsFromSafeArea;
 }
 
 - (void)setSemanticContentAttribute:(UISemanticContentAttribute)attribute API_AVAILABLE(ios(9.0), tvos(9.0)) {
@@ -611,12 +674,12 @@ static UIColor *defaultTintColor = nil;
 
 - (BOOL)isAccessibilityElement
 {
-  return isAccessibilityElement;
+  return _flags.isAccessibilityElement;
 }
 
 - (void)setIsAccessibilityElement:(BOOL)newIsAccessibilityElement
 {
-  isAccessibilityElement = newIsAccessibilityElement;
+  _flags.isAccessibilityElement = newIsAccessibilityElement;
   _flags.setIsAccessibilityElement = YES;
 }
 
@@ -745,34 +808,34 @@ static UIColor *defaultTintColor = nil;
 
 - (BOOL)accessibilityElementsHidden
 {
-  return accessibilityElementsHidden;
+  return _flags.accessibilityElementsHidden;
 }
 
 - (void)setAccessibilityElementsHidden:(BOOL)newAccessibilityElementsHidden
 {
-  accessibilityElementsHidden = newAccessibilityElementsHidden;
+  _flags.accessibilityElementsHidden = newAccessibilityElementsHidden;
   _flags.setAccessibilityElementsHidden = YES;
 }
 
 - (BOOL)accessibilityViewIsModal
 {
-  return accessibilityViewIsModal;
+  return _flags.accessibilityViewIsModal;
 }
 
 - (void)setAccessibilityViewIsModal:(BOOL)newAccessibilityViewIsModal
 {
-  accessibilityViewIsModal = newAccessibilityViewIsModal;
+  _flags.accessibilityViewIsModal = newAccessibilityViewIsModal;
   _flags.setAccessibilityViewIsModal = YES;
 }
 
 - (BOOL)shouldGroupAccessibilityChildren
 {
-  return shouldGroupAccessibilityChildren;
+  return _flags.shouldGroupAccessibilityChildren;
 }
 
 - (void)setShouldGroupAccessibilityChildren:(BOOL)newShouldGroupAccessibilityChildren
 {
-  shouldGroupAccessibilityChildren = newShouldGroupAccessibilityChildren;
+  _flags.shouldGroupAccessibilityChildren = newShouldGroupAccessibilityChildren;
   _flags.setShouldGroupAccessibilityChildren = YES;
 }
 
@@ -897,16 +960,16 @@ static UIColor *defaultTintColor = nil;
     layer.rasterizationScale = rasterizationScale;
 
   if (flags.setClipsToBounds)
-    layer.masksToBounds = clipsToBounds;
+    layer.masksToBounds = _flags.clipsToBounds;
 
   if (flags.setBackgroundColor)
     layer.backgroundColor = backgroundColor;
 
   if (flags.setOpaque)
-    layer.opaque = opaque;
+    layer.opaque = _flags.opaque;
 
   if (flags.setHidden)
-    layer.hidden = isHidden;
+    layer.hidden = _flags.hidden;
 
   if (flags.setAlpha)
     layer.opacity = alpha;
@@ -942,22 +1005,22 @@ static UIColor *defaultTintColor = nil;
     layer.borderColor = borderColor;
 
   if (flags.setNeedsDisplayOnBoundsChange)
-    layer.needsDisplayOnBoundsChange = needsDisplayOnBoundsChange;
+    layer.needsDisplayOnBoundsChange = _flags.needsDisplayOnBoundsChange;
   
   if (flags.setAllowsGroupOpacity)
-    layer.allowsGroupOpacity = allowsGroupOpacity;
+    layer.allowsGroupOpacity = _flags.allowsGroupOpacity;
 
   if (flags.setAllowsEdgeAntialiasing)
-    layer.allowsEdgeAntialiasing = allowsEdgeAntialiasing;
+    layer.allowsEdgeAntialiasing = _flags.allowsEdgeAntialiasing;
 
   if (flags.setEdgeAntialiasingMask)
     layer.edgeAntialiasingMask = edgeAntialiasingMask;
 
   if (flags.setAsyncTransactionContainer)
-    layer.asyncdisplaykit_asyncTransactionContainer = asyncTransactionContainer;
+    layer.asyncdisplaykit_asyncTransactionContainer = _flags.asyncTransactionContainer;
 
   if (flags.setOpaque)
-    ASDisplayNodeAssert(layer.opaque == opaque, @"Didn't set opaque as desired");
+    ASDisplayNodeAssert(layer.opaque == _flags.opaque, @"Didn't set opaque as desired");
 
   if (flags.setActions)
     layer.actions = actions;
@@ -1028,7 +1091,7 @@ static UIColor *defaultTintColor = nil;
     layer.actions = actions;
 
   if (flags.setClipsToBounds)
-    view.clipsToBounds = clipsToBounds;
+    view.clipsToBounds = _flags.clipsToBounds;
 
   if (flags.setBackgroundColor) {
     // We have to make sure certain nodes get the background color call directly set
@@ -1044,10 +1107,10 @@ static UIColor *defaultTintColor = nil;
     view.tintColor = self.tintColor;
 
   if (flags.setOpaque)
-    layer.opaque = opaque;
+    layer.opaque = _flags.opaque;
 
   if (flags.setHidden)
-    view.hidden = isHidden;
+    view.hidden = _flags.hidden;
 
   if (flags.setAlpha)
     view.alpha = alpha;
@@ -1059,11 +1122,11 @@ static UIColor *defaultTintColor = nil;
     view.contentMode = contentMode;
 
   if (flags.setUserInteractionEnabled)
-    view.userInteractionEnabled = userInteractionEnabled;
+    view.userInteractionEnabled = _flags.userInteractionEnabled;
 
   #if TARGET_OS_IOS
   if (flags.setExclusiveTouch)
-    view.exclusiveTouch = exclusiveTouch;
+    view.exclusiveTouch = _flags.exclusiveTouch;
   #endif
     
   if (flags.setShadowColor)
@@ -1088,35 +1151,35 @@ static UIColor *defaultTintColor = nil;
     view.autoresizingMask = autoresizingMask;
 
   if (flags.setAutoresizesSubviews)
-    view.autoresizesSubviews = autoresizesSubviews;
+    view.autoresizesSubviews = _flags.autoresizesSubviews;
 
   if (flags.setNeedsDisplayOnBoundsChange)
-    layer.needsDisplayOnBoundsChange = needsDisplayOnBoundsChange;
+    layer.needsDisplayOnBoundsChange = _flags.needsDisplayOnBoundsChange;
   
   if (flags.setAllowsGroupOpacity)
-    layer.allowsGroupOpacity = allowsGroupOpacity;
+    layer.allowsGroupOpacity = _flags.allowsGroupOpacity;
 
   if (flags.setAllowsEdgeAntialiasing)
-    layer.allowsEdgeAntialiasing = allowsEdgeAntialiasing;
+    layer.allowsEdgeAntialiasing = _flags.allowsEdgeAntialiasing;
 
   if (flags.setEdgeAntialiasingMask)
     layer.edgeAntialiasingMask = edgeAntialiasingMask;
 
   if (flags.setAsyncTransactionContainer)
-    view.asyncdisplaykit_asyncTransactionContainer = asyncTransactionContainer;
+    view.asyncdisplaykit_asyncTransactionContainer = _flags.asyncTransactionContainer;
 
   if (flags.setOpaque)
-    ASDisplayNodeAssert(layer.opaque == opaque, @"Didn't set opaque as desired");
+    ASDisplayNodeAssert(layer.opaque == _flags.opaque, @"Didn't set opaque as desired");
 
   if (flags.setLayoutMargins)
     view.layoutMargins = layoutMargins;
 
   if (flags.setPreservesSuperviewLayoutMargins)
-    view.preservesSuperviewLayoutMargins = preservesSuperviewLayoutMargins;
+    view.preservesSuperviewLayoutMargins = _flags.preservesSuperviewLayoutMargins;
 
   if (AS_AVAILABLE_IOS(11.0)) {
     if (flags.setInsetsLayoutMarginsFromSafeArea) {
-      view.insetsLayoutMarginsFromSafeArea = insetsLayoutMarginsFromSafeArea;
+      view.insetsLayoutMarginsFromSafeArea = _flags.insetsLayoutMarginsFromSafeArea;
     }
   }
 
@@ -1125,7 +1188,7 @@ static UIColor *defaultTintColor = nil;
   }
 
   if (flags.setIsAccessibilityElement)
-    view.isAccessibilityElement = isAccessibilityElement;
+    view.isAccessibilityElement = _flags.isAccessibilityElement;
 
   if (flags.setAccessibilityLabel)
     view.accessibilityLabel = accessibilityLabel;
@@ -1158,13 +1221,13 @@ static UIColor *defaultTintColor = nil;
     view.accessibilityLanguage = accessibilityLanguage;
 
   if (flags.setAccessibilityElementsHidden)
-    view.accessibilityElementsHidden = accessibilityElementsHidden;
+    view.accessibilityElementsHidden = _flags.accessibilityElementsHidden;
 
   if (flags.setAccessibilityViewIsModal)
-    view.accessibilityViewIsModal = accessibilityViewIsModal;
+    view.accessibilityViewIsModal = _flags.accessibilityViewIsModal;
 
   if (flags.setShouldGroupAccessibilityChildren)
-    view.shouldGroupAccessibilityChildren = shouldGroupAccessibilityChildren;
+    view.shouldGroupAccessibilityChildren = _flags.shouldGroupAccessibilityChildren;
 
   if (flags.setAccessibilityIdentifier)
     view.accessibilityIdentifier = accessibilityIdentifier;
@@ -1355,3 +1418,5 @@ static UIColor *defaultTintColor = nil;
 }
 
 @end
+
+#pragma clang diagnostic pop


### PR DESCRIPTION
    In Pinterest, these changes reduce the in-memory size of nodes an average of 9.17%. These objects accumulate in the heap, so reducing their size will allow more to accumulate before memory warnings.
    
    - Shrink BOOLs in ASDisplayNode, Add necessary ivars and setter/getters
    - Shrink ASPendingState BOOLs. Use unsigned int for these bitfields for clarity.
    - Shrink ASImageNode
    - Shrink ASControlNode
    - Shrink enums stored in ASDisplayNode, and reorder them in the ivar list to compact the space used.
    - Shrink BOOLs in ASCellNode
    - make ASScrollNode smaller by shrinking ASScrollDirection, which requires a change to ASRangeController
    - shrink size of ASNetworkImageNode by putting all the bitfields into 1 struct and moving the BOOL properties into there as well.
    - Make ASButtonNode smaller by shrinking enums, and reordering placement via ivars
    - Shrink _ASCollectionPendingState and associated enums
    - shrink ASPagerNode by declaring the BOOL next to the struct
    - Shrink ASTextNode
