### PR TITLE
deprecate ASGraphicsCreateImageWithOptions

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1499,7 +1499,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
       BOOL isRight = (idx == 1 || idx == 3);
 
       CGSize size = CGSizeMake(radius + 1, radius + 1);
-      UIImage *newContents = ASGraphicsCreateImageWithOptions(size, NO, self.contentsScaleForDisplay, nil, nil, ^{
+      UIImage *newContents = ASGraphicsCreateImageWithTraitCollectionAndOptions(self.primitiveTraitCollection, size, NO, self.contentsScaleForDisplay, nil, ^{
         CGContextRef ctx = UIGraphicsGetCurrentContext();
         if (isRight == YES) {
           CGContextTranslateCTM(ctx, -radius + 1, 0);

--- a/Source/ASMapNode.mm
+++ b/Source/ASMapNode.mm
@@ -221,7 +221,7 @@
                     
                     CGRect finalImageRect = CGRectMake(0, 0, image.size.width, image.size.height);
                     
-                    image = ASGraphicsCreateImageWithOptions(image.size, YES, image.scale, image, nil, ^{
+                    image = ASGraphicsCreateImageWithTraitCollectionAndOptions(strongSelf.primitiveTraitCollection, image.size, YES, image.scale, image, ^{
                       [image drawAtPoint:CGPointZero];
 
                       UIImage *pinImage;

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -140,6 +140,7 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
   CGFloat _contentScale;
   BOOL _opaque;
   CGRect _bounds;
+  ASPrimitiveTraitCollection _traitCollection;
 }
 @end
 
@@ -151,6 +152,7 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
                               contentScale:(CGFloat)contentScale
                                     opaque:(BOOL)opaque
                                     bounds:(CGRect)bounds
+                           traitCollection: (ASPrimitiveTraitCollection)traitCollection
 {
   self = [super init];
   if (self != nil) {
@@ -160,6 +162,7 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
     _contentScale = contentScale;
     _opaque = opaque;
     _bounds = bounds;
+    _traitCollection = traitCollection;
   }
   return self;
 }
@@ -554,7 +557,8 @@ static NSArray *DefaultLinkAttributeNames() {
                                                  textContainerInsets:_textContainerInset
                                                         contentScale:_contentsScaleForDisplay
                                                               opaque:self.isOpaque
-                                                              bounds:[self threadSafeBounds]];
+                                                              bounds:[self threadSafeBounds]
+                                                     traitCollection:self.primitiveTraitCollection];
 }
 
 + (UIImage *)displayWithParameters:(id<NSObject>)parameters isCancelled:(NS_NOESCAPE asdisplaynode_iscancelled_block_t)isCancelled
@@ -569,7 +573,7 @@ static NSArray *DefaultLinkAttributeNames() {
   UIEdgeInsets textContainerInsets = drawParameter ? drawParameter->_textContainerInsets : UIEdgeInsetsZero;
   ASTextKitRenderer *renderer = [drawParameter rendererForBounds:drawParameter->_bounds];
 
-  UIImage *result = ASGraphicsCreateImageWithOptions(CGSizeMake(drawParameter->_bounds.size.width, drawParameter->_bounds.size.height), drawParameter->_opaque, drawParameter->_contentScale, nil, nil, ^{
+  UIImage *result = ASGraphicsCreateImageWithTraitCollectionAndOptions(drawParameter->_traitCollection, CGSizeMake(drawParameter->_bounds.size.width, drawParameter->_bounds.size.height), drawParameter->_opaque, drawParameter->_contentScale, nil, ^{
     CGContextRef context = UIGraphicsGetCurrentContext();
     ASDisplayNodeAssert(context, @"This is no good without a context.");
     

--- a/Source/Debug/AsyncDisplayKit+Debug.mm
+++ b/Source/Debug/AsyncDisplayKit+Debug.mm
@@ -140,7 +140,7 @@ static BOOL __enableHitTestDebug = NO;
       UIColor *clipsBorderColor = [UIColor colorWithRed:30/255.0 green:90/255.0 blue:50/255.0 alpha:0.7];
       CGRect imgRect            = CGRectMake(0, 0, 2.0 * borderWidth + 1.0, 2.0 * borderWidth + 1.0);
 
-      UIImage *debugHighlightImage = ASGraphicsCreateImageWithOptions(imgRect.size, NO, 1, nil, nil, ^{
+      UIImage *debugHighlightImage = ASGraphicsCreateImageWithTraitCollectionAndOptions(self.primitiveTraitCollection, imgRect.size, NO, 1, nil, ^{
         [fillColor setFill];
         UIRectFill(imgRect);
 

--- a/Source/Details/ASGraphicsContext.h
+++ b/Source/Details/ASGraphicsContext.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return The rendered image. You can also render intermediary images using UIGraphicsGetImageFromCurrentImageContext.
  */
-AS_EXTERN UIImage *ASGraphicsCreateImageWithOptions(CGSize size, BOOL opaque, CGFloat scale, UIImage * _Nullable sourceImage, asdisplaynode_iscancelled_block_t NS_NOESCAPE _Nullable isCancelled, void (NS_NOESCAPE ^work)(void));
+AS_EXTERN UIImage *ASGraphicsCreateImageWithOptions(CGSize size, BOOL opaque, CGFloat scale, UIImage * _Nullable sourceImage, asdisplaynode_iscancelled_block_t NS_NOESCAPE _Nullable isCancelled, void (NS_NOESCAPE ^work)(void)) ASDISPLAYNODE_DEPRECATED_MSG("Use ASGraphicsCreateImageWithTraitCollectionAndOptions instead");
 
 /**
 * A wrapper for the UIKit drawing APIs.

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -209,7 +209,7 @@ using AS::MutexLocker;
     displayBlock = ^id{
       CHECK_CANCELLED_AND_RETURN_NIL();
 
-      UIImage *image = ASGraphicsCreateImageWithOptions(bounds.size, opaque, contentsScaleForDisplay, nil, isCancelledBlock, ^{
+      UIImage *image = ASGraphicsCreateImageWithTraitCollectionAndOptions(self.primitiveTraitCollection, bounds.size, opaque, contentsScaleForDisplay, nil, ^{
         for (dispatch_block_t block in displayBlocks) {
           if (isCancelledBlock()) return;
           block();
@@ -247,7 +247,7 @@ using AS::MutexLocker;
       };
 
       if (shouldCreateGraphicsContext) {
-        return ASGraphicsCreateImageWithOptions(bounds.size, opaque, contentsScaleForDisplay, nil, isCancelledBlock, workWithContext);
+        return ASGraphicsCreateImageWithTraitCollectionAndOptions(self.primitiveTraitCollection, bounds.size, opaque, contentsScaleForDisplay, nil, workWithContext);
       } else {
         workWithContext();
         return image;


### PR DESCRIPTION
`ASGraphicsCreateImageWithTraitCollectionAndOptions` supersedes `ASGraphicsCreateImageWithOptions`, thus we deprecate it.
Reference https://github.com/TextureGroup/Texture/pull/1675

>UIImage (ASDKResizableRoundedRects) is untouched cause requires deprecation of other things
>Documentation wasn't created
>ASImageNode Extras remains untouched: needs further deprecation(?)

PS
this is the same as https://github.com/TextureGroup/Texture/pull/1676