### PR TITLE
Keep using `unowned` macro

### DIFF
--- a/Source/ASConfigurationInternal.mm
+++ b/Source/ASConfigurationInternal.mm
@@ -80,7 +80,7 @@ NS_INLINE ASConfigurationManager *ASConfigurationManagerGet() {
   
   // Notify delegate if needed.
   if (newlyTriggered != 0) {
-    __unsafe_unretained id<ASConfigurationDelegate> del = _config.delegate;
+    unowned id<ASConfigurationDelegate> del = _config.delegate;
     dispatch_async(_delegateQueue, ^{
       [del textureDidActivateExperimentalFeatures:newlyTriggered];
     });

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -146,8 +146,8 @@ static void runLoopSourceCallback(void *info) {
     }
     
     // Self is guaranteed to outlive the observer.  Without the high cost of a weak pointer,
-    // __unsafe_unretained allows us to avoid flagging the memory cycle detector.
-    __unsafe_unretained __typeof__(self) weakSelf = self;
+    // unowned(__unsafe_unretained) allows us to avoid flagging the memory cycle detector.
+    unowned __typeof__(self) weakSelf = self;
     void (^handlerBlock) (CFRunLoopObserverRef observer, CFRunLoopActivity activity) = ^(CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
       [weakSelf processQueue];
     };
@@ -230,7 +230,7 @@ static void runLoopSourceCallback(void *info) {
        * object will be added to the autorelease pool. If the queue is strong,
        * it will retain the object until we transfer it (retain it) in itemsToProcess.
        */
-      __unsafe_unretained id ptr = (__bridge id)[_internalQueue pointerAtIndex:i];
+      unowned id ptr = (__bridge id)[_internalQueue pointerAtIndex:i];
       if (ptr != nil) {
         foundItemCount++;
         if (hasExecutionBlock) {
@@ -260,7 +260,7 @@ static void runLoopSourceCallback(void *info) {
     as_activity_scope_verbose(as_activity_create("Process run loop queue batch", _rootActivity, OS_ACTIVITY_FLAG_DEFAULT));
     const auto itemsEnd = itemsToProcess.cend();
     for (auto iterator = itemsToProcess.begin(); iterator < itemsEnd; iterator++) {
-      __unsafe_unretained id value = *iterator;
+      unowned id value = *iterator;
       _queueConsumer(value, isQueueDrained && iterator == itemsEnd - 1);
       as_log_verbose(ASDisplayLog(), "processed %@", value);
     }
@@ -375,8 +375,8 @@ dispatch_once_t _ASSharedCATransactionQueueOnceToken;
     }
 
     // Self is guaranteed to outlive the observer.  Without the high cost of a weak pointer,
-    // __unsafe_unretained allows us to avoid flagging the memory cycle detector.
-    __unsafe_unretained __typeof__(self) weakSelf = self;
+    // unowned(__unsafe_unretained) allows us to avoid flagging the memory cycle detector.
+    unowned __typeof__(self) weakSelf = self;
     _preTransactionObserver = CFRunLoopObserverCreateWithHandler(NULL, kCFRunLoopBeforeWaiting, true, kASASCATransactionQueueOrder, ^(CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
       while (!weakSelf->_internalQueue.empty()) {
         [weakSelf processQueue];

--- a/Source/Details/ASCollectionViewLayoutController.mm
+++ b/Source/Details/ASCollectionViewLayoutController.mm
@@ -81,7 +81,7 @@ typedef struct ASRangeGeometry ASRangeGeometry;
     }
     
     // Avoid excessive retains and releases, as well as property calls. We know the element is kept alive by map.
-    __unsafe_unretained ASCollectionElement *e = [map elementForLayoutAttributes:la];
+    unowned ASCollectionElement *e = [map elementForLayoutAttributes:la];
     if (e != nil && intersectsDisplay) {
       [display addObject:e];
     }

--- a/Source/Details/ASElementMap.mm
+++ b/Source/Details/ASElementMap.mm
@@ -193,7 +193,7 @@
 
 #pragma mark - NSFastEnumeration
 
-- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id  _Nullable __unsafe_unretained [])buffer count:(NSUInteger)len
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id  _Nullable unowned [])buffer count:(NSUInteger)len
 {
   return [_elementToIndexPathMap countByEnumeratingWithState:state objects:buffer count:len];
 }

--- a/Source/Details/ASPageTable.mm
+++ b/Source/Details/ASPageTable.mm
@@ -128,19 +128,19 @@ NSPointerArray *ASPageCoordinatesForPagesThatIntersectRect(CGRect rect, CGSize c
 
 - (id)objectForPage:(ASPageCoordinate)page
 {
-  __unsafe_unretained id key = (__bridge id)(void *)page;
+  unowned id key = (__bridge id)(void *)page;
   return [self objectForKey:key];
 }
 
 - (void)setObject:(id)object forPage:(ASPageCoordinate)page
 {
-  __unsafe_unretained id key = (__bridge id)(void *)page;
+  unowned id key = (__bridge id)(void *)page;
   [self setObject:object forKey:key];
 }
 
 - (void)removeObjectForPage:(ASPageCoordinate)page
 {
-  __unsafe_unretained id key = (__bridge id)(void *)page;
+  unowned id key = (__bridge id)(void *)page;
   [self removeObjectForKey:key];
 }
 

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -40,14 +40,14 @@ ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT BOOL ASDisplayNodeThreadIsMain()
 
 /// Same as ASLockScope(1) but lock isn't retained (be careful).
 #define ASLockScopeUnowned(nsLocking) \
-  __unsafe_unretained id<NSLocking> __lockToken __attribute__((cleanup(_ASLockScopeUnownedCleanup))) = nsLocking; \
+  unowned id<NSLocking> __lockToken __attribute__((cleanup(_ASLockScopeUnownedCleanup))) = nsLocking; \
   [__lockToken lock];
 
 ASDISPLAYNODE_INLINE void _ASLockScopeCleanup(id<NSLocking> __strong * const lockPtr) {
   [*lockPtr unlock];
 }
 
-ASDISPLAYNODE_INLINE void _ASLockScopeUnownedCleanup(id<NSLocking> __unsafe_unretained * const lockPtr) {
+ASDISPLAYNODE_INLINE void _ASLockScopeUnownedCleanup(id<NSLocking> unowned * const lockPtr) {
   [*lockPtr unlock];
 }
 

--- a/Source/Details/ASWeakSet.mm
+++ b/Source/Details/ASWeakSet.mm
@@ -71,7 +71,7 @@
   return count;
 }
 
-- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(__unsafe_unretained id  _Nonnull *)buffer count:(NSUInteger)len
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(unowned id  _Nonnull *)buffer count:(NSUInteger)len
 {
   return [_hashTable countByEnumeratingWithState:state objects:buffer count:len];
 }

--- a/Source/Layout/ASLayoutElement.mm
+++ b/Source/Layout/ASLayoutElement.mm
@@ -40,7 +40,7 @@ int32_t const ASLayoutElementContextDefaultTransitionID = ASLayoutElementContext
 
 #if AS_TLS_AVAILABLE
 
-static _Thread_local __unsafe_unretained ASLayoutElementContext *tls_context;
+static _Thread_local unowned ASLayoutElementContext *tls_context;
 
 void ASLayoutElementPushContext(ASLayoutElementContext *context)
 {

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -127,7 +127,7 @@ ASLayoutElementLayoutCalculationDefaults
 
 #pragma mark - NSFastEnumeration
 
-- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id __unsafe_unretained _Nullable [_Nonnull])buffer count:(NSUInteger)len
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id unowned _Nullable [_Nonnull])buffer count:(NSUInteger)len
 {
   return [_childrenArray countByEnumeratingWithState:state objects:buffer count:len];
 }

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -260,7 +260,7 @@ using AS::MutexLocker;
    Color the interval red if cancelled, green otherwise.
    */
 #if AS_SIGNPOST_ENABLE
-  __unsafe_unretained id ptrSelf = (id)self;
+  unowned id ptrSelf = (id)self;
   displayBlock = ^{
     ASSignpostStart(LayerDisplay, ptrSelf, "%@", ASObjectDescriptionMakeTiny(ptrSelf));
     id result = displayBlock();


### PR DESCRIPTION
Keep using `unowned` macro for code consistence, instead of using `__unsafe_unretained` directly. 