### PR TITLE
Only include UIUserInterfaceLevel in iOS target

### DIFF
--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -47,8 +47,10 @@ typedef struct {
   unowned UIContentSizeCategory preferredContentSizeCategory API_AVAILABLE(ios(10.0));
 
   CGSize containerSize;
-  
-  UIUserInterfaceLevel userInterfaceLevel API_AVAILABLE(ios(13.0));
+
+#if TARGET_OS_IOS
+  UIUserInterfaceLevel userInterfaceLevel API_AVAILABLE(ios(13.0)) API_UNAVAILABLE(tvos);
+#endif
   UIAccessibilityContrast accessibilityContrast API_AVAILABLE(ios(13.0));
   UILegibilityWeight legibilityWeight API_AVAILABLE(ios(13.0));
 } ASPrimitiveTraitCollection;
@@ -152,7 +154,10 @@ AS_SUBCLASSING_RESTRICTED
 
 @property (readonly) CGSize containerSize;
 
-@property (readonly) UIUserInterfaceLevel userInterfaceLevel API_AVAILABLE(ios(13.0));
+#if TARGET_OS_IOS
+@property (readonly) UIUserInterfaceLevel userInterfaceLevel API_AVAILABLE(ios(13.0)) API_UNAVAILABLE(tvos);
+#endif
+
 @property (readonly) UIAccessibilityContrast accessibilityContrast API_AVAILABLE(ios(13.0));
 @property (readonly) UILegibilityWeight legibilityWeight API_AVAILABLE(ios(13.0));
 

--- a/Source/Details/ASTraitCollection.mm
+++ b/Source/Details/ASTraitCollection.mm
@@ -41,8 +41,14 @@ ASPrimitiveTraitCollection ASPrimitiveTraitCollectionMakeDefault() {
   if (AS_AVAILABLE_IOS_TVOS(12, 10)) {
     tc.userInterfaceStyle = UIUserInterfaceStyleUnspecified;
   }
+
+#if TARGET_OS_IOS
   if(AS_AVAILABLE_IOS(13)){
     tc.userInterfaceLevel = UIUserInterfaceLevelUnspecified;
+  }
+#endif
+
+  if (AS_AVAILABLE_IOS(13)) {
     tc.accessibilityContrast = UIAccessibilityContrastUnspecified;
     tc.legibilityWeight = UILegibilityWeightUnspecified;
   }
@@ -66,8 +72,14 @@ ASPrimitiveTraitCollection ASPrimitiveTraitCollectionFromUITraitCollection(UITra
   if (AS_AVAILABLE_IOS_TVOS(12, 10)) {
     environmentTraitCollection.userInterfaceStyle = traitCollection.userInterfaceStyle;
   }
+
+#if TARGET_OS_IOS
   if(AS_AVAILABLE_IOS(13)){
     environmentTraitCollection.userInterfaceLevel = traitCollection.userInterfaceLevel;
+  }
+#endif
+
+  if (AS_AVAILABLE_IOS(13)) {
     environmentTraitCollection.accessibilityContrast = traitCollection.accessibilityContrast;
     environmentTraitCollection.legibilityWeight = traitCollection.legibilityWeight;
   }
@@ -180,7 +192,7 @@ ASDISPLAYNODE_INLINE NSString *AS_NSStringFromUIUserInterfaceStyle(UIUserInterfa
 }
 
 // Named so as not to conflict with a hidden Apple function, in case compiler decides not to inline
-API_AVAILABLE(ios(13))
+API_AVAILABLE(ios(13)) API_UNAVAILABLE(tvos)
 ASDISPLAYNODE_INLINE NSString *AS_NSStringFromUITraitEnvironmentUserInterfaceLevel(UIUserInterfaceLevel userInterfaceLevel) {
   switch (userInterfaceLevel) {
     case UIUserInterfaceLevelBase:
@@ -235,8 +247,14 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
     [props addObject:@{ @"preferredContentSizeCategory": traits.preferredContentSizeCategory }];
     [props addObject:@{ @"displayGamut": AS_NSStringFromUIDisplayGamut(traits.displayGamut) }];
   }
+
+#if TARGET_OS_IOS
   if (AS_AVAILABLE_IOS(13)){
     [props addObject:@{ @"userInterfaceLevel": AS_NSStringFromUITraitEnvironmentUserInterfaceLevel(traits.userInterfaceLevel) }];
+  }
+#endif
+
+  if (AS_AVAILABLE_IOS(13)) {
     [props addObject:@{ @"accessibilityContrast": AS_NSStringFromUITraitEnvironmentAccessibilityContrast(traits.accessibilityContrast) }];
     [props addObject:@{ @"legibilityWeight": AS_NSStringFromUITraitEnvironmentLegibilityWeight(traits.legibilityWeight) }];
   }
@@ -300,14 +318,19 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
 {
   return _prim.preferredContentSizeCategory;
 }
+
+#if TARGET_OS_IOS
 - (UIUserInterfaceLevel)userInterfaceLevel
 {
   return _prim.userInterfaceLevel;
 }
+#endif
+
 - (UIAccessibilityContrast)accessibilityContrast
 {
   return _prim.accessibilityContrast;
 }
+
 - (UILegibilityWeight)legibilityWeight
 {
   return _prim.legibilityWeight;


### PR DESCRIPTION
- UIUserInterfaceLevel was added to ASTraitCollection in #1568. However, it's unavailable on tvOS and thus broke our podspec linting CI job. Fix by only include it if the build target is iOS.