### PR TITLE
AS::Map function improvement

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		3917EBD51E9C2FC400D04A01 /* _ASCollectionReusableView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3917EBD31E9C2FC400D04A01 /* _ASCollectionReusableView.mm */; };
 		3C9C128519E616EF00E942A0 /* ASTableViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C9C128419E616EF00E942A0 /* ASTableViewTests.mm */; };
 		4080D66C2350384400CDC199 /* ASPINRemoteImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 68355B391CB57A5A001D4E68 /* ASPINRemoteImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		407B8BAE2310E2ED00CB979E /* ASLayoutSpecUtilitiesTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 407B8BAD2310E2ED00CB979E /* ASLayoutSpecUtilitiesTests.mm */; };
 		471D04B1224CB98600649215 /* ASImageNodeBackingSizeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 471D04B0224CB98600649215 /* ASImageNodeBackingSizeTests.mm */; };
 		4E9127691F64157600499623 /* ASRunLoopQueueTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4E9127681F64157600499623 /* ASRunLoopQueueTests.mm */; };
 		509E68601B3AED8E009B9150 /* ASScrollDirection.mm in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E111B371BD7007741D0 /* ASScrollDirection.mm */; };
@@ -679,6 +680,7 @@
 		3917EBD21E9C2FC400D04A01 /* _ASCollectionReusableView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASCollectionReusableView.h; sourceTree = "<group>"; };
 		3917EBD31E9C2FC400D04A01 /* _ASCollectionReusableView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _ASCollectionReusableView.mm; sourceTree = "<group>"; };
 		3C9C128419E616EF00E942A0 /* ASTableViewTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASTableViewTests.mm; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		407B8BAD2310E2ED00CB979E /* ASLayoutSpecUtilitiesTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ASLayoutSpecUtilitiesTests.mm; sourceTree = "<group>"; };
 		464052191A3F83C40061C0BA /* ASDataController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ASDataController.h; sourceTree = "<group>"; };
 		4640521A1A3F83C40061C0BA /* ASDataController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASDataController.mm; sourceTree = "<group>"; };
 		4640521B1A3F83C40061C0BA /* ASTableLayoutController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTableLayoutController.h; sourceTree = "<group>"; };
@@ -1388,6 +1390,7 @@
 				83A7D95D1D446A6E00BF333E /* ASWeakMapTests.mm */,
 				CC3B208D1C3F7D0A00798563 /* ASWeakSetTests.mm */,
 				695BE2541DC1245C008E6EA5 /* ASWrapperSpecSnapshotTests.mm */,
+				407B8BAD2310E2ED00CB979E /* ASLayoutSpecUtilitiesTests.mm */,
 				057D02C01AC0A66700C7AC3C /* AsyncDisplayKitTestHost */,
 				CC583ABF1EF9BAB400134156 /* Common */,
 				058D09C6195D04C000B7D73C /* Supporting Files */,
@@ -2333,6 +2336,7 @@
 				ACF6ED601B178DC700DA7C62 /* ASLayoutSpecSnapshotTestsHelper.mm in Sources */,
 				CC7FD9E11BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.mm in Sources */,
 				052EE0661A159FEF002C6279 /* ASMultiplexImageNodeTests.mm in Sources */,
+				407B8BAE2310E2ED00CB979E /* ASLayoutSpecUtilitiesTests.mm in Sources */,
 				058D0A3C195D057000B7D73C /* ASMutableAttributedStringBuilderTests.mm in Sources */,
 				F325E48C21745F9E00AC93A4 /* ASButtonNodeTests.mm in Sources */,
 				9692B4FF219E12370060C2C3 /* ASCollectionViewThrashTests.mm in Sources */,

--- a/Source/Private/Layout/ASLayoutSpecUtilities.h
+++ b/Source/Private/Layout/ASLayoutSpecUtilities.h
@@ -24,17 +24,15 @@ namespace AS {
   {
     // Some convenience type definitions
     typedef decltype(func(std::declval<typename T::value_type>())) value_type;
-    typedef std::vector<value_type> result_type;
 
     // Prepares an output vector of the appropriate size
-    result_type res(iterable.size());
+    std::vector<value_type> res;
+    res.reserve(iterable.size());
 
     // Let std::transform apply `func` to all elements
     // (use perfect forwarding for the function object)
-    std::transform(
-                   begin(iterable), end(iterable), res.begin(),
-                   std::forward<Func>(func)
-                   );
+    std::transform(std::begin(iterable), std::end(iterable), std::back_inserter(res),
+                   std::forward<Func>(func));
 
     return res;
   }

--- a/Tests/ASLayoutSpecUtilitiesTests.mm
+++ b/Tests/ASLayoutSpecUtilitiesTests.mm
@@ -1,0 +1,244 @@
+//
+//  ASLayoutSpecUtilitiesTests.m
+//  AsyncDisplayKitTests
+//
+//  Copyright (c) Pinterest, Inc.  All rights reserved.
+//  Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#import <XCTest/XCTest.h>
+#import "ASLayoutSpecUtilities.h"
+
+@interface ASLayoutSpecUtilitiesTests : XCTestCase
+
+@end
+
+@implementation ASLayoutSpecUtilitiesTests
+
+- (void)testMapVectorPrimitive
+{
+  std::vector<int> a = {3, 1, 4};
+  std::vector<int> b = AS::map(a, ^int(int i) {
+    return i * 2;
+  });
+  std::vector<int> c = {6, 2, 8};
+  XCTAssertEqual(b, c);
+}
+
+- (void)testMapVectorNSObject
+{
+  std::vector<NSString *> a = {@"2.16", @"3.14"};
+  std::vector<float> b = AS::map(a, ^float(NSString *str) {
+    return str.floatValue;
+  });
+  std::vector<float> c = {2.16, 3.14};
+  XCTAssertEqual(b, c);
+}
+
+- (void)testMapVectorStruct
+{
+  struct TestStruct
+  {
+    NSString *value;
+    
+    bool operator==(const TestStruct& rhs) const
+    {
+      return [value isEqualToString:rhs.value];
+    }
+  };
+
+  std::vector<TestStruct> a = {
+    {.value = @"2"},
+    {.value = @"1"},
+    {.value = @"6"}
+  };
+  std::vector<NSInteger> b = AS::map(a, ^NSInteger(TestStruct s) {
+    return s.value.integerValue;
+  });
+  std::vector<NSInteger> c = {2, 1, 6};
+  XCTAssertEqual(b, c);
+}
+
+- (void)testMapVectorClass
+{
+  class TestClass {
+  private:
+    NSString *_value;
+    
+  public:
+    TestClass (NSString *value)
+    {
+      _value = value;
+    }
+    
+    NSString *getValue() const noexcept
+    {
+      return _value;
+    }
+    
+    void setValue(NSString *value) noexcept
+    {
+      _value = value;
+    }
+    
+    bool operator==(const TestClass& rhs) const noexcept
+    {
+      return [getValue() isEqualToString:rhs.getValue()];
+    }
+  };
+  
+  std::vector<TestClass> a = {
+    TestClass(@"2"),
+    TestClass(@"1"),
+    TestClass(@"6")
+  };
+  std::vector<NSInteger> b = AS::map(a, ^NSInteger(TestClass c) {
+    return c.getValue().integerValue;
+  });
+  std::vector<NSInteger> c = {2, 1, 6};
+  XCTAssertEqual(b, c);
+}
+
+- (void)testMapVectorEmpty
+{
+  std::vector<NSString *> a = {};
+  std::vector<int> b = AS::map(a, ^int(NSString *str) {
+    return str.intValue;
+  });
+  std::vector<int> c = {};
+  XCTAssertEqual(b, c);
+}
+
+- (void)testMapNSFastEnumeration
+{
+  struct TestStruct {
+    NSString *value;
+    
+    bool operator==(const TestStruct& rhs) const
+    {
+      return [value isEqualToString:rhs.value];
+    }
+  };
+
+  NSArray<NSNumber *> *a = @[@1, @2, @3];
+  std::vector<TestStruct> b = AS::map(a, ^TestStruct(NSNumber *num) {
+    return {.value = num.stringValue};
+  });
+  std::vector<TestStruct> c = {
+    {.value = @"1"},
+    {.value = @"2"},
+    {.value = @"3"}
+  };
+  XCTAssertEqual(b, c);
+}
+
+- (void)testMapNSFastEnumerationEmpty
+{
+  NSArray<NSNumber *> *a = @[];
+  std::vector<int> b = AS::map(a, ^int(NSNumber *num) {
+    return num.intValue;
+  });
+  std::vector<int> c = {};
+  XCTAssertEqual(b, c);
+}
+
+- (void)testFilterVectorPrimitive
+{
+  std::vector<int> a = {1, 2, 3, 4};
+  std::vector<int> b = AS::filter(a, ^BOOL(int num) {
+    return num < 3;
+  });
+  std::vector<int> c = {1, 2};
+  XCTAssertEqual(b, c);
+}
+
+- (void)testFilterVectorNSObject
+{
+  std::vector<NSString *> a = {@"9", @"2", @"6"};
+  std::vector<NSString *> b = AS::filter(a, ^BOOL(NSString *str) {
+    return str.integerValue % 2 == 0;
+  });
+  std::vector<NSString *> c = {@"2", @"6"};
+  XCTAssertEqual(b, c);
+}
+
+- (void)testFilterVectorStruct
+{
+  struct TestStruct {
+    NSString *value;
+    
+    bool operator==(const TestStruct& rhs) const
+    {
+      return [value isEqualToString:rhs.value];
+    }
+  };
+
+  std::vector<TestStruct> a = {
+    {.value = @"6"},
+    {.value = @"8"},
+    {.value = @"3"},
+    {.value = @"9"}
+  };
+  std::vector<TestStruct> b = AS::filter(a, ^BOOL(TestStruct s) {
+    return s.value.integerValue == 3;
+  });
+  std::vector<TestStruct> c = {
+    {.value = @"3"}
+  };
+  XCTAssertEqual(b, c);
+}
+
+- (void)testFilterVectorClass
+{
+  class TestClass {
+  private:
+    NSString *_value;
+    
+  public:
+    TestClass (NSString *value)
+    {
+      _value = value;
+    }
+    
+    NSString *getValue() const noexcept
+    {
+      return _value;
+    }
+    
+    void setValue(NSString *value) noexcept
+    {
+      _value = value;
+    }
+    
+    bool operator==(const TestClass& rhs) const noexcept
+    {
+      return [getValue() isEqualToString:rhs.getValue()];
+    }
+  };
+  
+  std::vector<TestClass> a = {
+    TestClass(@"2"),
+    TestClass(@"1"),
+    TestClass(@"6")
+  };
+  std::vector<TestClass> b = AS::filter(a, ^BOOL(TestClass c) {
+    return c.getValue().integerValue > 1;
+  });
+  std::vector<TestClass> c = {
+    TestClass(@"2"),
+    TestClass(@"6")
+  };
+  XCTAssertEqual(b, c);
+}
+
+- (void)testFilterVectorEmpty
+{
+  std::vector<int> a = {};
+  std::vector<int> b = AS::filter(a, ^BOOL(int num) {
+    return num < 2;
+  });
+  std::vector<int> c = {};
+  XCTAssertEqual(b, c);
+}
+
+@end


### PR DESCRIPTION
1. Prefer using `reserve function` rather than `fill constructor` in `AS::map()` for **memory efficiency**
  
`fill constructor` **constructs** the vector with **n** elements and **initializes** each element with its default constructor, while `reserve function` just allocates memory, **0** element is need to be initialized. 

For example, after running ```result_type res(iterable.size());```, the `res` vector's size is equal to `iterable.size()`, while after running ```res.reserve(iterable.size());```, the `res` vector's size is 0.

Reference:
- http://www.cplusplus.com/reference/vector/vector/vector
- http://www.cplusplus.com/reference/vector/vector/reserve
- http://www.cplusplus.com/reference/iterator/back_inserter

2. Add tests for `ASLayoutSpecUtilities`