### PR TITLE
Prevent crashing during non critical logging at rotation

### DIFF
--- a/Source/Details/ASTraitCollection.mm
+++ b/Source/Details/ASTraitCollection.mm
@@ -244,7 +244,9 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
   }
   if (AS_AVAILABLE_IOS(10)) {
     [props addObject:@{ @"layoutDirection": AS_NSStringFromUITraitEnvironmentLayoutDirection(traits.layoutDirection) }];
-    [props addObject:@{ @"preferredContentSizeCategory": traits.preferredContentSizeCategory }];
+    if (traits.preferredContentSizeCategory != nil) {
+      [props addObject:@{ @"preferredContentSizeCategory": traits.preferredContentSizeCategory }];
+    }
     [props addObject:@{ @"displayGamut": AS_NSStringFromUIDisplayGamut(traits.displayGamut) }];
   }
 


### PR DESCRIPTION
As mentioned in the [Slack channel](https://asyncdisplaykit.slack.com/archives/C0V63R86T/p1578575412003700). 

I receive a crash during device rotation of certain screens. It happens when logging out new traits inside the `NSStringFromASPrimitiveTraitCollection` method during the  `ASViewController.mm#propagateNewTraitCollection` calls. 

The controller in question is an old UIStoryboard, I'm not sure of the reason for the nil `preferredContentSizeCategory` being nil, but given it's just a log, it shouldn't be crashing the app.

This PR simply adds a null check to the String conversion method, I'm not sure if someone can shed more light on whether or not this is appropriate, or the root cause might be cause for concern? @Adlai-Holler @nguyenhuy 