### PR TITLE
[Dev docs] Fix previous and next page links

### DIFF
--- a/docs/_docs/development/cell-node-lifecycle.md
+++ b/docs/_docs/development/cell-node-lifecycle.md
@@ -1,7 +1,0 @@
----
-title: Cell node lifecycle
-layout: docs
-permalink: /development/cell-node-lifecycle.html
----
-
-<p>👷👷‍♀️Under construction…</p>

--- a/docs/_docs/development/collection-animations.md
+++ b/docs/_docs/development/collection-animations.md
@@ -1,7 +1,0 @@
----
-title: Collection animations
-layout: docs
-permalink: /development/collection-animations.html
----
-
-<p>👷👷‍♀️Under construction…</p>

--- a/docs/_docs/development/collection-asynchronous-updates.md
+++ b/docs/_docs/development/collection-asynchronous-updates.md
@@ -2,6 +2,7 @@
 title: Collections and asynchronous updates
 layout: docs
 permalink: /development/collection-asynchronous-updates.html
+prevPage: layout-specs.html
 ---
 
 # At a glance

--- a/docs/_docs/development/how-to-debug.md
+++ b/docs/_docs/development/how-to-debug.md
@@ -2,6 +2,8 @@
 title: How to debug issues in Texture
 layout: docs
 permalink: /development/how-to-debug.html
+prevPage: how-to-develop.html
+nextPage: threading.html
 ---
 
 # Debug

--- a/docs/_docs/development/structure.md
+++ b/docs/_docs/development/structure.md
@@ -1,7 +1,0 @@
----
-title: Structure
-layout: docs
-permalink: /development/structure.html
----
-
-<p>👷👷‍♀️Under construction…</p>

--- a/docs/_docs/development/threading.md
+++ b/docs/_docs/development/threading.md
@@ -2,11 +2,9 @@
 title: Threading
 layout: docs
 permalink: /development/threading.html
-prevPage: how-to-develop.html
+prevPage: how-to-debug.html
 nextPage: node-lifecycle.html
 ---
-
-# Threading
 
 ## At a glance
 

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -13,7 +13,7 @@ sectionid: docs
 	
 	<div class="content">
 		<h1>
-	      {{ page.title }}
+	        {{ page.title }}
 	    </h1>
 	    <p>{{ page.description }}</p>
 	
@@ -23,12 +23,34 @@ sectionid: docs
 
 	
 	    <div class="docs-prevnext">
-	      {% if page.prevPage %}
-	        <a href="/docs/{{ page.prevPage }}">&larr; Prev</a>
-	      {% endif %}
-	      {% if page.nextPage %}
-	        <a class="right" href="/docs/{{ page.nextPage }}">Next &rarr;</a>
-	      {% endif %}
+            {% if page.prevPage %}
+                {% comment %}
+                    If prevPage already contains the dir, either /docs/ or /development/, don't append to it.
+                    Otherwise, it's a relative path so append the dir according to the page's permalink.
+                {% endcomment %}
+
+                {% if page.prevPage contains '/docs/' or page.prevPage contains '/development/' %}
+                    <a href="{{ page.prevPage }}">&larr; Prev</a>
+                {% elsif page.permalink contains '/docs/' %}
+                    <a href="/docs/{{ page.prevPage }}">&larr; Prev</a>
+                {% else %}
+                    <a href="/development/{{ page.prevPage }}">&larr; Prev</a>
+                {% endif %}
+            {% endif %}
+
+            {% if page.nextPage %}
+                {% comment %}
+                    Same deal for nextPage.
+                {% endcomment %}
+
+                {% if page.nextPage contains '/docs/' or page.nextPage contains '/development/' %}
+                    <a class="right" href="{{ page.nextPage }}">Next &rarr;</a>
+                {% elsif page.permalink contains '/docs/' %}
+                    <a class="right" href="/docs/{{ page.nextPage }}">Next &rarr;</a>
+                {% else %}
+                    <a class="right" href="/development/{{ page.nextPage }}">Next &rarr;</a>
+                {% endif %}
+            {% endif %}
 	    </div>
 	
 	    <a id="_"></a>


### PR DESCRIPTION
Our pages are organized in 2 dirs: `/docs/` and `/development/`.

Within a dir, `prevPage` and `nextPage` are relative (to the dir) so its path should be appended to their href links (see [docs/_layouts/docs.html](https://github.com/TextureGroup/Texture/compare/master...nguyenhuy:HN-Fix-Prevnext?expand=1#diff-c7714274956193f5a3dd8e30f038591c)). The dir is available in the page's `permalink` var.

Some prevPage and nextPage point to a page in a different dir in which case they must not be relative. Instead they must include the other dir's path and thus their links won't be modified.

Also removed some pages that are no longer needed and fixed some `prevPage` and `nextPage` values.

I tested this diff locally and all links worked fine.