### PR TITLE
Use flag for responder chain methods between view and node dispatching

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -170,24 +170,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   if (ASDisplayNodeSubclassOverridesSelector(c, @selector(touchesEnded:withEvent:))) {
     overrides |= ASDisplayNodeMethodOverrideTouchesEnded;
   }
-  
-  // Responder chain
-  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(canBecomeFirstResponder))) {
-    overrides |= ASDisplayNodeMethodOverrideCanBecomeFirstResponder;
-  }
-  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(becomeFirstResponder))) {
-    overrides |= ASDisplayNodeMethodOverrideBecomeFirstResponder;
-  }
-  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(canResignFirstResponder))) {
-    overrides |= ASDisplayNodeMethodOverrideCanResignFirstResponder;
-  }
-  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(resignFirstResponder))) {
-    overrides |= ASDisplayNodeMethodOverrideResignFirstResponder;
-  }
-  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(isFirstResponder))) {
-    overrides |= ASDisplayNodeMethodOverrideIsFirstResponder;
-  }
-  
+
   // Layout related methods
   if (ASDisplayNodeSubclassOverridesSelector(c, @selector(layoutSpecThatFits:))) {
     overrides |= ASDisplayNodeMethodOverrideLayoutSpecThatFits;
@@ -907,26 +890,6 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   }
 }
 
-#pragma mark - UIResponder
-
-#define HANDLE_NODE_RESPONDER_METHOD(__sel) \
-  /* All responder methods should be called on the main thread */ \
-  ASDisplayNodeAssertMainThread(); \
-  if (checkFlag(Synchronous)) { \
-    /* If the view is not a _ASDisplayView subclass (Synchronous) just call through to the view as we
-     expect it's a non _ASDisplayView subclass that will respond */ \
-    return [_view __sel]; \
-  } else { \
-    if (ASSubclassOverridesSelector([_ASDisplayView class], _viewClass, @selector(__sel))) { \
-    /* If the subclass overwrites canBecomeFirstResponder just call through
-       to it as we expect it will handle it */ \
-      return [_view __sel]; \
-    } else { \
-      /* Call through to _ASDisplayView's superclass to get it handled */ \
-      return [(_ASDisplayView *)_view __##__sel]; \
-    } \
-  } \
-
 - (void)checkResponderCompatibility
 {
 #if ASDISPLAYNODE_ASSERTIONS_ENABLED
@@ -942,60 +905,6 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
     ASDisplayNodeAssert(!ASDisplayNodeSubclassOverridesSelector(self.class, @selector(isFirstResponder)), ([NSString stringWithFormat:message, @"isFirstResponder"]));
   }
 #endif
-}
-
-- (BOOL)__canBecomeFirstResponder
-{
-  if (_view == nil) {
-    // By default we return NO if not view is created yet
-    return NO;
-  }
-  
-  HANDLE_NODE_RESPONDER_METHOD(canBecomeFirstResponder);
-}
-
-- (BOOL)__becomeFirstResponder
-{
-  // Note: This implicitly loads the view if it hasn't been loaded yet.
-  [self view];
-
-  if (![self canBecomeFirstResponder]) {
-    return NO;
-  }
-
-  HANDLE_NODE_RESPONDER_METHOD(becomeFirstResponder);
-}
-
-- (BOOL)__canResignFirstResponder
-{
-  if (_view == nil) {
-    // By default we return YES if no view is created yet
-    return YES;
-  }
-  
-  HANDLE_NODE_RESPONDER_METHOD(canResignFirstResponder);
-}
-
-- (BOOL)__resignFirstResponder
-{
-  // Note: This implicitly loads the view if it hasn't been loaded yet.
-  [self view];
-
-  if (![self canResignFirstResponder]) {
-    return NO;
-  }
-  
-  HANDLE_NODE_RESPONDER_METHOD(resignFirstResponder);
-}
-
-- (BOOL)__isFirstResponder
-{
-  if (_view == nil) {
-    // If no view is created yet we can just return NO as it's unlikely it's the first responder
-    return NO;
-  }
-  
-  HANDLE_NODE_RESPONDER_METHOD(isFirstResponder);
 }
 
 #pragma mark <ASDebugNameProvider>

--- a/Source/Details/_ASDisplayView.h
+++ b/Source/Details/_ASDisplayView.h
@@ -31,14 +31,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)__forwardTouchesEnded:(NSSet *)touches withEvent:(UIEvent *)event;
 - (void)__forwardTouchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event;
 
-// These methods expose a way for ASDisplayNode responder methods to let the view call super responder methods
-// They are called from ASDisplayNode to pass through UIResponder methods to the view
-- (BOOL)__canBecomeFirstResponder;
-- (BOOL)__becomeFirstResponder;
-- (BOOL)__canResignFirstResponder;
-- (BOOL)__resignFirstResponder;
-- (BOOL)__isFirstResponder;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -32,14 +32,16 @@
 
 @implementation _ASDisplayView
 {
-  BOOL _inHitTest;
-  BOOL _inPointInside;
+  struct _ASDisplayViewInternalFlags {
+    unsigned inHitTest:1;
+    unsigned inPointInside:1;
 
-  BOOL _inCanBecomeFirstResponder;
-  BOOL _inBecomeFirstResponder;
-  BOOL _inCanResignFirstResponder;
-  BOOL _inResignFirstResponder;
-  BOOL _inIsFirstResponder;
+    unsigned inCanBecomeFirstResponder:1;
+    unsigned inBecomeFirstResponder:1;
+    unsigned inCanResignFirstResponder:1;
+    unsigned inResignFirstResponder:1;
+    unsigned inIsFirstResponder:1;
+  } _internalFlags;
 
   NSArray *_accessibilityElements;
   CGRect _lastAccessibilityElementsFrame;
@@ -338,10 +340,10 @@
   // hitTest:, it will call it on the view, which is _ASDisplayView.  After calling into the node, any additional calls
   // should use the UIView implementation of hitTest:
   ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  if (!_inHitTest) {
-    _inHitTest = YES;
+  if (!_internalFlags.inHitTest) {
+    _internalFlags.inHitTest = YES;
     UIView *hitView = [node hitTest:point withEvent:event];
-    _inHitTest = NO;
+    _internalFlags.inHitTest = NO;
     return hitView;
   } else {
     return [super hitTest:point withEvent:event];
@@ -352,10 +354,10 @@
 {
   // See comments in -hitTest:withEvent: for the strategy here.
   ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  if (!_inPointInside) {
-    _inPointInside = YES;
+  if (!_internalFlags.inPointInside) {
+    _internalFlags.inPointInside = YES;
     BOOL result = [node pointInside:point withEvent:event];
-    _inPointInside = NO;
+    _internalFlags.inPointInside = NO;
     return result;
   } else {
     return [super pointInside:point withEvent:event];
@@ -381,10 +383,10 @@
 - (BOOL)canBecomeFirstResponder
 {
   ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  if (!_inCanBecomeFirstResponder) {
-    _inCanBecomeFirstResponder = YES;
+  if (!_internalFlags.inCanBecomeFirstResponder) {
+    _internalFlags.inCanBecomeFirstResponder = YES;
     BOOL result = [node canBecomeFirstResponder];
-    _inCanBecomeFirstResponder = NO;
+    _internalFlags.inCanBecomeFirstResponder = NO;
     return result;
   } else {
     return [super canBecomeFirstResponder];
@@ -394,10 +396,10 @@
 - (BOOL)becomeFirstResponder
 {
   ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  if (!_inBecomeFirstResponder) {
-    _inBecomeFirstResponder = YES;
+  if (!_internalFlags.inBecomeFirstResponder) {
+    _internalFlags.inBecomeFirstResponder = YES;
     BOOL result = [node becomeFirstResponder];
-    _inBecomeFirstResponder = NO;
+    _internalFlags.inBecomeFirstResponder = NO;
     return result;
   } else {
     return [super becomeFirstResponder];
@@ -407,10 +409,10 @@
 - (BOOL)canResignFirstResponder
 {
   ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  if (!_inCanResignFirstResponder) {
-    _inCanResignFirstResponder = YES;
+  if (!_internalFlags.inCanResignFirstResponder) {
+    _internalFlags.inCanResignFirstResponder = YES;
     BOOL result = [node canResignFirstResponder];
-    _inCanResignFirstResponder = NO;
+    _internalFlags.inCanResignFirstResponder = NO;
     return result;
   } else {
     return [super canResignFirstResponder];
@@ -420,10 +422,10 @@
 - (BOOL)resignFirstResponder
 {
   ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  if (!_inResignFirstResponder) {
-    _inResignFirstResponder = YES;
+  if (!_internalFlags.inResignFirstResponder) {
+    _internalFlags.inResignFirstResponder = YES;
     BOOL result = [node resignFirstResponder];
-    _inResignFirstResponder = NO;
+    _internalFlags.inResignFirstResponder = NO;
     return result;
   } else {
     return [super resignFirstResponder];
@@ -433,10 +435,10 @@
 - (BOOL)isFirstResponder
 {
   ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  if (!_inIsFirstResponder) {
-    _inIsFirstResponder = YES;
+  if (!_internalFlags.inIsFirstResponder) {
+    _internalFlags.inIsFirstResponder = YES;
     BOOL result = [node isFirstResponder];
-    _inIsFirstResponder = NO;
+    _internalFlags.inIsFirstResponder = NO;
     return result;
   } else {
     return [super isFirstResponder];

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -127,32 +127,58 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
 
 - (BOOL)canBecomeFirstResponder
 {
-  ASDisplayNodeAssertMainThread();
-  return [self __canBecomeFirstResponder];
-}
-
-- (BOOL)canResignFirstResponder
-{
-  ASDisplayNodeAssertMainThread();
-  return [self __canResignFirstResponder];
-}
-
-- (BOOL)isFirstResponder
-{
-  ASDisplayNodeAssertMainThread();
-  return [self __isFirstResponder];
+  if (_view == nil) {
+    // By default we return NO if not view is created yet
+    return NO;
+  }
+  return [_view canBecomeFirstResponder];
 }
 
 - (BOOL)becomeFirstResponder
 {
   ASDisplayNodeAssertMainThread();
-  return [self __becomeFirstResponder];
+
+  // Note: This implicitly loads the view if it hasn't been loaded yet.
+  [self view];
+
+  if (![self canBecomeFirstResponder]) {
+    return NO;
+  }
+  return [_view becomeFirstResponder];
+}
+
+- (BOOL)canResignFirstResponder
+{
+  ASDisplayNodeAssertMainThread();
+
+  if (_view == nil) {
+    // By default we return YES if no view is created yet
+    return YES;
+  }
+  return [_view canResignFirstResponder];
 }
 
 - (BOOL)resignFirstResponder
 {
   ASDisplayNodeAssertMainThread();
-  return [self __resignFirstResponder];
+
+  // Note: This implicitly loads the view if it hasn't been loaded yet.
+  [self view];
+
+  if (![self canResignFirstResponder]) {
+    return NO;
+  }
+  return [_view resignFirstResponder];
+}
+
+- (BOOL)isFirstResponder
+{
+  ASDisplayNodeAssertMainThread();
+  if (_view == nil) {
+    // If no view is created yet we can just return NO as it's unlikely it's the first responder
+    return NO;
+  }
+  return [_view isFirstResponder];
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -46,11 +46,6 @@ typedef NS_OPTIONS(unsigned short, ASDisplayNodeMethodOverrides)
   ASDisplayNodeMethodOverrideLayoutSpecThatFits     = 1 << 4,
   ASDisplayNodeMethodOverrideCalcLayoutThatFits     = 1 << 5,
   ASDisplayNodeMethodOverrideCalcSizeThatFits       = 1 << 6,
-  ASDisplayNodeMethodOverrideCanBecomeFirstResponder= 1 << 7,
-  ASDisplayNodeMethodOverrideBecomeFirstResponder   = 1 << 8,
-  ASDisplayNodeMethodOverrideCanResignFirstResponder= 1 << 9,
-  ASDisplayNodeMethodOverrideResignFirstResponder   = 1 << 10,
-  ASDisplayNodeMethodOverrideIsFirstResponder       = 1 << 11,
 };
 
 typedef NS_OPTIONS(uint_least32_t, ASDisplayNodeAtomicFlags)
@@ -318,13 +313,6 @@ static constexpr CACornerMask kASCACornerAllCorners =
 - (BOOL)__selfOrParentHasVisibilityNotificationsDisabled;
 - (void)__incrementVisibilityNotificationsDisabled;
 - (void)__decrementVisibilityNotificationsDisabled;
-
-// Helper methods for UIResponder forwarding
-- (BOOL)__canBecomeFirstResponder;
-- (BOOL)__becomeFirstResponder;
-- (BOOL)__canResignFirstResponder;
-- (BOOL)__resignFirstResponder;
-- (BOOL)__isFirstResponder;
 
 /// Helper method to summarize whether or not the node run through the display process
 - (BOOL)_implementsDisplay;


### PR DESCRIPTION
Use same flag paradigm we use within `-[_ASDisplayView hitTest:withEvent:]` and `-[_ASDisplayView pointInside:withEvent:]` for responder chain methods.