### PR TITLE
Restore call pattern where UIView methods drive __enterHierarchy and __exitHierarchy for view-backed nodes

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1722,10 +1722,14 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
 
 - (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event
 {
-  if (event == kCAOnOrderIn) {
-    [self __enterHierarchy];
-  } else if (event == kCAOnOrderOut) {
-    [self __exitHierarchy];
+  // Only drive __enterHierarchy and __exitHierarchy if the node is layer-backed.
+  // View-backed nodes handle them in _ASDisplayView's -willMoveToWindow: and -didMoveToWindow.
+  if (self.isLayerBacked) {
+    if (event == kCAOnOrderIn) {
+      [self __enterHierarchy];
+    } else if (event == kCAOnOrderOut) {
+      [self __exitHierarchy];
+    }
   }
 
   return [self layerActionForKey:event];

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -99,6 +99,24 @@
   return nodeAction;
 }
 
+- (void)willMoveToWindow:(UIWindow *)newWindow
+{
+  ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+  BOOL visible = (newWindow != nil);
+  if (visible && !node.inHierarchy) {
+    [node __enterHierarchy];
+  }
+}
+
+- (void)didMoveToWindow
+{
+  ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
+  BOOL visible = (self.window != nil);
+  if (!visible && node.inHierarchy) {
+    [node __exitHierarchy];
+  }
+}
+
 - (void)willMoveToSuperview:(UIView *)newSuperview
 {
   // Keep the node alive while the view is in a view hierarchy.  This helps ensure that async-drawing views can always


### PR DESCRIPTION
After #1396, some view-backed nodes in our app stop responding to tap events. I tracked this issue down to [this change](https://github.com/TextureGroup/Texture/pull/1396/files#diff-7fbc7d84a259cbfbee7546a5310dddcfR162) which suggests that the order of execution matters.

This diff attempts to fix the issue by restoring the previous call order where `__enterHierarchy` and `__exitHierarchy` are driven by `_ASDisplayView`'s `-willMoveToWindow:` and `-didMoveToWindow` if the node is view-backed. Layer-backed nodes will still call `__enterHierarchy`/`__exitHierarchy` when they get `kCAOnOrderIn`/`kCAOnOrderOut`.

This maintains the layer-action support introduced in #1396.