### PR TITLE
[GitHub CI] Add step to block PRs from forked repositories unless they have the right label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ jobs:
     name: Build approval
     runs-on: macOS-10.14
     steps:
-    - name: Block if a pull request is from a forked repository and it hasn't been labeled by a maintainer
-      if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI approved')
-      run: exit 255
+    #- name: Block if a pull request is from a forked repository and it hasn't been labeled by a maintainer
+    #  if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI approved')
+    #  run: exit 255
     - name: Approved!
-      if: failure() == false
+    #  if: failure() == false
       run: exit 0
   buildsh:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,15 @@
 name: CI
 
-on: push
+on: [push, pull_request]
 
 jobs:
+  build-approval:
+    name: Build approval
+    runs-on: macOS-10.14
+    steps:
+    - name: Only approve a pull request from a forked repository if it's been labeled by a maintainer.
+      if: github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels, 'CI approved'))
+      run: echo You may proceed!  
   buildsh:
     strategy:
       matrix:
@@ -26,6 +33,7 @@ jobs:
             name: Build examples (examples-pt4)
     name: ${{ matrix.name }}
     runs-on: macOS-10.14
+    needs: build-approval
     steps:
     - name: Checkout the Git repository
       uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
     name: Build approval
     runs-on: macOS-10.14
     steps:
-    - name: Only approve a pull request from a forked repository if it's been labeled by a maintainer.
-      if: github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels, 'CI approved'))
-      run: echo You may proceed!  
+    - name: Block if a pull request is from a forked repository and it hasn't been labeled by a maintainer.
+      if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels, 'CI approved')
+      run: exit 255
   buildsh:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,12 @@ jobs:
     name: Build approval
     runs-on: macOS-10.14
     steps:
-    - name: Block if a pull request is from a forked repository and it hasn't been labeled by a maintainer.
-      if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels, 'CI approved')
+    - name: Block if a pull request is from a forked repository and it hasn't been labeled by a maintainer
+      if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI approved')
       run: exit 255
+    - name: Approved!
+      if: failure() == false
+      run: exit 0
   buildsh:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ jobs:
     name: Build approval
     runs-on: macOS-10.14
     steps:
-    #- name: Block if a pull request is from a forked repository and it hasn't been labeled by a maintainer
-    #  if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI approved')
-    #  run: exit 255
+    - name: Block if a pull request from a forked repository isn't from, and isn't labeled by, a maintainer
+      if: github.event_name == 'pull_request' && !contains('OWNER, MEMBER, COLLABORATOR', github.event.pull_request.author_association) && !contains(github.event.pull_request.labels.*.name, 'CI approved')
+      run: exit 255
     - name: Approved!
-    #  if: failure() == false
+      if: failure() == false
       run: exit 0
   buildsh:
     strategy:


### PR DESCRIPTION
Block pull requests from forked repositories that aren't from, and aren't labeled by, a maintainer.