### PR TITLE
Fix alwaysHandleTruncationTokenTap

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -1029,11 +1029,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   if (!_passthroughNonlinkTouches) {
     return [super pointInside:point withEvent:event];
   }
-
-  if (_alwaysHandleTruncationTokenTap) {
-    return YES;
-  }
-  
+    
   NSRange range = NSMakeRange(0, 0);
   NSString *linkAttributeName = nil;
   BOOL inAdditionalTruncationMessage = NO;
@@ -1043,6 +1039,10 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
                                                      range:&range
                              inAdditionalTruncationMessage:&inAdditionalTruncationMessage
                                            forHighlighting:YES];
+    
+  if (_alwaysHandleTruncationTokenTap && inAdditionalTruncationMessage) {
+    return YES;
+  }
   
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);


### PR DESCRIPTION
Previously enabling alwaysHandleTruncationTokenTap would break passthroughNonlinkTouches as it didn’t check if the tap was in the additionalTruncationMessage.

Feature introduced here https://github.com/TextureGroup/Texture/pull/1520