### PR TITLE
Discard _pendingDisplayNodes after subtree is rendered

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1387,6 +1387,8 @@ NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp = @"AS
   [_pendingDisplayNodes removeObject:node];
 
   if (_pendingDisplayNodes.isEmpty) {
+    // Reclaim object memory.
+    _pendingDisplayNodes = nil;
     
     [self hierarchyDisplayDidFinish];
     [self enumerateInterfaceStateDelegates:^(id<ASInterfaceStateDelegate> delegate) {


### PR DESCRIPTION
There's a lot more we could do to optimize this, but at least this makes the memory growth curve less steep. @bolsinga 💕 

### Before (note NSHashTables)
<img width="1136" alt="Screen Shot 2019-05-10 at 11 28 25 AM" src="https://user-images.githubusercontent.com/2466893/57548852-dc0fab80-7316-11e9-94c9-1bcb17082843.png">

### After

<img width="1136" alt="Screen Shot 2019-05-10 at 11 28 23 AM" src="https://user-images.githubusercontent.com/2466893/57548870-e631aa00-7316-11e9-9005-baa17ecfe2c2.png">
