### PR TITLE
Fix for images retrieved from the memory cache being reported as disk cache hits.

### DIFF
--- a/Source/ASMultiplexImageNode.mm
+++ b/Source/ASMultiplexImageNode.mm
@@ -806,7 +806,7 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   ASDisplayNodeAssertNotNil(completionBlock, @"completionBlock is required");
 
   if (_cache) {
-    [_cache cachedImageWithURL:imageURL callbackQueue:dispatch_get_main_queue() completion:^(id <ASImageContainerProtocol> imageContainer) {
+    [_cache cachedImageWithURL:imageURL callbackQueue:dispatch_get_main_queue() completion:^(id <ASImageContainerProtocol> imageContainer, BOOL isFromMemoryCache) {
       completionBlock([imageContainer asdk_image]);
     }];
   }

--- a/Source/ASMultiplexImageNode.mm
+++ b/Source/ASMultiplexImageNode.mm
@@ -806,7 +806,7 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   ASDisplayNodeAssertNotNil(completionBlock, @"completionBlock is required");
 
   if (_cache) {
-    [_cache cachedImageWithURL:imageURL callbackQueue:dispatch_get_main_queue() completion:^(id <ASImageContainerProtocol> imageContainer, BOOL isFromMemoryCache) {
+    [_cache cachedImageWithURL:imageURL callbackQueue:dispatch_get_main_queue() completion:^(id <ASImageContainerProtocol> imageContainer, __unused ASImageCacheType cacheType ) {
       completionBlock([imageContainer asdk_image]);
     }];
   }

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -867,7 +867,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 
         as_log_verbose(ASImageLoadingLog(), "Decaching image for %@ url: %@", self, URL);
         
-        ASImageCacherCompletion completion = ^(id <ASImageContainerProtocol> imageContainer) {
+        ASImageCacherCompletion completion = ^(id <ASImageContainerProtocol> imageContainer, BOOL isFromMemoryCache) {
           // If the cache sentinel changed, that means this request was cancelled.
           if (ASLockedSelf(self->_cacheSentinel != cacheSentinel)) {
             return;
@@ -888,7 +888,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
               [delegate imageNodeDidLoadImageFromCache:self];
             }
             as_log_verbose(ASImageLoadingLog(), "Decached image for %@ img: %@ url: %@", self, [imageContainer asdk_image], URL);
-            finished(imageContainer, nil, nil, ASNetworkImageSourceAsynchronousCache, nil);
+            finished(imageContainer, nil, nil, isFromMemoryCache ? ASNetworkImageSourceSynchronousCache : ASNetworkImageSourceAsynchronousCache, nil);
           }
         };
         

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -867,7 +867,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
 
         as_log_verbose(ASImageLoadingLog(), "Decaching image for %@ url: %@", self, URL);
         
-        ASImageCacherCompletion completion = ^(id <ASImageContainerProtocol> imageContainer, BOOL isFromMemoryCache) {
+        ASImageCacherCompletion completion = ^(id <ASImageContainerProtocol> imageContainer, ASImageCacheType cacheType) {
           // If the cache sentinel changed, that means this request was cancelled.
           if (ASLockedSelf(self->_cacheSentinel != cacheSentinel)) {
             return;
@@ -887,8 +887,8 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
             if (delegateDidLoadImageFromCache) {
               [delegate imageNodeDidLoadImageFromCache:self];
             }
-            as_log_verbose(ASImageLoadingLog(), "Decached image for %@ img: %@ url: %@", self, [imageContainer asdk_image], URL);
-            finished(imageContainer, nil, nil, isFromMemoryCache ? ASNetworkImageSourceSynchronousCache : ASNetworkImageSourceAsynchronousCache, nil);
+            as_log_verbose(ASImageLoadingLog(), "Decached image for %@ img: %@ url: %@ cacheType: %@", self, [imageContainer asdk_image], URL, cacheType);
+            finished(imageContainer, nil, nil, cacheType == ASImageCacheTypeSynchronous ? ASNetworkImageSourceSynchronousCache : ASNetworkImageSourceAsynchronousCache, nil);
           }
         };
         

--- a/Source/Details/ASImageProtocols.h
+++ b/Source/Details/ASImageProtocols.h
@@ -21,8 +21,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 typedef NS_ENUM(NSInteger, ASImageCacheType) {
-  ASImageCacheTypeSynchronous = 0,
-  ASImageCacheTypeAsynchronous,
+  ASImageCacheTypeAsynchronous = 0,
+  ASImageCacheTypeSynchronous,
+
 };
 
 typedef void(^ASImageCacherCompletion)(id <ASImageContainerProtocol> _Nullable imageFromCache, ASImageCacheType cacheType);

--- a/Source/Details/ASImageProtocols.h
+++ b/Source/Details/ASImageProtocols.h
@@ -23,7 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSInteger, ASImageCacheType) {
   ASImageCacheTypeAsynchronous = 0,
   ASImageCacheTypeSynchronous,
-
 };
 
 typedef void(^ASImageCacherCompletion)(id <ASImageContainerProtocol> _Nullable imageFromCache, ASImageCacheType cacheType);

--- a/Source/Details/ASImageProtocols.h
+++ b/Source/Details/ASImageProtocols.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-typedef void(^ASImageCacherCompletion)(id <ASImageContainerProtocol> _Nullable imageFromCache);
+typedef void(^ASImageCacherCompletion)(id <ASImageContainerProtocol> _Nullable imageFromCache, BOOL isFromMemoryCache);
 
 @protocol ASImageCacheProtocol <NSObject>
 

--- a/Source/Details/ASImageProtocols.h
+++ b/Source/Details/ASImageProtocols.h
@@ -20,7 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-typedef void(^ASImageCacherCompletion)(id <ASImageContainerProtocol> _Nullable imageFromCache, BOOL isFromMemoryCache);
+typedef NS_ENUM(NSInteger, ASImageCacheType) {
+  ASImageCacheTypeSynchronous = 0,
+  ASImageCacheTypeAsynchronous,
+};
+
+typedef void(^ASImageCacherCompletion)(id <ASImageContainerProtocol> _Nullable imageFromCache, ASImageCacheType cacheType);
 
 @protocol ASImageCacheProtocol <NSObject>
 

--- a/Source/Details/ASPINRemoteImageDownloader.mm
+++ b/Source/Details/ASPINRemoteImageDownloader.mm
@@ -231,14 +231,15 @@ static dispatch_once_t shared_init_predicate;
 {
   [[self sharedPINRemoteImageManager] imageFromCacheWithURL:URL processorKey:nil options:PINRemoteImageManagerDownloadOptionsSkipDecode completion:^(PINRemoteImageManagerResult * _Nonnull result) {
     [ASPINRemoteImageDownloader _performWithCallbackQueue:callbackQueue work:^{
+      const BOOL isFromMemoryCache = result.resultType == PINRemoteImageResultTypeMemoryCache;
 #if PIN_ANIMATED_AVAILABLE
       if (result.alternativeRepresentation) {
-        completion(result.alternativeRepresentation);
+        completion(result.alternativeRepresentation, isFromMemoryCache);
       } else {
-        completion(result.image);
+        completion(result.image, isFromMemoryCache);
       }
 #else
-      completion(result.image);
+      completion(result.image, isFromMemoryCache);
 #endif
     }];
   }];

--- a/Source/Details/ASPINRemoteImageDownloader.mm
+++ b/Source/Details/ASPINRemoteImageDownloader.mm
@@ -231,15 +231,15 @@ static dispatch_once_t shared_init_predicate;
 {
   [[self sharedPINRemoteImageManager] imageFromCacheWithURL:URL processorKey:nil options:PINRemoteImageManagerDownloadOptionsSkipDecode completion:^(PINRemoteImageManagerResult * _Nonnull result) {
     [ASPINRemoteImageDownloader _performWithCallbackQueue:callbackQueue work:^{
-      ASImageCacheType source = (result.resultType == PINRemoteImageResultTypeMemoryCache ? ASImageCacheTypeSynchronous : ASImageCacheTypeAsynchronous);
+      ASImageCacheType cacheType = (result.resultType == PINRemoteImageResultTypeMemoryCache ? ASImageCacheTypeSynchronous : ASImageCacheTypeAsynchronous);
 #if PIN_ANIMATED_AVAILABLE
       if (result.alternativeRepresentation) {
-        completion(result.alternativeRepresentation, source);
+        completion(result.alternativeRepresentation, cacheType);
       } else {
-        completion(result.image, source);
+        completion(result.image, cacheType);
       }
 #else
-      completion(result.image, source);
+      completion(result.image, cacheType);
 #endif
     }];
   }];

--- a/Source/Details/ASPINRemoteImageDownloader.mm
+++ b/Source/Details/ASPINRemoteImageDownloader.mm
@@ -231,15 +231,15 @@ static dispatch_once_t shared_init_predicate;
 {
   [[self sharedPINRemoteImageManager] imageFromCacheWithURL:URL processorKey:nil options:PINRemoteImageManagerDownloadOptionsSkipDecode completion:^(PINRemoteImageManagerResult * _Nonnull result) {
     [ASPINRemoteImageDownloader _performWithCallbackQueue:callbackQueue work:^{
-      const BOOL isFromMemoryCache = result.resultType == PINRemoteImageResultTypeMemoryCache;
+      ASImageCacheType source = (result.resultType == PINRemoteImageResultTypeMemoryCache ? ASImageCacheTypeSynchronous : ASImageCacheTypeAsynchronous);
 #if PIN_ANIMATED_AVAILABLE
       if (result.alternativeRepresentation) {
-        completion(result.alternativeRepresentation, isFromMemoryCache);
+        completion(result.alternativeRepresentation, source);
       } else {
-        completion(result.image, isFromMemoryCache);
+        completion(result.image, source);
       }
 #else
-      completion(result.image, isFromMemoryCache);
+      completion(result.image, source);
 #endif
     }];
   }];

--- a/Tests/ASMultiplexImageNodeTests.mm
+++ b/Tests/ASMultiplexImageNodeTests.mm
@@ -112,7 +112,7 @@
   OCMExpect([mockCache cachedImageWithURL:[self _testImageURL] callbackQueue:OCMOCK_ANY completion:[OCMArg isNotNil]])
   .andDo(^(NSInvocation *inv) {
     ASImageCacherCompletion completionBlock = [inv as_argumentAtIndexAsObject:4];
-    completionBlock([self _testImage]);
+    completionBlock([self _testImage], ASImageCacheTypeAsynchronous);
   });
 
   imageNode.imageIdentifiers = @[imageIdentifier];
@@ -217,7 +217,7 @@
   OCMExpect([mockCache cachedImageWithURL:[self _testImageURL] callbackQueue:OCMOCK_ANY completion:[OCMArg isNotNil]])
   .andDo(^(NSInvocation *inv){
     ASImageCacherCompletion completion = [inv as_argumentAtIndexAsObject:4];
-    completion(nil);
+    completion(nil, ASImageCacheTypeAsynchronous);
   });
 
   // Mock a 50%-progress URL download.

--- a/Tests/ASNetworkImageNodeTests.mm
+++ b/Tests/ASNetworkImageNodeTests.mm
@@ -109,7 +109,7 @@
 
 - (void)cachedImageWithURL:(NSURL *)URL callbackQueue:(dispatch_queue_t)callbackQueue completion:(ASImageCacherCompletion)completion
 {
-  completion(nil);
+  completion(nil, ASImageCacheTypeAsynchronous);
 }
 
 @end


### PR DESCRIPTION
Best as I can tell, a source type of `ASNetworkImageSourceAsynchronousCache` was meant to indicate a disk cache hit and `ASNetworkImageSourceSynchronousCache` was meant to indicate a memory cache hit. This change adds reporting of memory cache hits to the async rendering path.