### PR TITLE
Should not play if the video is already played

### DIFF
--- a/Source/ASVideoNode.mm
+++ b/Source/ASVideoNode.mm
@@ -453,6 +453,10 @@ static NSString * const kRate = @"rate";
 {
   [super didEnterVisibleState];
   
+  if ([self isPlaying]) {
+    return;
+  }
+  
   BOOL shouldPlay = NO;
   {
     ASLockScopeSelf();


### PR DESCRIPTION
if the video played in `-[UIViewController viewWillAppear:]` method, it will be playing the video in `-[ASVideoNode didEnterVisibleState]` too. because of the `_lastPlaybackTime` variable not recorded in `[ASVideoNode didExitVisibleState]` (video paused in `-[UIViewController viewWillDisappear:]` manually), the video will play at beginning.