### PR TITLE
add new networking image delegate method when image does not load from cache

### DIFF
--- a/Source/ASNetworkImageNode.h
+++ b/Source/ASNetworkImageNode.h
@@ -173,6 +173,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)imageNodeDidLoadImageFromCache:(ASNetworkImageNode *)imageNode;
 
 /**
+ * Notification that the image node is not able to load image from cache
+ *
+ * @param imageNode The sender.
+ *
+ * @discussion Called on the main thread.
+ */
+- (void)imageNodeDidFailToLoadImageFromCache:(ASNetworkImageNode *)imageNode;
+
+/**
  * Notification that the image node will load image from network
  *
  * @param imageNode The sender.

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -57,6 +57,7 @@
       unsigned int delegateDidLoadImage:1;
       unsigned int delegateDidLoadImageFromCache:1;
       unsigned int delegateDidLoadImageWithInfo:1;
+      unsigned int delegateDidFailToLoadImageFromCache:1;
 
       unsigned int downloaderImplementsSetProgress:1;
       unsigned int downloaderImplementsSetPriority:1;
@@ -298,6 +299,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
   _networkImageNodeFlags.delegateDidLoadImage = [delegate respondsToSelector:@selector(imageNode:didLoadImage:)];
   _networkImageNodeFlags.delegateDidLoadImageFromCache = [delegate respondsToSelector:@selector(imageNodeDidLoadImageFromCache:)];
   _networkImageNodeFlags.delegateDidLoadImageWithInfo = [delegate respondsToSelector:@selector(imageNode:didLoadImage:info:)];
+  _networkImageNodeFlags.delegateDidFailToLoadImageFromCache = [delegate respondsToSelector:@selector(imageNodeDidFailToLoadImageFromCache:)];
 }
 
 - (id<ASNetworkImageNodeDelegate>)delegate
@@ -665,6 +667,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
     BOOL delegateWillLoadImageFromCache = _networkImageNodeFlags.delegateWillLoadImageFromCache;
     BOOL delegateWillLoadImageFromNetwork = _networkImageNodeFlags.delegateWillLoadImageFromNetwork;
     BOOL delegateDidLoadImageFromCache = _networkImageNodeFlags.delegateDidLoadImageFromCache;
+    BOOL delegateDidFailToLoadImageFromCache = _networkImageNodeFlags.delegateDidFailToLoadImageFromCache;
     BOOL isImageLoaded = _networkImageNodeFlags.imageLoaded;
     __block NSURL *URL = _URL;
     id currentDownloadIdentifier = _downloadIdentifier;
@@ -824,6 +827,9 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
           }
           
           if ([imageContainer asdk_image] == nil && [imageContainer asdk_animatedImageData] == nil && self->_downloader != nil) {
+            if (delegateDidFailToLoadImageFromCache) {
+              [delegate imageNodeDidFailToLoadImageFromCache:self];
+            }
             if (delegateWillLoadImageFromNetwork) {
               [delegate imageNodeWillLoadImageFromNetwork:self];
             }


### PR DESCRIPTION
There is a missing delegate when image cannot load from cache. 