### PR TITLE
Shrink Button Node

### DIFF
--- a/Source/ASButtonNode+Private.h
+++ b/Source/ASButtonNode+Private.h
@@ -31,14 +31,15 @@
   UIImage *_disabledBackgroundImage;
   
   CGFloat _contentSpacing;
-  BOOL  _laysOutHorizontally;
-  ASVerticalAlignment _contentVerticalAlignment;
-  ASHorizontalAlignment _contentHorizontalAlignment;
   UIEdgeInsets _contentEdgeInsets;
-  ASButtonNodeImageAlignment _imageAlignment;
   ASTextNode *_titleNode;
   ASImageNode *_imageNode;
   ASImageNode *_backgroundImageNode;
+
+  BOOL  _laysOutHorizontally;
+  ASVerticalAlignment _contentVerticalAlignment;
+  ASHorizontalAlignment _contentHorizontalAlignment;
+  ASButtonNodeImageAlignment _imageAlignment;
 }
 
 @end

--- a/Source/ASButtonNode.h
+++ b/Source/ASButtonNode.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Image alignment defines where the image will be placed relative to the text.
  */
-typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
+typedef NS_ENUM(unsigned char, ASButtonNodeImageAlignment) {
   /** Places the image before the text. */
   ASButtonNodeImageAlignmentBeginning,
   /** Places the image after the text. */

--- a/Source/Layout/ASStackLayoutDefines.h
+++ b/Source/Layout/ASStackLayoutDefines.h
@@ -108,7 +108,7 @@ typedef NS_ENUM(NSUInteger, ASStackLayoutAlignContent) {
 };
 
 /** Orientation of children along horizontal axis */
-typedef NS_ENUM(NSUInteger, ASHorizontalAlignment) {
+typedef NS_ENUM(unsigned char, ASHorizontalAlignment) {
   /** No alignment specified. Default value */
   ASHorizontalAlignmentNone,
   /** Left aligned */
@@ -128,7 +128,7 @@ typedef NS_ENUM(NSUInteger, ASHorizontalAlignment) {
 };
 
 /** Orientation of children along vertical axis */
-typedef NS_ENUM(NSUInteger, ASVerticalAlignment) {
+typedef NS_ENUM(unsigned char, ASVerticalAlignment) {
   /** No alignment specified. Default value */
   ASVerticalAlignmentNone,
   /** Top aligned */


### PR DESCRIPTION
Button: 1312 to 1288 bytes, running on iPhone SE simulator. 1.9% reduction.

Shrink the enums it stores, and place them next to each other (along with a BOOL) to reduce instance size.