### PR TITLE
Don't clear contents when exit display state be called for animated image node

### DIFF
--- a/Source/ASImageNode+AnimatedImage.mm
+++ b/Source/ASImageNode+AnimatedImage.mm
@@ -315,18 +315,7 @@
 #if ASAnimatedImageDebug
     NSLog(@"exiting display state: %p", self);
 #endif
-    
-  // Check to see if we're an animated image before calling super in case someone
-  // decides they want to clear out the animatedImage itself on exiting the display
-  // state
-  BOOL isAnimatedImage = self.animatedImage != nil;
   [super didExitDisplayState];
-  
-  // Also clear out the contents we've set to be good citizens, we'll put it back in when we become visible.
-  if (isAnimatedImage) {
-    self.contents = nil;
-    [self setCoverImage:nil];
-  }
 }
 
 #pragma mark - Display Link Callbacks


### PR DESCRIPTION
Seems `kCAOnOrderOut` is be called not only when layer removing or hidden, it also can be called when layer is going to be visible. 

Reproducible steps:
1: Set `ASNetworkImageNode`'s url to a GIF image.
2: Run `AsyncDisplayKitOverview` example project.
3: Click into `ASNetworkImageNode` example, we can see layer's `contents` would be cleared after gif played some frames.