### PR TITLE
Fix placeholder

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -878,6 +878,18 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   _flags.automaticallyRelayoutOnLayoutMarginsChanges = flag;
 }
 
+- (BOOL)placeholderEnabled
+{
+  MutexLocker l(__instanceLock__);
+  return _flags.placeholderEnabled;
+}
+
+- (void)setPlaceholderEnabled:(BOOL)flag
+{
+  MutexLocker l(__instanceLock__);
+  _flags.placeholderEnabled = flag;
+}
+
 - (void)__setNodeController:(ASNodeController *)controller
 {
   // See docs for why we don't lock.

--- a/Tests/ASDisplayNodeTests.mm
+++ b/Tests/ASDisplayNodeTests.mm
@@ -182,6 +182,11 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   return &self->_clipCornerLayers;
 }
 
++ (UIImage *)displayWithParameters:(id<NSObject>)parameter isCancelled:(NS_NOESCAPE asdisplaynode_iscancelled_block_t)isCancelled
+{
+  return nil;
+}
+
 @end
 
 @interface ASSynchronousTestDisplayNodeViaViewClass : ASDisplayNode
@@ -2724,6 +2729,27 @@ static bool stringContainsPointer(NSString *description, id p) {
   OCMExpect([mockNode layerActionForKey:@"position"]);
   node.layer.position = CGPointMake(10, 10);
   OCMVerifyAll(mockNode);
+}
+
+- (void)testPlaceholder
+{
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 50, 50)];
+  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
+  node.placeholderEnabled = YES;
+  node.frame = window.bounds;
+  [window addSubnode:node];
+  [window makeKeyAndVisible];
+  
+  CALayer *layer = node.layer;
+  XCTAssertNotNil(layer);
+  BOOL hasPlaceholderLayer = NO;
+  for (CALayer *sublayer in layer.sublayers) {
+    if (sublayer.zPosition == 9999.0) {
+      hasPlaceholderLayer = YES;
+      break;
+    }
+  }
+  XCTAssertTrue(hasPlaceholderLayer);
 }
 
 @end


### PR DESCRIPTION
Placeholder is not working anymore since `placeholderEnabled` is read from _flags but never set to it.
```
if (_flags.placeholderEnabled && !_placeholderImage && [self _locked_displaysAsynchronously]) {
```
```
- (BOOL)_locked_shouldHavePlaceholderLayer
{
  DISABLED_ASAssertLocked(__instanceLock__);
  return (_flags.placeholderEnabled && [self _implementsDisplay]);
}
```