### PR TITLE
Propagate ASTraitCollection for snapshot testing

### DIFF
--- a/Tests/ASSnapshotTestCase.mm
+++ b/Tests/ASSnapshotTestCase.mm
@@ -36,7 +36,7 @@ NSOrderedSet *ASSnapshotTestCaseDefaultSuffixes(void)
   // Since the goal of this method is to just to ensure a node is rendered before snapshotting, this should be reasonable default for all callers.
 #if AS_AT_LEAST_IOS13
   if (@available(iOS 13.0, *)) {
-    node.primitiveTraitCollection = ASPrimitiveTraitCollectionFromUITraitCollection(UITraitCollection.currentTraitCollection);
+    ASTraitCollectionPropagateDown(node, ASPrimitiveTraitCollectionFromUITraitCollection(UITraitCollection.currentTraitCollection));
   }
 #endif // #if AS_AT_LEAST_IOS13
   node.displaysAsynchronously = NO;


### PR DESCRIPTION
Our helper methods set the current trait collection on the node we want
to snapshot but did not propagate the trait collection as expected.