### PR TITLE
[Bug] ASButtonNode TintColor Change

### DIFF
--- a/Source/ASButtonNode.mm
+++ b/Source/ASButtonNode.mm
@@ -562,4 +562,11 @@
   _titleNode.hidden = (_titleNode.attributedText.length == 0);
 }
 
+- (void)tintColorDidChange
+{
+  [super tintColorDidChange];
+  _imageNode.imageModificationBlock = ASImageNodeTintColorModificationBlock(self.tintColor);
+  [_imageNode setNeedsDisplay];
+}
+
 @end

--- a/Tests/ASButtonNodeTests.mm
+++ b/Tests/ASButtonNodeTests.mm
@@ -51,4 +51,13 @@
                 buttonNode.defaultAccessibilityTraits);
 }
 
+- (void)testTintColor
+{
+  ASButtonNode *buttonNode = nil;
+  buttonNode = [[ASButtonNode alloc] init];
+  XCTAssertFalse(buttonNode.tintColor == [UIColor whiteColor]);
+  buttonNode.tintColor = [UIColor whiteColor];
+  XCTAssertTrue(buttonNode.tintColor == [UIColor whiteColor]);
+}
+
 @end


### PR DESCRIPTION
ASButtonNode tintColor doesn't work.
In normally, Some developer use an ASImageNodeTintColorModificationBlock
I hope that imageNode applied tintColor automatically from ASButtonNode tintColor property

```objc
- (void)tintColorDidChange
{
  [super tintColorDidChange];
  _imageNode.imageModificationBlock = ASImageNodeTintColorModificationBlock(self.tintColor);
  [_imageNode setNeedsDisplay];
}
```