### PR TITLE
Fix a comment bug in `ASVideoNode` and `ASVideoPlayerNode`

### DIFF
--- a/Source/ASVideoNode.h
+++ b/Source/ASVideoNode.h
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property BOOL shouldAggressivelyRecoverFromStall;
 
 @property (readonly) ASVideoNodePlayerState playerState;
-//! Defaults to 1000
+//! Defaults to 10000
 @property int32_t periodicTimeObserverTimescale;
 
 //! Defaults to AVLayerVideoGravityResizeAspect

--- a/Source/ASVideoPlayerNode.h
+++ b/Source/ASVideoPlayerNode.h
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// You should never set any value on the backing video node. Use exclusivively the video player node to set properties
 @property (nonatomic, readonly) ASVideoNode *videoNode;
 
-//! Defaults to 100
+//! Defaults to 10000
 @property (nonatomic) int32_t periodicTimeObserverTimescale;
 //! Defaults to AVLayerVideoGravityResizeAspect
 @property (nonatomic, copy) NSString *gravity;


### PR DESCRIPTION
Update `periodicTimeObserverTimescale`'s comment default value to `10000`, according to the real value set in the implementation. 