### PR TITLE
Fixes accessibilityLabel bug on ASButtonNode that has no title

### DIFF
--- a/Source/ASButtonNode.mm
+++ b/Source/ASButtonNode.mm
@@ -179,9 +179,10 @@
     newTitle = _normalAttributedTitle;
   }
 
-  // Calling self.titleNode is essential here because _titleNode is lazily created by the getter.
-  if (((_titleNode != nil && self.titleNode.attributedText.length > 0) || newTitle.length > 0) && [self.titleNode.attributedText isEqualToAttributedString:newTitle] == NO) {
-    _titleNode.attributedText = newTitle;
+  NSAttributedString *attributedString = _titleNode.attributedText;
+  if ((attributedString.length > 0 || newTitle.length > 0) && [attributedString isEqualToAttributedString:newTitle] == NO) {
+    // Calling self.titleNode is essential here because _titleNode is lazily created by the getter.
+    self.titleNode.attributedText = newTitle;
     [self unlock];
     
     self.accessibilityLabel = self.defaultAccessibilityLabel;

--- a/Source/ASButtonNode.mm
+++ b/Source/ASButtonNode.mm
@@ -180,7 +180,7 @@
   }
 
   // Calling self.titleNode is essential here because _titleNode is lazily created by the getter.
-  if ((_titleNode != nil || newTitle.length > 0) && [self.titleNode.attributedText isEqualToAttributedString:newTitle] == NO) {
+  if (((_titleNode != nil && self.titleNode.attributedText.length > 0) || newTitle.length > 0) && [self.titleNode.attributedText isEqualToAttributedString:newTitle] == NO) {
     _titleNode.attributedText = newTitle;
     [self unlock];
     

--- a/Tests/ASButtonNodeTests.mm
+++ b/Tests/ASButtonNodeTests.mm
@@ -66,4 +66,13 @@
   XCTAssertTrue([buttonNode.accessibilityLabel isEqualToString:@"My Test"]);
 }
 
+- (void)testUpdateTitle
+{
+  NSAttributedString *title = [[NSAttributedString alloc] initWithString:@"MyTitle"];
+  ASButtonNode *buttonNode = [[ASButtonNode alloc] init];
+  [buttonNode setAttributedTitle:title forState:UIControlStateNormal];
+  XCTAssertTrue([[buttonNode attributedTitleForState:UIControlStateNormal] isEqualToAttributedString:title]);
+  XCTAssert([buttonNode.titleNode.attributedText isEqualToAttributedString:title]);
+}
+
 @end

--- a/Tests/ASButtonNodeTests.mm
+++ b/Tests/ASButtonNodeTests.mm
@@ -10,6 +10,7 @@
 
 #import <AsyncDisplayKit/ASButtonNode.h>
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
+#import <AsyncDisplayKit/ASTextNode.h>
 
 @interface ASButtonNodeTests : XCTestCase
 @end
@@ -49,6 +50,20 @@
                 @"Default accessibility traits should return disabled button accessibility trait, "
                 @"instead returns %llu",
                 buttonNode.defaultAccessibilityTraits);
+}
+
+/// Test the accessbility label consistency for buttons that do not have a title
+/// In this test case, the button is empty but its titleNode is not nil.
+/// If we give this button an accessibility label and then change its state,
+/// we still want the accessbility unchanged, instead of going back to the default accessibility label.
+- (void)testAccessibilityWithoutATitle
+{
+  ASButtonNode *buttonNode = [[ASButtonNode alloc] init];
+  buttonNode.accessibilityLabel = @"My Test";
+  // Make sure the title node is not nil.
+  buttonNode.titleNode.placeholderColor = [UIColor whiteColor];
+  buttonNode.selected = YES;
+  XCTAssertTrue([buttonNode.accessibilityLabel isEqualToString:@"My Test"]);
 }
 
 @end


### PR DESCRIPTION
We use the `ASButtonNode` as a pure icon button that has no title, and I also give this button an accessibility label. Since this buttton's `titleNode` will be non-nil if the `self.titleNode` getter is ever called, my accessibility label will get reset to empty string every time the button's state changes (`selected`, `enabled`, etc.). However, I'd like my button's accessibility label to remain consistent in this case. This PR addresses this problem, i.e. if the button title and the new title are both either empty or nil, we do not reset the accessibility label. Also added corresponding test.