### PR TITLE
The problem is when using LINE_BREAK_MODE_BY_WORD_WRAPPING, the TextNode

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -198,6 +198,7 @@ static NSArray *DefaultLinkAttributeNames() {
     self.userInteractionEnabled = NO;
     self.needsDisplayOnBoundsChange = YES;
     
+    _truncationMode = NSLineBreakByTruncatingTail;
     _textContainer.truncationType = ASTextTruncationTypeEnd;
     
     // The common case is for a text node to be non-opaque and blended over some background.


### PR DESCRIPTION
The problem is when using LINE_BREAK_MODE_BY_WORD_WRAPPING, the TextNode
still truncates at the tail.

Root cause:
In ASTextNode2, it sets the _textContainer.truncationType = ASTextTruncationTypeNone when truncationMode is not one of (tail/head/middle): https://github.com/TextureGroup/Texture/blob/master/Source/ASTextNode2.mm#L1319. However, this logic doesn't work for WORD_WRAPPING, because the default value is word wrap already and ASCompareAssign(_truncationMode, truncationMode) returns false in this case.

Look at the existing logic, since we already set the default _textContainer.truncationType to truncationEnd, make  _truncationMode default to tail could fix this problem and makes them consistent.

The reason it works well in https://github.com/TextureGroup/Texture/blob/master/Tests/ASTextNode2SnapshotTests.mm is because in the set of test cases we reuse the textNode; and the node may have a different truncationMode that inherits from the last test cases; and this allow textNode to apply WORD_WRAPPING correctly.