### PR TITLE
Fix ASTextNode2 supportsLayerBacking

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -292,7 +292,10 @@ static NSArray *DefaultLinkAttributeNames() {
   for (NSString *linkAttributeName in _linkAttributeNames) {
     __block BOOL hasLink = NO;
     [attributedText enumerateAttribute:linkAttributeName inRange:range options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired usingBlock:^(id  _Nullable value, NSRange range, BOOL * _Nonnull stop) {
-      hasLink = (value != nil);
+      if (value == nil) {
+        return;
+      }
+      hasLink = YES;
       *stop = YES;
     }];
     if (hasLink) {

--- a/Tests/ASTextNode2Tests.mm
+++ b/Tests/ASTextNode2Tests.mm
@@ -107,4 +107,18 @@
   XCTAssertFalse(accessibleTextNode.isAccessibilityElement);
 }
 
+- (void)testSupportsLayerBacking
+{
+  ASTextNode2 *textNode = [[ASTextNode2 alloc] init];
+  textNode.attributedText = [[NSAttributedString alloc] initWithString:@"new string"];
+  XCTAssertTrue(textNode.supportsLayerBacking);
+
+  NSString *link = @"https://texturegroup.com";
+  NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"Texture Website: %@", link]];
+  NSRange linkRange = [attributedText.string rangeOfString:link];
+  [attributedText addAttribute:NSLinkAttributeName value:link range:linkRange];
+  textNode.attributedText = attributedText;
+  XCTAssertFalse(textNode.supportsLayerBacking);
+}
+
 @end


### PR DESCRIPTION
`[NSAttributedString enumerateAttribute:inRange:options:usingBlock]` can be called multiple times with a value of nil. The current logic didn't consider this to find out if a links is present within the attributed string.