### PR TITLE
ASSignpost: Add support for the os_signpost API, fixes

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1110,12 +1110,12 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   as_activity_scope_verbose(as_activity_create("Calculate node layout", AS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT));
   as_log_verbose(ASLayoutLog(), "Calculating layout for %@ sizeRange %@", self, NSStringFromASSizeRange(constrainedSize));
 
-#if AS_KDEBUG_ENABLE
+#if AS_SIGNPOST_ENABLE
   // We only want one calculateLayout signpost interval per thread.
   // Currently there is no fallback for profiling i386, since it's not useful.
   static _Thread_local NSInteger tls_callDepth;
   if (tls_callDepth++ == 0) {
-    ASSignpostStart(ASSignpostCalculateLayout);
+    ASSignpostStart(CalculateLayout, self, "%@", ASObjectDescriptionMakeTiny(self));
   }
 #endif
 
@@ -1124,9 +1124,9 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   ASLayout *result = [self calculateLayoutThatFits:resolvedRange];
   as_log_verbose(ASLayoutLog(), "Calculated layout %@", result);
 
-#if AS_KDEBUG_ENABLE
+#if AS_SIGNPOST_ENABLE
   if (--tls_callDepth == 0) {
-    ASSignpostEnd(ASSignpostCalculateLayout);
+    ASSignpostEnd(CalculateLayout, self, "");
   }
 #endif
   

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -215,7 +215,7 @@ static void runLoopSourceCallback(void *info) {
       return;
     }
 
-    ASSignpostStart(ASSignpostRunLoopQueueBatch);
+    ASSignpostStart(RunLoopQueueBatch, self, "%s", object_getClassName(self));
 
     // Snatch the next batch of items.
     NSInteger maxCountToProcess = MIN(internalQueueCount, self.batchSize);
@@ -278,7 +278,7 @@ static void runLoopSourceCallback(void *info) {
     CFRunLoopWakeUp(_runLoop);
   }
   
-  ASSignpostEnd(ASSignpostRunLoopQueueBatch);
+  ASSignpostEnd(RunLoopQueueBatch, self, "count: %d", (int)count);
 }
 
 - (void)enqueue:(id)object
@@ -440,7 +440,7 @@ dispatch_once_t _ASSharedCATransactionQueueOnceToken;
     return;
   }
   as_activity_scope_verbose(as_activity_create("Process run loop queue batch", _rootActivity, OS_ACTIVITY_FLAG_DEFAULT));
-  ASSignpostStart(ASSignpostRunLoopQueueBatch);
+  ASSignpostStart(RunLoopQueueBatch, self, "CATransactionQueue");
   
   // Swap buffers, clear our hash table.
   _internalQueue.swap(_batchBuffer);
@@ -455,7 +455,7 @@ dispatch_once_t _ASSharedCATransactionQueueOnceToken;
   }
   _batchBuffer.clear();
   as_log_verbose(ASDisplayLog(), "processed %lu items", (unsigned long)count);
-  ASSignpostEnd(ASSignpostRunLoopQueueBatch);
+  ASSignpostEnd(RunLoopQueueBatch, self, "count: %d", (int)count);
 }
 
 - (void)enqueue:(id<ASCATransactionQueueObserving>)object

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -123,6 +123,8 @@
 
 #define ASOVERLOADABLE __attribute__((overloadable))
 
+/// Xcode >= 10.
+#define AS_HAS_OS_SIGNPOST __has_include(<os/signpost.h>)
 
 #if __has_attribute(noescape)
 #define AS_NOESCAPE __attribute__((noescape))

--- a/Source/Base/ASLog.h
+++ b/Source/Base/ASLog.h
@@ -69,8 +69,10 @@ AS_EXTERN os_log_t ASMainThreadDeallocationLog(void);
 #define ASLockingLogEnabled 0
 AS_EXTERN os_log_t ASLockingLog(void);
 
+#if AS_HAS_OS_SIGNPOST
 /// Uses the special POI category for Instruments. Used by ASSignpost.h.
 AS_EXTERN os_log_t ASPointsOfInterestLog(void);
+#endif
 
 /**
  * The activity tracing system changed a lot between iOS 9 and 10.

--- a/Source/Base/ASLog.h
+++ b/Source/Base/ASLog.h
@@ -69,6 +69,9 @@ AS_EXTERN os_log_t ASMainThreadDeallocationLog(void);
 #define ASLockingLogEnabled 0
 AS_EXTERN os_log_t ASLockingLog(void);
 
+/// Uses the special POI category for Instruments. Used by ASSignpost.h.
+AS_EXTERN os_log_t ASPointsOfInterestLog(void);
+
 /**
  * The activity tracing system changed a lot between iOS 9 and 10.
  * In iOS 10, the system was merged with logging and became much more powerful

--- a/Source/Base/ASLog.mm
+++ b/Source/Base/ASLog.mm
@@ -8,7 +8,9 @@
 
 #import <AsyncDisplayKit/ASLog.h>
 #import <stdatomic.h>
+#if AS_HAS_OS_SIGNPOST
 #import <os/signpost.h>
+#endif
 
 static atomic_bool __ASLogEnabled = ATOMIC_VAR_INIT(YES);
 
@@ -52,6 +54,8 @@ os_log_t ASLockingLog() {
   return (ASLockingLogEnabled && ASLoggingIsEnabled()) ? ASCreateOnce(os_log_create("org.TextureGroup.Texture", "Locking")) : OS_LOG_DISABLED;
 }
 
+#if AS_HAS_OS_SIGNPOST
 os_log_t ASPointsOfInterestLog() {
   return ASCreateOnce(os_log_create("org.TextureGroup.Texture", OS_LOG_CATEGORY_POINTS_OF_INTEREST));
 }
+#endif

--- a/Source/Base/ASLog.mm
+++ b/Source/Base/ASLog.mm
@@ -8,6 +8,7 @@
 
 #import <AsyncDisplayKit/ASLog.h>
 #import <stdatomic.h>
+#import <os/signpost.h>
 
 static atomic_bool __ASLogEnabled = ATOMIC_VAR_INIT(YES);
 
@@ -49,4 +50,8 @@ os_log_t ASMainThreadDeallocationLog() {
 
 os_log_t ASLockingLog() {
   return (ASLockingLogEnabled && ASLoggingIsEnabled()) ? ASCreateOnce(os_log_create("org.TextureGroup.Texture", "Locking")) : OS_LOG_DISABLED;
+}
+
+os_log_t ASPointsOfInterestLog() {
+  return ASCreateOnce(os_log_create("org.TextureGroup.Texture", OS_LOG_CATEGORY_POINTS_OF_INTEREST));
 }

--- a/Source/Base/ASSignpost.h
+++ b/Source/Base/ASSignpost.h
@@ -22,7 +22,7 @@ typedef NS_ENUM(uint32_t, ASSignpostName) {
   
   // Misc
   ASSignpostDeallocQueueDrain = 375,      // One chunk of dealloc queue work. arg0 is count.
-  ASSignpostStatusBarOrientationChange,   // From WillChangeStatusBarOrientation to animation end.
+  ASSignpostOrientationChange,            // From WillChangeStatusBarOrientation to animation end.
 };
 
 #if defined(PROFILE) && __has_include(<sys/kdebug_signpost.h>)

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -147,7 +147,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
     return;
   }
 
-  ASSignpostStart(ASSignpostDataControllerBatch);
+  ASSignpostStart(DataControllerBatch, self, "%@", ASObjectDescriptionMakeTiny(weakDataSource));
 
   {
     as_activity_create_for_scope("Data controller batch");
@@ -179,7 +179,7 @@ typedef void (^ASDataControllerSynchronizationBlock)();
     });
   }
 
-  ASSignpostEndCustom(ASSignpostDataControllerBatch, self, 0, (weakDataSource != nil ? ASSignpostColorDefault : ASSignpostColorRed));
+  ASSignpostEnd(DataControllerBatch, self, "count: %lu", (unsigned long)nodeCount);
 }
 
 /**

--- a/Source/Details/ASObjectDescriptionHelpers.mm
+++ b/Source/Details/ASObjectDescriptionHelpers.mm
@@ -85,7 +85,10 @@ NSString *ASObjectDescriptionMake(__autoreleasing id object, NSArray<NSDictionar
 }
 
 NSString *ASObjectDescriptionMakeTiny(__autoreleasing id object) {
-  return ASObjectDescriptionMake(object, nil);
+  static constexpr int kBufSize = 64;
+  char buf[kBufSize];
+  int len = snprintf(buf, kBufSize, "<%s: %p>", object_getClassName(object), object);
+  return (__bridge_transfer NSString *)CFStringCreateWithBytes(NULL, (const UInt8 *)buf, len, kCFStringEncodingASCII, false);
 }
 
 NSString *ASStringWithQuotesIfMultiword(NSString *string) {

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -225,7 +225,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   auto visibleElements = [_dataSource visibleElementsForRangeController:self];
   NSHashTable *newVisibleNodes = [NSHashTable hashTableWithOptions:NSHashTableObjectPointerPersonality];
 
-  ASSignpostStart(ASSignpostRangeControllerUpdate);
+  ASSignpostStart(RangeControllerUpdate, _dataSource, "%@", ASObjectDescriptionMakeTiny(_dataSource));
 
   // Get the scroll direction. Default to using the previous one, if they're not scrolling.
   ASScrollDirection scrollDirection = [_dataSource scrollDirectionForRangeController:self];
@@ -243,6 +243,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
       [newVisibleNodes addObject:element.node];
     }
     [self _setVisibleNodes:newVisibleNodes];
+    ASSignpostEnd(RangeControllerUpdate, _dataSource, "");
     return; // don't do anything for this update, but leave _rangeIsValid == NO to make sure we update it later
   }
 
@@ -424,7 +425,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   NSLog(@"Range update complete; modifiedIndexPaths: %@, rangeMode: %d", [self descriptionWithIndexPaths:modifiedIndexPaths], rangeMode);
 #endif
   
-  ASSignpostEnd(ASSignpostRangeControllerUpdate);
+  ASSignpostEnd(RangeControllerUpdate, _dataSource, "");
 }
 
 #pragma mark - Notification observers

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -262,7 +262,7 @@ using AS::MutexLocker;
    If we're profiling, wrap the display block with signpost start and end.
    Color the interval red if cancelled, green otherwise.
    */
-#if AS_KDEBUG_ENABLE
+#if AS_SIGNPOST_ENABLE
   __unsafe_unretained id ptrSelf = (id)self;
   displayBlock = ^{
     ASSignpostStart(LayerDisplay, ptrSelf, "%@", ASObjectDescriptionMakeTiny(ptrSelf));

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -263,11 +263,11 @@ using AS::MutexLocker;
    Color the interval red if cancelled, green otherwise.
    */
 #if AS_KDEBUG_ENABLE
-  __unsafe_unretained id ptrSelf = self;
+  __unsafe_unretained id ptrSelf = (id)self;
   displayBlock = ^{
-    ASSignpostStartCustom(ASSignpostLayerDisplay, ptrSelf, 0);
+    ASSignpostStart(LayerDisplay, ptrSelf, "%@", ASObjectDescriptionMakeTiny(ptrSelf));
     id result = displayBlock();
-    ASSignpostEndCustom(ASSignpostLayerDisplay, ptrSelf, 0, isCancelledBlock() ? ASSignpostColorRed : ASSignpostColorGreen);
+    ASSignpostEnd(LayerDisplay, ptrSelf, "(%d %d), canceled: %d", (int)bounds.size.width, (int)bounds.size.height, (int)isCancelledBlock());
     return result;
   };
 #endif

--- a/Source/Private/ASInternalHelpers.mm
+++ b/Source/Private/ASInternalHelpers.mm
@@ -44,7 +44,7 @@ BOOL ASDefaultAllowsEdgeAntialiasing()
   return edgeAntialiasing;
 }
 
-#if AS_KDEBUG_ENABLE
+#if AS_SIGNPOST_ENABLE
 void _ASInitializeSignpostObservers(void)
 {
 #if !TARGET_OS_TV
@@ -80,7 +80,7 @@ void ASInitializeFrameworkMainThread(void)
       allowsEdgeAntialiasingFromUIKitOrNil = @(layer.allowsEdgeAntialiasing);
     }
     ASNotifyInitialized();
-#if AS_KDEBUG_ENABLE
+#if AS_SIGNPOST_ENABLE
     _ASInitializeSignpostObservers();
 #endif
   });

--- a/Source/Private/ASInternalHelpers.mm
+++ b/Source/Private/ASInternalHelpers.mm
@@ -47,8 +47,8 @@ BOOL ASDefaultAllowsEdgeAntialiasing()
 #if AS_SIGNPOST_ENABLE
 void _ASInitializeSignpostObservers(void)
 {
+  // Orientation changes. Unavailable on tvOS.
 #if !TARGET_OS_TV
-  // Orientation changes.
   [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationWillChangeStatusBarOrientationNotification object:nil queue:nil usingBlock:^(NSNotification *note) {
     UIInterfaceOrientation orientation = (UIInterfaceOrientation)[note.userInfo[UIApplicationStatusBarOrientationUserInfoKey] integerValue];
     ASSignpostStart(OrientationChange, (id)nil, "from %s", UIInterfaceOrientationIsPortrait(orientation) ? "portrait" : "landscape");
@@ -62,9 +62,9 @@ void _ASInitializeSignpostObservers(void)
     }];
     [CATransaction commit];
   }];
-#endif
+#endif  // TARGET_OS_TV
 }
-#endif
+#endif  // AS_SIGNPOST_ENABLE
 
 void ASInitializeFrameworkMainThread(void)
 {

--- a/Source/Private/ASInternalHelpers.mm
+++ b/Source/Private/ASInternalHelpers.mm
@@ -51,14 +51,14 @@ void _ASInitializeSignpostObservers(void)
   // Orientation changes.
   [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationWillChangeStatusBarOrientationNotification object:nil queue:nil usingBlock:^(NSNotification *note) {
     UIInterfaceOrientation orientation = (UIInterfaceOrientation)[note.userInfo[UIApplicationStatusBarOrientationUserInfoKey] integerValue];
-    ASSignpostStart(StatusBarOrientationChange, (id)nil, "from %s", UIInterfaceOrientationIsPortrait(orientation) ? "portrait" : "landscape");
+    ASSignpostStart(OrientationChange, (id)nil, "from %s", UIInterfaceOrientationIsPortrait(orientation) ? "portrait" : "landscape");
     [CATransaction begin];
   }];
   [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidChangeStatusBarOrientationNotification object:nil queue:nil usingBlock:^(NSNotification *note) {
     // When profiling, go ahead and commit the transaction early so that it happens as part of our interval.
     UIInterfaceOrientation orientation = (UIInterfaceOrientation)[note.userInfo[UIApplicationStatusBarOrientationUserInfoKey] integerValue];
     [CATransaction setCompletionBlock:^{
-      ASSignpostEnd(StatusBarOrientationChange, (id)nil, "to %s", UIInterfaceOrientationIsPortrait(orientation) ? "portrait" : "landscape");
+      ASSignpostEnd(OrientationChange, (id)nil, "to %s", UIInterfaceOrientationIsPortrait(orientation) ? "portrait" : "landscape");
     }];
     [CATransaction commit];
   }];


### PR DESCRIPTION
- Removes support for colored intervals. These weren't really useful and they aren't part of the signpost api.
- Fixes warnings when building for profiling.
- Fixes an issue with range controller interval logging.
- Adds an interval for interface orientation changes.
- Removes some enum values that aren't used.
- Still has no impact when not profiling.

### Before
<img width="1396" alt="Screen Shot 2019-05-07 at 4 36 57 PM" src="https://user-images.githubusercontent.com/2466893/57339459-82c13580-70e6-11e9-95e8-e05bb45a4771.png">
### After
<img width="1396" alt="Screen Shot 2019-05-07 at 4 36 44 PM" src="https://user-images.githubusercontent.com/2466893/57339473-8b197080-70e6-11e9-9b40-90fb3890ae65.png">

Tested on iOS 10 and iOS 12.