### PR TITLE
[GitHub CI] Remove build approval step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,6 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build-approval:
-    name: Build approval
-    runs-on: macOS-10.14
-    steps:
-    - name: Block if a pull request from a forked repository isn't from, and isn't labeled by, a maintainer
-      if: github.event_name == 'pull_request' && !contains('OWNER, MEMBER, COLLABORATOR', github.event.pull_request.author_association) && !contains(github.event.pull_request.labels.*.name, 'CI approved')
-      run: exit 255
-    - name: Approved!
-      if: failure() == false
-      run: exit 0
   buildsh:
     strategy:
       matrix:
@@ -36,7 +26,6 @@ jobs:
             name: Build examples (examples-pt4)
     name: ${{ matrix.name }}
     runs-on: macOS-10.14
-    needs: build-approval
     steps:
     - name: Checkout the Git repository
       uses: actions/checkout@v1


### PR DESCRIPTION
In #1627 I introduced an approval step that is meant to block PRs from forked repos unless they're labeled as "CI approved" by a maintainer. Turned out it doesn't work. When a label is added, a pull_request event with "labeled" as its action is fired but GitHub CI didn't restart the workflow. My guess is it checked the PR's commit and branch and determined that nothing has changed. Here is what the doc says: "A workflow runs on a specific version of code in your repository, determined by the commit SHA and Git ref" ([Source](https://help.github.com/en/articles/events-that-trigger-workflows#webhook-events)).

This diff removes the approval step so all PRs will be automatically built. Here are current [usage limits](https://help.github.com/en/articles/workflow-syntax-for-github-actions#usage-limits) in case we run into them.