### PR TITLE
Fix tint color dead lock #1731

### DIFF
--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -302,44 +302,48 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 
 - (NSObject *)drawParametersForAsyncLayer:(_ASDisplayLayer *)layer
 {
-  ASLockScopeSelf();
-
-  UIImage *drawImage = _image;
-  if (AS_AVAILABLE_IOS_TVOS(13, 10)) {
-    if (_imageNodeFlags.regenerateFromImageAsset && drawImage != nil) {
-      _imageNodeFlags.regenerateFromImageAsset = NO;
-      UITraitCollection *tc = [UITraitCollection traitCollectionWithUserInterfaceStyle:_primitiveTraitCollection.userInterfaceStyle];
-      UIImage *generatedImage = [drawImage.imageAsset imageWithTraitCollection:tc];
-      if ( generatedImage != nil ) {
-        drawImage = generatedImage;
+  ASImageNodeDrawParameters *drawParameters = [[ASImageNodeDrawParameters alloc] init];
+  
+  {
+    ASLockScopeSelf();
+    UIImage *drawImage = _image;
+    if (AS_AVAILABLE_IOS_TVOS(13, 10)) {
+      if (_imageNodeFlags.regenerateFromImageAsset && drawImage != nil) {
+        _imageNodeFlags.regenerateFromImageAsset = NO;
+        UITraitCollection *tc = [UITraitCollection traitCollectionWithUserInterfaceStyle:_primitiveTraitCollection.userInterfaceStyle];
+        UIImage *generatedImage = [drawImage.imageAsset imageWithTraitCollection:tc];
+        if ( generatedImage != nil ) {
+          drawImage = generatedImage;
+        }
       }
     }
+
+    drawParameters->_image = drawImage;
+    drawParameters->_bounds = [self threadSafeBounds];
+    drawParameters->_opaque = self.opaque;
+    drawParameters->_contentsScale = _contentsScaleForDisplay;
+    drawParameters->_backgroundColor = self.backgroundColor;
+    drawParameters->_contentMode = self.contentMode;
+    drawParameters->_cropEnabled = _imageNodeFlags.cropEnabled;
+    drawParameters->_forceUpscaling = _imageNodeFlags.forceUpscaling;
+    drawParameters->_forcedSize = _forcedSize;
+    drawParameters->_cropRect = _cropRect;
+    drawParameters->_cropDisplayBounds = _cropDisplayBounds;
+    drawParameters->_imageModificationBlock = _imageModificationBlock;
+    drawParameters->_willDisplayNodeContentWithRenderingContext = _willDisplayNodeContentWithRenderingContext;
+    drawParameters->_didDisplayNodeContentWithRenderingContext = _didDisplayNodeContentWithRenderingContext;
+    drawParameters->_traitCollection = _primitiveTraitCollection;
+
+    // Hack for now to retain the weak entry that was created while this drawing happened
+    drawParameters->_didDrawBlock = ^(ASWeakMapEntry *entry){
+      ASLockScopeSelf();
+      _weakCacheEntry = entry;
+    };
   }
 
-  ASImageNodeDrawParameters *drawParameters = [[ASImageNodeDrawParameters alloc] init];
-  drawParameters->_image = drawImage;
-  drawParameters->_bounds = [self threadSafeBounds];
-  drawParameters->_opaque = self.opaque;
-  drawParameters->_contentsScale = _contentsScaleForDisplay;
-  drawParameters->_backgroundColor = self.backgroundColor;
+  // we need to unlock before we access the tintColor.
+  // this is to avoid dead locking by walking up the tree
   drawParameters->_tintColor = self.tintColor;
-  drawParameters->_contentMode = self.contentMode;
-  drawParameters->_cropEnabled = _imageNodeFlags.cropEnabled;
-  drawParameters->_forceUpscaling = _imageNodeFlags.forceUpscaling;
-  drawParameters->_forcedSize = _forcedSize;
-  drawParameters->_cropRect = _cropRect;
-  drawParameters->_cropDisplayBounds = _cropDisplayBounds;
-  drawParameters->_imageModificationBlock = _imageModificationBlock;
-  drawParameters->_willDisplayNodeContentWithRenderingContext = _willDisplayNodeContentWithRenderingContext;
-  drawParameters->_didDisplayNodeContentWithRenderingContext = _didDisplayNodeContentWithRenderingContext;
-  drawParameters->_traitCollection = _primitiveTraitCollection;
-
-
-  // Hack for now to retain the weak entry that was created while this drawing happened
-  drawParameters->_didDrawBlock = ^(ASWeakMapEntry *entry){
-    ASLockScopeSelf();
-    _weakCacheEntry = entry;
-  };
 
   return drawParameters;
 }

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -319,11 +319,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
     }
 
     drawParameters->_image = drawImage;
-    drawParameters->_bounds = [self threadSafeBounds];
-    drawParameters->_opaque = self.opaque;
     drawParameters->_contentsScale = _contentsScaleForDisplay;
-    drawParameters->_backgroundColor = self.backgroundColor;
-    drawParameters->_contentMode = self.contentMode;
     drawParameters->_cropEnabled = _imageNodeFlags.cropEnabled;
     drawParameters->_forceUpscaling = _imageNodeFlags.forceUpscaling;
     drawParameters->_forcedSize = _forcedSize;
@@ -340,9 +336,13 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
       _weakCacheEntry = entry;
     };
   }
-
-  // we need to unlock before we access the tintColor.
-  // this is to avoid dead locking by walking up the tree
+  
+  // We need to unlock before we access the other accessor.
+  // Especially tintColor because it needs to walk up the view hierarchy
+  drawParameters->_bounds = [self threadSafeBounds];
+  drawParameters->_opaque = self.opaque;
+  drawParameters->_backgroundColor = self.backgroundColor;
+  drawParameters->_contentMode = self.contentMode;
   drawParameters->_tintColor = self.tintColor;
 
   return drawParameters;

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -546,9 +546,11 @@ static NSArray *DefaultLinkAttributeNames() {
 
 - (NSObject *)drawParametersForAsyncLayer:(_ASDisplayLayer *)layer
 {
+  /// have to access tintColor outside of the lock to prevent dead lock when accessing up the view hierarchy
+  UIColor *tintColor = self.tintColor;
   ASLockScopeSelf();
   if (_textColorFollowsTintColor) {
-    _cachedTintColor = self.tintColor;
+    _cachedTintColor = tintColor;
   } else {
     _cachedTintColor = nil;
   }


### PR DESCRIPTION
https://github.com/TextureGroup/Texture/issues/#1731
Fix the dead lock issue caused by holding the imageNode's instance lock while walking up the view hierarchy to get the superNode's `tintColor`. If another thread is walking down the tree while holding the supernode's instance lock and trying to acquire the imageNode's lock, then we run into this dead lock.