### PR TITLE
Assign accessibilityElements to _accessibilityElements

### DIFF
--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -256,7 +256,7 @@ static void CollectAccessibilityElementsForView(UIView *view, NSMutableArray *el
 - (void)setAccessibilityElements:(NSArray *)accessibilityElements
 {
   ASDisplayNodeAssertMainThread();
-  _accessibilityElements = nil;
+  _accessibilityElements = accessibilityElements;
 }
 
 - (NSArray *)accessibilityElements


### PR DESCRIPTION
We should assign the `accessibilityElements` to the `_accessibilityElements` property.