### PR TITLE
Revert "Prevent crashing during non critical logging at rotation"

### DIFF
--- a/Source/Details/ASTraitCollection.mm
+++ b/Source/Details/ASTraitCollection.mm
@@ -244,9 +244,7 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
   }
   if (AS_AVAILABLE_IOS(10)) {
     [props addObject:@{ @"layoutDirection": AS_NSStringFromUITraitEnvironmentLayoutDirection(traits.layoutDirection) }];
-    if (traits.preferredContentSizeCategory != nil) {
-      [props addObject:@{ @"preferredContentSizeCategory": traits.preferredContentSizeCategory }];
-    }
+    [props addObject:@{ @"preferredContentSizeCategory": traits.preferredContentSizeCategory }];
     [props addObject:@{ @"displayGamut": AS_NSStringFromUIDisplayGamut(traits.displayGamut) }];
   }
 


### PR DESCRIPTION
Reverts TextureGroup/Texture#1770. Deferring the fix so we can find the root cause of the crash.