### PR TITLE
Use YGNode properties for style value storage when Yoga is available

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -212,6 +212,8 @@
 		9D9AA56921E23EE200172C09 /* ASDisplayNode+LayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9D9AA56721E23EE200172C09 /* ASDisplayNode+LayoutSpec.mm */; };
 		9D9AA56B21E254B800172C09 /* ASDisplayNode+Yoga.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D9AA56A21E254B800172C09 /* ASDisplayNode+Yoga.h */; };
 		9D9AA56D21E2568500172C09 /* ASDisplayNode+LayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D9AA56C21E2568500172C09 /* ASDisplayNode+LayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9DC6C85922D243E0005BB8B2 /* ASLayoutElementStyleYoga.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DC6C85722D243E0005BB8B2 /* ASLayoutElementStyleYoga.h */; };
+		9DC6C85A22D243E0005BB8B2 /* ASLayoutElementStyleYoga.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9DC6C85822D243E0005BB8B2 /* ASLayoutElementStyleYoga.mm */; };
 		9F06E5CD1B4CAF4200F015D8 /* ASCollectionViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9F06E5CC1B4CAF4200F015D8 /* ASCollectionViewTests.mm */; };
 		9F98C0261DBE29E000476D92 /* ASControlTargetAction.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9F98C0241DBDF2A300476D92 /* ASControlTargetAction.mm */; };
 		9F98C0271DBE29FC00476D92 /* ASControlTargetAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F98C0231DBDF2A300476D92 /* ASControlTargetAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -781,6 +783,8 @@
 		9D9AA56721E23EE200172C09 /* ASDisplayNode+LayoutSpec.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "ASDisplayNode+LayoutSpec.mm"; sourceTree = "<group>"; };
 		9D9AA56A21E254B800172C09 /* ASDisplayNode+Yoga.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+Yoga.h"; sourceTree = "<group>"; };
 		9D9AA56C21E2568500172C09 /* ASDisplayNode+LayoutSpec.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+LayoutSpec.h"; sourceTree = "<group>"; };
+		9DC6C85722D243E0005BB8B2 /* ASLayoutElementStyleYoga.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASLayoutElementStyleYoga.h; sourceTree = "<group>"; };
+		9DC6C85822D243E0005BB8B2 /* ASLayoutElementStyleYoga.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ASLayoutElementStyleYoga.mm; sourceTree = "<group>"; };
 		9F06E5CC1B4CAF4200F015D8 /* ASCollectionViewTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASCollectionViewTests.mm; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		9F98C0231DBDF2A300476D92 /* ASControlTargetAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASControlTargetAction.h; sourceTree = "<group>"; };
 		9F98C0241DBDF2A300476D92 /* ASControlTargetAction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASControlTargetAction.mm; sourceTree = "<group>"; };
@@ -1695,6 +1699,8 @@
 				E55D86311CA8A14000A0C26F /* ASLayoutElement.mm */,
 				698C8B601CAB49FC0052DC3F /* ASLayoutElementExtensibility.h */,
 				9CDC18CB1B910E12004965E2 /* ASLayoutElementPrivate.h */,
+				9DC6C85722D243E0005BB8B2 /* ASLayoutElementStyleYoga.h */,
+				9DC6C85822D243E0005BB8B2 /* ASLayoutElementStyleYoga.mm */,
 				ACF6ED0D1B17843500DA7C62 /* ASLayoutSpec.h */,
 				ACF6ED0E1B17843500DA7C62 /* ASLayoutSpec.mm */,
 				6977965D1D8AC8D3007E93D7 /* ASLayoutSpec+Subclasses.h */,
@@ -1993,6 +1999,7 @@
 				CC0F88631E4281E700576FED /* ASSupplementaryNodeSource.h in Headers */,
 				254C6B771BF94DF4003EC431 /* ASTextKitAttributes.h in Headers */,
 				254C6B7D1BF94DF4003EC431 /* ASTextKitShadower.h in Headers */,
+				9DC6C85922D243E0005BB8B2 /* ASLayoutElementStyleYoga.h in Headers */,
 				690ED58E1E36BCA6000627C0 /* ASLayoutElementStylePrivate.h in Headers */,
 				CC55A70D1E529FA200594372 /* UIResponder+AsyncDisplayKit.h in Headers */,
 				254C6B731BF94DF4003EC431 /* ASTextKitCoreTextAdditions.h in Headers */,
@@ -2467,6 +2474,7 @@
 				AC6145441D8AFD4F003D62A2 /* ASSection.mm in Sources */,
 				E5775AFE1F13CF7400CAC9BC /* _ASCollectionGalleryLayoutItem.mm in Sources */,
 				34EFC75E1B701BF000AD841F /* ASInternalHelpers.mm in Sources */,
+				9DC6C85A22D243E0005BB8B2 /* ASLayoutElementStyleYoga.mm in Sources */,
 				34EFC7681B701CDE00AD841F /* ASLayout.mm in Sources */,
 				DECBD6EA1BE56E1900CF4905 /* ASButtonNode.mm in Sources */,
 				CCCCCCE01EC3EF060087FE10 /* ASTextRunDelegate.mm in Sources */,

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -66,6 +66,7 @@ using AS::MutexLocker;
   DISABLED_ASAssertLocked(__instanceLock__);
   if (_style == nil) {
 #if YOGA
+    if (ASActivateExperimentalFeature(ASExperimentalLayoutElementStyleYogaNode)) {
 #if USE_YOGA_NODE
     // In Yoga mode we use the delegate to inform the tree if properties changes
     _style = (ASLayoutElementStyle *)[[ASLayoutElementStyleYoga alloc] initWithDelegate:self];
@@ -73,7 +74,10 @@ using AS::MutexLocker;
     // In Yoga mode we use the delegate to inform the tree if properties changes
     _style = [[ASLayoutElementStyle alloc] initWithDelegate:self];
 #endif // USE_YOGA_NODE
-
+    } else {
+      // In Yoga mode we use the delegate to inform the tree if properties changes
+      _style = [[ASLayoutElementStyle alloc] initWithDelegate:self];
+    }
 #else
     _style = [[ASLayoutElementStyle alloc] init];
 #endif // YOGA

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -21,6 +21,10 @@
 #import <AsyncDisplayKit/ASDisplayNode+Yoga.h>
 #import <AsyncDisplayKit/NSArray+Diffing.h>
 
+#if YOGA
+#import <AsyncDisplayKit/ASLayoutElementStyleYoga.h>
+#endif
+
 using AS::MutexLocker;
 
 @interface ASDisplayNode (ASLayoutElementStyleDelegate) <ASLayoutElementStyleDelegate>
@@ -62,11 +66,17 @@ using AS::MutexLocker;
   DISABLED_ASAssertLocked(__instanceLock__);
   if (_style == nil) {
 #if YOGA
+#if USE_YOGA_NODE
+    // In Yoga mode we use the delegate to inform the tree if properties changes
+    _style = (ASLayoutElementStyle *)[[ASLayoutElementStyleYoga alloc] initWithDelegate:self];
+#else
     // In Yoga mode we use the delegate to inform the tree if properties changes
     _style = [[ASLayoutElementStyle alloc] initWithDelegate:self];
+#endif // USE_YOGA_NODE
+
 #else
     _style = [[ASLayoutElementStyle alloc] init];
-#endif
+#endif // YOGA
   }
   return _style;
 }

--- a/Source/ASDisplayNode+Layout.mm
+++ b/Source/ASDisplayNode+Layout.mm
@@ -122,7 +122,9 @@ using AS::MutexLocker;
 
 #pragma mark ASLayoutElementStyleExtensibility
 
+#if AS_USE_LAYOUT_EXTENSIBILITY
 ASLayoutElementStyleExtensibilityForwarding
+#endif
 
 #pragma mark ASPrimitiveTraitCollection
 

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -31,6 +31,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalRemoveTextKitInitialisingLock = 1 << 10,    // exp_remove_textkit_initialising_lock
   ASExperimentalDrawingGlobal = 1 << 11,                    // exp_drawing_global
   ASExperimentalOptimizeDataControllerPipeline = 1 << 12,   // exp_optimize_data_controller_pipeline
+  ASExperimentalLayoutElementStyleYogaNode = 1 << 13,       // exp_layout_element_style_yoga_node
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -24,7 +24,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_oom_bg_dealloc_disable",
                                       @"exp_remove_textkit_initialising_lock",
                                       @"exp_drawing_global",
-                                      @"exp_optimize_data_controller_pipeline"]));
+                                      @"exp_optimize_data_controller_pipeline",
+                                      @"exp_layout_element_style_yoga_node"]));
   if (flags == ASExperimentalFeatureAll) {
     return allNames;
   }

--- a/Source/Base/ASAvailability.h
+++ b/Source/Base/ASAvailability.h
@@ -75,6 +75,18 @@
   #define YOGA __has_include(YOGA_HEADER_PATH)
 #endif
 
+#if YOGA
+  #ifndef USE_YOGA_NODE
+    #define USE_YOGA_NODE 0
+  #endif
+#else
+  #define USE_YOGA_NODE 0
+#endif
+
+#ifndef AS_USE_LAYOUT_EXTENSIBILITY
+  #define AS_USE_LAYOUT_EXTENSIBILITY 1
+#endif
+
 #ifdef ASTEXTNODE_EXPERIMENT_GLOBAL_ENABLE
   #error "ASTEXTNODE_EXPERIMENT_GLOBAL_ENABLE is unavailable. See ASConfiguration.h."
 #endif

--- a/Source/Layout/ASLayoutElement.h
+++ b/Source/Layout/ASLayoutElement.h
@@ -167,7 +167,12 @@ AS_EXTERN NSString * const ASLayoutElementStyleLayoutPositionProperty;
 - (void)style:(__kindof ASLayoutElementStyle *)style propertyDidChange:(NSString *)propertyName;
 @end
 
-@interface ASLayoutElementStyle : NSObject <ASStackLayoutElement, ASAbsoluteLayoutElement, ASLayoutElementExtensibility, ASLocking>
+@interface ASLayoutElementStyle : NSObject <ASStackLayoutElement,
+                                            ASAbsoluteLayoutElement,
+#if AS_USE_LAYOUT_EXTENSIBILITY
+                                            ASLayoutElementExtensibility,
+#endif
+                                            ASLocking>
 
 /**
  * @abstract Initializes the layoutElement style with a specified delegate

--- a/Source/Layout/ASLayoutElementStyleYoga.h
+++ b/Source/Layout/ASLayoutElementStyleYoga.h
@@ -1,0 +1,152 @@
+//
+//  ASLayoutElementStyleYoga.h
+//  Texture
+//
+//  Copyright (c) Pinterest, Inc.  All rights reserved.
+//  Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASLayoutElement.h>
+#import <AsyncDisplayKit/ASLayoutElementPrivate.h>
+#import <AsyncDisplayKit/ASLayoutElementExtensibility.h>
+#import <AsyncDisplayKit/ASDimensionInternal.h>
+#import <AsyncDisplayKit/ASStackLayoutElement.h>
+#import <AsyncDisplayKit/ASAbsoluteLayoutElement.h>
+#import <AsyncDisplayKit/ASTraitCollection.h>
+#import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
+#import <AsyncDisplayKit/ASLocking.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ASLayoutElementStyleYoga : NSObject <ASStackLayoutElement,
+                                                ASAbsoluteLayoutElement,
+                                                ASLayoutElementExtensibility,
+                                                ASLocking>
+
+/**
+ * @abstract Initializes the layoutElement style with a specified delegate
+ */
+- (instancetype)initWithDelegate:(id<ASLayoutElementStyleDelegate>)delegate;
+
+/**
+ * @abstract The object that acts as the delegate of the style.
+ *
+ * @discussion The delegate must adopt the ASLayoutElementStyleDelegate protocol. The delegate is not retained.
+ */
+@property (nullable, nonatomic, weak, readonly) id<ASLayoutElementStyleDelegate> delegate;
+
+
+#pragma mark - Sizing
+
+/**
+ * @abstract The width property specifies the width of the content area of an ASLayoutElement.
+ * The minWidth and maxWidth properties override width.
+ * Defaults to ASDimensionAuto
+ */
+@property (nonatomic) ASDimension width;
+
+/**
+ * @abstract The height property specifies the height of the content area of an ASLayoutElement
+ * The minHeight and maxHeight properties override height.
+ * Defaults to ASDimensionAuto
+ */
+@property (nonatomic) ASDimension height;
+
+/**
+ * @abstract The minHeight property is used to set the minimum height of a given element. It prevents the used value
+ * of the height property from becoming smaller than the value specified for minHeight.
+ * The value of minHeight overrides both maxHeight and height.
+ * Defaults to ASDimensionAuto
+ */
+@property (nonatomic) ASDimension minHeight;
+
+/**
+ * @abstract The maxHeight property is used to set the maximum height of an element. It prevents the used value of the
+ * height property from becoming larger than the value specified for maxHeight.
+ * The value of maxHeight overrides height, but minHeight overrides maxHeight.
+ * Defaults to ASDimensionAuto
+ */
+@property (nonatomic) ASDimension maxHeight;
+
+/**
+ * @abstract The minWidth property is used to set the minimum width of a given element. It prevents the used value of
+ * the width property from becoming smaller than the value specified for minWidth.
+ * The value of minWidth overrides both maxWidth and width.
+ * Defaults to ASDimensionAuto
+ */
+@property (nonatomic) ASDimension minWidth;
+
+/**
+ * @abstract The maxWidth property is used to set the maximum width of a given element. It prevents the used value of
+ * the width property from becoming larger than the value specified for maxWidth.
+ * The value of maxWidth overrides width, but minWidth overrides maxWidth.
+ * Defaults to ASDimensionAuto
+ */
+@property (nonatomic) ASDimension maxWidth;
+
+#pragma mark - ASLayoutElementStyleSizeHelpers
+
+/**
+ * @abstract Provides a suggested size for a layout element. If the optional minSize or maxSize are provided,
+ * and the preferredSize exceeds these, the minSize or maxSize will be enforced. If this optional value is not
+ * provided, the layout element’s size will default to it’s intrinsic content size provided calculateSizeThatFits:
+ *
+ * @discussion This method is optional, but one of either preferredSize or preferredLayoutSize is required
+ * for nodes that either have no intrinsic content size or
+ * should be laid out at a different size than its intrinsic content size. For example, this property could be
+ * set on an ASImageNode to display at a size different from the underlying image size.
+ *
+ * @warning Calling the getter when the size's width or height are relative will cause an assert.
+ */
+@property (nonatomic) CGSize preferredSize;
+
+ /**
+ * @abstract An optional property that provides a minimum size bound for a layout element. If provided, this restriction will
+ * always be enforced. If a parent layout element’s minimum size is smaller than its child’s minimum size, the child’s
+ * minimum size will be enforced and its size will extend out of the layout spec’s.
+ *
+ * @discussion For example, if you set a preferred relative width of 50% and a minimum width of 200 points on an
+ * element in a full screen container, this would result in a width of 160 points on an iPhone screen. However,
+ * since 160 pts is lower than the minimum width of 200 pts, the minimum width would be used.
+ */
+@property (nonatomic) CGSize minSize;
+- (CGSize)minSize UNAVAILABLE_ATTRIBUTE;
+
+/**
+ * @abstract An optional property that provides a maximum size bound for a layout element. If provided, this restriction will
+ * always be enforced.  If a child layout element’s maximum size is smaller than its parent, the child’s maximum size will
+ * be enforced and its size will extend out of the layout spec’s.
+ *
+ * @discussion For example, if you set a preferred relative width of 50% and a maximum width of 120 points on an
+ * element in a full screen container, this would result in a width of 160 points on an iPhone screen. However,
+ * since 160 pts is higher than the maximum width of 120 pts, the maximum width would be used.
+ */
+@property (nonatomic) CGSize maxSize;
+- (CGSize)maxSize UNAVAILABLE_ATTRIBUTE;
+
+/**
+ * @abstract Provides a suggested RELATIVE size for a layout element. An ASLayoutSize uses percentages rather
+ * than points to specify layout. E.g. width should be 50% of the parent’s width. If the optional minLayoutSize or
+ * maxLayoutSize are provided, and the preferredLayoutSize exceeds these, the minLayoutSize or maxLayoutSize
+ * will be enforced. If this optional value is not provided, the layout element’s size will default to its intrinsic content size
+ * provided calculateSizeThatFits:
+ */
+@property (nonatomic) ASLayoutSize preferredLayoutSize;
+
+/**
+ * @abstract An optional property that provides a minimum RELATIVE size bound for a layout element. If provided, this
+ * restriction will always be enforced. If a parent layout element’s minimum relative size is smaller than its child’s minimum
+ * relative size, the child’s minimum relative size will be enforced and its size will extend out of the layout spec’s.
+ */
+@property (nonatomic) ASLayoutSize minLayoutSize;
+
+/**
+ * @abstract An optional property that provides a maximum RELATIVE size bound for a layout element. If provided, this
+ * restriction will always be enforced. If a parent layout element’s maximum relative size is smaller than its child’s maximum
+ * relative size, the child’s maximum relative size will be enforced and its size will extend out of the layout spec’s.
+ */
+@property (nonatomic) ASLayoutSize maxLayoutSize;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Layout/ASLayoutElementStyleYoga.mm
+++ b/Source/Layout/ASLayoutElementStyleYoga.mm
@@ -1,0 +1,809 @@
+//
+//  ASLayoutElementStyleYoga.mm
+//  Texture
+//
+//  Copyright (c) Pinterest, Inc.  All rights reserved.
+//  Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <AsyncDisplayKit/ASAvailability.h>
+#import <AsyncDisplayKit/ASLayoutElementStyleYoga.h>
+#import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
+#import <AsyncDisplayKit/ASDisplayNodeInternal.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
+#import <AsyncDisplayKit/ASLayout.h>
+#import <AsyncDisplayKit/ASLayoutElement.h>
+#import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
+#import <AsyncDisplayKit/ASThread.h>
+
+#if YOGA
+
+#import YOGA_HEADER_PATH
+#import <AsyncDisplayKit/ASYogaUtilities.h>
+
+NSString * const ASYogaFlexWrapProperty = @"ASLayoutElementStyleLayoutFlexWrapProperty";
+NSString * const ASYogaFlexDirectionProperty = @"ASYogaFlexDirectionProperty";
+NSString * const ASYogaDirectionProperty = @"ASYogaDirectionProperty";
+NSString * const ASYogaSpacingProperty = @"ASYogaSpacingProperty";
+NSString * const ASYogaJustifyContentProperty = @"ASYogaJustifyContentProperty";
+NSString * const ASYogaAlignItemsProperty = @"ASYogaAlignItemsProperty";
+NSString * const ASYogaPositionTypeProperty = @"ASYogaPositionTypeProperty";
+NSString * const ASYogaPositionProperty = @"ASYogaPositionProperty";
+NSString * const ASYogaMarginProperty = @"ASYogaMarginProperty";
+NSString * const ASYogaPaddingProperty = @"ASYogaPaddingProperty";
+NSString * const ASYogaBorderProperty = @"ASYogaBorderProperty";
+NSString * const ASYogaAspectRatioProperty = @"ASYogaAspectRatioProperty";
+NSString * const ASYogaOverflowProperty = @"ASYogaOverflowProperty";
+NSString * const ASLayoutElementStyleParentAlignStyle = @"ASLayoutElementStyleParentAlignStyle";
+
+using AS::MutexLocker;
+
+#define ASLayoutElementStyleCallDelegate(propertyName)\
+do {\
+  [_delegate style:(ASLayoutElementStyle *)self propertyDidChange:propertyName];\
+} while(0)
+
+@implementation ASLayoutElementStyleYoga {
+  AS::RecursiveMutex __instanceLock__;
+  YGNodeRef _yogaNode;
+
+  std::atomic<CGFloat> _spacingBefore;
+  std::atomic<CGFloat> _spacingAfter;
+  std::atomic<CGFloat> _ascender;
+  std::atomic<CGFloat> _descender;
+
+  std::atomic<ASStackLayoutAlignItems> _parentAlignStyle;
+}
+
+@dynamic width, height, minWidth, maxWidth, minHeight, maxHeight;
+@dynamic preferredSize, minSize, maxSize, preferredLayoutSize, minLayoutSize, maxLayoutSize;
+@dynamic layoutPosition;
+
+#pragma mark - Lifecycle
+
+- (instancetype)initWithDelegate:(id<ASLayoutElementStyleDelegate>)delegate
+{
+  self = [self init];
+  if (self) {
+    _delegate = delegate;
+  }
+  return self;
+}
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    // If we use the Yoga node as backing store  we have to create a yoga node for
+    // every ASDisplayNode
+    [self yogaNodeCreateIfNeeded];
+
+    std::atomic_init(&_parentAlignStyle, ASStackLayoutAlignItemsNotSet);
+
+    // Set default values that differ between Yoga and Texture
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, FlexBasis, ASDimensionAuto);
+    YGNodeStyleSetFlexDirection(_yogaNode, yogaFlexDirection(ASStackLayoutDirectionVertical));
+    YGNodeStyleSetAlignItems(_yogaNode, yogaAlignItems(ASStackLayoutAlignItemsStretch));
+    YGNodeStyleSetAspectRatio(_yogaNode, YGUndefined);
+  }
+  return self;
+}
+
+ASSynthesizeLockingMethodsWithMutex(__instanceLock__)
+
+#pragma mark - ASLayoutElementStyleSize
+
+- (ASLayoutElementSize)size
+{
+  MutexLocker l(__instanceLock__);
+  return (ASLayoutElementSize){
+    dimensionForYogaValue(YGNodeStyleGetWidth(_yogaNode)),
+    dimensionForYogaValue(YGNodeStyleGetHeight(_yogaNode)),
+    dimensionForYogaValue(YGNodeStyleGetMinWidth(_yogaNode)),
+    dimensionForYogaValue(YGNodeStyleGetMaxWidth(_yogaNode)),
+    dimensionForYogaValue(YGNodeStyleGetMinHeight(_yogaNode)),
+    dimensionForYogaValue(YGNodeStyleGetMaxHeight(_yogaNode)),
+  };
+}
+
+- (void)setSize:(ASLayoutElementSize)size
+{
+  MutexLocker l(__instanceLock__);
+  YGNODE_STYLE_SET_DIMENSION(_yogaNode, Width, size.width);
+  YGNODE_STYLE_SET_DIMENSION(_yogaNode, Height, size.height);
+  YGNODE_STYLE_SET_DIMENSION(_yogaNode, MinWidth, size.minWidth);
+  YGNODE_STYLE_SET_DIMENSION(_yogaNode, MaxWidth, size.maxWidth);
+  YGNODE_STYLE_SET_DIMENSION(_yogaNode, MinHeight, size.minHeight);
+  YGNODE_STYLE_SET_DIMENSION(_yogaNode, MaxHeight, size.maxHeight);
+}
+
+#pragma mark - ASLayoutElementStyleSizeForwarding
+
+- (ASDimension)width
+{
+  MutexLocker l(__instanceLock__);
+  return dimensionForYogaValue(YGNodeStyleGetWidth(_yogaNode));
+}
+
+- (void)setWidth:(ASDimension)width
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, Width, width);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleWidthProperty);
+}
+
+- (ASDimension)height
+{
+  MutexLocker l(__instanceLock__);
+  return dimensionForYogaValue(YGNodeStyleGetHeight(_yogaNode));
+}
+
+- (void)setHeight:(ASDimension)height
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, Height, height);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleHeightProperty);
+}
+
+- (ASDimension)minWidth
+{
+  MutexLocker l(__instanceLock__);
+  return dimensionForYogaValue(YGNodeStyleGetMinWidth(_yogaNode));
+}
+
+- (void)setMinWidth:(ASDimension)minWidth
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, MinWidth, minWidth);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMinWidthProperty);
+}
+
+- (ASDimension)maxWidth
+{
+  MutexLocker l(__instanceLock__);
+  return dimensionForYogaValue(YGNodeStyleGetMaxWidth(_yogaNode));
+}
+
+- (void)setMaxWidth:(ASDimension)maxWidth
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, MaxWidth, maxWidth);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMaxWidthProperty);
+}
+
+- (ASDimension)minHeight
+{
+  MutexLocker l(__instanceLock__);
+  return dimensionForYogaValue(YGNodeStyleGetMinWidth(_yogaNode));
+}
+
+- (void)setMinHeight:(ASDimension)minHeight
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, MinHeight, minHeight);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMinHeightProperty);
+}
+
+- (ASDimension)maxHeight
+{
+  MutexLocker l(__instanceLock__);
+  return dimensionForYogaValue(YGNodeStyleGetMaxHeight(_yogaNode));
+}
+
+- (void)setMaxHeight:(ASDimension)maxHeight
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, MaxHeight, maxHeight);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMaxHeightProperty);
+}
+
+
+#pragma mark - ASLayoutElementStyleSizeHelpers
+
+- (void)setPreferredSize:(CGSize)preferredSize
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, Width, ASDimensionMakeWithPoints(preferredSize.width));
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, Height, ASDimensionMakeWithPoints(preferredSize.height));
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleWidthProperty);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleHeightProperty);
+}
+
+- (CGSize)preferredSize
+{
+  MutexLocker l(__instanceLock__);
+  YGValue width = YGNodeStyleGetWidth(_yogaNode);
+  YGValue height = YGNodeStyleGetHeight(_yogaNode);
+  if (width.unit != YGUnitPoint) {
+    NSCAssert(NO, @"Cannot get preferredSize of element with fractional width. Width: %f.",  width.value);
+    return CGSizeZero;
+  }
+
+  if (height.unit != YGUnitPoint) {
+    NSCAssert(height.unit != YGUnitPoint, @"Cannot get preferredSize of element with fractional height. Height: %f.", height.value);
+    return CGSizeZero;
+  }
+
+  return (CGSize){cgFloatForYogaFloat(width.value, 0), cgFloatForYogaFloat(height.value, 0)};
+}
+
+- (void)setMinSize:(CGSize)minSize
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNodeStyleSetMinWidth(_yogaNode, minSize.width);
+    YGNodeStyleSetMinHeight(_yogaNode, minSize.height);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMinWidthProperty);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMinHeightProperty);
+}
+
+- (void)setMaxSize:(CGSize)maxSize
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNodeStyleSetMaxWidth(_yogaNode, maxSize.width);
+    YGNodeStyleSetMaxHeight(_yogaNode, maxSize.height);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMaxWidthProperty);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMaxHeightProperty);
+}
+
+- (ASLayoutSize)preferredLayoutSize
+{
+  return ASLayoutSizeMake(
+    dimensionForYogaValue(YGNodeStyleGetWidth(_yogaNode)),
+    dimensionForYogaValue(YGNodeStyleGetHeight(_yogaNode))
+  );
+}
+
+- (void)setPreferredLayoutSize:(ASLayoutSize)preferredLayoutSize
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, Width, preferredLayoutSize.width);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, Width, preferredLayoutSize.height);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleWidthProperty);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleHeightProperty);
+}
+
+- (ASLayoutSize)minLayoutSize
+{
+  return ASLayoutSizeMake(
+    dimensionForYogaValue(YGNodeStyleGetMinWidth(_yogaNode)),
+    dimensionForYogaValue(YGNodeStyleGetMinHeight(_yogaNode))
+  );
+}
+
+- (void)setMinLayoutSize:(ASLayoutSize)minLayoutSize
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, MinWidth, minLayoutSize.width);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, MinHeight, minLayoutSize.height);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMinWidthProperty);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMinHeightProperty);
+}
+
+- (ASLayoutSize)maxLayoutSize
+{
+  MutexLocker l(__instanceLock__);
+  return ASLayoutSizeMake(
+    dimensionForYogaValue(YGNodeStyleGetMaxWidth(_yogaNode)),
+    dimensionForYogaValue(YGNodeStyleGetMaxHeight(_yogaNode))
+  );
+}
+
+- (void)setMaxLayoutSize:(ASLayoutSize)maxLayoutSize
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, MaxWidth, maxLayoutSize.width);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, MaxHeight, maxLayoutSize.height);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMaxWidthProperty);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMaxHeightProperty);
+}
+
+#pragma mark - ASStackLayoutElement
+
+- (void)setSpacingBefore:(CGFloat)spacingBefore
+{
+  // Not an equivalent on _yogaNode
+  if (_spacingBefore.exchange(spacingBefore) != spacingBefore) {
+    ASLayoutElementStyleCallDelegate(ASLayoutElementStyleSpacingBeforeProperty);
+  }
+}
+
+- (CGFloat)spacingBefore
+{
+  // Not an equivalent on _yogaNode
+  return _spacingBefore.load();
+}
+
+- (void)setSpacingAfter:(CGFloat)spacingAfter
+{
+  // Not an equivalent on _yogaNode
+  if (_spacingAfter.exchange(spacingAfter) != spacingAfter) {
+    ASLayoutElementStyleCallDelegate(ASLayoutElementStyleSpacingAfterProperty);
+  }
+}
+
+- (CGFloat)spacingAfter
+{
+  // Not an equivalent on _yogaNode
+  return _spacingAfter.load();
+}
+
+- (void)setFlexGrow:(CGFloat)flexGrow
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNodeStyleSetFlexGrow(_yogaNode, flexGrow);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleFlexGrowProperty);
+}
+
+- (CGFloat)flexGrow
+{
+  MutexLocker l(__instanceLock__);
+  return YGNodeStyleGetFlexGrow(_yogaNode);
+}
+
+- (void)setFlexShrink:(CGFloat)flexShrink
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNodeStyleSetFlexShrink(_yogaNode, flexShrink);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleFlexShrinkProperty);
+}
+
+- (CGFloat)flexShrink
+{
+  MutexLocker l(__instanceLock__);
+  return YGNodeStyleGetFlexShrink(_yogaNode);
+}
+
+- (void)setFlexBasis:(ASDimension)flexBasis
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNODE_STYLE_SET_DIMENSION(_yogaNode, FlexBasis, flexBasis);
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleFlexBasisProperty);
+}
+
+- (ASDimension)flexBasis
+{
+  MutexLocker l(__instanceLock__);
+  return dimensionForYogaValue(YGNodeStyleGetFlexBasis(_yogaNode));
+}
+
+- (void)setAlignSelf:(ASStackLayoutAlignSelf)alignSelf
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNodeStyleSetAlignSelf(_yogaNode, yogaAlignSelf(alignSelf));
+  }
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleAlignSelfProperty);
+}
+
+- (ASStackLayoutAlignSelf)alignSelf
+{
+  MutexLocker l(__instanceLock__);
+  return stackAlignSelf(YGNodeStyleGetAlignSelf(_yogaNode));
+}
+
+- (void)setAscender:(CGFloat)ascender
+{
+  // Not an equivalent on _yogaNode
+  if (_ascender.exchange(ascender) != ascender) {
+    ASLayoutElementStyleCallDelegate(ASLayoutElementStyleAscenderProperty);
+  }
+}
+
+- (CGFloat)ascender
+{
+  // Not an equivalent on _yogaNode
+  return _ascender.load();
+}
+
+- (void)setDescender:(CGFloat)descender
+{
+  // Not an equivalent on _yogaNode
+  if (_descender.exchange(descender) != descender) {
+    ASLayoutElementStyleCallDelegate(ASLayoutElementStyleDescenderProperty);
+  }
+}
+
+- (CGFloat)descender
+{
+  // Not an equivalent on _yogaNode
+  return _descender.load();
+}
+
+#pragma mark - ASAbsoluteLayoutElement
+
+- (void)setLayoutPosition:(CGPoint)layoutPosition
+{
+  NSCAssert(NO, @"layoutPosition not supported in Yoga");
+}
+
+- (CGPoint)layoutPosition
+{
+  NSCAssert(NO, @"layoutPosition not supported in Yoga");
+  return CGPointZero;
+}
+
+#pragma mark - Extensibility
+
+- (void)setLayoutOptionExtensionBool:(BOOL)value atIndex:(int)idx
+{
+  NSCAssert(NO, @"Layout option extensions not supported in Yoga");
+}
+
+- (BOOL)layoutOptionExtensionBoolAtIndex:(int)idx
+{
+  NSCAssert(NO, @"Layout option extensions not supported in Yoga");
+  return NO;
+}
+
+- (void)setLayoutOptionExtensionInteger:(NSInteger)value atIndex:(int)idx
+{
+  NSCAssert(NO, @"Layout option extensions not supported in Yoga");
+}
+
+- (NSInteger)layoutOptionExtensionIntegerAtIndex:(int)idx
+{
+  NSCAssert(NO, @"Layout option extensions not supported in Yoga");
+  return 0;
+}
+
+- (void)setLayoutOptionExtensionEdgeInsets:(UIEdgeInsets)value atIndex:(int)idx
+{
+  NSCAssert(NO, @"Layout option extensions not supported in Yoga");
+}
+
+- (UIEdgeInsets)layoutOptionExtensionEdgeInsetsAtIndex:(int)idx
+{
+  NSCAssert(NO, @"Layout option extensions not supported in Yoga");
+  return UIEdgeInsetsZero;
+}
+
+#pragma mark - Debugging
+
+- (NSString *)description
+{
+  return ASObjectDescriptionMake(self, [self propertiesForDescription]);
+}
+
+- (NSMutableArray<NSDictionary *> *)propertiesForDescription
+{
+  NSMutableArray<NSDictionary *> *result = [NSMutableArray array];
+
+  if ((self.minLayoutSize.width.unit != ASDimensionUnitAuto ||
+    self.minLayoutSize.height.unit != ASDimensionUnitAuto)) {
+    [result addObject:@{ @"minLayoutSize" : NSStringFromASLayoutSize(self.minLayoutSize) }];
+  }
+
+  if ((self.preferredLayoutSize.width.unit != ASDimensionUnitAuto ||
+    self.preferredLayoutSize.height.unit != ASDimensionUnitAuto)) {
+    [result addObject:@{ @"preferredSize" : NSStringFromASLayoutSize(self.preferredLayoutSize) }];
+  }
+
+  if ((self.maxLayoutSize.width.unit != ASDimensionUnitAuto ||
+    self.maxLayoutSize.height.unit != ASDimensionUnitAuto)) {
+    [result addObject:@{ @"maxLayoutSize" : NSStringFromASLayoutSize(self.maxLayoutSize) }];
+  }
+
+  if (self.alignSelf != ASStackLayoutAlignSelfAuto) {
+    [result addObject:@{ @"alignSelf" : [@[@"ASStackLayoutAlignSelfAuto",
+                                          @"ASStackLayoutAlignSelfStart",
+                                          @"ASStackLayoutAlignSelfEnd",
+                                          @"ASStackLayoutAlignSelfCenter",
+                                          @"ASStackLayoutAlignSelfStretch"] objectAtIndex:self.alignSelf] }];
+  }
+
+  if (self.ascender != 0) {
+    [result addObject:@{ @"ascender" : @(self.ascender) }];
+  }
+
+  if (self.descender != 0) {
+    [result addObject:@{ @"descender" : @(self.descender) }];
+  }
+
+  if (ASDimensionEqualToDimension(self.flexBasis, ASDimensionAuto) == NO) {
+    [result addObject:@{ @"flexBasis" : NSStringFromASDimension(self.flexBasis) }];
+  }
+
+  if (self.flexGrow != 0) {
+    [result addObject:@{ @"flexGrow" : @(self.flexGrow) }];
+  }
+
+  if (self.flexShrink != 0) {
+    [result addObject:@{ @"flexShrink" : @(self.flexShrink) }];
+  }
+
+  if (self.spacingAfter != 0) {
+    [result addObject:@{ @"spacingAfter" : @(self.spacingAfter) }];
+  }
+
+  if (self.spacingBefore != 0) {
+    [result addObject:@{ @"spacingBefore" : @(self.spacingBefore) }];
+  }
+
+  return result;
+}
+
++ (void)initialize
+{
+  [super initialize];
+  YGConfigSetPointScaleFactor(YGConfigGetDefault(), ASScreenScale());
+  // Yoga recommends using Web Defaults for all new projects. This will be enabled for Texture very soon.
+  //YGConfigSetUseWebDefaults(YGConfigGetDefault(), true);
+}
+
+- (YGNodeRef)yogaNode
+{
+  return _yogaNode;
+}
+
+- (YGNodeRef)yogaNodeCreateIfNeeded
+{
+  if (_yogaNode == NULL) {
+    _yogaNode = YGNodeNew();
+  }
+  return _yogaNode;
+}
+
+- (void)destroyYogaNode
+{
+  if (_yogaNode != NULL) {
+    if (ASDisplayNode *delegateAsNode = ASDynamicCast(_delegate, ASDisplayNode)) {
+      MutexLocker l(delegateAsNode->__instanceLock__);
+      ASLayoutElementYogaUpdateMeasureFunc(_yogaNode, nil);
+    }
+    YGNodeFree(_yogaNode);
+    _yogaNode = NULL;
+  }
+}
+
+- (void)dealloc
+{
+  [self destroyYogaNode];
+}
+
+- (YGWrap)flexWrap
+{
+  MutexLocker l(__instanceLock__);
+  return YGNodeStyleGetFlexWrap(_yogaNode);
+}
+
+- (ASStackLayoutDirection)flexDirection
+{
+  MutexLocker l(__instanceLock__);
+  return stackFlexDirection(YGNodeStyleGetFlexDirection(_yogaNode));
+}
+
+- (YGDirection)direction
+{
+  MutexLocker l(__instanceLock__);
+  return YGNodeStyleGetDirection(_yogaNode);
+}
+
+- (ASStackLayoutJustifyContent)justifyContent
+{
+  return stackJustifyContent(YGNodeStyleGetJustifyContent(_yogaNode));
+}
+
+- (ASStackLayoutAlignItems)alignItems
+{
+  return stackAlignItems(YGNodeStyleGetAlignItems(_yogaNode));
+}
+
+- (YGPositionType)positionType
+{
+  MutexLocker l(__instanceLock__);
+  return YGNodeStyleGetPositionType(_yogaNode);
+}
+
+- (ASEdgeInsets)position
+{
+  MutexLocker l(__instanceLock__);
+  AS_EDGE_INSETS_FROM_YGNODE_STYLE(_yogaNode, Position, dimensionForYogaValue);
+}
+
+- (ASEdgeInsets)margin
+{
+  MutexLocker l(__instanceLock__);
+  AS_EDGE_INSETS_FROM_YGNODE_STYLE(_yogaNode, Margin, dimensionForYogaValue);
+}
+
+- (ASEdgeInsets)padding
+{
+  MutexLocker l(__instanceLock__);
+  AS_EDGE_INSETS_FROM_YGNODE_STYLE(_yogaNode, Padding, dimensionForYogaValue);
+}
+
+- (ASEdgeInsets)border
+{
+  MutexLocker l(__instanceLock__);
+  AS_EDGE_INSETS_FROM_YGNODE_STYLE(_yogaNode, Border, [](float border) -> ASDimension {
+    return ASDimensionMake(ASDimensionUnitPoints, cgFloatForYogaFloat(border, 0));
+  });
+}
+
+- (CGFloat)aspectRatio
+{
+  MutexLocker l(__instanceLock__);
+  return YGNodeStyleGetAspectRatio(_yogaNode);
+}
+
+// private (ASLayoutElementStylePrivate.h)
+- (ASStackLayoutAlignItems)parentAlignStyle
+{
+  // Not an equivalent on _yogaNode
+  return _parentAlignStyle.load();
+}
+
+- (YGOverflow)overflow
+{
+  MutexLocker l(__instanceLock__);
+  return YGNodeStyleGetOverflow(_yogaNode);
+}
+
+- (void)setFlexWrap:(YGWrap)flexWrap
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNodeStyleSetFlexWrap(_yogaNode, flexWrap);
+  }
+  ASLayoutElementStyleCallDelegate(ASYogaFlexWrapProperty);
+}
+
+- (void)setFlexDirection:(ASStackLayoutDirection)flexDirection
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNodeStyleSetFlexDirection(_yogaNode, yogaFlexDirection(flexDirection));
+  }
+  ASLayoutElementStyleCallDelegate(ASYogaFlexDirectionProperty);
+}
+
+- (void)setDirection:(YGDirection)direction
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNodeStyleSetDirection(_yogaNode, direction);
+  }
+  ASLayoutElementStyleCallDelegate(ASYogaDirectionProperty);
+}
+
+- (void)setJustifyContent:(ASStackLayoutJustifyContent)justify
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNodeStyleSetJustifyContent(_yogaNode, yogaJustifyContent(justify));
+  }
+  ASLayoutElementStyleCallDelegate(ASYogaJustifyContentProperty);
+}
+
+- (void)setAlignItems:(ASStackLayoutAlignItems)alignItems
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNodeStyleSetAlignItems(_yogaNode, yogaAlignItems(alignItems));
+  }
+  ASLayoutElementStyleCallDelegate(ASYogaAlignItemsProperty);
+}
+
+- (void)setPositionType:(YGPositionType)positionType
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNodeStyleSetPositionType(_yogaNode, positionType);
+  }
+  ASLayoutElementStyleCallDelegate(ASYogaPositionTypeProperty);
+}
+
+- (void)setPosition:(ASEdgeInsets)position
+{
+  {
+  MutexLocker l(__instanceLock__);
+    YGEdge edge = YGEdgeLeft;
+    for (int i = 0; i < YGEdgeAll + 1; ++i) {
+      YGNODE_STYLE_SET_DIMENSION_WITH_EDGE(_yogaNode, Position, dimensionForEdgeWithEdgeInsets(edge, position), edge);
+      edge = (YGEdge)(edge + 1);
+    }
+  }
+  ASLayoutElementStyleCallDelegate(ASYogaPositionProperty);
+}
+
+- (void)setMargin:(ASEdgeInsets)margin
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGEdge edge = YGEdgeLeft;
+    for (int i = 0; i < YGEdgeAll + 1; ++i) {
+      YGNODE_STYLE_SET_DIMENSION_WITH_EDGE(_yogaNode, Margin, dimensionForEdgeWithEdgeInsets(edge, margin), edge);
+      edge = (YGEdge)(edge + 1);
+    }
+  }
+  ASLayoutElementStyleCallDelegate(ASYogaMarginProperty);
+}
+
+- (void)setPadding:(ASEdgeInsets)padding
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGEdge edge = YGEdgeLeft;
+    for (int i = 0; i < YGEdgeAll + 1; ++i) {
+      YGNODE_STYLE_SET_DIMENSION_WITH_EDGE(_yogaNode, Padding, dimensionForEdgeWithEdgeInsets(edge, padding), edge);
+      edge = (YGEdge)(edge + 1);
+    }
+  }
+  ASLayoutElementStyleCallDelegate(ASYogaPaddingProperty);
+}
+
+- (void)setBorder:(ASEdgeInsets)border
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGEdge edge = YGEdgeLeft;
+    for (int i = 0; i < YGEdgeAll + 1; ++i) {
+      YGNODE_STYLE_SET_FLOAT_WITH_EDGE(_yogaNode, Border, dimensionForEdgeWithEdgeInsets(edge, border), edge);
+      edge = (YGEdge)(edge + 1);
+    }
+  }
+  ASLayoutElementStyleCallDelegate(ASYogaBorderProperty);
+}
+
+- (void)setAspectRatio:(CGFloat)aspectRatio
+{
+  {
+    MutexLocker l(__instanceLock__);
+    if (aspectRatio > FLT_EPSILON && aspectRatio < CGFLOAT_MAX / 2.0) {
+      YGNodeStyleSetAspectRatio(_yogaNode, aspectRatio);
+    }
+  }
+  ASLayoutElementStyleCallDelegate(ASYogaAspectRatioProperty);
+}
+
+// private (ASLayoutElementStylePrivate.h)
+- (void)setParentAlignStyle:(ASStackLayoutAlignItems)style
+{
+  // Not an equivalent on _yogaNode
+  if (_parentAlignStyle.exchange(style) != style) {
+    ASLayoutElementStyleCallDelegate(ASLayoutElementStyleParentAlignStyle);
+  }
+}
+
+- (void)setOverflow:(YGOverflow)overflow
+{
+  {
+    MutexLocker l(__instanceLock__);
+    YGNodeStyleSetOverflow(_yogaNode, overflow);
+  }
+  ASLayoutElementStyleCallDelegate(ASYogaOverflowProperty);
+}
+
+@end
+
+#endif /* YOGA */

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -160,7 +160,9 @@ ASLayoutElementLayoutCalculationDefaults
 
 #pragma mark - ASLayoutElementStyleExtensibility
 
+#if AS_USE_LAYOUT_EXTENSIBILITY
 ASLayoutElementStyleExtensibilityForwarding
+#endif
 
 #pragma mark - ASDescriptionProvider
 

--- a/Source/Layout/ASYogaUtilities.h
+++ b/Source/Layout/ASYogaUtilities.h
@@ -32,12 +32,19 @@ AS_EXTERN void ASDisplayNodePerformBlockOnEveryYogaChild(ASDisplayNode *node, vo
 #pragma mark - Yoga Type Conversion Helpers
 
 AS_EXTERN YGAlign yogaAlignItems(ASStackLayoutAlignItems alignItems);
+AS_EXTERN ASStackLayoutAlignItems stackAlignItems(YGAlign alignItems);
 AS_EXTERN YGJustify yogaJustifyContent(ASStackLayoutJustifyContent justifyContent);
+AS_EXTERN ASStackLayoutJustifyContent stackJustifyContent(YGJustify justifyContent);
 AS_EXTERN YGAlign yogaAlignSelf(ASStackLayoutAlignSelf alignSelf);
+AS_EXTERN ASStackLayoutAlignSelf stackAlignSelf(YGAlign alignSelf);
 AS_EXTERN YGFlexDirection yogaFlexDirection(ASStackLayoutDirection direction);
+AS_EXTERN ASStackLayoutDirection stackFlexDirection(YGFlexDirection direction);
 AS_EXTERN float yogaFloatForCGFloat(CGFloat value);
+AS_EXTERN CGFloat cgFloatForYogaFloat(float yogaFloat, CGFloat undefinedDefault);
 AS_EXTERN float yogaDimensionToPoints(ASDimension dimension);
 AS_EXTERN float yogaDimensionToPercent(ASDimension dimension);
+AS_EXTERN YGValue yogaValueForDimension(ASDimension dimension);
+AS_EXTERN ASDimension dimensionForYogaValue(YGValue value);
 AS_EXTERN ASDimension dimensionForEdgeWithEdgeInsets(YGEdge edge, ASEdgeInsets insets);
 
 AS_EXTERN void ASLayoutElementYogaUpdateMeasureFunc(YGNodeRef yogaNode, id <ASLayoutElement> layoutElement);
@@ -74,5 +81,43 @@ AS_EXTERN YGSize ASLayoutElementYogaMeasureFunc(YGNodeRef yogaNode,
   } else { \
     YGNodeStyleSet##property(yogaNode, edge, YGUndefined); \
   } \
+
+#define AS_EDGE_INSETS_FROM_YGNODE_STYLE(yogaNode, property, dimensionFunc) \
+  ASEdgeInsets insets;\
+  YGEdge edge = YGEdgeLeft; \
+  for (int i = 0; i < YGEdgeAll + 1; ++i) { \
+    ASDimension dimension = dimensionFunc(YGNodeStyleGet##property(yogaNode, edge)); \
+    switch (edge) { \
+      case YGEdgeLeft: \
+        insets.left = dimension; \
+        break; \
+      case YGEdgeTop: \
+        insets.top = dimension; \
+        break; \
+      case YGEdgeRight: \
+        insets.right = dimension; \
+        break; \
+      case YGEdgeBottom: \
+        insets.bottom = dimension; \
+        break; \
+      case YGEdgeStart: \
+        insets.start = dimension; \
+        break; \
+      case YGEdgeEnd: \
+        insets.end = dimension; \
+        break; \
+      case YGEdgeHorizontal: \
+        insets.horizontal = dimension; \
+        break; \
+      case YGEdgeVertical: \
+        insets.vertical = dimension; \
+        break; \
+      case YGEdgeAll: \
+        insets.all = dimension; \
+        break; \
+    } \
+    edge = (YGEdge)(edge + 1); \
+  } \
+  return insets; \
 
 #endif /* YOGA */

--- a/Source/Private/_ASCollectionGalleryLayoutItem.mm
+++ b/Source/Private/_ASCollectionGalleryLayoutItem.mm
@@ -35,7 +35,9 @@
   return self;
 }
 
+#if AS_USE_LAYOUT_EXTENSIBILITY
 ASLayoutElementStyleExtensibilityForwarding
+#endif
 
 - (ASTraitCollection *)asyncTraitCollection
 {


### PR DESCRIPTION
Our `ASLayoutElement` copies of the `ASLayoutElementStyle` values are pretty big. Just the insets properties are 36 ASDimensions, each of which is 16 bytes, so 576 bytes! In total `ASLayoutElementStyle` is 912 Bytes. This PR tries to reduce the size of the `ASLayoutElementStyle` by introducing the following flags:
- `USE_YOGA_NODE`: Tries to reduces the size of the `ASLayotElementStyle` by using the backing Yoga node if Yoga is available. (`NO` by default)
- `AS_USE_LAYOUT_EXTENSIBILITY`: Removes the possibility to extend the `ASLayoutElementStyle` with custom properties (`YES` by default)

The results are promising (reduction of bytes for one `ASLayoutElementStyle` object):
- `!AS_USE_LAYOUT_EXTENSIBILITY` : 992 Bytes -> 912 Bytes (reduction of 80 bytes)
- `USE_YOGA_NODE`: 992 Bytes -> 240 Bytes (reduction of 752 bytes)
- `USE_YOGA_NODE` + `!AS_USE_LAYOUT_EXTENSIBILITY`: 992 bytes -> 160 bytes (total reduction of 832 bytes)
