### PR TITLE
Shrink LayoutSpec classes

### DIFF
--- a/Source/Layout/ASStackLayoutDefines.h
+++ b/Source/Layout/ASStackLayoutDefines.h
@@ -10,7 +10,7 @@
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
 /** The direction children are stacked in */
-typedef NS_ENUM(NSUInteger, ASStackLayoutDirection) {
+typedef NS_ENUM(unsigned char, ASStackLayoutDirection) {
   /** Children are stacked vertically */
   ASStackLayoutDirectionVertical,
   /** Children are stacked horizontally */
@@ -24,7 +24,7 @@ typedef NS_ENUM(NSUInteger, ASStackLayoutDirection) {
 };
 
 /** If no children are flexible, how should this spec justify its children in the available space? */
-typedef NS_ENUM(NSUInteger, ASStackLayoutJustifyContent) {
+typedef NS_ENUM(unsigned char, ASStackLayoutJustifyContent) {
   /**
    On overflow, children overflow out of this spec's bounds on the right/bottom side.
    On underflow, children are left/top-aligned within this spec's bounds.
@@ -58,7 +58,7 @@ typedef NS_ENUM(NSUInteger, ASStackLayoutJustifyContent) {
 };
 
 /** Orientation of children along cross axis */
-typedef NS_ENUM(NSUInteger, ASStackLayoutAlignItems) {
+typedef NS_ENUM(unsigned char, ASStackLayoutAlignItems) {
   /** Align children to start of cross axis */
   ASStackLayoutAlignItemsStart,
   /** Align children with end of cross axis */
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSUInteger, ASStackLayoutAlignItems) {
  Each child may override their parent stack's cross axis alignment.
  @see ASStackLayoutAlignItems
  */
-typedef NS_ENUM(NSUInteger, ASStackLayoutAlignSelf) {
+typedef NS_ENUM(unsigned char, ASStackLayoutAlignSelf) {
   /** Inherit alignment value from containing stack. */
   ASStackLayoutAlignSelfAuto,
   /** Align to start of cross axis */
@@ -92,13 +92,13 @@ typedef NS_ENUM(NSUInteger, ASStackLayoutAlignSelf) {
 };
 
 /** Whether children are stacked into a single or multiple lines. */
-typedef NS_ENUM(NSUInteger, ASStackLayoutFlexWrap) {
+typedef NS_ENUM(unsigned char, ASStackLayoutFlexWrap) {
   ASStackLayoutFlexWrapNoWrap,
   ASStackLayoutFlexWrapWrap,
 };
 
 /** Orientation of lines along cross axis if there are multiple lines. */
-typedef NS_ENUM(NSUInteger, ASStackLayoutAlignContent) {
+typedef NS_ENUM(unsigned char, ASStackLayoutAlignContent) {
   ASStackLayoutAlignContentStart,
   ASStackLayoutAlignContentCenter,
   ASStackLayoutAlignContentEnd,


### PR DESCRIPTION
- Resize enums to make `ASStackLayoutSpec` 40 bytes smaller. This applies to the subclasses too.