### PR TITLE
Fix CFRelease on null variable when using truncationAttributedText

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -674,11 +674,17 @@ static NSArray *DefaultLinkAttributeNames() {
       
       CTLineRef truncationTokenLine = CTLineCreateWithAttributedString((CFAttributedStringRef)_truncationAttributedText);
       CFIndex truncationTokenLineGlyphCount = truncationTokenLine ? CTLineGetGlyphCount(truncationTokenLine) : 0;
-      CFRelease(truncationTokenLine);
+      
+      if (truncationTokenLine) {
+        CFRelease(truncationTokenLine);
+      }
       
       CTLineRef additionalTruncationTokenLine = CTLineCreateWithAttributedString((CFAttributedStringRef)_additionalTruncationMessage);
-      CFIndex additionalTruncationTokenLineGlyphCount = additionalTruncationTokenLine ? CTLineGetGlyphCount(additionalTruncationTokenLine) : 0;   
-      CFRelease(additionalTruncationTokenLine);
+      CFIndex additionalTruncationTokenLineGlyphCount = additionalTruncationTokenLine ? CTLineGetGlyphCount(additionalTruncationTokenLine) : 0;
+      
+      if (additionalTruncationTokenLine) {
+        CFRelease(additionalTruncationTokenLine);
+      }
 
       switch (_textContainer.truncationType) {
         case ASTextTruncationTypeStart: {


### PR DESCRIPTION
I was hitting a crash in ASTextNode2 (in an ASCellNode) while using `truncationAttributedText` and `additionalTruncationMessage`. It seemed to only happen on a tap event when `maximumNumberOfLines` was 0, and the text was long enough to run off screen requiring the user to scroll. The node rendered fine, but crashed as the user touched down to scroll. A quick null check before calling `CFRelease` was enough to fix it.

