### PR TITLE
Fix comment typo for `showsHorizontalScrollIndicator` in ASCollectionNode

### DIFF
--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -121,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A Boolean value that controls whether the horizontal scroll indicator is visible.
- * The default value of this property is NO.
+ * The default value of this property is YES.
  */
 @property (nonatomic) BOOL showsHorizontalScrollIndicator;
 


### PR DESCRIPTION
There is an comment typo on `ASCollectionNode`'s `showsHorizontalScrollIndicator`.

`showsHorizontalScrollIndicator` is initialized to `YES` in the `ASCollectionNode`'s initializer.

It should be `YES` in `ASCollectionNode.h`

```objc
// ASCollectionNode.mm
- (instancetype)init
{
  self = [super init];
  if (self) {
    _rangeMode = ASLayoutRangeModeUnspecified;
    _tuningParameters = [ASAbstractLayoutController defaultTuningParameters];
    _allowsSelection = YES;
    _allowsMultipleSelection = NO;
    _inverted = NO;
    _contentInset = UIEdgeInsetsZero;
    _contentOffset = CGPointZero;
    _animatesContentOffset = NO;
    _showsVerticalScrollIndicator = YES;
    _showsHorizontalScrollIndicator = YES;
  }
  return self;
}
```

```diff
// ASCollectionNode.h
/**
 * A Boolean value that controls whether the horizontal scroll indicator is visible.
- * The default value of this property is NO.
+ * The default value of this property is YES.
 */
@property (nonatomic) BOOL showsHorizontalScrollIndicator;
```