### PR TITLE
Use backgroundColor ivar instead of property access in traitCollectionDidChange

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -445,7 +445,7 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
       BOOL needsClippingCornerUpdate = NO;
       CGFloat cornerRadius = _cornerRadius;
       ASCornerRoundingType cornerRoundingType = _cornerRoundingType;
-      UIColor *backgroundColor = self.backgroundColor;
+      UIColor *backgroundColor = _backgroundColor;
       if (_loaded(self)) {
         if (self.isLayerBacked) {
           // Background colors do not dynamically update for layer backed nodes since they utilize CGColorRef


### PR DESCRIPTION
`traitCollectionDidChange` isn't necessarily called on Main, but our `self.backgroundColor` property access must be done on main once the view is loaded.

I originally opted to use `self.backgroundColor` rather than `_backgroundColor` in #1674, but I think we should use the ivar here. This _could_ get out-of-sync if someone modified the UIView's background color instead of updating the node, but I think that's unlikely, so we should be safe to use the ivar here.