### PR TITLE
Shrink ASLayout

### DIFF
--- a/Source/Layout/ASLayoutElement.h
+++ b/Source/Layout/ASLayoutElement.h
@@ -31,7 +31,7 @@ AS_EXTERN CGFloat const ASLayoutElementParentDimensionUndefined;
 AS_EXTERN CGSize const ASLayoutElementParentSizeUndefined;
 
 /** Type of ASLayoutElement  */
-typedef NS_ENUM(NSUInteger, ASLayoutElementType) {
+typedef NS_ENUM(unsigned char, ASLayoutElementType) {
   ASLayoutElementTypeLayoutSpec,
   ASLayoutElementTypeDisplayNode
 };


### PR DESCRIPTION
- Shrink the enum. Save 8 bytes. There are 1000s of these in the heap after running Pinterest for 10 minutes.