### PR TITLE
Bridge CTFontRef directly to UIFont when converting attributes on NSAttributedString

### DIFF
--- a/Source/TextKit/ASTextKitCoreTextAdditions.mm
+++ b/Source/TextKit/ASTextKitCoreTextAdditions.mm
@@ -73,8 +73,9 @@ NSDictionary *NSAttributedStringAttributesForCoreTextAttributes(NSDictionary *co
       CGFloat fontSize = CTFontGetSize(coreTextFont);
       UIFont *font = [UIFont fontWithName:fontName size:fontSize];
       ASDisplayNodeCAssertNotNil(font, @"unable to load font %@ with size %f", fontName, fontSize);
-      if (font == nil) {
+      if (font == nil || ![font.familyName isEqualToString:fontName]) {
         // Gracefully fail if we were unable to load the font.
+        // Additionally UIFont is returning a different font family than expected, fallback to the system font
         font = [UIFont systemFontOfSize:fontSize];
       }
       cleanAttributes[NSFontAttributeName] = font;

--- a/Source/TextKit/ASTextKitCoreTextAdditions.mm
+++ b/Source/TextKit/ASTextKitCoreTextAdditions.mm
@@ -76,7 +76,14 @@ NSDictionary *NSAttributedStringAttributesForCoreTextAttributes(NSDictionary *co
       if (font == nil || ![font.familyName isEqualToString:fontName]) {
         // Gracefully fail if we were unable to load the font.
         // Additionally UIFont is returning a different font family than expected, fallback to the system font
-        font = [UIFont systemFontOfSize:fontSize];
+        CTFontSymbolicTraits symbolicTraits = CTFontGetSymbolicTraits(coreTextFont);
+          if (symbolicTraits & kCTFontTraitItalic) {
+              font = [UIFont italicSystemFontOfSize:fontSize];
+          } else if (symbolicTraits & kCTFontTraitBold) {
+              font = [UIFont boldSystemFontOfSize:fontSize];
+          } else {
+              font = [UIFont systemFontOfSize:fontSize];
+          }
       }
       cleanAttributes[NSFontAttributeName] = font;
     }

--- a/Source/TextKit/ASTextKitCoreTextAdditions.mm
+++ b/Source/TextKit/ASTextKitCoreTextAdditions.mm
@@ -77,13 +77,13 @@ NSDictionary *NSAttributedStringAttributesForCoreTextAttributes(NSDictionary *co
         // Gracefully fail if we were unable to load the font.
         // Additionally UIFont is returning a different font family than expected, fallback to the system font
         CTFontSymbolicTraits symbolicTraits = CTFontGetSymbolicTraits(coreTextFont);
-          if (symbolicTraits & kCTFontTraitItalic) {
-              font = [UIFont italicSystemFontOfSize:fontSize];
-          } else if (symbolicTraits & kCTFontTraitBold) {
-              font = [UIFont boldSystemFontOfSize:fontSize];
-          } else {
-              font = [UIFont systemFontOfSize:fontSize];
-          }
+        if (symbolicTraits & kCTFontTraitItalic) {
+          font = [UIFont italicSystemFontOfSize:fontSize];
+        } else if (symbolicTraits & kCTFontTraitBold) {
+          font = [UIFont boldSystemFontOfSize:fontSize];
+        } else {
+          font = [UIFont systemFontOfSize:fontSize];
+        }
       }
       cleanAttributes[NSFontAttributeName] = font;
     }

--- a/Source/TextKit/ASTextKitCoreTextAdditions.mm
+++ b/Source/TextKit/ASTextKitCoreTextAdditions.mm
@@ -68,24 +68,9 @@ NSDictionary *NSAttributedStringAttributesForCoreTextAttributes(NSDictionary *co
 
     // kCTFontAttributeName -> NSFontAttributeName
     if ([coreTextKey isEqualToString:(NSString *)kCTFontAttributeName]) {
+      // Its reference type, CTFontRef, is toll-free bridged with UIFont in iOS and NSFont in OS X
       CTFontRef coreTextFont = (__bridge CTFontRef)coreTextValue;
-      NSString *fontName = (__bridge_transfer NSString *)CTFontCopyPostScriptName(coreTextFont);
-      CGFloat fontSize = CTFontGetSize(coreTextFont);
-      UIFont *font = [UIFont fontWithName:fontName size:fontSize];
-      ASDisplayNodeCAssertNotNil(font, @"unable to load font %@ with size %f", fontName, fontSize);
-      if (font == nil || ![font.familyName isEqualToString:fontName]) {
-        // Gracefully fail if we were unable to load the font.
-        // Additionally UIFont is returning a different font family than expected, fallback to the system font
-        CTFontSymbolicTraits symbolicTraits = CTFontGetSymbolicTraits(coreTextFont);
-        if (symbolicTraits & kCTFontTraitItalic) {
-          font = [UIFont italicSystemFontOfSize:fontSize];
-        } else if (symbolicTraits & kCTFontTraitBold) {
-          font = [UIFont boldSystemFontOfSize:fontSize];
-        } else {
-          font = [UIFont systemFontOfSize:fontSize];
-        }
-      }
-      cleanAttributes[NSFontAttributeName] = font;
+      cleanAttributes[NSFontAttributeName] = (__bridge UIFont *)coreTextFont;
     }
     // kCTKernAttributeName -> NSKernAttributeName
     else if ([coreTextKey isEqualToString:(NSString *)kCTKernAttributeName]) {


### PR DESCRIPTION
In iOS13, there is an issue with the font returned from "-[UIFontj fontWithName:size:]". When asking for "SFUI-Regular" returns "Times New Roman" font. It seems like a reasonable default would be to return the system font in the case that the requested font was not respected.