### PR TITLE
Cut version 2.8.1 #changelog

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,3 +1,3 @@
 issues=false
-since-tag=2.8
+since-tag=2.8.1
 future-release=2.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [2.8.1](https://github.com/TextureGroup/Texture/tree/2.8) (2019-05-05)
+[Full Changelog](https://github.com/TextureGroup/Texture/compare/2.8...2.8.1)
+
+**Merged pull requests:**
+
+- Update for 9.4.1 CI [\#1392](https://github.com/TextureGroup/Texture/pull/1392) ([garrettmoon](https://github.com/garrettmoon))
+- Disable ASAssertLocked and ASAssertUnlocked [\#1412](https://github.com/TextureGroup/Texture/pull/1412) ([nguyenhuy](https://github.com/nguyenhuy))
+
 ## [2.8](https://github.com/TextureGroup/Texture/tree/2.8) (2019-02-12)
 [Full Changelog](https://github.com/TextureGroup/Texture/compare/2.7...2.8)
 

--- a/Texture.podspec
+++ b/Texture.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |spec|
   spec.name         = 'Texture'
-  spec.version      = '2.8'
+  spec.version      = '2.8.1'
   spec.license      =  { :type => 'Apache 2',  }
   spec.homepage     = 'http://texturegroup.org'
-  spec.authors      = { 'Huy Nguyen' => 'hi@huytnguyen.me', 'Garrett Moon' => 'garrett@excitedpixel.com', 'Scott Goodson' => 'scottgoodson@gmail.com', 'Michael Schneider' => 'mischneider1@gmail.com', 'Adlai Holler' => 'adlai@icloud.com' }
+  spec.authors      = { 'Huy Nguyen' => 'hi@huynguyen.dev', 'Garrett Moon' => 'garrett@excitedpixel.com', 'Scott Goodson' => 'scottgoodson@gmail.com', 'Michael Schneider' => 'mischneider1@gmail.com', 'Adlai Holler' => 'adlai@icloud.com' }
   spec.summary      = 'Smooth asynchronous user interfaces for iOS apps.'
   spec.source       = { :git => 'https://github.com/TextureGroup/Texture.git', :tag => spec.version.to_s }
   spec.module_name  = 'AsyncDisplayKit'


### PR DESCRIPTION
This diff updates `Texture.podspec`, `CHANGELOG.md` and `.github_changelog_generator` on master to match what went into `2.8.1` release. Note that this release is **not** based off master but the 2.8 release tag. See the [release branch](https://github.com/TextureGroup/Texture/tree/2.8.1) for details.