### PR TITLE
Add new property alwaysHandleTapTruncationAction to ASTextNode2 and ASTextNode.

### DIFF
--- a/Source/ASTextNode.h
+++ b/Source/ASTextNode.h
@@ -213,8 +213,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  @abstract if YES will not intercept touches for non-link areas of the text. Default is NO.
+ @discussion If you still want to handle tap truncation action when passthroughNonlinkTouches is YES,
+ you should set the alwaysHandleTapTruncationAction to YES.
  */
 @property (nonatomic) BOOL passthroughNonlinkTouches;
+
+/**
+ @abstract Always handle tap truncationAction, even the passthroughNonlinkTouches is YES. Default is NO.
+ */
+@property (nonatomic) BOOL alwaysHandleTapTruncationAction;
 
 @end
 

--- a/Source/ASTextNode.h
+++ b/Source/ASTextNode.h
@@ -214,14 +214,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract if YES will not intercept touches for non-link areas of the text. Default is NO.
  @discussion If you still want to handle tap truncation action when passthroughNonlinkTouches is YES,
- you should set the alwaysHandleTapTruncationAction to YES.
+ you should set the alwaysHandleTruncationTokenTap to YES.
  */
 @property (nonatomic) BOOL passthroughNonlinkTouches;
 
 /**
  @abstract Always handle tap truncationAction, even the passthroughNonlinkTouches is YES. Default is NO.
+ @discussion if this is set to YES, the [ASTextNodeDelegate textNodeTappedTruncationToken:] callback will be called.
  */
-@property (nonatomic) BOOL alwaysHandleTapTruncationAction;
+@property (nonatomic) BOOL alwaysHandleTruncationTokenTap;
 
 @end
 

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -1143,6 +1143,12 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   return _alwaysHandleTruncationTokenTap;
 }
 
+- (void)setAlwaysHandleTruncationTokenTap:(BOOL)alwaysHandleTruncationTokenTap
+{
+  ASLockScopeSelf();
+  _alwaysHandleTruncationTokenTap = alwaysHandleTruncationTokenTap;
+}
+
 #pragma mark - Shadow Properties
 
 - (CGColorRef)shadowColor

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -209,6 +209,7 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
   ASTextNodeHighlightStyle _highlightStyle;
   BOOL _longPressCancelsTouches;
   BOOL _passthroughNonlinkTouches;
+  BOOL _alwaysHandleTapTruncationAction;
 }
 @dynamic placeholderEnabled;
 
@@ -1010,7 +1011,8 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
 
-  if (range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
+  if ((range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) ||
+    _alwaysHandleTapTruncationAction) {
     return YES;
   } else {
     return NO;

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -993,7 +993,8 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
 {
   ASDisplayNodeAssertMainThread();
-  
+  ASLockScopeSelf(); // Protect usage of _passthroughNonlinkTouches and _alwaysHandleTruncationTokenTap ivars.
+
   if (!_passthroughNonlinkTouches) {
     return [super pointInside:point withEvent:event];
   }

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -998,6 +998,10 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
     return [super pointInside:point withEvent:event];
   }
 
+  if (_alwaysHandleTruncationTokenTap) {
+    return YES;
+  }
+
   NSRange range = NSMakeRange(0, 0);
   NSString *linkAttributeName = nil;
   BOOL inAdditionalTruncationMessage = NO;
@@ -1011,8 +1015,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
 
-  if (_alwaysHandleTruncationTokenTap ||
-    (range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil)) {
+  if (range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
     return YES;
   } else {
     return NO;

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -209,7 +209,7 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
   ASTextNodeHighlightStyle _highlightStyle;
   BOOL _longPressCancelsTouches;
   BOOL _passthroughNonlinkTouches;
-  BOOL _alwaysHandleTapTruncationAction;
+  BOOL _alwaysHandleTruncationTokenTap;
 }
 @dynamic placeholderEnabled;
 
@@ -1012,7 +1012,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
 
   if ((range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) ||
-    _alwaysHandleTapTruncationAction) {
+    _alwaysHandleTruncationTokenTap) {
     return YES;
   } else {
     return NO;

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -1011,8 +1011,8 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
 
-  if ((range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) ||
-    _alwaysHandleTruncationTokenTap) {
+  if (_alwaysHandleTruncationTokenTap ||
+    (range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil)) {
     return YES;
   } else {
     return NO;

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -1134,6 +1134,12 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   return [_highlightedLinkAttributeName isEqualToString:ASTextNodeTruncationTokenAttributeName];
 }
 
+- (BOOL)alwaysHandleTruncationTokenTap
+{
+  ASLockScopeSelf();
+  return _alwaysHandleTruncationTokenTap;
+}
+
 #pragma mark - Shadow Properties
 
 - (CGColorRef)shadowColor

--- a/Source/ASTextNode2.h
+++ b/Source/ASTextNode2.h
@@ -210,14 +210,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract if YES will not intercept touches for non-link areas of the text. Default is NO.
  @discussion If you still want to handle tap truncation action when passthroughNonlinkTouches is YES,
- you should set the alwaysHandleTapTruncationAction to YES.
+ you should set the alwaysHandleTruncationTokenTap to YES.
  */
 @property (nonatomic) BOOL passthroughNonlinkTouches;
 
 /**
  @abstract Always handle tap truncationAction, even the passthroughNonlinkTouches is YES. Default is NO.
+ @discussion if this is set to YES, the [ASTextNodeDelegate textNodeTappedTruncationToken:] callback will be called.
  */
-@property (nonatomic) BOOL alwaysHandleTapTruncationAction;
+@property (nonatomic) BOOL alwaysHandleTruncationTokenTap;
 
 + (void)enableDebugging;
 

--- a/Source/ASTextNode2.h
+++ b/Source/ASTextNode2.h
@@ -209,8 +209,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  @abstract if YES will not intercept touches for non-link areas of the text. Default is NO.
+ @discussion If you still want to handle tap truncation action when passthroughNonlinkTouches is YES,
+ you should set the alwaysHandleTapTruncationAction to YES.
  */
 @property (nonatomic) BOOL passthroughNonlinkTouches;
+
+/**
+ @abstract Always handle tap truncationAction, even the passthroughNonlinkTouches is YES. Default is NO.
+ */
+@property (nonatomic) BOOL alwaysHandleTapTruncationAction;
 
 + (void)enableDebugging;
 

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -1119,6 +1119,12 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   return [ASLockedSelf(_highlightedLinkAttributeName) isEqualToString:ASTextNodeTruncationTokenAttributeName];
 }
 
+- (BOOL)alwaysHandleTruncationTokenTap
+{
+  ASLockScopeSelf();
+  return _alwaysHandleTruncationTokenTap;
+}
+  
 #pragma mark - Shadow Properties
 
 /**

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -1127,6 +1127,12 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   ASLockScopeSelf();
   return _alwaysHandleTruncationTokenTap;
 }
+
+- (void)setAlwaysHandleTruncationTokenTap:(BOOL)alwaysHandleTruncationTokenTap
+{
+  ASLockScopeSelf();
+  _alwaysHandleTruncationTokenTap = alwaysHandleTruncationTokenTap;
+}
   
 #pragma mark - Shadow Properties
 

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -968,7 +968,8 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
 {
   ASDisplayNodeAssertMainThread();
-  
+  ASLockScopeSelf(); // Protect usage of _passthroughNonlinkTouches and _alwaysHandleTruncationTokenTap ivars.
+
   if (!_passthroughNonlinkTouches) {
     return [super pointInside:point withEvent:event];
   }

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -177,6 +177,7 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
   ASTextNodeHighlightStyle _highlightStyle;
   BOOL _longPressCancelsTouches;
   BOOL _passthroughNonlinkTouches;
+  BOOL _alwaysHandleTapTruncationAction;
 }
 @dynamic placeholderEnabled;
 
@@ -985,7 +986,8 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
   
-  if (range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
+  if ((range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) ||
+    _alwaysHandleTapTruncationAction) {
     return YES;
   } else {
     return NO;

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -177,7 +177,7 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
   ASTextNodeHighlightStyle _highlightStyle;
   BOOL _longPressCancelsTouches;
   BOOL _passthroughNonlinkTouches;
-  BOOL _alwaysHandleTapTruncationAction;
+  BOOL _alwaysHandleTruncationTokenTap;
 }
 @dynamic placeholderEnabled;
 
@@ -987,7 +987,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
   
   if ((range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) ||
-    _alwaysHandleTapTruncationAction) {
+    _alwaysHandleTruncationTokenTap) {
     return YES;
   } else {
     return NO;

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -972,6 +972,10 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   if (!_passthroughNonlinkTouches) {
     return [super pointInside:point withEvent:event];
   }
+
+  if (_alwaysHandleTruncationTokenTap) {
+    return YES;
+  }
   
   NSRange range = NSMakeRange(0, 0);
   NSString *linkAttributeName = nil;
@@ -986,8 +990,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
   
-  if (_alwaysHandleTruncationTokenTap ||
-    (range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil)) {
+  if (range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
     return YES;
   } else {
     return NO;

--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -986,8 +986,8 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
   
-  if ((range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) ||
-    _alwaysHandleTruncationTokenTap) {
+  if (_alwaysHandleTruncationTokenTap ||
+    (range.length > 0 && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil)) {
     return YES;
   } else {
     return NO;


### PR DESCRIPTION
After this [PR](https://github.com/TextureGroup/Texture/pull/1184), `ASTextNode` and `ASTextNode2` don't handle touches on additional attributed message if `passthroughNonlinkTouches` is YES. But sometimes we maybe want to handle these touches action, even if `passthroughNonlinkTouches` is YES.  

So I add the new property `alwaysHandleTapTruncationAction` to `ASTextNode` and `ASTextNode2`, when `alwaysHandleTapTruncationAction` is YES, `ASTextNode` and `ASTextNode2` always handle touches on additional attributed message.