### PR TITLE
Fix element lookup for supplementary attributes.

### DIFF
--- a/Source/Private/ASCollectionLayout.mm
+++ b/Source/Private/ASCollectionLayout.mm
@@ -338,7 +338,12 @@ static const ASScrollDirection kASStaticScrollDirection = (ASScrollDirectionRigh
   if (NSUInteger count = blockingAttrs.count) {
     ASDispatchApply(count, queue, 0, ^(size_t i) {
       UICollectionViewLayoutAttributes *attrs = blockingAttrs[i];
-      ASCellNode *node = [elements elementForItemAtIndexPath:attrs.indexPath].node;
+      ASCellNode *node;
+      if (attrs.representedElementKind == nil) {
+        node = [elements elementForItemAtIndexPath:attrs.indexPath].node;
+      } else {
+        node = [elements supplementaryElementOfKind:attrs.representedElementKind atIndexPath:attrs.indexPath].node;
+      }
       CGSize expectedSize = attrs.frame.size;
       if (! CGSizeEqualToSize(expectedSize, node.calculatedSize)) {
         [node layoutThatFits:ASCollectionLayoutElementSizeRangeFromSize(expectedSize)];
@@ -353,7 +358,12 @@ static const ASScrollDirection kASStaticScrollDirection = (ASScrollDirectionRigh
       __strong ASElementMap *strongElements = weakElements;
       if (strongElements) {
         UICollectionViewLayoutAttributes *attrs = nonBlockingAttrs[i];
-        ASCellNode *node = [elements elementForItemAtIndexPath:attrs.indexPath].node;
+        ASCellNode *node;
+        if (attrs.representedElementKind == nil) {
+          node = [elements elementForItemAtIndexPath:attrs.indexPath].node;
+        } else {
+          node = [elements supplementaryElementOfKind:attrs.representedElementKind atIndexPath:attrs.indexPath].node;
+        }
         CGSize expectedSize = attrs.frame.size;
         if (! CGSizeEqualToSize(expectedSize, node.calculatedSize)) {
           [node layoutThatFits:ASCollectionLayoutElementSizeRangeFromSize(expectedSize)];


### PR DESCRIPTION
The `_measureElementsInRect()` function in `ASCollectionLayout.mm` was performing a `[elementForItemAtIndexPath:]` on the index path for every attribute. Some of those attributes might be supplementary views, but this distinction was being ignored. The fix will check the `representedElementKind` to see if the item is a supplementary view and if it is, `[supplementaryElementOfKind:atIndexPath:]` will be called instead.