### PR TITLE
Fix ASBasicImageDownloaderTests

### DIFF
--- a/Tests/ASBasicImageDownloaderTests.mm
+++ b/Tests/ASBasicImageDownloaderTests.mm
@@ -23,7 +23,9 @@
   XCTestExpectation *secondExpectation = [self expectationWithDescription:@"Second ASBasicImageDownloader completion handler should be called within 3 seconds"];
 
   ASBasicImageDownloader *downloader = [ASBasicImageDownloader sharedImageDownloader];
-  NSURL *URL = [NSURL URLWithString:@"http://wrongPath/wrongResource.png"];
+  NSURL *URL = [[NSBundle bundleForClass:[self class]] URLForResource:@"logo-square"
+                                                        withExtension:@"png"
+                                                         subdirectory:@"TestResources"];
 
   [downloader downloadImageWithURL:URL
                      callbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)


### PR DESCRIPTION
Fix the following error in `ASBasicImageDownloaderTests` when building Tests:

```
  testAsynchronouslyDownloadTheSameURLTwice, Asynchronous wait failed: Exceeded timeout of 30 seconds, with unfulfilled expectations: "First ASBasicImageDownloader completion handler should be called within 3 seconds", "Second ASBasicImageDownloader completion handler should be called within 3 seconds".
```