### PR TITLE
[ASDataController] Add an experiment that avoids flushing editing queue before starting the data pipeline pipeline

### DIFF
--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -27,9 +27,10 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalSkipClearData = 1 << 6,                     // exp_skip_clear_data
   ASExperimentalDidEnterPreloadSkipASMLayout = 1 << 7,      // exp_did_enter_preload_skip_asm_layout
   ASExperimentalDispatchApply = 1 << 8,                     // exp_dispatch_apply
-  ASExperimentalOOMBackgroundDeallocDisable = 1 << 9,      // exp_oom_bg_dealloc_disable
+  ASExperimentalOOMBackgroundDeallocDisable = 1 << 9,       // exp_oom_bg_dealloc_disable
   ASExperimentalRemoveTextKitInitialisingLock = 1 << 10,    // exp_remove_textkit_initialising_lock
   ASExperimentalDrawingGlobal = 1 << 11,                    // exp_drawing_global
+  ASExperimentalOptimizeDataControllerPipeline = 1 << 12,   // exp_optimize_data_controller_pipeline
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -23,7 +23,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_dispatch_apply",
                                       @"exp_oom_bg_dealloc_disable",
                                       @"exp_remove_textkit_initialising_lock",
-                                      @"exp_drawing_global"]));
+                                      @"exp_drawing_global",
+                                      @"exp_optimize_data_controller_pipeline"]));
   if (flags == ASExperimentalFeatureAll) {
     return allNames;
   }

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -561,12 +561,6 @@ typedef void (^ASDataControllerSynchronizationBlock)();
     os_log_debug(ASCollectionLog(), "performBatchUpdates %@ %@", ASViewToDisplayNode(ASDynamicCast(self.dataSource, UIView)), changeSet);
   }
   
-  NSTimeInterval transactionQueueFlushDuration = 0.0f;
-  {
-    AS::ScopeTimer t(transactionQueueFlushDuration);
-    dispatch_group_wait(_editingTransactionGroup, DISPATCH_TIME_FOREVER);
-  }
-  
   // If the initial reloadData has not been called, just bail because we don't have our old data source counts.
   // See ASUICollectionViewTests.testThatIssuingAnUpdateBeforeInitialReloadIsUnacceptable
   // for the issue that UICollectionView has that we're choosing to workaround.

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -560,7 +560,15 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   } else {
     os_log_debug(ASCollectionLog(), "performBatchUpdates %@ %@", ASViewToDisplayNode(ASDynamicCast(self.dataSource, UIView)), changeSet);
   }
-  
+
+  if (!ASActivateExperimentalFeature(ASExperimentalOptimizeDataControllerPipeline)) {
+    NSTimeInterval transactionQueueFlushDuration = 0.0f;
+    {
+      AS::ScopeTimer t(transactionQueueFlushDuration);
+      dispatch_group_wait(_editingTransactionGroup, DISPATCH_TIME_FOREVER);
+    }
+  }
+
   // If the initial reloadData has not been called, just bail because we don't have our old data source counts.
   // See ASUICollectionViewTests.testThatIssuingAnUpdateBeforeInitialReloadIsUnacceptable
   // for the issue that UICollectionView has that we're choosing to workaround.

--- a/Tests/ASCollectionModernDataSourceTests.mm
+++ b/Tests/ASCollectionModernDataSourceTests.mm
@@ -34,6 +34,11 @@
 
 - (void)setUp {
   [super setUp];
+
+  ASConfiguration *config = [ASConfiguration new];
+  config.experimentalFeatures = ASExperimentalOptimizeDataControllerPipeline;
+  [ASConfigurationManager test_resetWithConfiguration:config];
+
   // Default is 2 sections: 2 items in first, 1 item in second.
   sections = [NSMutableArray array];
   [sections addObject:[ASTestSection new]];

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -16,7 +16,9 @@
 #import <OCMock/OCMock.h>
 #import <AsyncDisplayKit/ASCollectionView+Undeprecated.h>
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
+
 #import "ASDisplayNodeTestsHelper.h"
+#import "ASTestCase.h"
 
 @interface ASTextCellNodeWithSetSelectedCounter : ASTextCellNode
 
@@ -166,11 +168,19 @@
 
 @end
 
-@interface ASCollectionViewTests : XCTestCase
+@interface ASCollectionViewTests : ASTestCase
 
 @end
 
 @implementation ASCollectionViewTests
+
+- (void)setUp
+{
+  [super setUp];
+  ASConfiguration *config = [ASConfiguration new];
+  config.experimentalFeatures = ASExperimentalOptimizeDataControllerPipeline;
+  [ASConfigurationManager test_resetWithConfiguration:config];
+}
 
 - (void)tearDown
 {

--- a/Tests/ASCollectionViewThrashTests.mm
+++ b/Tests/ASCollectionViewThrashTests.mm
@@ -37,7 +37,6 @@
 - (void)tearDown
 {
   [super tearDown];
-  
   if (_failed && _update != nil) {
     NSLog(@"Failed update %@: %@", _update, _update.logFriendlyBase64Representation);
   }

--- a/Tests/ASCollectionViewThrashTests.mm
+++ b/Tests/ASCollectionViewThrashTests.mm
@@ -12,9 +12,10 @@
 #import <AsyncDisplayKit/ASCollectionView.h>
 #import <stdatomic.h>
 
+#import "ASTestCase.h"
 #import "ASThrashUtility.h"
 
-@interface ASCollectionViewThrashTests : XCTestCase
+@interface ASCollectionViewThrashTests : ASTestCase
 
 @end
 
@@ -25,8 +26,18 @@
   BOOL _failed;
 }
 
+- (void)setUp
+{
+  [super setUp];
+  ASConfiguration *config = [ASConfiguration new];
+  config.experimentalFeatures = ASExperimentalOptimizeDataControllerPipeline;
+  [ASConfigurationManager test_resetWithConfiguration:config];
+}
+
 - (void)tearDown
 {
+  [super tearDown];
+  
   if (_failed && _update != nil) {
     NSLog(@"Failed update %@: %@", _update, _update.logFriendlyBase64Representation);
   }

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -29,7 +29,8 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalDispatchApply,
   ASExperimentalOOMBackgroundDeallocDisable,
   ASExperimentalRemoveTextKitInitialisingLock,
-  ASExperimentalDrawingGlobal
+  ASExperimentalDrawingGlobal,
+  ASExperimentalOptimizeDataControllerPipeline
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -53,7 +54,8 @@ static ASExperimentalFeatures features[] = {
     @"exp_dispatch_apply",
     @"exp_oom_bg_dealloc_disable",
     @"exp_remove_textkit_initialising_lock",
-    @"exp_drawing_global"
+    @"exp_drawing_global",
+    @"exp_optimize_data_controller_pipeline"
   ];
 }
 

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -59,7 +59,8 @@ static ASExperimentalFeatures features[] = {
   ];
 }
 
-- (ASExperimentalFeatures)allFeatures {
+- (ASExperimentalFeatures)allFeatures
+{
   ASExperimentalFeatures allFeatures = 0;
   for (int i = 0; i < sizeof(features)/sizeof(ASExperimentalFeatures); i++) {
     allFeatures |= features[i];

--- a/Tests/ASTableViewTests.mm
+++ b/Tests/ASTableViewTests.mm
@@ -22,6 +22,7 @@
 #import <AsyncDisplayKit/ASTableView+Undeprecated.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 
+#import "ASTestCase.h"
 #import "ASXCTExtensions.h"
 
 #define NumberOfSections 10
@@ -217,11 +218,19 @@
 
 @end
 
-@interface ASTableViewTests : XCTestCase
+@interface ASTableViewTests : ASTestCase
 @property (nonatomic, retain) ASTableView *testTableView;
 @end
 
 @implementation ASTableViewTests
+
+- (void)setUp
+{
+  [super setUp];
+  ASConfiguration *config = [ASConfiguration new];
+  config.experimentalFeatures = ASExperimentalOptimizeDataControllerPipeline;
+  [ASConfigurationManager test_resetWithConfiguration:config];
+}
 
 - (void)testDataSourceImplementsNecessaryMethods
 {

--- a/Tests/ASTableViewThrashTests.mm
+++ b/Tests/ASTableViewThrashTests.mm
@@ -13,9 +13,10 @@
 #import <AsyncDisplayKit/ASTableView+Undeprecated.h>
 #import <stdatomic.h>
 
+#import "ASTestCase.h"
 #import "ASThrashUtility.h"
 
-@interface ASTableViewThrashTests: XCTestCase
+@interface ASTableViewThrashTests: ASTestCase
 @end
 
 @implementation ASTableViewThrashTests
@@ -27,8 +28,17 @@
 
 #pragma mark Overrides
 
+- (void)setUp
+{
+  [super setUp];
+  ASConfiguration *config = [ASConfiguration new];
+  config.experimentalFeatures = ASExperimentalOptimizeDataControllerPipeline;
+  [ASConfigurationManager test_resetWithConfiguration:config];
+}
+
 - (void)tearDown
 {
+  [super tearDown];
   if (_failed && _update != nil) {
     NSLog(@"Failed update %@: %@", _update, _update.logFriendlyBase64Representation);
   }


### PR DESCRIPTION
Step 1 of the pipeline is on main thread and needs pendingMap which was updated by the end of step 1 of the run. And step 1 operates on data source index space. So it should be ok to start it ASAP -- without waiting for any running work on the background editing queue.
    
One potential race condition after this change is that it's possible for main thread to query the data source (step 1) while the editing queue consumes the last change set (step 3). However, as long as the client's each nodeBlock and the node's layout code capture/reference an individual model object (as opposed to the whole data set) -- which is what clients are supposed to do anyways, then everything should be fine.
    
The benefit of this diff is that the pipeline will be able to accept many more change sets within a short time window, for example when clients submit a burst of separate small updates.
    
I tested this diff against our test suite several times and smoke tested it in our code base without any issues.