### PR TITLE
Remove ivar of ASCellNode.owningNode

### DIFF
--- a/Source/ASCellNode.mm
+++ b/Source/ASCellNode.mm
@@ -201,6 +201,11 @@
   return _viewController;
 }
 
+- (id<ASRangeManagingNode>)owningNode
+{
+  return self.collectionElement.owningNode;
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 
@@ -306,7 +311,7 @@
   // in which case it is not valid to perform a convertRect (this actually crashes on iOS 8).
   UIScrollView *scrollView = (_scrollView != nil && view.superview != nil && [view isDescendantOfView:_scrollView]) ? _scrollView : nil;
   if (scrollView) {
-    cellFrame = [view convertRect:view.bounds toView:_scrollView];
+    cellFrame = [view convertRect:view.bounds toView:scrollView];
   }
   
   // If we did not convert, we'll pass along CGRectZero and a nil scrollView.  The EventInvisible call is thus equivalent to
@@ -323,7 +328,7 @@
   
   UIScrollView *scrollView = self.scrollView;
   
-  ASDisplayNode *owningNode = scrollView.asyncdisplaykit_node;
+  id<ASRangeManagingNode> owningNode = self.owningNode;
   if ([owningNode isKindOfClass:[ASCollectionNode class]]) {
     NSIndexPath *ip = [(ASCollectionNode *)owningNode indexPathForNode:self];
     if (ip != nil) {

--- a/Source/Details/ASCollectionElement.mm
+++ b/Source/Details/ASCollectionElement.mm
@@ -53,7 +53,6 @@
       ASDisplayNodeFailAssert(@"Node block returned nil node!");
       node = [[ASCellNode alloc] init];
     }
-    node.owningNode = _owningNode;
     node.collectionElement = self;
     ASTraitCollectionPropagateDown(node, _traitCollection);
     node.nodeModel = _nodeModel;

--- a/Source/Private/ASCellNode+Internal.h
+++ b/Source/Private/ASCellNode+Internal.h
@@ -53,8 +53,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (weak, nullable) ASCollectionElement *collectionElement;
 
-@property (weak, nullable) id<ASRangeManagingNode> owningNode;
-
 @property (nonatomic, readonly) BOOL shouldUseUIKitCell;
 
 @end


### PR DESCRIPTION
The pointer is available via the node's `collectionElement`. There is no point to store it again in the node. Removing the ivar helps to reduce the memory footprint of ASCellNode and avoid the need to set it.