### PR TITLE
Allow setting AVPlayer

### DIFF
--- a/Source/ASVideoNode.h
+++ b/Source/ASVideoNode.h
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)pause;
 - (BOOL)isPlaying;
 - (void)resetToPlaceholder;
+- (void)setPlayer:(AVPlayer *)player;
 
 // TODO: copy
 @property (nullable) AVAsset *asset;


### PR DESCRIPTION
Hello. In my previous work, I've run into a problem, where I needed to change standard AVPlayer to AVQueuePlayer, because of it's prefetching feature. So to fix that I usually change the header file with this exact change. I think it may come in handy to other developers, who may want to use AVQueuePlayer instead of AVPlayer.