### PR TITLE
Update Danger workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -9,10 +9,6 @@ jobs:
     steps:
     - name: Checkout the Git repository
       uses: actions/checkout@v1
-    # Danger JS would fail because of the below missing module.
-    # TODO: Report to Danger JS
-    - name: Install missing module
-      run: yarn add -D @babel/plugin-transform-flow-strip-types
     # TODO: Figure out why GITHUB_TOKEN isn't enough for Danger JS to create a comment.
     # Our dangerfile.js escalates any warnings as failures to get more attention.
     #
@@ -29,3 +25,4 @@ jobs:
       uses: danger/danger-js@9.1.8
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DANGER_DISABLE_TRANSPILATION: true 


### PR DESCRIPTION
Turned out that `@babel/plugin-transform-flow-strip-types` is needed for TypeScript/Bale transpilation with we don't need because we use JS. So instead of installing the module, we can. just disable transpilation by `DANGER_DISABLE_TRANSPILATION` environment variable to `true`.

Test plan: Tested manually [here](https://github.com/TextureGroup/Texture/commit/a4cfe347914c23aafe08603bf82372d4cb94136c/checks).