### PR TITLE
ASImageNode tintColor improvements.

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -453,6 +453,7 @@
 		CCF18FF41D2575E300DF5895 /* NSIndexSet+ASHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CCF1FF5E20C4785000AAD8FC /* ASLocking.h in Headers */ = {isa = PBXBuildFile; fileRef = CCF1FF5D20C4785000AAD8FC /* ASLocking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D933F041224AD17F00FF495E /* ASTransactionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = D933F040224AD17F00FF495E /* ASTransactionTests.mm */; };
+		D99F9158232990F30083CC8E /* ASImageNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D99F9157232990F30083CC8E /* ASImageNodeTests.m */; };
 		DB55C2671C641AE4004EDCF5 /* ASContextTransitioning.h in Headers */ = {isa = PBXBuildFile; fileRef = DB55C2651C641AE4004EDCF5 /* ASContextTransitioning.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB7121BCD50849C498C886FB /* libPods-AsyncDisplayKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */; };
 		DB78412E1C6BCE1600A9E2B4 /* _ASTransitionContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = DB55C2601C6408D6004EDCF5 /* _ASTransitionContext.mm */; };
@@ -996,6 +997,7 @@
 		D785F6601A74327E00291744 /* ASScrollNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASScrollNode.h; sourceTree = "<group>"; };
 		D785F6611A74327E00291744 /* ASScrollNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASScrollNode.mm; sourceTree = "<group>"; };
 		D933F040224AD17F00FF495E /* ASTransactionTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ASTransactionTests.mm; sourceTree = "<group>"; };
+		D99F9157232990F30083CC8E /* ASImageNodeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ASImageNodeTests.m; sourceTree = "<group>"; };
 		DB55C25F1C6408D6004EDCF5 /* _ASTransitionContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = _ASTransitionContext.h; path = ../_ASTransitionContext.h; sourceTree = "<group>"; };
 		DB55C2601C6408D6004EDCF5 /* _ASTransitionContext.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = _ASTransitionContext.mm; path = ../_ASTransitionContext.mm; sourceTree = "<group>"; };
 		DB55C2651C641AE4004EDCF5 /* ASContextTransitioning.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASContextTransitioning.h; sourceTree = "<group>"; };
@@ -1335,6 +1337,7 @@
 				697B31591CFE4B410049936F /* ASEditableTextNodeTests.mm */,
 				471D04B0224CB98600649215 /* ASImageNodeBackingSizeTests.mm */,
 				056D21541ABCEF50001107EF /* ASImageNodeSnapshotTests.mm */,
+				D99F9157232990F30083CC8E /* ASImageNodeTests.m */,
 				ACF6ED551B178DC700DA7C62 /* ASInsetLayoutSpecSnapshotTests.mm */,
 				CCE4F9B21F0D60AC00062E4E /* ASIntegerMapTests.mm */,
 				69FEE53C1D95A9AF0086F066 /* ASLayoutElementStyleTests.mm */,
@@ -2352,6 +2355,7 @@
 				CC35CEC620DD87280006448D /* ASCollectionsTests.mm in Sources */,
 				ACF6ED631B178DC700DA7C62 /* ASStackLayoutSpecSnapshotTests.mm in Sources */,
 				CCE4F9BA1F0DBB5000062E4E /* ASLayoutTestNode.mm in Sources */,
+				D99F9158232990F30083CC8E /* ASImageNodeTests.m in Sources */,
 				CCAA0B82206ADECB0057B336 /* ASRecursiveUnfairLockTests.mm in Sources */,
 				81E95C141D62639600336598 /* ASTextNodeSnapshotTests.mm in Sources */,
 				3C9C128519E616EF00E942A0 /* ASTableViewTests.mm in Sources */,

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -620,10 +620,8 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
   [self setNeedsDisplay];
 }
 
-- (void)tintColorDidChange
+- (void)_setNeedsDisplayOnTemplatedImages
 {
-  [super tintColorDidChange];
-
   BOOL isTemplateImage = NO;
   {
     AS::MutexLocker l(__instanceLock__);
@@ -635,7 +633,21 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
   }
 }
 
+- (void)tintColorDidChange
+{
+  [super tintColorDidChange];
+
+  [self _setNeedsDisplayOnTemplatedImages];
+}
+
 #pragma mark Interface State
+
+- (void)didEnterHierarchy
+{
+  [super didEnterHierarchy];
+
+  [self _setNeedsDisplayOnTemplatedImages];
+}
 
 - (void)clearContents
 {

--- a/Tests/ASImageNodeTests.m
+++ b/Tests/ASImageNodeTests.m
@@ -1,9 +1,9 @@
 //
 //  ASImageNodeTests.m
-//  AsyncDisplayKitTests
+//  Texture
 //
-//  Created by Greg Bolsinga on 9/11/19.
-//  Copyright © 2019 Pinterest. All rights reserved.
+//  Copyright (c) Pinterest, Inc.  All rights reserved.
+//  Licensed under Apache 2.0: http://www.apache.org/licenses/LICENSE-2.0
 //
 
 #import <XCTest/XCTest.h>

--- a/Tests/ASImageNodeTests.m
+++ b/Tests/ASImageNodeTests.m
@@ -1,0 +1,116 @@
+//
+//  ASImageNodeTests.m
+//  AsyncDisplayKitTests
+//
+//  Created by Greg Bolsinga on 9/11/19.
+//  Copyright © 2019 Pinterest. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import <AsyncDisplayKit/ASImageNode.h>
+#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
+
+@interface ASImageTestNode : ASImageNode
+@property (nonatomic, readonly) NSUInteger setNeedsDisplayCount;
+@end
+
+@implementation ASImageTestNode
+
+- (void)setNeedsDisplay
+{
+  // Do not call super so that the background mechanics do not fire up.
+  _setNeedsDisplayCount += 1;
+}
+
+@end
+
+@interface ASImageNodeTests : XCTestCase
+
+@end
+
+@implementation ASImageNodeTests
+
+- (void)testImage_didEnterHierarchy
+{
+  id imageMock = OCMClassMock(UIImage.class);
+
+  ASImageTestNode *imageNode = [[ASImageTestNode alloc] init];
+  imageNode.layerBacked = YES;
+  imageNode.image = imageMock;
+
+  CALayer *layer = imageNode.layer;
+  XCTAssertNotNil(layer);
+  id<CALayerDelegate> layerDelegate = layer.delegate;
+
+  NSUInteger initialSetNeedsDisplayCount = imageNode.setNeedsDisplayCount;
+  XCTAssertEqual(initialSetNeedsDisplayCount, 1);
+
+  [layerDelegate actionForLayer:layer forKey:kCAOnOrderIn];
+
+  XCTAssertEqual(imageNode.setNeedsDisplayCount, initialSetNeedsDisplayCount);
+
+  [layerDelegate actionForLayer:layer forKey:kCAOnOrderOut];
+
+  [imageMock stopMocking];
+}
+
+- (void)testTemplateImage_didEnterHierarchy
+{
+  id imageMock = OCMClassMock(UIImage.class);
+  OCMStub([imageMock renderingMode]).andReturn(UIImageRenderingModeAlwaysTemplate);
+
+  ASImageTestNode *imageNode = [[ASImageTestNode alloc] init];
+  imageNode.layerBacked = YES;
+  imageNode.image = imageMock;
+
+  CALayer *layer = imageNode.layer;
+  XCTAssertNotNil(layer);
+  id<CALayerDelegate> layerDelegate = layer.delegate;
+
+  NSUInteger initialSetNeedsDisplayCount = imageNode.setNeedsDisplayCount;
+  XCTAssertEqual(initialSetNeedsDisplayCount, 1);
+
+  [layerDelegate actionForLayer:layer forKey:kCAOnOrderIn];
+
+  XCTAssertEqual(imageNode.setNeedsDisplayCount, initialSetNeedsDisplayCount + 1);
+
+  [layerDelegate actionForLayer:layer forKey:kCAOnOrderOut];
+
+  [imageMock stopMocking];
+}
+
+- (void)testImage_tintColorDidChange
+{
+  id imageMock = OCMClassMock(UIImage.class);
+
+  ASImageTestNode *imageNode = [[ASImageTestNode alloc] init];
+  imageNode.image = imageMock;
+
+  NSUInteger initialSetNeedsDisplayCount = imageNode.setNeedsDisplayCount;
+  XCTAssertEqual(initialSetNeedsDisplayCount, 1);
+
+  [imageNode tintColorDidChange];
+  XCTAssertEqual(imageNode.setNeedsDisplayCount, initialSetNeedsDisplayCount);
+
+  [imageMock stopMocking];
+}
+
+- (void)testTemplateImage_tintColorDidChange
+{
+  id imageMock = OCMClassMock(UIImage.class);
+  OCMStub([imageMock renderingMode]).andReturn(UIImageRenderingModeAlwaysTemplate);
+
+  ASImageTestNode *imageNode = [[ASImageTestNode alloc] init];
+  imageNode.image = imageMock;
+
+  NSUInteger initialSetNeedsDisplayCount = imageNode.setNeedsDisplayCount;
+  XCTAssertEqual(initialSetNeedsDisplayCount, 1);
+
+  [imageNode tintColorDidChange];
+  XCTAssertEqual(imageNode.setNeedsDisplayCount, initialSetNeedsDisplayCount + 1);
+
+  [imageMock stopMocking];
+}
+
+@end


### PR DESCRIPTION
When ASImageNodes changes tintColor or enters the hierarchy, ensure `-setNeedsDisplay` is called if the image is templated. Basically apply #1629 to the hierarchy code as well, and backfill unit tests for that change too. Add unit tests to ensure this behavior works.