### PR TITLE
Remove _ASDisplayLayer's delegateDidChangeBounds flag

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -549,14 +549,6 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
     _view = [self _locked_viewToLoad];
     _view.asyncdisplaykit_node = self;
     _layer = _view.layer;
-    // Needed to force `-[_ASDisplayLayer setDelegate:]` to evaluate
-    // It appears that UIKit might be setting the delegate ivar directly which
-    // bypasses establishing the `_delegateFlags` ivar on `ASDisplayLayer`
-    // This is critical for things like ASPagerNode, ASCollectionNode that depend
-    // on layer delegateFlags to forward bounds changes
-    if (_layer.delegate == _view) {
-      [_layer setDelegate:_view];
-    }
   }
   _layer.asyncdisplaykit_node = self;
   

--- a/Source/Details/_ASDisplayLayer.mm
+++ b/Source/Details/_ASDisplayLayer.mm
@@ -22,21 +22,11 @@
 @implementation _ASDisplayLayer
 {
   BOOL _attemptedDisplayWhileZeroSized;
-
-  struct {
-    BOOL delegateDidChangeBounds:1;
-  } _delegateFlags;
 }
 
 @dynamic displaysAsynchronously;
 
 #pragma mark - Properties
-
-- (void)setDelegate:(id)delegate
-{
-  [super setDelegate:delegate];
-  _delegateFlags.delegateDidChangeBounds = [delegate respondsToSelector:@selector(layer:didChangeBoundsWithOldValue:newValue:)];
-}
 
 - (void)setDisplaySuspended:(BOOL)displaySuspended
 {
@@ -59,12 +49,11 @@
   if (!valid) {
     return;
   }
-  if (_delegateFlags.delegateDidChangeBounds) {
+  if ([self.delegate respondsToSelector:@selector(layer:didChangeBoundsWithOldValue:newValue:)]) {
     CGRect oldBounds = self.bounds;
     [super setBounds:bounds];
     self.asyncdisplaykit_node.threadSafeBounds = bounds;
     [(id<ASCALayerExtendedDelegate>)self.delegate layer:self didChangeBoundsWithOldValue:oldBounds newValue:bounds];
-    
   } else {
     [super setBounds:bounds];
     self.asyncdisplaykit_node.threadSafeBounds = bounds;


### PR DESCRIPTION
We rely on the delegate setter to be called to set the flag. However, a recent change in iOS 13 (beta) causes the setter to not be called at all and thus we had to put up a workaround (https://github.com/TextureGroup/Texture/pull/1609). While the workaround works, the performance benefit that the flag provides doesn't warranty the extra complexity IMO. So I think we should just remove everything.