### PR TITLE
Remove unused ASExperimentalRemoveTextKitInitialisingLock code.

### DIFF
--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -28,10 +28,9 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalDidEnterPreloadSkipASMLayout = 1 << 7,                      // exp_did_enter_preload_skip_asm_layout
   ASExperimentalDispatchApply = 1 << 8,                                     // exp_dispatch_apply
   ASExperimentalOOMBackgroundDeallocDisable = 1 << 9,                       // exp_oom_bg_dealloc_disable
-  ASExperimentalRemoveTextKitInitialisingLock = 1 << 10,                    // exp_remove_textkit_initialising_lock
-  ASExperimentalDrawingGlobal = 1 << 11,                                    // exp_drawing_global
-  ASExperimentalOptimizeDataControllerPipeline = 1 << 12,                   // exp_optimize_data_controller_pipeline
-  ASExperimentalTraitCollectionDidChangeWithPreviousCollection = 1 << 13,   // exp_trait_collection_did_change_with_previous_collection
+  ASExperimentalDrawingGlobal = 1 << 10,                                    // exp_drawing_global
+  ASExperimentalOptimizeDataControllerPipeline = 1 << 11,                   // exp_optimize_data_controller_pipeline
+  ASExperimentalTraitCollectionDidChangeWithPreviousCollection = 1 << 12,   // exp_trait_collection_did_change_with_previous_collection
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/TextKit/ASTextKitContext.mm
+++ b/Source/TextKit/ASTextKitContext.mm
@@ -37,9 +37,7 @@
     static dispatch_once_t onceToken;
     // Concurrently initialising TextKit components crashes (rdar://18448377) so we use a global lock.
     dispatch_once(&onceToken, ^{
-      if (!ASActivateExperimentalFeature(ASExperimentalRemoveTextKitInitialisingLock)) {
         mutex = new AS::Mutex();
-      }
     });
     if (mutex != NULL) {
       mutex->lock();


### PR DESCRIPTION
ASExperimentalRemoveTextKitInitialisingLock is not in use; pruning for code clarity. 