### PR TITLE
[Need Design Review] Set up an experiment to share one lock across each entire embedding

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -336,6 +336,9 @@
 		CC0F88631E4281E700576FED /* ASSupplementaryNodeSource.h in Headers */ = {isa = PBXBuildFile; fileRef = CCE04B2B1E314A32006AEBBB /* ASSupplementaryNodeSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CC0F886C1E4286FA00576FED /* ReferenceImages_64 in Resources */ = {isa = PBXBuildFile; fileRef = CC0F88691E4286FA00576FED /* ReferenceImages_64 */; };
 		CC0F886D1E4286FA00576FED /* ReferenceImages_iOS_10 in Resources */ = {isa = PBXBuildFile; fileRef = CC0F886A1E4286FA00576FED /* ReferenceImages_iOS_10 */; };
+		CC1122C5229F79320061BD2C /* ASNodeContext.h in Headers */ = {isa = PBXBuildFile; fileRef = CC1122C3229F79320061BD2C /* ASNodeContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC1122C6229F79320061BD2C /* ASNodeContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC1122C4229F79320061BD2C /* ASNodeContext.mm */; };
+		CC1122C9229F7C990061BD2C /* ASNodeContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CC1122C8229F7C990061BD2C /* ASNodeContext+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CC11F97A1DB181180024D77B /* ASNetworkImageNodeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC11F9791DB181180024D77B /* ASNetworkImageNodeTests.mm */; };
 		CC18248C200D49C800875940 /* ASTextNodeCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = CC18248B200D49C800875940 /* ASTextNodeCommon.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CC224E962066CA6D00BBA57F /* configuration.json in Resources */ = {isa = PBXBuildFile; fileRef = CC224E952066CA6D00BBA57F /* configuration.json */; };
@@ -862,6 +865,9 @@
 		CC0F885E1E4280B800576FED /* _ASCollectionViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASCollectionViewCell.h; sourceTree = "<group>"; };
 		CC0F88691E4286FA00576FED /* ReferenceImages_64 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ReferenceImages_64; sourceTree = "<group>"; };
 		CC0F886A1E4286FA00576FED /* ReferenceImages_iOS_10 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ReferenceImages_iOS_10; sourceTree = "<group>"; };
+		CC1122C3229F79320061BD2C /* ASNodeContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASNodeContext.h; sourceTree = "<group>"; };
+		CC1122C4229F79320061BD2C /* ASNodeContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ASNodeContext.mm; sourceTree = "<group>"; };
+		CC1122C8229F7C990061BD2C /* ASNodeContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ASNodeContext+Private.h"; sourceTree = "<group>"; };
 		CC11F9791DB181180024D77B /* ASNetworkImageNodeTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASNetworkImageNodeTests.mm; sourceTree = "<group>"; };
 		CC18248B200D49C800875940 /* ASTextNodeCommon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASTextNodeCommon.h; sourceTree = "<group>"; };
 		CC224E952066CA6D00BBA57F /* configuration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = configuration.json; sourceTree = "<group>"; };
@@ -1237,6 +1243,9 @@
 				CCED5E3D2020D36800395C40 /* ASNetworkImageLoadInfo.mm */,
 				055B9FA61A1C154B00035D6D /* ASNetworkImageNode.h */,
 				055B9FA71A1C154B00035D6D /* ASNetworkImageNode.mm */,
+				CC1122C3229F79320061BD2C /* ASNodeContext.h */,
+				CC1122C8229F7C990061BD2C /* ASNodeContext+Private.h */,
+				CC1122C4229F79320061BD2C /* ASNodeContext.mm */,
 				698371D91E4379CD00437585 /* ASNodeController+Beta.h */,
 				698371DA1E4379CD00437585 /* ASNodeController+Beta.mm */,
 				DBDB83921C6E879900D0098C /* ASPagerFlowLayout.h */,
@@ -1931,7 +1940,9 @@
 				A2763D7A1CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.h in Headers */,
 				C018DF21216BF26700181FDA /* ASAbstractLayoutController+FrameworkPrivate.h in Headers */,
 				34EFC7611B701C9C00AD841F /* ASBackgroundLayoutSpec.h in Headers */,
+				CC1122C5229F79320061BD2C /* ASNodeContext.h in Headers */,
 				B35062591B010F070018CF92 /* ASBaseDefines.h in Headers */,
+				CC1122C9229F7C990061BD2C /* ASNodeContext+Private.h in Headers */,
 				B35062131B010EFD0018CF92 /* ASBasicImageDownloader.h in Headers */,
 				B35062151B010EFD0018CF92 /* ASBatchContext.h in Headers */,
 				B35061F31B010EFD0018CF92 /* ASCellNode.h in Headers */,
@@ -2336,6 +2347,7 @@
 				69B225671D72535E00B25B22 /* ASDisplayNodeLayoutTests.mm in Sources */,
 				C057D9BD20B5453D00FC9112 /* ASTextNode2SnapshotTests.mm in Sources */,
 				ACF6ED621B178DC700DA7C62 /* ASRatioLayoutSpecSnapshotTests.mm in Sources */,
+				CC1122C7229F79320061BD2C /* ASNodeContext.mm in Sources */,
 				7AB338691C55B97B0055FDE8 /* ASRelativeLayoutSpecSnapshotTests.mm in Sources */,
 				CCDD148B1EEDCD9D0020834E /* ASCollectionModernDataSourceTests.mm in Sources */,
 				1A6C00111FAB4EDD00D05926 /* ASCornerLayoutSpecSnapshotTests.mm in Sources */,
@@ -2524,6 +2536,7 @@
 				254C6B871BF94F8A003EC431 /* ASTextKitEntityAttribute.mm in Sources */,
 				34566CB31BC1213700715E6B /* ASPhotosFrameworkImageRequest.mm in Sources */,
 				254C6B831BF94F8A003EC431 /* ASTextKitCoreTextAdditions.mm in Sources */,
+				CC1122C6229F79320061BD2C /* ASNodeContext.mm in Sources */,
 				CCCCCCE21EC3EF060087FE10 /* ASTextUtilities.mm in Sources */,
 				CC55A70E1E529FA200594372 /* UIResponder+AsyncDisplayKit.mm in Sources */,
 				CC56013C1F06E9A700DC4FBE /* ASIntegerMap.mm in Sources */,

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -25,6 +25,7 @@
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
 #import <AsyncDisplayKit/ASElementMap.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
+#import <AsyncDisplayKit/ASNodeContext+Private.h>
 #import <AsyncDisplayKit/UICollectionViewLayout+ASConvenience.h>
 #import <AsyncDisplayKit/ASRangeController.h>
 #import <AsyncDisplayKit/_ASCollectionViewCell.h>
@@ -1952,7 +1953,9 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   }
   if (!block && !cell && _asyncDataSourceFlags.collectionNodeNodeForItem) {
     GET_COLLECTIONNODE_OR_RETURN(collectionNode, ^{ return [[ASCellNode alloc] init]; });
+    ASNodeContextPushNewIfEnabled();
     cell = [_asyncDataSource collectionNode:collectionNode nodeForItemAtIndexPath:indexPath];
+    ASNodeContextPopIfEnabled();
   }
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -1960,7 +1963,9 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     block = [_asyncDataSource collectionView:self nodeBlockForItemAtIndexPath:indexPath];
   }
   if (!block && !cell && _asyncDataSourceFlags.collectionViewNodeForItem) {
+    ASNodeContextPushNewIfEnabled();
     cell = [_asyncDataSource collectionView:self nodeForItemAtIndexPath:indexPath];
+    ASNodeContextPopIfEnabled();
   }
 #pragma clang diagnostic pop
 

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -21,6 +21,8 @@
 #import <AsyncDisplayKit/ASDisplayNode+Yoga.h>
 #import <AsyncDisplayKit/NSArray+Diffing.h>
 
+#define __instanceLock__ _mutexOrPtr.get()
+
 using AS::MutexLocker;
 
 @interface ASDisplayNode (ASLayoutElementStyleDelegate) <ASLayoutElementStyleDelegate>

--- a/Source/ASDisplayNode+LayoutSpec.mm
+++ b/Source/ASDisplayNode+LayoutSpec.mm
@@ -18,6 +18,7 @@
 #import <AsyncDisplayKit/ASLog.h>
 #import <AsyncDisplayKit/ASThread.h>
 
+#define __instanceLock__ _mutexOrPtr.get()
 
 @implementation ASDisplayNode (ASLayoutSpec)
 

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 #define AS_MAX_INTERFACE_STATE_DELEGATES 4
 #endif
 
-@class ASDisplayNode;
+@class ASDisplayNode, ASNodeContext;
 @protocol ASContextTransitioning;
 
 /**
@@ -190,6 +190,11 @@ AS_EXTERN NSInteger const ASDefaultDrawingPriority;
  * @note You will usually NOT call this. See the limitations documented in @c initWithLayerBlock:
  */
 - (void)setLayerBlock:(ASDisplayNodeLayerBlock)layerBlock;
+
+/**
+ * Get the context for this node, if one was set during creation.
+ */
+@property (nullable, readonly) ASNodeContext *nodeContext;
 
 /** 
  * @abstract Returns whether the node is synchronous.

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -60,6 +60,12 @@
 // TODO(wsdwsd0829): Rework enabling code to ensure that interface state behavior is not altered when ASCATransactionQueue is disabled.
 #define ENABLE_NEW_EXIT_HIERARCHY_BEHAVIOR 0
 
+/**
+ * A temporary convenience macro during the transition from __instanceLock__ to context-or-instance lock.
+ * A diff will come soon with a massive find-and-replace.
+ */
+#define __instanceLock__ _mutexOrPtr.get()
+
 using AS::MutexLocker;
 
 static ASDisplayNodeNonFatalErrorBlock _nonFatalErrorBlock = nil;
@@ -313,7 +319,13 @@ __attribute__((constructor)) static void ASLoadFrameworkInitializer(void)
 - (void)_initializeInstance
 {
   [self _staticInitialize];
-  __instanceLock__.SetDebugNameWithObject(self);
+  if (ASNodeContext *ctx = ASNodeContextGet()) {
+    _nodeContext = ctx;
+    new (&_mutexOrPtr) AS::MutexOrPointer(&ctx->_mutex);
+  } else {
+    new (&_mutexOrPtr) AS::MutexOrPointer(nullptr);
+    _mutexOrPtr.get().SetDebugNameWithObject(self);
+  }
   
   _viewClass = [self.class viewClass];
   _layerClass = [self.class layerClass];
@@ -2115,6 +2127,7 @@ ASDISPLAYNODE_INLINE BOOL subtreeIsRasterized(ASDisplayNode *node) {
   ASDisplayNodeAssertThreadAffinity(self);
   // TODO: Disabled due to PR: https://github.com/TextureGroup/Texture/pull/1204
   DISABLED_ASAssertUnlocked(__instanceLock__);
+  ASDisplayNodeAssert(subnode->_nodeContext == _nodeContext, @"Cannot mix nodes from different contexts.");
   
   as_log_verbose(ASNodeLog(), "Insert subnode %@ at index %zd of %@ and remove subnode %@", subnode, subnodeIndex, self, oldSubnode);
   

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -323,6 +323,9 @@ __attribute__((constructor)) static void ASLoadFrameworkInitializer(void)
     _nodeContext = ctx;
     new (&_mutexOrPtr) AS::MutexOrPointer(&ctx->_mutex);
   } else {
+    ASDisplayNodeAssert(!ASActivateExperimentalFeature(ASExperimentalNodeContext), @"In node context experiment, but no"
+                        "node context. Did you forget to push one before creating your node for an ASViewController?"
+                        "Please report to the maintainers what circumstance this happened in if it seems unusual.");
     new (&_mutexOrPtr) AS::MutexOrPointer(nullptr);
     _mutexOrPtr.get().SetDebugNameWithObject(self);
   }

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -32,6 +32,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalTransactionOperationRetainCycle = 1 << 11,  // exp_transaction_operation_retain_cycle
   ASExperimentalRemoveTextKitInitialisingLock = 1 << 12,    // exp_remove_textkit_initialising_lock
   ASExperimentalDrawingGlobal = 1 << 13,                    // exp_drawing_global
+  ASExperimentalNodeContext = 1 << 13,                      // exp_node_context
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -32,6 +32,8 @@
 // TODO: It would be nice to remove this dependency; it's the only subclass using more than +FrameworkSubclasses.h
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h>
 
+#define __instanceLock__ _mutexOrPtr.get()
+
 static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
 typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);

--- a/Source/ASNodeContext+Private.h
+++ b/Source/ASNodeContext+Private.h
@@ -1,0 +1,36 @@
+//
+//  ASNodeContext+Private.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 5/29/19.
+//  Copyright © 2019 Pinterest. All rights reserved.
+//
+
+#import <AsyncDisplayKit/ASNodeContext.h>
+#import <AsyncDisplayKit/ASThread.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Only here during experimentation.
+ */
+NS_INLINE void ASNodeContextPushNewIfEnabled() {
+  if (ASActivateExperimentalFeature(ASExperimentalNodeContext)) {
+    ASNodeContextPush([[ASNodeContext alloc] init]);
+  }
+}
+
+NS_INLINE void ASNodeContextPopIfEnabled() {
+  if (ASActivateExperimentalFeature(ASExperimentalNodeContext)) {
+    ASNodeContextPop();
+  }
+}
+
+@interface ASNodeContext () {
+@package
+  AS::RecursiveMutex _mutex;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ASNodeContext.h
+++ b/Source/ASNodeContext.h
@@ -1,0 +1,58 @@
+//
+//  ASNodeContext.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 5/29/19.
+//  Copyright © 2019 Pinterest. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import <AsyncDisplayKit/AsyncDisplayKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class ASNodeContext;
+
+/**
+ * Push the current default context, which will apply to any nodes initialized with `init` instead of `initWithContext:`.
+ *
+ * A default context is provided by the system under the following circumstances:
+ * - During the execution of a node block for ASCollectionNode or ASTableNode.
+ * - During the call to `nodeForItem:` & related methods for ASCollectionNode or ASTableNode.
+ * - During the execution of `calculateLayoutThatFits:` or `layoutSpecThatFits:` (context of receiver is pushed.)
+ *
+ * @discussion Generally users will not need to call this function themselves.
+ */
+AS_EXTERN void ASNodeContextPush(unowned ASNodeContext *context);
+
+/**
+ * Get the current default context, if there is one.
+ */
+AS_EXTERN ASNodeContext *_Nullable ASNodeContextGet(void);
+
+/**
+ * Pop the current context, matching a previous call to ASNodeContextPush.
+ */
+AS_EXTERN void ASNodeContextPop(void);
+
+/**
+ * A node context is an object that is shared by, and uniquely identifies, an "embedding" of nodes. For example,
+ * each cell in a collection view has its own context. Each ASViewController's node has its own context. You can
+ * also explicitly establish a context for a node tree in another context.
+ *
+ * Node contexts store the mutex that is shared by all member nodes for synchronization. Operations such as addSubnode:
+ * will lock the context's mutex for the duration of the work.
+ *
+ * Nodes may not be moved from one context to another. For instance, you may not detach a subnode of a cell node,
+ * and reattach it to a subtree of another cell node in the same or another collection view.
+ *
+ * Node contexts are established in the `-initWithContext:` method and do not change. For ease of use, a default
+ * context will be used from the `-init` method if available.
+ */
+AS_SUBCLASSING_RESTRICTED
+@interface ASNodeContext : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ASNodeContext.mm
+++ b/Source/ASNodeContext.mm
@@ -1,0 +1,61 @@
+//
+//  ASNodeContext.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 5/29/19.
+//  Copyright © 2019 Pinterest. All rights reserved.
+//
+
+#import <AsyncDisplayKit/ASNodeContext+Private.h>
+
+#import <AsyncDisplayKit/ASAssert.h>
+
+#if AS_TLS_AVAILABLE
+
+#import <stack>
+
+static thread_local std::stack<ASNodeContext *> gContexts;
+
+void ASNodeContextPush(unowned ASNodeContext *context) {
+  gContexts.push(context);
+}
+
+ASNodeContext *ASNodeContextGet() {
+  return gContexts.empty() ? nil : gContexts.top();
+}
+
+void ASNodeContextPop() {
+  ASDisplayNodeCAssertFalse(gContexts.empty());
+  gContexts.pop();
+}
+
+#else   // !AS_TLS_AVAILABLE
+
+// Only on 32-bit simulator. Performance expendable.
+
+// Points to a NSMutableArray<ASNodeContext *>.
+static constexpr NSString *ASNodeContextStackKey = @"org.TextureGroup.Texture.nodeContexts";
+
+void ASNodeContextPush(ASNodeContext *context) {
+  unowned NSMutableDictionary *td = NSThread.currentThread.threadDictionary;
+  unowned NSMutableArray<ASNodeContext *> *stack = td[ASNodeContextStackKey];
+  if (!stack) {
+    td[ASNodeContextStackKey] = [[NSMutableArray alloc] initWithObjects:context, nil];
+  } else {
+    [stack addObject:context];
+  }
+}
+
+ASNodeContext *ASNodeContextGet() {
+  return [NSThread.currentThread.threadDictionary[ASNodeContextStackKey] lastObject];
+}
+
+void ASNodeContextPop() {
+  [NSThread.currentThread.threadDictionary[ASNodeContextStackKey] removeLastObject];
+}
+
+#endif  // !AS_TLS_AVAILABLE
+
+@implementation ASNodeContext
+
+@end

--- a/Source/ASNodeController+Beta.h
+++ b/Source/ASNodeController+Beta.h
@@ -19,6 +19,8 @@
 // Until an ASNodeController can be provided in place of an ASCellNode, some apps may prefer to have
 // nodes keep their controllers alive (and a weak reference from controller to node)
 
+@property (readonly) ASNodeContext *nodeContext;
+
 @property (nonatomic) BOOL shouldInvertStrongReference;
 
 - (void)loadNode;

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -24,6 +24,7 @@
 #import <AsyncDisplayKit/ASElementMap.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASLayout.h>
+#import <AsyncDisplayKit/ASNodeContext+Private.h>
 #import <AsyncDisplayKit/ASTableNode+Beta.h>
 #import <AsyncDisplayKit/ASRangeController.h>
 #import <AsyncDisplayKit/ASEqualityHelpers.h>
@@ -1743,7 +1744,9 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   } else if (_asyncDataSourceFlags.tableNodeNodeForRow) {
     ASCellNode *node = nil;
     if (ASTableNode *tableNode = self.tableNode) {
+      ASNodeContextPushNewIfEnabled();
     	node = [_asyncDataSource tableNode:tableNode nodeForRowAtIndexPath:indexPath];
+      ASNodeContextPopIfEnabled();
     }
     if ([node isKindOfClass:[ASCellNode class]]) {
       block = ^{
@@ -1757,7 +1760,9 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     block = [_asyncDataSource tableView:self nodeBlockForRowAtIndexPath:indexPath];
   } else if (_asyncDataSourceFlags.tableViewNodeForRow) {
+    ASNodeContextPushNewIfEnabled();
     ASCellNode *node = [_asyncDataSource tableView:self nodeForRowAtIndexPath:indexPath];
+    ASNodeContextPopIfEnabled();
 #pragma clang diagnostic pop
     if ([node isKindOfClass:[ASCellNode class]]) {
       block = ^{

--- a/Source/ASVideoNode.mm
+++ b/Source/ASVideoNode.mm
@@ -20,6 +20,8 @@
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
 #import <AsyncDisplayKit/ASThread.h>
 
+#define __instanceLock__ _mutexOrPtr.get()
+
 static BOOL ASAssetIsEqual(AVAsset *asset1, AVAsset *asset2) {
   return ASObjectIsEqual(asset1, asset2)
   || ([asset1 isKindOfClass:[AVURLAsset class]]

--- a/Source/AsyncDisplayKit.h
+++ b/Source/AsyncDisplayKit.h
@@ -13,6 +13,7 @@
 #import <AsyncDisplayKit/ASDisplayNode+Ancestry.h>
 #import <AsyncDisplayKit/ASDisplayNode+Convenience.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
+#import <AsyncDisplayKit/ASNodeContext.h>
 #import <AsyncDisplayKit/ASConfiguration.h>
 #import <AsyncDisplayKit/ASConfigurationDelegate.h>
 #import <AsyncDisplayKit/ASConfigurationInternal.h>

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -26,6 +26,7 @@
 #import <AsyncDisplayKit/ASSignpost.h>
 #import <AsyncDisplayKit/ASMainSerialQueue.h>
 #import <AsyncDisplayKit/ASMutableElementMap.h>
+#import <AsyncDisplayKit/ASNodeContext+Private.h>
 #import <AsyncDisplayKit/ASRangeManagingNode.h>
 #import <AsyncDisplayKit/ASThread.h>
 #import <AsyncDisplayKit/ASTwoDimensionalArrayUtils.h>
@@ -165,11 +166,13 @@ typedef void (^ASDataControllerSynchronizationBlock)();
 
       unowned ASCollectionElement *element = elements[i];
 
+      ASNodeContextPushNewIfEnabled();
       NSMutableDictionary *dict = [[NSThread currentThread] threadDictionary];
       dict[ASThreadDictMaxConstraintSizeKey] =
           [NSValue valueWithCGSize:element.constrainedSize.max];
       unowned ASCellNode *node = element.node;
       [dict removeObjectForKey:ASThreadDictMaxConstraintSizeKey];
+      ASNodeContextPopIfEnabled();
 
       // Layout the node if the size range is valid.
       ASSizeRange sizeRange = element.constrainedSize;

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -18,6 +18,8 @@
 #import <AsyncDisplayKit/ASSignpost.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
 
+#define __instanceLock__ _mutexOrPtr.get()
+
 using AS::MutexLocker;
 
 @interface ASDisplayNode () <_ASDisplayLayerDelegate>

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -15,6 +15,8 @@
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
 #import <AsyncDisplayKit/ASPendingStateController.h>
 
+#define __instanceLock__ _mutexOrPtr.get()
+
 /**
  * The following macros are conveniences to help in the common tasks related to the bridging that ASDisplayNode does to UIView and CALayer.
  * In general, a property can either be:

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -18,6 +18,7 @@
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
 #import <AsyncDisplayKit/ASLayoutElement.h>
 #import <AsyncDisplayKit/ASLayoutTransition.h>
+#import <AsyncDisplayKit/ASNodeContext+Private.h>
 #import <AsyncDisplayKit/ASThread.h>
 #import <AsyncDisplayKit/_ASTransitionContext.h>
 #import <AsyncDisplayKit/ASWeakSet.h>
@@ -82,8 +83,8 @@ static constexpr CACornerMask kASCACornerAllCorners =
 @interface ASDisplayNode () <_ASTransitionContextCompletionDelegate, CALayerDelegate>
 {
 @package
-  AS::RecursiveMutex __instanceLock__;
-
+  AS::MutexOrPointer _mutexOrPtr;
+  ASNodeContext *_nodeContext;
   _ASPendingState *_pendingViewState;
 
   UIView *_view;


### PR DESCRIPTION
This diff works. 

Basically when a node is initialized it needs a target "context." Node context might be a cell in a table, or a view controller, or some silo'd off area that we will prohibit users from changing for a given node.

If we're willing to accept this restriction, then the context can own a mutex which is an invariant, and which is pointed to by all the nodes in the context, and we can freely traverse the tree, go crazy, and do whatever we need to do during our transactions on the tree. Right now we are tippy-toeing around things that should be easy, like upward propagation of layout invalidation.

So first of all, please people take a look and give useful feedback.

One thing you'll notice is in the `ASDisplayNode+*.mm` files I have redefined __instanceLock__ as a macro that points to our `_mutexOrPtr.get()` which acts as the switch during experimentation. As soon as this lands, I will land a find-and-repalce that removes those macros. It's just to keep this diff from being cluttered.

The end state is for all the major consumers to experiment with this, prove it works, then launch it and remove the forking. Nodes no longer own their own mutexes, all nodes have a context, boom.