### PR TITLE
Migrate example projects to the recommended `-nodeBlock` data source method

### DIFF
--- a/examples/ASDKTube/Sample/Controller/VideoFeedNodeController.m
+++ b/examples/ASDKTube/Sample/Controller/VideoFeedNodeController.m
@@ -66,12 +66,12 @@
   return _videoFeedData.count;
 }
 
-- (ASCellNode *)tableNode:(ASTableNode *)tableNode nodeForRowAtIndexPath:(NSIndexPath *)indexPath
-{
+- (ASCellNodeBlock)tableNode:(ASTableNode *)tableNode nodeBlockForRowAtIndexPath:(NSIndexPath *)indexPath {
   VideoModel *videoObject = [_videoFeedData objectAtIndex:indexPath.row];
-  VideoContentCell *cellNode = [[VideoContentCell alloc] initWithVideoObject:videoObject];
-  
-  return cellNode;
+  return ^{
+    VideoContentCell *cellNode = [[VideoContentCell alloc] initWithVideoObject:videoObject];
+    return cellNode;
+  };
 }
 
 @end

--- a/examples/CustomCollectionView-Swift/Sample/ViewController.swift
+++ b/examples/CustomCollectionView-Swift/Sample/ViewController.swift
@@ -52,9 +52,11 @@ class ViewController: ASViewController<ASCollectionNode>, MosaicCollectionViewLa
     _collectionNode.view.isScrollEnabled = true
   }
 
-  func collectionNode(_ collectionNode: ASCollectionNode, nodeForItemAt indexPath: IndexPath) -> ASCellNode {
+  func collectionNode(_ collectionNode: ASCollectionNode, nodeBlockForItemAt indexPath: IndexPath) -> ASCellNodeBlock {
     let image = _sections[indexPath.section][indexPath.item]
-    return ImageCellNode(with: image)
+    return {
+      return ImageCellNode(with: image)
+    }
   }
   
   

--- a/examples/HorizontalWithinVerticalScrolling/Sample/ViewController.m
+++ b/examples/HorizontalWithinVerticalScrolling/Sample/ViewController.m
@@ -55,9 +55,10 @@
 
 #pragma mark - ASTableNode
 
-- (ASCellNode *)tableNode:(ASTableNode *)tableNode nodeForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-  return [[HorizontalScrollCellNode alloc] initWithElementSize:CGSizeMake(100, 100)];
+- (ASCellNodeBlock)tableNode:(ASTableNode *)tableNode nodeBlockForRowAtIndexPath:(NSIndexPath *)indexPath {
+  return ^{
+    return [[HorizontalScrollCellNode alloc] initWithElementSize:CGSizeMake(100, 100)];
+  };
 }
 
 - (NSInteger)tableNode:(ASTableNode *)tableNode numberOfRowsInSection:(NSInteger)section

--- a/examples/Kittens/Sample/ViewController.m
+++ b/examples/Kittens/Sample/ViewController.m
@@ -100,17 +100,20 @@ static const NSInteger kMaxLitterSize = 100;        // max number of kitten cell
   return 1 + _kittenDataSource.count;
 }
 
-- (ASCellNode *)tableNode:(ASTableNode *)tableNode nodeForRowAtIndexPath:(NSIndexPath *)indexPath
-{
+- (ASCellNodeBlock)tableNode:(ASTableNode *)tableNode nodeBlockForRowAtIndexPath:(NSIndexPath *)indexPath {
   // special-case the first row
   if ([_blurbNodeIndexPath compare:indexPath] == NSOrderedSame) {
-    BlurbNode *node = [[BlurbNode alloc] init];
-    return node;
+    return ^{
+      BlurbNode *node = [[BlurbNode alloc] init];
+      return node;
+    };
   }
 
   NSValue *size = _kittenDataSource[indexPath.row - 1];
-  KittenNode *node = [[KittenNode alloc] initWithKittenOfSize:size.CGSizeValue];
-  return node;
+  return ^{
+    KittenNode *node = [[KittenNode alloc] initWithKittenOfSize:size.CGSizeValue];
+    return node;
+  };
 }
 
 - (void)tableNode:(ASTableNode *)tableNode didSelectRowAtIndexPath:(NSIndexPath *)indexPath

--- a/examples/LayoutSpecExamples-Swift/Sample/OverviewViewController.swift
+++ b/examples/LayoutSpecExamples-Swift/Sample/OverviewViewController.swift
@@ -50,8 +50,11 @@ extension OverviewViewController: ASTableDataSource {
     return layoutExamples.count
   }
 
-  func tableNode(_ tableNode: ASTableNode, nodeForRowAt indexPath: IndexPath) -> ASCellNode {
-    return OverviewCellNode(layoutExampleType: layoutExamples[indexPath.row])
+  func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
+    let layoutExample = layoutExamples[indexPath.row]
+    return {
+      return OverviewCellNode(layoutExampleType: layoutExample)
+    }
   }
 }
 

--- a/examples/LayoutSpecExamples/Sample/OverviewViewController.m
+++ b/examples/LayoutSpecExamples/Sample/OverviewViewController.m
@@ -62,9 +62,11 @@
   return [_layoutExamples count];
 }
 
-- (ASCellNode *)tableNode:(ASTableNode *)tableNode nodeForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-  return [[OverviewCellNode alloc] initWithLayoutExampleClass:_layoutExamples[indexPath.row]];
+- (ASCellNodeBlock)tableNode:(ASTableNode *)tableNode nodeBlockForRowAtIndexPath:(NSIndexPath *)indexPath {
+    Class layoutExample = _layoutExamples[indexPath.row];
+    return ^{
+        return [[OverviewCellNode alloc] initWithLayoutExampleClass:layoutExample];
+    };
 }
 
 - (void)tableNode:(ASTableNode *)tableNode didSelectRowAtIndexPath:(NSIndexPath *)indexPath

--- a/examples/Swift/Sample/ViewController.swift
+++ b/examples/Swift/Sample/ViewController.swift
@@ -41,21 +41,24 @@ final class ViewController: ASViewController<ASDisplayNode>, ASTableDataSource, 
 
   // MARK: ASTableNode data source and delegate.
 
-  func tableNode(_ tableNode: ASTableNode, nodeForRowAt indexPath: IndexPath) -> ASCellNode {
+  func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
     // Should read the row count directly from table view but
     // https://github.com/facebook/AsyncDisplayKit/issues/1159
     let rowCount = self.tableNode(tableNode, numberOfRowsInSection: 0)
 
     if state.fetchingMore && indexPath.row == rowCount - 1 {
-      let node = TailLoadingCellNode()
-      node.style.height = ASDimensionMake(44.0)
-      return node;
+      return {
+        let node = TailLoadingCellNode()
+        node.style.height = ASDimensionMake(44.0)
+        return node;
+      }
     }
-
-    let node = ASTextCellNode()
-    node.text = String(format: "[%ld.%ld] says hello!", indexPath.section, indexPath.row)
-
-    return node
+    
+    return {
+      let node = ASTextCellNode()
+      node.text = String(format: "[%ld.%ld] says hello!", indexPath.section, indexPath.row)
+      return node
+    }
   }
 
   func numberOfSections(in tableNode: ASTableNode) -> Int {

--- a/examples/VerticalWithinHorizontalScrolling/Sample/ViewController.m
+++ b/examples/VerticalWithinHorizontalScrolling/Sample/ViewController.m
@@ -64,13 +64,14 @@
 #pragma mark -
 #pragma mark ASPagerNode.
 
-- (ASCellNode *)pagerNode:(ASPagerNode *)pagerNode nodeAtIndex:(NSInteger)index
-{
+- (ASCellNodeBlock)pagerNode:(ASPagerNode *)pagerNode nodeBlockAtIndex:(NSInteger)index {
   CGSize boundsSize = pagerNode.bounds.size;
   CGSize gradientRowSize = CGSizeMake(boundsSize.width, 100);
-  GradientTableNode *node = [[GradientTableNode alloc] initWithElementSize:gradientRowSize];
-  node.pageNumber = index;
-  return node;
+  return ^{
+    GradientTableNode *node = [[GradientTableNode alloc] initWithElementSize:gradientRowSize];
+    node.pageNumber = index;
+    return node;
+  };
 }
 
 - (ASSizeRange)pagerNode:(ASPagerNode *)pagerNode constrainedSizeForNodeAtIndex:(NSInteger)index;


### PR DESCRIPTION
Migrate example projects to the recommended `-nodeBlock` data source method, so node containers will be able to prepare and display all of its cells concurrently