### PR TITLE
Reclaim CALayer asyncTransactions, use pointer-based NSMutableSet instead

### DIFF
--- a/Source/Details/Transactions/_ASAsyncTransactionContainer+Private.h
+++ b/Source/Details/Transactions/_ASAsyncTransactionContainer+Private.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class _ASAsyncTransaction;
 
 @interface CALayer (ASAsyncTransactionContainerTransactions)
-@property (nonatomic, nullable, setter=asyncdisplaykit_setAsyncLayerTransactions:) NSHashTable<_ASAsyncTransaction *> *asyncdisplaykit_asyncLayerTransactions;
+@property (nonatomic, nullable, setter=asyncdisplaykit_setAsyncLayerTransactions:) NSMutableSet<_ASAsyncTransaction *> *asyncdisplaykit_asyncLayerTransactions;
 
 - (void)asyncdisplaykit_asyncTransactionContainerWillBeginTransaction:(_ASAsyncTransaction *)transaction;
 - (void)asyncdisplaykit_asyncTransactionContainerDidCompleteTransaction:(_ASAsyncTransaction *)transaction;

--- a/Source/Details/Transactions/_ASAsyncTransactionContainer.mm
+++ b/Source/Details/Transactions/_ASAsyncTransactionContainer.mm
@@ -11,6 +11,7 @@
 #import <AsyncDisplayKit/_ASAsyncTransactionContainer+Private.h>
 
 #import <AsyncDisplayKit/ASConfigurationInternal.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/_ASAsyncTransaction.h>
 #import <AsyncDisplayKit/_ASAsyncTransactionGroup.h>
 
@@ -49,9 +50,9 @@
 {
   _ASAsyncTransaction *transaction = self.asyncdisplaykit_currentAsyncTransaction;
   if (transaction == nil) {
-    NSHashTable *transactions = self.asyncdisplaykit_asyncLayerTransactions;
+    NSMutableSet<_ASAsyncTransaction *> *transactions = self.asyncdisplaykit_asyncLayerTransactions;
     if (transactions == nil) {
-      transactions = [NSHashTable hashTableWithOptions:NSHashTableObjectPointerPersonality];
+      transactions = ASCreatePointerBasedMutableSet();
       self.asyncdisplaykit_asyncLayerTransactions = transactions;
     }
     __weak CALayer *weakSelf = self;
@@ -62,6 +63,10 @@
           return;
         }
         [self.asyncdisplaykit_asyncLayerTransactions removeObject:completedTransaction];
+        if (self.asyncdisplaykit_asyncLayerTransactions.count == 0) {
+          // Reclaim object memory.
+          self.asyncdisplaykit_asyncLayerTransactions = nil;
+        }
         [self asyncdisplaykit_asyncTransactionContainerDidCompleteTransaction:completedTransaction];
       }];
     } else {
@@ -71,6 +76,10 @@
           return;
         }
         [transactions removeObject:completedTransaction];
+        if (transactions.count == 0) {
+          // Reclaim object memory.
+          self.asyncdisplaykit_asyncLayerTransactions = nil;
+        }
         [self asyncdisplaykit_asyncTransactionContainerDidCompleteTransaction:completedTransaction];
       }];
     }

--- a/Source/Private/ASInternalHelpers.h
+++ b/Source/Private/ASInternalHelpers.h
@@ -117,6 +117,11 @@ ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASImageDownloaderPriority ASImageDown
 - (NSComparisonResult)asdk_inverseCompare:(NSIndexPath *)otherIndexPath;
 @end
 
+/**
+ * Create an NSMutableSet that uses pointers for hash & equality.
+ */
+AS_EXTERN NSMutableSet *ASCreatePointerBasedMutableSet(void);
+
 NS_ASSUME_NONNULL_END
 
 #ifndef AS_INITIALIZE_FRAMEWORK_MANUALLY

--- a/Source/Private/ASInternalHelpers.mm
+++ b/Source/Private/ASInternalHelpers.mm
@@ -257,3 +257,15 @@ CGFloat ASRoundPixelValue(CGFloat f)
 }
 
 @end
+
+NSMutableSet *ASCreatePointerBasedMutableSet()
+{
+  static CFSetCallBacks callbacks;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    callbacks = kCFTypeSetCallBacks;
+    callbacks.equal = nullptr;
+    callbacks.hash = nullptr;
+  });
+  return (__bridge_transfer NSMutableSet *)CFSetCreateMutable(NULL, 0, &callbacks);
+}


### PR DESCRIPTION
Scrolling down to the end of a feed (~100 items) on my iPad this data had:

### Before: 310KB, all persistent
<img width="1586" alt="Screen Shot 2019-05-10 at 11 58 11 AM" src="https://user-images.githubusercontent.com/2466893/57550706-f9934400-731b-11e9-857e-4f0de8535452.png">

### After: 110KB, all transient
<img width="1586" alt="Screen Shot 2019-05-10 at 11 52 26 AM" src="https://user-images.githubusercontent.com/2466893/57550724-04e66f80-731c-11e9-891e-888dce29e5db.png">