### PR TITLE
Fix Opting-Out of Linking with Photos Framework

### DIFF
--- a/Source/ASMultiplexImageNode.h
+++ b/Source/ASMultiplexImageNode.h
@@ -9,7 +9,14 @@
 
 #import <AsyncDisplayKit/ASImageNode.h>
 #import <AsyncDisplayKit/ASImageProtocols.h>
+
+#if AS_USE_PHOTOS
 #import <Photos/Photos.h>
+#else
+@class PHAsset;
+@class PHImageManager;
+@class PHImageRequestOptions;
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -125,10 +132,11 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
 
 /**
  * @abstract The image manager that this image node should use when requesting images from the Photos framework. If this is `nil` (the default), then `PHImageManager.defaultManager` is used.
- 
+
  * @see `+[NSURL URLWithAssetLocalIdentifier:targetSize:contentMode:options:]` below.
  */
 @property (nullable, nonatomic) PHImageManager *imageManager API_AVAILABLE(ios(8.0), tvos(10.0));
+
 @end
 
 
@@ -249,6 +257,9 @@ didFinishDownloadingImageWithIdentifier:(ASImageIdentifier)imageIdentifier
 @end
 
 #pragma mark -
+
+#if AS_USE_PHOTOS
+
 @interface NSURL (ASPhotosFrameworkURLs)
 
 /**
@@ -265,5 +276,7 @@ didFinishDownloadingImageWithIdentifier:(ASImageIdentifier)imageIdentifier
                                options:(PHImageRequestOptions *)options NS_RETURNS_RETAINED AS_WARN_UNUSED_RESULT API_AVAILABLE(ios(8.0), tvos(10.0));
 
 @end
+
+#endif
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
AS_USE_PHOTOS currently allows opting out of linking with the Photos framework / Photos features of Texture, however with the ASMultiplexImageNode header, it still imports from the Photos framework and when "Automatically Link with Frameworks" is enabled, it'll link with Photos.framework.

This fixes that by conditionally importing / excluding unavailable API based on whether or not AS_USE_PHOTOS is enabled.