### PR TITLE
Shrink Pager and Scroll Node

### DIFF
--- a/Source/ASPagerNode.mm
+++ b/Source/ASPagerNode.mm
@@ -29,6 +29,7 @@
     unsigned nodeBlockAtIndex:1;
     unsigned nodeAtIndex:1;
   } _pagerDataSourceFlags;
+    BOOL _allowsAutomaticInsetsAdjustment;
 
   __weak id <ASPagerDelegate> _pagerDelegate;
   ASPagerNodeProxy *_proxyDelegate;

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -13,6 +13,7 @@
 #import <AsyncDisplayKit/ASAssert.h>
 #import <AsyncDisplayKit/ASCellNode+Internal.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>
+#import <AsyncDisplayKit/ASCollectionView.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h> // Required for interfaceState and hierarchyState setter methods.
 #import <AsyncDisplayKit/ASElementMap.h>
@@ -413,10 +414,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   if (ASDisplayNode.shouldShowRangeDebugOverlay) {
     ASScrollDirection scrollableDirections = ASScrollDirectionUp | ASScrollDirectionDown;
     if ([_dataSource isKindOfClass:NSClassFromString(@"ASCollectionView")]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
-      scrollableDirections = (ASScrollDirection)[_dataSource performSelector:@selector(scrollableDirections)];
-#pragma clang diagnostic pop
+        scrollableDirections = ((ASCollectionView *)_dataSource).scrollableDirections;
     }
     
     [self updateRangeController:self

--- a/Source/Details/ASScrollDirection.h
+++ b/Source/Details/ASScrollDirection.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_OPTIONS(NSInteger, ASScrollDirection) {
+typedef NS_OPTIONS(unsigned char, ASScrollDirection) {
   ASScrollDirectionNone  = 0,
   ASScrollDirectionRight = 1 << 0,
   ASScrollDirectionLeft  = 1 << 1,


### PR DESCRIPTION
Running on iPhone SE Simulator:
ASPagerNode 1240 to 1232 bytes .7% reduction
ASScrollNode 1104 to 1096 bytes .7% reduction

- make ASScrollNode smaller by shrinking ASScrollDirection, which requires a change to ASRangeController
- shrink ASPagerNode by declaring the BOOL next to the struct