### PR TITLE
Add empty ASViewController initializer to facilitate subclassing

### DIFF
--- a/Source/ASViewController.h
+++ b/Source/ASViewController.h
@@ -38,6 +38,15 @@ typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitWindowSizeBlock)(C
  */
 - (instancetype)initWithNode:(DisplayNodeType)node NS_DESIGNATED_INITIALIZER;
 
+/**
+* ASViewController initializer. Useful for interoperability with normal UIViewControllers.
+*
+* @return An ASViewController instance with a nil node whose root view will be backed by a standard UIView as with a normal UIViewController.
+*
+* @see ASVisibilityDepth
+*/
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
 NS_ASSUME_NONNULL_END
 
 /**

--- a/Source/ASViewController.mm
+++ b/Source/ASViewController.mm
@@ -64,6 +64,17 @@
   return self;
 }
 
+- (instancetype)init
+{
+  if (!(self = [super initWithNibName:nil bundle:nil])) {
+    return nil;
+  }
+
+  [self _initializeInstance];
+
+  return self;
+}
+
 - (void)_initializeInstance
 {
   if (_node == nil) {

--- a/examples/CustomCollectionView-Swift/Sample/ViewController.swift
+++ b/examples/CustomCollectionView-Swift/Sample/ViewController.swift
@@ -17,7 +17,7 @@ class ViewController: ASViewController<ASCollectionNode>, MosaicCollectionViewLa
   let _layoutInspector = MosaicCollectionViewLayoutInspector()
   let kNumberOfImages: UInt = 14
 
-  init() {
+  override init() {
     let layout = MosaicCollectionViewLayout()
     layout.numberOfColumns = 3;
     layout.headerHeight = 44;

--- a/examples/LayoutSpecExamples-Swift/Sample/OverviewViewController.swift
+++ b/examples/LayoutSpecExamples-Swift/Sample/OverviewViewController.swift
@@ -13,7 +13,7 @@ class OverviewViewController: ASViewController<ASTableNode> {
   let tableNode = ASTableNode()
   let layoutExamples: [LayoutExampleNode.Type]
 
-  init() {
+  override init() {
     layoutExamples = [
       HeaderWithRightAndLeftItems.self,
       PhotoWithInsetTextOverlay.self,

--- a/examples/Swift/Sample/ViewController.swift
+++ b/examples/Swift/Sample/ViewController.swift
@@ -29,7 +29,7 @@ final class ViewController: ASViewController<ASDisplayNode>, ASTableDataSource, 
 
   fileprivate(set) var state: State = .empty
 
-  init() {
+  override init() {
     super.init(node: ASTableNode())
     tableNode.delegate = self
     tableNode.dataSource = self


### PR DESCRIPTION
[Take 2 of #1740 because I'm an idiot]

Per Slack discussion with @nguyenhuy.

If you want to use `ASViewController` throughout your app as a generalized `UIViewController` stand in (as [the docs mention](http://texturegroup.org/docs/containers-asviewcontroller.html)) it's tricky (at least in Swift) when you want to take a non-node based normal `UIViewController` and make it inherit from `ASViewController` (again to perhaps have a consistent root subclass) because there's only one designated initializer in `ASViewController`, `init(node:)` which does not accept nil values despite the docs indicating that should be okay.

Currently the only course of action is to pass in a dummy node (e.g.: `ASViewController(node: ASDisplayNode())`). Other courses of action include unmarking `init(node:)` as the designated initializer or letting it accept nil values, but neither of those are optimal, per @nguyhuy:

> ah, you only hit this limitation while subclassing. When people initialize it directly, we want to steer them to do the right thing by making the node param nonnull.

A proposed solution would be to introduce a second designated "empty" initializer that would just use the underlying `UIViewController`, make `node` nil, and facilitate subclassing, which is what I did in this PR.

Other context: 

- https://github.com/facebookarchive/AsyncDisplayKit/pull/3021
- https://github.com/TextureGroup/Texture/pull/1054