### PR TITLE
Use lock to access the image renderingMode when tint color changes

### DIFF
--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -610,7 +610,14 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 - (void)tintColorDidChange
 {
   [super tintColorDidChange];
-  if (_image.renderingMode == UIImageRenderingModeAlwaysTemplate) {
+
+  BOOL isTemplateImage = NO;
+  {
+    AS::MutexLocker l(__instanceLock__);
+    isTemplateImage = (_image.renderingMode == UIImageRenderingModeAlwaysTemplate);
+  }
+
+  if (isTemplateImage) {
     [self setNeedsDisplay];
   }
 }


### PR DESCRIPTION
Missing with #1629. Other code accesses this ivar with a lock, so doing it here for consistency sake.