### PR TITLE
Stop setting `frameInterval` for animated image optimization

### DIFF
--- a/Source/ASImageNode+AnimatedImage.mm
+++ b/Source/ASImageNode+AnimatedImage.mm
@@ -244,13 +244,10 @@
   NSLog(@"starting animation: %p", self);
 #endif
 
-  // Get frame interval before holding display link lock to avoid deadlock
-  NSUInteger frameInterval = self.animatedImage.frameInterval;
   AS::MutexLocker l(_displayLinkLock);
   if (_displayLink == nil) {
     _playHead = 0;
     _displayLink = [CADisplayLink displayLinkWithTarget:[ASWeakProxy weakProxyWithTarget:self] selector:@selector(displayLinkFired:)];
-    _displayLink.frameInterval = frameInterval;
     _lastSuccessfulFrameIndex = NSUIntegerMax;
     
     [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:_animatedImageRunLoopMode];


### PR DESCRIPTION
We previously tried to optimize showing animated images (e.g. GIF) by calling
display link for updating the frame just when when we need the next frame, but
this resulted in some frames dropping when `frameInterval` wasn't respected like
you can find from this GIF:
https://i.pinimg.com/originals/58/9c/e8/589ce828d2ef0797da0e85b1c6d2f2b3.gif

Since the the display link fire method continues if we detect we're
at the same image index as before, let's just remove this optimization.