### PR TITLE
Minor changes to tint color support

### DIFF
--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -705,7 +705,13 @@ AS_EXTERN NSInteger const ASDefaultDrawingPriority;
 @property (nullable, copy) UIColor *backgroundColor;           // default=nil
 
 @property (null_resettable, copy) UIColor *tintColor;          // default=Blue
-- (void)tintColorDidChange;                                    // Notifies the node when the tintColor has changed.
+
+/**
+ * Notifies the node when the tintColor has changed.
+ *
+ * @note This method is guaranteed to be called if the tintColor is changed after the node loaded.
+ */
+- (void)tintColorDidChange;
 
 /**
  * @abstract A flag used to determine how a node lays out its content when its bounds change.


### PR DESCRIPTION
Quick follow up on https://github.com/TextureGroup/Texture/pull/1617:
- Need to assert thread affinity in the getter when the node is view-backed and loaded. This is because UIView properties can't be accessed off main thread.
- When the node is view-backed, we shouldn't ascend the node hierarchy. UIView should already ascend the view hierarchy and we currently don't support adding a view-backed node as a subnode of a layer-backed node (the other way around is fine).
- `_getFromViewOnly` and `_setToViewOnly` check if the node loaded and do the right thing. So by checking `layerBacked` first, we can use them simplify our getter and setter.