### PR TITLE
Shrink ASDisplayNode from 1072 to 968 bytes, reduction of 10.74%

### DIFF
--- a/Source/ASDisplayNode+Beta.h
+++ b/Source/ASDisplayNode+Beta.h
@@ -25,7 +25,7 @@ AS_EXTERN void ASPerformBlockOnBackgroundThread(void (^block)(void)); // DISPATC
 /**
  * Bitmask to indicate what performance measurements the cell should record.
  */
-typedef NS_OPTIONS(NSUInteger, ASDisplayNodePerformanceMeasurementOptions) {
+typedef NS_OPTIONS(unsigned char, ASDisplayNodePerformanceMeasurementOptions) {
   ASDisplayNodePerformanceMeasurementOptionLayoutSpec = 1 << 0,
   ASDisplayNodePerformanceMeasurementOptionLayoutComputation = 1 << 1
 };

--- a/Source/ASDisplayNode+InterfaceState.h
+++ b/Source/ASDisplayNode+InterfaceState.h
@@ -16,7 +16,7 @@
  * The defualt state, ASInterfaceStateNone, means that the element is not predicted to be onscreen soon and
  * preloading should not be performed. Swift: use [] for the default behavior.
  */
-typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
+typedef NS_OPTIONS(unsigned char, ASInterfaceState)
 {
     /** The element is not predicted to be onscreen soon and preloading should not be performed */
     ASInterfaceStateNone          = 0,

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -547,13 +547,13 @@ ASLayoutElementStyleExtensibilityForwarding
 - (BOOL)automaticallyManagesSubnodes
 {
   MutexLocker l(__instanceLock__);
-  return _automaticallyManagesSubnodes;
+  return _flags.automaticallyManagesSubnodes;
 }
 
 - (void)setAutomaticallyManagesSubnodes:(BOOL)automaticallyManagesSubnodes
 {
   MutexLocker l(__instanceLock__);
-  _automaticallyManagesSubnodes = automaticallyManagesSubnodes;
+  _flags.automaticallyManagesSubnodes = automaticallyManagesSubnodes;
 }
 
 @end
@@ -1027,7 +1027,7 @@ ASLayoutElementStyleExtensibilityForwarding
   // We generate placeholders at -layoutThatFits: time so that a node is guaranteed to have a placeholder ready to go.
   // This is also because measurement is usually asynchronous, but placeholders need to be set up synchronously.
   // First measurement is guaranteed to be before the node is onscreen, so we can create the image async. but still have it appear sync.
-  if (_placeholderEnabled && !_placeholderImage && [self _locked_displaysAsynchronously]) {
+  if (_flags.placeholderEnabled && !_placeholderImage && [self _locked_displaysAsynchronously]) {
     
     // Zero-sized nodes do not require a placeholder.
     CGSize layoutSize = _calculatedDisplayNodeLayout.layout.size;

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -167,11 +167,11 @@
 }
 
 - (BOOL)willApplyNextYogaCalculatedLayout {
-  return _willApplyNextYogaCalculatedLayout;
+  return _flags.willApplyNextYogaCalculatedLayout;
 }
 
 - (void)setWillApplyNextYogaCalculatedLayout:(BOOL)willApplyNextYogaCalculatedLayout {
-  _willApplyNextYogaCalculatedLayout = willApplyNextYogaCalculatedLayout;
+  _flags.willApplyNextYogaCalculatedLayout = willApplyNextYogaCalculatedLayout;
 }
 
 - (void)setYogaLayoutInProgress:(BOOL)yogaLayoutInProgress

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -70,7 +70,7 @@ typedef ASLayoutSpec * _Nonnull(^ASLayoutSpecBlock)(__kindof ASDisplayNode *node
  */
 typedef void (^ASDisplayNodeNonFatalErrorBlock)(NSError *error);
 
-typedef NS_ENUM(NSInteger, ASCornerRoundingType) {
+typedef NS_ENUM(unsigned char, ASCornerRoundingType) {
   ASCornerRoundingTypeDefaultSlowCALayer,
   ASCornerRoundingTypePrecomposited,
   ASCornerRoundingTypeClipping

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -337,11 +337,11 @@ __attribute__((constructor)) static void ASLoadFrameworkInitializer(void)
   _flags.canCallSetNeedsDisplayOfLayer = YES;
 
   _fallbackSafeAreaInsets = UIEdgeInsetsZero;
-  _fallbackInsetsLayoutMarginsFromSafeArea = YES;
-  _isViewControllerRoot = NO;
+  _flags.fallbackInsetsLayoutMarginsFromSafeArea = YES;
+  _flags.isViewControllerRoot = NO;
 
-  _automaticallyRelayoutOnSafeAreaChanges = NO;
-  _automaticallyRelayoutOnLayoutMarginsChanges = NO;
+  _flags.automaticallyRelayoutOnSafeAreaChanges = NO;
+  _flags.automaticallyRelayoutOnLayoutMarginsChanges = NO;
 
   [self baseDidInit];
 }
@@ -861,37 +861,37 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
 - (BOOL)isViewControllerRoot
 {
   MutexLocker l(__instanceLock__);
-  return _isViewControllerRoot;
+  return _flags.isViewControllerRoot;
 }
 
 - (void)setViewControllerRoot:(BOOL)flag
 {
   MutexLocker l(__instanceLock__);
-  _isViewControllerRoot = flag;
+  _flags.isViewControllerRoot = flag;
 }
 
 - (BOOL)automaticallyRelayoutOnSafeAreaChanges
 {
   MutexLocker l(__instanceLock__);
-  return _automaticallyRelayoutOnSafeAreaChanges;
+  return _flags.automaticallyRelayoutOnSafeAreaChanges;
 }
 
 - (void)setAutomaticallyRelayoutOnSafeAreaChanges:(BOOL)flag
 {
   MutexLocker l(__instanceLock__);
-  _automaticallyRelayoutOnSafeAreaChanges = flag;
+  _flags.automaticallyRelayoutOnSafeAreaChanges = flag;
 }
 
 - (BOOL)automaticallyRelayoutOnLayoutMarginsChanges
 {
   MutexLocker l(__instanceLock__);
-  return _automaticallyRelayoutOnLayoutMarginsChanges;
+  return _flags.automaticallyRelayoutOnLayoutMarginsChanges;
 }
 
 - (void)setAutomaticallyRelayoutOnLayoutMarginsChanges:(BOOL)flag
 {
   MutexLocker l(__instanceLock__);
-  _automaticallyRelayoutOnLayoutMarginsChanges = flag;
+  _flags.automaticallyRelayoutOnLayoutMarginsChanges = flag;
 }
 
 - (void)__setNodeController:(ASNodeController *)controller
@@ -2593,7 +2593,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (BOOL)_locked_shouldHavePlaceholderLayer
 {
   DISABLED_ASAssertLocked(__instanceLock__);
-  return (_placeholderEnabled && [self _implementsDisplay]);
+  return (_flags.placeholderEnabled && [self _implementsDisplay]);
 }
 
 - (void)_locked_setupPlaceholderLayerIfNeeded
@@ -2638,13 +2638,13 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (BOOL)placeholderEnabled
 {
   MutexLocker l(__instanceLock__);
-  return _placeholderEnabled;
+  return _flags.placeholderEnabled;
 }
 
 - (void)setPlaceholderEnabled:(BOOL)placeholderEnabled
 {
   MutexLocker l(__instanceLock__);
-  _placeholderEnabled = placeholderEnabled;
+  _flags.placeholderEnabled = placeholderEnabled;
 }
 
 - (NSTimeInterval)placeholderFadeDuration
@@ -3144,7 +3144,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (void)addInterfaceStateDelegate:(id <ASInterfaceStateDelegate>)interfaceStateDelegate
 {
   MutexLocker l(__instanceLock__);
-  _hasHadInterfaceStateDelegates = YES;
+  _flags.hasHadInterfaceStateDelegates = YES;
   for (int i = 0; i < AS_MAX_INTERFACE_STATE_DELEGATES; i++) {
     if (_interfaceStateDelegates[i] == nil) {
       _interfaceStateDelegates[i] = interfaceStateDelegate;
@@ -3326,7 +3326,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   {
     ASLockScopeSelf();
     // Fast path for non-delegating nodes.
-    if (!_hasHadInterfaceStateDelegates) {
+    if (!_flags.hasHadInterfaceStateDelegates) {
       return;
     }
 
@@ -3538,13 +3538,13 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (void)setIsAccessibilityContainer:(BOOL)isAccessibilityContainer
 {
   MutexLocker l(__instanceLock__);
-  _isAccessibilityContainer = isAccessibilityContainer;
+  _flags.isAccessibilityContainer = isAccessibilityContainer;
 }
 
 - (BOOL)isAccessibilityContainer
 {
   MutexLocker l(__instanceLock__);
-  return _isAccessibilityContainer;
+  return _flags.isAccessibilityContainer;
 }
 
 - (NSString *)defaultAccessibilityLabel

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -287,7 +287,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 {
   ASLockScopeSelf();
   if (ASCompareAssignCopy(_placeholderColor, placeholderColor)) {
-    _placeholderEnabled = (placeholderColor != nil);
+    _flags.placeholderEnabled = (placeholderColor != nil);
   }
 }
 

--- a/Source/Private/ASDisplayNode+FrameworkPrivate.h
+++ b/Source/Private/ASDisplayNode+FrameworkPrivate.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  cancelled below the point they are enabled.  They continue to the leaves of the hierarchy.
  */
 
-typedef NS_OPTIONS(NSUInteger, ASHierarchyState)
+typedef NS_OPTIONS(unsigned char, ASHierarchyState)
 {
   /** The node may or may not have a supernode, but no supernode has a special hierarchy-influencing option enabled. */
   ASHierarchyStateNormal                  = 0,
@@ -115,11 +115,6 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyStateChange(ASHierarc
 #undef HIERARCHY_STATE_DELTA
 
 @interface ASDisplayNode () <ASDescriptionProvider, ASDebugDescriptionProvider>
-{
-@protected
-  ASInterfaceState _interfaceState;
-  ASHierarchyState _hierarchyState;
-}
 
 // The view class to use when creating a new display node instance. Defaults to _ASDisplayView.
 + (Class)viewClass;

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -943,7 +943,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
   {
     _bridge_prologue_write;
 
-    _fallbackInsetsLayoutMarginsFromSafeArea = insetsLayoutMarginsFromSafeArea;
+    _flags.fallbackInsetsLayoutMarginsFromSafeArea = insetsLayoutMarginsFromSafeArea;
 
     if (AS_AVAILABLE_IOS(11.0)) {
       if (!_flags.layerBacked) {
@@ -1027,7 +1027,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
       return _getFromViewOnly(insetsLayoutMarginsFromSafeArea);
     }
   }
-  return _fallbackInsetsLayoutMarginsFromSafeArea;
+  return _flags.fallbackInsetsLayoutMarginsFromSafeArea;
 }
 
 @end
@@ -1056,13 +1056,13 @@ nodeProperty = nodeValueExpr; _setToViewOnly(viewAndPendingViewStateProperty, vi
 - (BOOL)isAccessibilityElement
 {
   _bridge_prologue_read;
-  return _getAccessibilityFromViewOrProperty(_isAccessibilityElement, isAccessibilityElement);
+  return _getAccessibilityFromViewOrProperty(_flags.isAccessibilityElement, isAccessibilityElement);
 }
 
 - (void)setIsAccessibilityElement:(BOOL)isAccessibilityElement
 {
   _bridge_prologue_write;
-  _setAccessibilityToViewAndProperty(_isAccessibilityElement, isAccessibilityElement, isAccessibilityElement, isAccessibilityElement);
+  _setAccessibilityToViewAndProperty(_flags.isAccessibilityElement, isAccessibilityElement, isAccessibilityElement, isAccessibilityElement);
 }
 
 - (NSString *)accessibilityLabel
@@ -1192,37 +1192,37 @@ nodeProperty = nodeValueExpr; _setToViewOnly(viewAndPendingViewStateProperty, vi
 - (BOOL)accessibilityElementsHidden
 {
   _bridge_prologue_read;
-  return _getAccessibilityFromViewOrProperty(_accessibilityElementsHidden, accessibilityElementsHidden);
+  return _getAccessibilityFromViewOrProperty(_flags.accessibilityElementsHidden, accessibilityElementsHidden);
 }
 
 - (void)setAccessibilityElementsHidden:(BOOL)accessibilityElementsHidden
 {
   _bridge_prologue_write;
-  _setAccessibilityToViewAndProperty(_accessibilityElementsHidden, accessibilityElementsHidden, accessibilityElementsHidden, accessibilityElementsHidden);
+  _setAccessibilityToViewAndProperty(_flags.accessibilityElementsHidden, accessibilityElementsHidden, accessibilityElementsHidden, accessibilityElementsHidden);
 }
 
 - (BOOL)accessibilityViewIsModal
 {
   _bridge_prologue_read;
-  return _getAccessibilityFromViewOrProperty(_accessibilityViewIsModal, accessibilityViewIsModal);
+  return _getAccessibilityFromViewOrProperty(_flags.accessibilityViewIsModal, accessibilityViewIsModal);
 }
 
 - (void)setAccessibilityViewIsModal:(BOOL)accessibilityViewIsModal
 {
   _bridge_prologue_write;
-  _setAccessibilityToViewAndProperty(_accessibilityViewIsModal, accessibilityViewIsModal, accessibilityViewIsModal, accessibilityViewIsModal);
+  _setAccessibilityToViewAndProperty(_flags.accessibilityViewIsModal, accessibilityViewIsModal, accessibilityViewIsModal, accessibilityViewIsModal);
 }
 
 - (BOOL)shouldGroupAccessibilityChildren
 {
   _bridge_prologue_read;
-  return _getAccessibilityFromViewOrProperty(_shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren);
+  return _getAccessibilityFromViewOrProperty(_flags.shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren);
 }
 
 - (void)setShouldGroupAccessibilityChildren:(BOOL)shouldGroupAccessibilityChildren
 {
   _bridge_prologue_write;
-  _setAccessibilityToViewAndProperty(_shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren);
+  _setAccessibilityToViewAndProperty(_flags.shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren);
 }
 
 - (NSString *)accessibilityIdentifier

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -221,7 +221,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
 
   // Placeholder support
   UIImage *_placeholderImage;
-  BOOL _placeholderEnabled;
   CALayer *_placeholderLayer;
   NSTimeInterval _placeholderFadeDuration;
 

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -15,6 +15,7 @@
 #import <atomic>
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
+#import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
 #import <AsyncDisplayKit/ASLayoutElement.h>
 #import <AsyncDisplayKit/ASLayoutTransition.h>
 #import <AsyncDisplayKit/ASThread.h>
@@ -35,7 +36,7 @@ BOOL ASDisplayNodeNeedsSpecialPropertiesHandling(BOOL isSynchronous, BOOL isLaye
 /// Get the pending view state for the node, creating one if needed.
 _ASPendingState * ASDisplayNodeGetPendingState(ASDisplayNode * node);
 
-typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
+typedef NS_OPTIONS(unsigned short, ASDisplayNodeMethodOverrides)
 {
   ASDisplayNodeMethodOverrideNone                   = 0,
   ASDisplayNodeMethodOverrideTouchesBegan           = 1 << 0,
@@ -84,9 +85,7 @@ static constexpr CACornerMask kASCACornerAllCorners =
   AS::RecursiveMutex __instanceLock__;
 
   _ASPendingState *_pendingViewState;
-  ASInterfaceState _pendingInterfaceState;
-  ASInterfaceState _preExitingInterfaceState;
-  
+
   UIView *_view;
   CALayer *_layer;
 
@@ -126,8 +125,34 @@ static constexpr CACornerMask kASCACornerAllCorners =
     unsigned isInHierarchy:1;
     unsigned visibilityNotificationsDisabled:VISIBILITY_NOTIFICATIONS_DISABLED_BITS;
     unsigned isDeallocating:1;
+
+#if YOGA
+      unsigned willApplyNextYogaCalculatedLayout:1;
+#endif
+      // Automatically manages subnodes
+      unsigned automaticallyManagesSubnodes:1; // Main thread only
+      unsigned placeholderEnabled:1;
+      // Accessibility support
+      unsigned isAccessibilityElement:1;
+      unsigned accessibilityElementsHidden:1;
+      unsigned accessibilityViewIsModal:1;
+      unsigned shouldGroupAccessibilityChildren:1;
+      unsigned isAccessibilityContainer:1;
+      unsigned fallbackInsetsLayoutMarginsFromSafeArea:1;
+      unsigned automaticallyRelayoutOnSafeAreaChanges:1;
+      unsigned automaticallyRelayoutOnLayoutMarginsChanges:1;
+      unsigned isViewControllerRoot:1;
+      unsigned hasHadInterfaceStateDelegates:1;
   } _flags;
-  
+
+  ASInterfaceState _interfaceState;
+  ASHierarchyState _hierarchyState;
+  ASInterfaceState _pendingInterfaceState;
+  ASInterfaceState _preExitingInterfaceState;
+  ASCornerRoundingType _cornerRoundingType;
+  ASDisplayNodePerformanceMeasurementOptions _measurementOptions;
+  ASDisplayNodeMethodOverrides _methodOverrides;
+
 @protected
   ASDisplayNode * __weak _supernode;
   NSMutableArray<ASDisplayNode *> *_subnodes;
@@ -142,7 +167,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
 
   // This is the desired contentsScale, not the scale at which the layer's contents should be displayed
   CGFloat _contentsScaleForDisplay;
-  ASDisplayNodeMethodOverrides _methodOverrides;
 
   UIEdgeInsets _hitTestSlop;
 
@@ -161,11 +185,7 @@ static constexpr CACornerMask kASCACornerAllCorners =
   NSMutableArray<ASDisplayNode *> *_yogaChildren;
   __weak ASDisplayNode *_yogaParent;
   ASLayout *_yogaCalculatedLayout;
-  BOOL _willApplyNextYogaCalculatedLayout;
 #endif
-
-  // Automatically manages subnodes
-  BOOL _automaticallyManagesSubnodes; // Main thread only
 
   // Layout Transition
   _ASTransitionContext *_pendingLayoutTransitionContext;
@@ -185,7 +205,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
 
 
   // Layout Spec performance measurement
-  ASDisplayNodePerformanceMeasurementOptions _measurementOptions;
   NSTimeInterval _layoutSpecTotalTime;
   NSInteger _layoutSpecNumberOfPasses;
   NSTimeInterval _layoutComputationTotalTime;
@@ -214,7 +233,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
 
   // Corner Radius support
   CGFloat _cornerRadius;
-  ASCornerRoundingType _cornerRoundingType;
   CALayer *_clipCornerLayers[NUM_CLIP_CORNER_LAYERS];
   CACornerMask _maskedCorners;
 
@@ -223,7 +241,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
 
 
   // Accessibility support
-  BOOL _isAccessibilityElement;
   NSString *_accessibilityLabel;
   NSAttributedString *_accessibilityAttributedLabel;
   NSString *_accessibilityHint;
@@ -233,28 +250,17 @@ static constexpr CACornerMask kASCACornerAllCorners =
   UIAccessibilityTraits _accessibilityTraits;
   CGRect _accessibilityFrame;
   NSString *_accessibilityLanguage;
-  BOOL _accessibilityElementsHidden;
-  BOOL _accessibilityViewIsModal;
-  BOOL _shouldGroupAccessibilityChildren;
   NSString *_accessibilityIdentifier;
   UIAccessibilityNavigationStyle _accessibilityNavigationStyle;
   NSArray *_accessibilityCustomActions;
   NSArray *_accessibilityHeaderElements;
   CGPoint _accessibilityActivationPoint;
   UIBezierPath *_accessibilityPath;
-  BOOL _isAccessibilityContainer;
 
 
   // Safe Area support
   // These properties are used on iOS 10 and lower, where safe area is not supported by UIKit.
   UIEdgeInsets _fallbackSafeAreaInsets;
-  BOOL _fallbackInsetsLayoutMarginsFromSafeArea;
-
-  BOOL _automaticallyRelayoutOnSafeAreaChanges;
-  BOOL _automaticallyRelayoutOnLayoutMarginsChanges;
-
-  BOOL _isViewControllerRoot;
-
 
 #pragma mark - ASDisplayNode (Debugging)
   ASLayout *_unflattenedLayout;
@@ -268,7 +274,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
 #endif
 
   /// Fast path: tells whether we've ever had an interface state delegate before.
-  BOOL _hasHadInterfaceStateDelegates;
   __weak id<ASInterfaceStateDelegate> _interfaceStateDelegates[AS_MAX_INTERFACE_STATE_DELEGATES];
 }
 


### PR DESCRIPTION
These objects accumulate in the heap, so reducing their size will allow more to accumulate before memory warnings.

Group the `BOOL`s into a struct. Shrink the various stored `enum`s to fit the size of their contents. Move the ivars around so that the smaller `enum` are near eachother and the bitfield struct.