### PR TITLE
Shrink TextNode(2)

### DIFF
--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -208,11 +208,13 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
 
   NSString *_highlightedLinkAttributeName;
   id _highlightedLinkAttributeValue;
-  ASTextNodeHighlightStyle _highlightStyle;
   NSRange _highlightRange;
   ASHighlightOverlayLayer *_activeHighlightLayer;
 
   UILongPressGestureRecognizer *_longPressGestureRecognizer;
+  ASTextNodeHighlightStyle _highlightStyle;
+  BOOL _longPressCancelsTouches;
+  BOOL _passthroughNonlinkTouches;
 }
 @dynamic placeholderEnabled;
 
@@ -263,6 +265,11 @@ static NSArray *DefaultLinkAttributeNames() {
 - (void)dealloc
 {
   CGColorRelease(_shadowColor);
+}
+
+- (BOOL)usingExperiment
+{
+    return NO;
 }
 
 #pragma mark - Description

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -170,12 +170,14 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
   
   NSString *_highlightedLinkAttributeName;
   id _highlightedLinkAttributeValue;
-  ASTextNodeHighlightStyle _highlightStyle;
   NSRange _highlightRange;
   ASHighlightOverlayLayer *_activeHighlightLayer;
   UIColor *_placeholderColor;
   
   UILongPressGestureRecognizer *_longPressGestureRecognizer;
+  ASTextNodeHighlightStyle _highlightStyle;
+  BOOL _longPressCancelsTouches;
+  BOOL _passthroughNonlinkTouches;
 }
 @dynamic placeholderEnabled;
 

--- a/Source/ASTextNodeCommon.h
+++ b/Source/ASTextNodeCommon.h
@@ -22,7 +22,7 @@
 /**
  * Highlight styles.
  */
-typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
+typedef NS_ENUM(unsigned char, ASTextNodeHighlightStyle) {
   /**
    * Highlight style for text on a light background.
    */


### PR DESCRIPTION
Running in iPhone SE Simulator:
- ASTextNode: 1360 to 1352 bytes .6% reduction
- ASTextNode2: 1360 to 1304 bytes 4.3% reduction

Shrink stored enum sizes. Group BOOLs near these smaller enums. Override -usingExperiment to return constant instead of never set, but allocated ivar.