### PR TITLE
Avoid querying for NSAttributedString attributes on empty string

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -519,12 +519,11 @@ static NSArray *DefaultLinkAttributeNames() {
   }
 
   // Apply tint color if needed and foreground color is not already specified
-  if (self.textColorFollowsTintColor) {
+  if (self.textColorFollowsTintColor && attributedString.length > 0) {
     // Apply tint color if specified and if foreground color is undefined for attributedString
     NSRange limit = NSMakeRange(0, attributedString.length);
-    NSRange effectiveRange;
     // Look for previous attributes that define foreground color
-    UIColor *attributeValue = (UIColor *)[attributedString attribute:NSForegroundColorAttributeName atIndex:limit.location effectiveRange:&effectiveRange];
+    UIColor *attributeValue = (UIColor *)[attributedString attribute:NSForegroundColorAttributeName atIndex:limit.location effectiveRange:NULL];
     UIColor *tintColor = self.tintColor;
     if (attributeValue == nil && tintColor) {
       // None are found, apply tint color if available. Fallback to "black" text color

--- a/Source/TextKit/ASTextKitContext.mm
+++ b/Source/TextKit/ASTextKitContext.mm
@@ -50,7 +50,6 @@
     __instanceLock__ = std::make_shared<AS::Mutex>();
     
     // Create the TextKit component stack with our default configuration.
-    
     _textStorage = [[NSTextStorage alloc] init];
     _layoutManager = [[ASLayoutManager alloc] init];
     _layoutManager.usesFontLeading = NO;
@@ -58,14 +57,13 @@
     
     // Instead of calling [NSTextStorage initWithAttributedString:], setting attributedString just after calling addlayoutManager can fix CJK language layout issues.
     // See https://github.com/facebook/AsyncDisplayKit/issues/2894
-    if (attributedString) {
+    if (attributedString && attributedString.length > 0) {
       [_textStorage setAttributedString:attributedString];
 
       // Apply tint color if specified and if foreground color is undefined for attributedString
       NSRange limit = NSMakeRange(0, attributedString.length);
-      NSRange effectiveRange;
       // Look for previous attributes that define foreground color
-      UIColor *attributeValue = (UIColor *)[attributedString attribute:NSForegroundColorAttributeName atIndex:limit.location effectiveRange:&effectiveRange];
+      UIColor *attributeValue = (UIColor *)[attributedString attribute:NSForegroundColorAttributeName atIndex:limit.location effectiveRange:NULL];
       if (attributeValue == nil) {
         // None are found, apply tint color if available. Fallback to "black" text color
         if (tintColor) {

--- a/Tests/ASTextNode2Tests.mm
+++ b/Tests/ASTextNode2Tests.mm
@@ -121,4 +121,13 @@
   XCTAssertFalse(textNode.supportsLayerBacking);
 }
 
+- (void)testEmptyStringSize
+{
+  CGSize constrainedSize = CGSizeMake(100, CGFLOAT_MAX);
+  _textNode.attributedText = [[NSAttributedString alloc] initWithString:@""];
+  CGSize sizeWithEmptyString = [_textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
+  XCTAssertTrue(ASIsCGSizeValidForSize(sizeWithEmptyString));
+  XCTAssertTrue(sizeWithEmptyString.width == 0);
+}
+
 @end

--- a/Tests/ASTextNodeTests.mm
+++ b/Tests/ASTextNodeTests.mm
@@ -262,6 +262,15 @@
   XCTAssertGreaterThan(sizeWithExclusionPaths.height, sizeWithoutExclusionPaths.height, @"Setting exclusions paths should invalidate the calculated size and return a greater size");
 }
 
+- (void)testEmptyStringSize
+{
+  CGSize constrainedSize = CGSizeMake(100, CGFLOAT_MAX);
+  _textNode.attributedText = [[NSAttributedString alloc] initWithString:@""];
+  CGSize sizeWithEmptyString = [_textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
+  XCTAssertTrue(ASIsCGSizeValidForSize(sizeWithEmptyString));
+  XCTAssertTrue(sizeWithEmptyString.width == 0);
+}
+
 #if AS_ENABLE_TEXTNODE
 - (void)testThatTheExperimentWorksCorrectly
 {


### PR DESCRIPTION
Resolves crash with stack trace:
```
Fatal Exception: NSRangeException
NSRLEArray objectAtIndex:effectiveRange:: Out of bounds

0  CoreFoundation                 0x1eab6298c __exceptionPreprocess
1  libobjc.A.dylib                0x1e9d3b9f8 objc_exception_throw
2  CoreFoundation                 0x1eaa6cbc0 -[NSCache init]
3  Foundation                     0x1eb4e4a7c -[NSRLEArray objectAtIndex:effectiveRange:]
4  Foundation                     0x1eb4e4c34 -[NSConcreteAttributedString attribute:atIndex:effectiveRange:]
5  PinterestEnterprise            0x10419ecdc -[ASTextKitContext initWithAttributedString:tintColor:lineBreakMode:maximumNumberOfLines:exclusionPaths:constrainedSize:] + 68 (ASTextKitContext.mm:68)
6  PinterestEnterprise            0x1041a3c48 -[ASTextKitRenderer initWithTextKitAttributes:constrainedSize:] + 63 (ASTextKitRenderer.mm:63)
7  PinterestEnterprise            0x104107d08 rendererForAttributes(ASTextKitAttributes, CGSize) + 126 (ASTextNode.mm:126)
8  PinterestEnterprise            0x104108bb8 -[ASTextNode _locked_rendererWithBounds:] + 367 (ASTextNode.mm:367)
9  PinterestEnterprise            0x104108fa8 -[ASTextNode calculateSizeThatFits:] + 426 (ASTextNode.mm:426)
10 PinterestEnterprise            0x1040d4828 -[ASDisplayNode(ASLayoutSpec) calculateLayoutLayoutSpec:] + 43 (ASDisplayNode+LayoutSpec.mm:43)
11 PinterestEnterprise            0x1040d7f58 -[ASDisplayNode calculateLayoutThatFits:] + 1056 (ASDisplayNode.mm:1056)
12 PinterestEnterprise            0x1040d7ebc -[ASDisplayNode calculateLayoutThatFits:restrictedToSize:relativeToParentSize:] + 1048 (ASDisplayNode.mm:1048)
13 PinterestEnterprise            0x1040d07cc -[ASDisplayNode(ASLayoutElement) layoutThatFits:parentSize:] + 109 (ASDisplayNode+Layout.mm:109)
14 PinterestEnterprise            0x10416dd68 crossChildLayout(ASStackLayoutSpecChild const&, ASStackLayoutSpecStyle const&, double, double, double, double, CGSize) + 65 (ASStackUnpositionedLayout.mm:65)
15 PinterestEnterprise            0x10416da98 invocation function for block in layoutItemsAlongUnconstrainedStackDimension(std::__1::vector<ASStackLayoutSpecItem, std::__1::allocator<ASStackLayoutSpecItem> >&, ASStackLayoutSpecStyle const&, bool, ASSizeRange const&, CGSize, bool) + 689 (ASStackUnpositionedLayout.mm:689)
16 PinterestEnterprise            0x10416d900 dispatchApplyIfNeeded(unsigned long, bool, void (unsigned long) block_pointer) + 83 (ASStackUnpositionedLayout.mm:83)
17 PinterestEnterprise            0x10416cbd8 ASStackUnpositionedLayout::compute(std::__1::vector<ASStackLayoutSpecChild, std::__1::allocator<ASStackLayoutSpecChild> > const&, ASStackLayoutSpecStyle const&, ASSizeRange const&, bool) + 636 (ASStackUnpositionedLayout.mm:636)
18 PinterestEnterprise            0x104154e8c -[ASStackLayoutSpec calculateLayoutThatFits:] + 149 (ASStackLayoutSpec.mm:149)
19 PinterestEnterprise            0x104151c68 -[ASLayoutSpec calculateLayoutThatFits:restrictedToSize:relativeToParentSize:] + 80 (ASLayoutSpec.mm:80)
20 PinterestEnterprise            0x104151af8 -[ASLayoutSpec layoutThatFits:parentSize:] + 80 (ASLayoutSpec.mm:80)
21 PinterestEnterprise            0x10414b9e8 -[ASInsetLayoutSpec calculateLayoutThatFits:restrictedToSize:relativeToParentSize:] + 102 (ASInsetLayoutSpec.mm:102)
22 PinterestEnterprise            0x104151af8 -[ASLayoutSpec layoutThatFits:parentSize:] + 80 (ASLayoutSpec.mm:80)
23 PinterestEnterprise            0x1040d49a8 -[ASDisplayNode(ASLayoutSpec) calculateLayoutLayoutSpec:] + 93 (ASDisplayNode+LayoutSpec.mm:93)
24 PinterestEnterprise            0x1040d7f58 -[ASDisplayNode calculateLayoutThatFits:] + 1056 (ASDisplayNode.mm:1056)
25 PinterestEnterprise            0x1040d7ebc -[ASDisplayNode calculateLayoutThatFits:restrictedToSize:relativeToParentSize:] + 1048 (ASDisplayNode.mm:1048)
```