### PR TITLE
Defer image asset regeneration to draw loop

### DIFF
--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -303,11 +303,12 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 
   if (AS_AVAILABLE_IOS_TVOS(13, 10)) {
     if (_imageNodeFlags.regenerateFromImageAsset && _image != nil) {
-        UITraitCollection *tc = [UITraitCollection traitCollectionWithUserInterfaceStyle:_primitiveTraitCollection.userInterfaceStyle];
-        UIImage *updatedImage = [_image.imageAsset imageWithTraitCollection:tc];
-        if ( updatedImage != nil ) {
-            _image = updatedImage;
-        }
+      _imageNodeFlags.regenerateFromImageAsset = NO;
+      UITraitCollection *tc = [UITraitCollection traitCollectionWithUserInterfaceStyle:_primitiveTraitCollection.userInterfaceStyle];
+      UIImage *updatedImage = [_image.imageAsset imageWithTraitCollection:tc];
+      if ( updatedImage != nil ) {
+        _image = updatedImage;
+      }
     }
   }
 

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -183,6 +183,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 
   _imageNodeFlags.cropEnabled = YES;
   _imageNodeFlags.forceUpscaling = NO;
+  _imageNodeFlags.regenerateFromImageAsset = NO;
   _cropRect = CGRectMake(0.5, 0.5, 0, 0);
   _cropDisplayBounds = CGRectNull;
   _placeholderColor = ASDisplayNodeDefaultPlaceholderColor();
@@ -775,7 +776,8 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
   if (AS_AVAILABLE_IOS_TVOS(13, 10)) {
     AS::MutexLocker l(__instanceLock__);
       // update image if userInterfaceStyle was changed (dark mode)
-      if (_image != nil && _primitiveTraitCollection.userInterfaceStyle != previousTraitCollection.userInterfaceStyle) {
+      if (_image != nil
+          && _primitiveTraitCollection.userInterfaceStyle != previousTraitCollection.userInterfaceStyle) {
         _imageNodeFlags.regenerateFromImageAsset = YES;
       }
   }

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -303,10 +303,10 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 
   UIImage *drawImage = _image;
   if (AS_AVAILABLE_IOS_TVOS(13, 10)) {
-    if (_imageNodeFlags.regenerateFromImageAsset && _image != nil) {
+    if (_imageNodeFlags.regenerateFromImageAsset && drawImage != nil) {
       _imageNodeFlags.regenerateFromImageAsset = NO;
       UITraitCollection *tc = [UITraitCollection traitCollectionWithUserInterfaceStyle:_primitiveTraitCollection.userInterfaceStyle];
-      UIImage *generatedImage = [_image.imageAsset imageWithTraitCollection:tc];
+      UIImage *generatedImage = [drawImage.imageAsset imageWithTraitCollection:tc];
       if ( generatedImage != nil ) {
         drawImage = generatedImage;
       }

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -300,6 +300,16 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 {
   ASLockScopeSelf();
 
+  if (AS_AVAILABLE_IOS_TVOS(13, 10)) {
+    if (_imageNodeFlags.regenerateFromImageAsset && _image != nil) {
+        UITraitCollection *tc = [UITraitCollection traitCollectionWithUserInterfaceStyle:_primitiveTraitCollection.userInterfaceStyle];
+        UIImage *updatedImage = [_image.imageAsset imageWithTraitCollection:tc];
+        if ( updatedImage != nil ) {
+            _image = updatedImage;
+        }
+    }
+  }
+
   ASImageNodeDrawParameters *drawParameters = [[ASImageNodeDrawParameters alloc] init];
   drawParameters->_image = _image;
   drawParameters->_bounds = [self threadSafeBounds];
@@ -762,16 +772,11 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
 - (void)asyncTraitCollectionDidChangeWithPreviousTraitCollection:(ASPrimitiveTraitCollection)previousTraitCollection {
   [super asyncTraitCollectionDidChangeWithPreviousTraitCollection:previousTraitCollection];
 
-  if (AS_AVAILABLE_IOS_TVOS(12, 10)) {
+  if (AS_AVAILABLE_IOS_TVOS(13, 10)) {
     AS::MutexLocker l(__instanceLock__);
       // update image if userInterfaceStyle was changed (dark mode)
       if (_image != nil && _primitiveTraitCollection.userInterfaceStyle != previousTraitCollection.userInterfaceStyle) {
-          UITraitCollection *tc = [UITraitCollection traitCollectionWithUserInterfaceStyle:_primitiveTraitCollection.userInterfaceStyle];
-          // get an updated image from asset catalog
-          UIImage *updatedImage = [_image.imageAsset imageWithTraitCollection:tc];
-          if ( updatedImage != nil ) {
-              _image = updatedImage;
-          }
+        _imageNodeFlags.regenerateFromImageAsset = YES;
       }
   }
 }

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -301,19 +301,20 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 {
   ASLockScopeSelf();
 
+  UIImage *drawImage = _image;
   if (AS_AVAILABLE_IOS_TVOS(13, 10)) {
     if (_imageNodeFlags.regenerateFromImageAsset && _image != nil) {
       _imageNodeFlags.regenerateFromImageAsset = NO;
       UITraitCollection *tc = [UITraitCollection traitCollectionWithUserInterfaceStyle:_primitiveTraitCollection.userInterfaceStyle];
-      UIImage *updatedImage = [_image.imageAsset imageWithTraitCollection:tc];
-      if ( updatedImage != nil ) {
-        _image = updatedImage;
+      UIImage *generatedImage = [_image.imageAsset imageWithTraitCollection:tc];
+      if ( generatedImage != nil ) {
+        drawImage = generatedImage;
       }
     }
   }
 
   ASImageNodeDrawParameters *drawParameters = [[ASImageNodeDrawParameters alloc] init];
-  drawParameters->_image = _image;
+  drawParameters->_image = drawImage;
   drawParameters->_bounds = [self threadSafeBounds];
   drawParameters->_opaque = self.opaque;
   drawParameters->_contentsScale = _contentsScaleForDisplay;

--- a/Source/Private/ASImageNode+AnimatedImagePrivate.h
+++ b/Source/Private/ASImageNode+AnimatedImagePrivate.h
@@ -28,6 +28,7 @@
     unsigned int animatedImagePaused:1;
     unsigned int cropEnabled:1; // Defaults to YES.
     unsigned int forceUpscaling:1; //Defaults to NO.
+    unsigned int regenerateFromImageAsset:1; //Defaults to NO.
   } _imageNodeFlags;
 }
 


### PR DESCRIPTION
There is a potential dealloc race condition that can occur when attempting to perform work with image asset out of the main thread. Moving that work into the image node draw loop if necessary