### PR TITLE
Add `copy` sematic to `userInfo` property in `ASTextRunDelegate`

### DIFF
--- a/Source/Private/TextExperiment/String/ASTextRunDelegate.h
+++ b/Source/Private/TextExperiment/String/ASTextRunDelegate.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Additional information about the the run delegate.
  */
-@property (nullable, nonatomic) NSDictionary *userInfo;
+@property (nullable, nonatomic, copy) NSDictionary *userInfo;
 
 /**
  The typographic ascent of glyphs in the run.


### PR DESCRIPTION
For attributes whose type is an `immutable` value class that conforms to the `NSCopying` protocol, it almost always should specify `copy` in the `property` declaration.