### PR TITLE
Fix node using wrong color with ASTraitCollection when using overrideUserInterfaceStyle

### DIFF
--- a/Source/ASCollectionViewProtocols.h
+++ b/Source/ASCollectionViewProtocols.h
@@ -95,6 +95,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)collectionView:(UICollectionView *)collectionView canPerformAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(nullable id)sender ASDISPLAYNODE_DEPRECATED_MSG("Implement collectionNode:canPerformAction:forItemAtIndexPath:withSender: instead.");
 - (void)collectionView:(UICollectionView *)collectionView performAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(nullable id)sender ASDISPLAYNODE_DEPRECATED_MSG("Implement collectionNode:performAction:forItemAtIndexPath:withSender: instead.");
 
+- (nullable UIContextMenuConfiguration *)collectionView:(UICollectionView *)collectionView contextMenuConfigurationForItemAtIndexPath:(NSIndexPath *)indexPath point:(CGPoint)point API_AVAILABLE(ios(13.0)) API_UNAVAILABLE(watchos, tvos);
+
+- (nullable UITargetedPreview *)collectionView:(UICollectionView *)collectionView previewForHighlightingContextMenuWithConfiguration:(UIContextMenuConfiguration *)configuration API_AVAILABLE(ios(13.0)) API_UNAVAILABLE(watchos, tvos);
+
+- (nullable UITargetedPreview *)collectionView:(UICollectionView *)collectionView previewForDismissingContextMenuWithConfiguration:(UIContextMenuConfiguration *)configuration API_AVAILABLE(ios(13.0)) API_UNAVAILABLE(watchos, tvos);
+
+- (void)collectionView:(UICollectionView *)collectionView willPerformPreviewActionForMenuWithConfiguration:(UIContextMenuConfiguration *)configuration animator:(id<UIContextMenuInteractionCommitAnimating>)animator API_AVAILABLE(ios(13.0)) API_UNAVAILABLE(watchos, tvos);
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -453,6 +453,11 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
           CGFloat cornerRadius = _cornerRadius;
           ASCornerRoundingType cornerRoundingType = _cornerRoundingType;
           UIColor *backgroundColor = _backgroundColor;
+          if (@available(iOS 13.0, *)) {
+             UITraitCollection *tempTraitCollection = [UITraitCollection traitCollectionWithUserInterfaceStyle:_primitiveTraitCollection.userInterfaceStyle];
+             backgroundColor = [backgroundColor resolvedColorWithTraitCollection:tempTraitCollection];
+          }
+         
           __instanceLock__.unlock();
           // TODO: we should resolve color using node's trait collection
           // but Texture changes it from many places, so we may receive the wrong one.
@@ -590,7 +595,10 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   } else {
     TIME_SCOPED(_debugTimeToCreateView);
     _view = [self _locked_viewToLoad];
-    _primitiveTraitCollection = ASPrimitiveTraitCollectionFromUITraitCollection(_view.traitCollection);
+    if ([self supernode] == nil) {
+      // Move to supernode wil propagateDown other way
+        _primitiveTraitCollection = ASPrimitiveTraitCollectionFromUITraitCollection(_view.traitCollection);
+    }
     _view.asyncdisplaykit_node = self;
     _layer = _view.layer;
   }

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -590,6 +590,7 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   } else {
     TIME_SCOPED(_debugTimeToCreateView);
     _view = [self _locked_viewToLoad];
+    _primitiveTraitCollection = ASPrimitiveTraitCollectionFromUITraitCollection(_view.traitCollection);
     _view.asyncdisplaykit_node = self;
     _layer = _view.layer;
   }

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -525,9 +525,6 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
       UITraitCollection *tempTraitCollection = [UITraitCollection traitCollectionWithUserInterfaceStyle:key.userInterfaceStyle];
       backgroundColor = [backgroundColor resolvedColorWithTraitCollection:tempTraitCollection];
       tintColor = [tintColor resolvedColorWithTraitCollection:tempTraitCollection];
-
-    } else {
-      // Fallback on earlier versions
     }
 
     // if view is opaque, fill the context with background color

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -517,10 +517,22 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
       key.willDisplayNodeContentWithRenderingContext(context, drawParameters);
       contextIsClean = NO;
     }
+    
+    UIColor *backgroundColor = key.backgroundColor;
+    UIColor *tintColor = key.tintColor;
+    
+    if (@available(iOS 13.0, *)) {
+      UITraitCollection *tempTraitCollection = [UITraitCollection traitCollectionWithUserInterfaceStyle:key.userInterfaceStyle];
+      backgroundColor = [backgroundColor resolvedColorWithTraitCollection:tempTraitCollection];
+      tintColor = [tintColor resolvedColorWithTraitCollection:tempTraitCollection];
+
+    } else {
+      // Fallback on earlier versions
+    }
 
     // if view is opaque, fill the context with background color
-    if (key.isOpaque && key.backgroundColor) {
-      [key.backgroundColor setFill];
+    if (key.isOpaque && backgroundColor) {
+      [backgroundColor setFill];
       UIRectFill({ .size = key.backingSize });
       contextIsClean = NO;
     }
@@ -541,8 +553,8 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
     BOOL canUseCopy = (contextIsClean || ASImageAlphaInfoIsOpaque(CGImageGetAlphaInfo(image.CGImage)));
     CGBlendMode blendMode = canUseCopy ? kCGBlendModeCopy : kCGBlendModeNormal;
     UIImageRenderingMode renderingMode = [image renderingMode];
-    if (renderingMode == UIImageRenderingModeAlwaysTemplate && key.tintColor) {
-      [key.tintColor setFill];
+    if (renderingMode == UIImageRenderingModeAlwaysTemplate && tintColor) {
+      [tintColor setFill];
     }
 
     @synchronized(image) {

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -216,6 +216,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
     if (reset || hadURL) {
       [self _setCurrentImageQuality:(hadURL ? 0.0 : 1.0)];
       [self _locked__setImage:_defaultImage];
+      [self _locked_setAnimatedImage:nil];
     }
   }
 


### PR DESCRIPTION
In UIKit, you can set `overrideUserInterfaceStyle` to **UIView/UIViewController** forcing them to display in specific mode

`ASDisplayNode` init with `userInterfaceStyle  = .unspecific`, and only update **userInterfaceStyle** when UIView call `traitCollectionDidChange`, it will miss UIView's default value of `traitCollection.userInterfaceStyle ` 

Another change will be fixing colors using in drawing part of `ASDisplayNode` & `ASImageNode`  in case `overrideUserInterfaceStyle` feature is NOT pass through

Finally, just forwarding iOS13 new api to outsider