### PR TITLE
Support setting `accessibilityElements`

### DIFF
--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -782,6 +782,12 @@ AS_EXTERN NSInteger const ASDefaultDrawingPriority;
 
 @end
 
+/**
+ * Accessibility elements modification block. Used to modify/override the elements returned by
+ * `accessibilityElements` for a node.
+ */
+typedef NSArray *_Nonnull(^ASDisplayNodeAccessibilityElementsBlock)(NSArray * _Nonnull);
+
 @interface ASDisplayNode (UIViewBridgeAccessibility)
 
 // Accessibility support
@@ -802,12 +808,16 @@ AS_EXTERN NSInteger const ASDefaultDrawingPriority;
 @property           BOOL shouldGroupAccessibilityChildren;
 @property           UIAccessibilityNavigationStyle accessibilityNavigationStyle;
 @property (nullable, copy)   NSArray *accessibilityCustomActions API_AVAILABLE(ios(8.0),tvos(9.0));
+
 #if TARGET_OS_TV
 @property (nullable, copy) 	NSArray *accessibilityHeaderElements;
 #endif
 
 // Accessibility identification support
 @property (nullable, copy)   NSString *accessibilityIdentifier;
+
+/// Block used for modifying/overriding the a11y elements returned by `accessibilityElements`.
+@property (nullable, copy)   ASDisplayNodeAccessibilityElementsBlock accessibilityElementsBlock;
 
 @end
 

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3515,7 +3515,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
 - (void)setAccessibilityElementsBlock:(ASDisplayNodeAccessibilityElementsBlock)accessibilityElementsBlock
 {
   MutexLocker l(__instanceLock__);
-  _accessibilityElementsBlock = accessibilityElementsBlock;
+  _accessibilityElementsBlock = [accessibilityElementsBlock copy];
 }
 
 - (ASDisplayNodeAccessibilityElementsBlock)accessibilityElementsBlock

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3512,6 +3512,18 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   return _flags.isAccessibilityContainer;
 }
 
+- (void)setAccessibilityElementsBlock:(ASDisplayNodeAccessibilityElementsBlock)accessibilityElementsBlock
+{
+  MutexLocker l(__instanceLock__);
+  _accessibilityElementsBlock = accessibilityElementsBlock;
+}
+
+- (ASDisplayNodeAccessibilityElementsBlock)accessibilityElementsBlock
+{
+  MutexLocker l(__instanceLock__);
+  return _accessibilityElementsBlock;
+}
+
 - (NSString *)defaultAccessibilityLabel
 {
   return nil;

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -287,6 +287,12 @@ static void CollectAccessibilityElementsForView(UIView *view, NSMutableArray *el
   NSMutableArray *accessibilityElements = [[NSMutableArray alloc] init];
   CollectAccessibilityElementsForView(self.view, accessibilityElements);
   SortAccessibilityElements(accessibilityElements);
+
+  if (_accessibilityElementsBlock) {
+    NSArray *accessibilityElementsCopy = [accessibilityElements copy];
+    accessibilityElements = _accessibilityElementsBlock(accessibilityElementsCopy);
+  }
+
   return accessibilityElements;
 }
 

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -252,6 +252,7 @@ static constexpr CACornerMask kASCACornerAllCorners =
   NSArray *_accessibilityHeaderElements;
   CGPoint _accessibilityActivationPoint;
   UIBezierPath *_accessibilityPath;
+  ASDisplayNodeAccessibilityElementsBlock _accessibilityElementsBlock;
 
 
   // Safe Area support

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -50,6 +50,40 @@
   XCTAssertEqual([node.view indexOfAccessibilityElement:node.view.accessibilityElements.firstObject], 0);*/
 }
 
+- (void)testAccessibilityElementsBlock
+{
+  // Setup nodes
+  ASDisplayNode *node = nil;
+  ASDisplayNode *innerNode1 = nil;
+  ASDisplayNode *innerNode2 = nil;
+  node = [[ASDisplayNode alloc] init];
+  innerNode1 = [[ASDisplayNode alloc] init];
+  innerNode2 = [[ASDisplayNode alloc] init];
+
+  innerNode1.accessibilityLabel = @"hello";
+  innerNode1.isAccessibilityElement = YES;
+  innerNode2.accessibilityLabel = @"world";
+  innerNode2.isAccessibilityElement = YES;
+
+  // Attach the subnodes to the parent node, then check that all the subnodes added are returned as accessibilityElements
+  [node addSubnode:innerNode1];
+  [node addSubnode:innerNode2];
+
+  XCTAssertTrue(node.view.accessibilityElements.count == 2);
+  XCTAssertEqualObjects([node.view.accessibilityElements[0] accessibilityLabel], [innerNode1 accessibilityLabel]);
+  XCTAssertEqualObjects([node.view.accessibilityElements[1] accessibilityLabel], [innerNode2 accessibilityLabel]);
+
+  // Override accessibilityElements, check that only the specified element is returned as accessibilityElements
+  node.accessibilityElementsBlock = ^NSArray * _Nonnull(NSArray *_Nonnull elements) {
+    return @[innerNode2];
+  };
+
+  XCTAssertTrue(node.view.accessibilityElements.count == 1);
+  XCTAssertEqualObjects([node.view.accessibilityElements.firstObject accessibilityLabel],
+                        [innerNode2 accessibilityLabel],
+                        @"Parent node accessibilityElements override broken");
+}
+
 - (void)testThatSubnodeAccessibilityLabelAggregationWorks
 {
   // Setup nodes


### PR DESCRIPTION
Sometimes we want to override `accessibilityElements` so that we can
skip over elements unnecessary for interacting with the app using VoiceOver
or limit the interaction to child viewcontrollers presented, etc.

For this purpose, this commit adds support for setting custom
`accessibilityElements`. If not set, `accessibilityElements` should still
return the elements found from the view/layer hierarchy.