### PR TITLE
Keep the atomics - does not affect memory reduction work

### DIFF
--- a/Source/ASControlNode.h
+++ b/Source/ASControlNode.h
@@ -11,9 +11,6 @@
 
 #pragma once
 
-#pragma clang diagnostic push
-#pragma clang diagnostic error "-Wobjc-missing-property-synthesis"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -150,5 +147,3 @@ static UIControlState const ASControlStateSelected ASDISPLAYNODE_DEPRECATED_MSG(
 #endif
 
 NS_ASSUME_NONNULL_END
-
-#pragma clang diagnostic pop

--- a/Source/ASControlNode.mm
+++ b/Source/ASControlNode.mm
@@ -33,7 +33,6 @@
   // Control Attributes
   BOOL _enabled;
   BOOL _highlighted;
-  BOOL _selected;
 
   // Tracking
   BOOL _tracking;
@@ -120,68 +119,6 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
   if (self.tracking) {
     [self _cancelTrackingWithEvent:nil];
   }
-}
-
-#pragma mark - ASDisplayNode Overrides
-
-- (BOOL)isEnabled
-{
-  ASLockScopeSelf();
-  return _enabled;
-}
-
-- (void)setEnabled:(BOOL)enabled
-{
-  ASLockScopeSelf();
-  _enabled = enabled;
-}
-
-- (BOOL)isHighlighted
-{
-  ASLockScopeSelf();
-  return _highlighted;
-}
-
-- (void)setHighlighted:(BOOL)highlighted
-{
-  ASLockScopeSelf();
-  _highlighted = highlighted;
-}
-
-- (void)setSelected:(BOOL)selected
-{
-  ASLockScopeSelf();
-  _selected = selected;
-}
-
-- (BOOL)isSelected
-{
-  ASLockScopeSelf();
-  return _selected;
-}
-
-- (void)setTracking:(BOOL)tracking
-{
-  ASLockScopeSelf();
-  _tracking = tracking;
-}
-
-- (BOOL)isTracking
-{
-  ASLockScopeSelf();
-  return _tracking;
-}
-
-- (void)setTouchInside:(BOOL)touchInside
-{
-  ASLockScopeSelf();
-  _touchInside = touchInside;
-}
-
-- (BOOL)isTouchInside
-{
-  ASLockScopeSelf();
-  return _touchInside;
 }
 
 #pragma clang diagnostic push

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -20,9 +20,6 @@
 #import <AsyncDisplayKit/ASLayoutElement.h>
 #import <AsyncDisplayKit/ASLocking.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic error "-Wobjc-missing-property-synthesis"
-
 NS_ASSUME_NONNULL_BEGIN
 
 #define ASDisplayNodeLoggingEnabled 0
@@ -990,5 +987,3 @@ typedef NS_ENUM(NSInteger, ASLayoutEngineType) {
 @end
 
 NS_ASSUME_NONNULL_END
-
-#pragma clang diagnostic pop

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -2634,42 +2634,6 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   return NO;
 }
 
-- (BOOL)placeholderEnabled
-{
-  MutexLocker l(__instanceLock__);
-  return _flags.placeholderEnabled;
-}
-
-- (void)setPlaceholderEnabled:(BOOL)placeholderEnabled
-{
-  MutexLocker l(__instanceLock__);
-  _flags.placeholderEnabled = placeholderEnabled;
-}
-
-- (NSTimeInterval)placeholderFadeDuration
-{
-  MutexLocker l(__instanceLock__);
-  return _placeholderFadeDuration;
-}
-
-- (void)setPlaceholderFadeDuration:(NSTimeInterval)placeholderFadeDuration
-{
-  MutexLocker l(__instanceLock__);
-  _placeholderFadeDuration = placeholderFadeDuration;
-}
-
-- (NSInteger)drawingPriority
-{
-  MutexLocker l(__instanceLock__);
-  return _drawingPriority;
-}
-
-- (void)setDrawingPriority:(NSInteger)drawingPriority
-{
-  MutexLocker l(__instanceLock__);
-  _drawingPriority = drawingPriority;
-}
-
 #pragma mark - Hierarchy State
 
 - (BOOL)isInHierarchy

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -222,9 +222,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
   // Placeholder support
   UIImage *_placeholderImage;
   CALayer *_placeholderLayer;
-  NSTimeInterval _placeholderFadeDuration;
-
-  NSInteger _drawingPriority;
 
   // keeps track of nodes/subnodes that have not finished display, used with placeholders
   ASWeakSet *_pendingDisplayNodes;


### PR DESCRIPTION
Revert "Ensure ASControlMode properties lock before accessing their ivars (#1476)"
This reverts commit ce1e1956f402a7b762119b0f5fa8df4fccd927e6.

Revert "Make sure all ASDisplayNode properties have backing ivars for consistency. (#1475)"
This reverts commit d6061f4390f64d0faff1b3432084362f8f9e147d.
- Except the unused property `interfaceStateSuspended` is still removed (this is a memory saver).