### PR TITLE
Fix `_ASAsyncTransaction` initialization method

### DIFF
--- a/Source/Details/Transactions/_ASAsyncTransaction.mm
+++ b/Source/Details/Transactions/_ASAsyncTransaction.mm
@@ -333,7 +333,7 @@ ASAsyncTransactionQueue & ASAsyncTransactionQueue::instance()
 
 - (instancetype)initWithCompletionBlock:(void(^)(_ASAsyncTransaction *, BOOL))completionBlock
 {
-  if ((self = [self init])) {
+  if ((self = [super init])) {
     _completionBlock = completionBlock;
     self.state = ASAsyncTransactionStateOpen;
   }


### PR DESCRIPTION
[According to Apple](https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/Initialization/Initialization.html#//apple_ref/doc/uid/TP40010810-CH6-SW3), the superclass (super) initializer need to be Invoked first. 