### PR TITLE
[ASDisplayViewAccessibility] A few accessibility improvements

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,35 +2,16 @@ PODS:
   - FBSnapshotTestCase/Core (2.1.4)
   - JGMethodSwizzler (2.0.1)
   - OCMock (3.4.1)
-  - PINCache (3.0.1-beta.7):
-    - PINCache/Arc-exception-safe (= 3.0.1-beta.7)
-    - PINCache/Core (= 3.0.1-beta.7)
-  - PINCache/Arc-exception-safe (3.0.1-beta.7):
-    - PINCache/Core
-  - PINCache/Core (3.0.1-beta.7):
-    - PINOperation (~> 1.1.1)
-  - PINOperation (1.1.1)
-  - PINRemoteImage (3.0.0-beta.14):
-    - PINRemoteImage/PINCache (= 3.0.0-beta.14)
-  - PINRemoteImage/Core (3.0.0-beta.14):
-    - PINOperation
-  - PINRemoteImage/PINCache (3.0.0-beta.14):
-    - PINCache (= 3.0.1-beta.7)
-    - PINRemoteImage/Core
 
 DEPENDENCIES:
   - FBSnapshotTestCase/Core (~> 2.1)
   - JGMethodSwizzler (from `https://github.com/JonasGessner/JGMethodSwizzler`, branch `master`)
   - OCMock (= 3.4.1)
-  - PINRemoteImage (= 3.0.0-beta.14)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - FBSnapshotTestCase
     - OCMock
-    - PINCache
-    - PINOperation
-    - PINRemoteImage
 
 EXTERNAL SOURCES:
   JGMethodSwizzler:
@@ -46,10 +27,7 @@ SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   JGMethodSwizzler: 7328146117fffa8a4038c42eb7cd3d4c75006f97
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
-  PINCache: 7cb9ae068c8f655717f7c644ef1dff9fd573e979
-  PINOperation: a6219e6fc9db9c269eb7a7b871ac193bcf400aac
-  PINRemoteImage: 81bbff853acc71c6de9e106e9e489a791b8bbb08
 
-PODFILE CHECKSUM: 445046ac151568c694ff286684322273f0b597d6
+PODFILE CHECKSUM: 345a6700f5fdec438ef5553e1eebf62653862733
 
-COCOAPODS: 1.6.0
+COCOAPODS: 1.9.1

--- a/Schemas/configuration.json
+++ b/Schemas/configuration.json
@@ -24,6 +24,7 @@
                     "exp_did_enter_preload_skip_asm_layout",
                     "exp_dispatch_apply",
                     "exp_oom_bg_dealloc_disable",
+                    "exp_do_not_cache_accessibility_elements",
                 ]
     		}
 		}

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -31,6 +31,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalDrawingGlobal = 1 << 10,                                    // exp_drawing_global
   ASExperimentalOptimizeDataControllerPipeline = 1 << 11,                   // exp_optimize_data_controller_pipeline
   ASExperimentalTraitCollectionDidChangeWithPreviousCollection = 1 << 12,   // exp_trait_collection_did_change_with_previous_collection
+  ASExperimentalDoNotCacheAccessibilityElements = 1 << 13,                  // exp_do_not_cache_accessibility_elements
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -24,7 +24,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_oom_bg_dealloc_disable",
                                       @"exp_drawing_global",
                                       @"exp_optimize_data_controller_pipeline",
-                                      @"exp_trait_collection_did_change_with_previous_collection"]));
+                                      @"exp_trait_collection_did_change_with_previous_collection",
+                                      @"exp_do_not_cache_accessibility_elements"]));
   if (flags == ASExperimentalFeatureAll) {
     return allNames;
   }

--- a/Source/Details/_ASDisplayViewAccessiblity.h
+++ b/Source/Details/_ASDisplayViewAccessiblity.h
@@ -23,7 +23,7 @@
 //
 // In general this seems to work fairly well. However, if you want to provide a custom sort you can do so via
 // setUserDefinedComparator(). The two elements you are comparing are NSObjects, which conforms to the informal
-// UIAccessibilityProtocol, so you can safely compare properties like accessibilityFrame.
+// UIAccessibility protocol, so you can safely compare properties like accessibilityFrame.
 typedef NSComparisonResult (^ASSortAccessibilityElementsComparator)(NSObject *, NSObject *);
 
 // Use this method to supply your own custom sort comparator used to determine the order of the accessibility elements

--- a/Source/Details/_ASDisplayViewAccessiblity.h
+++ b/Source/Details/_ASDisplayViewAccessiblity.h
@@ -14,3 +14,17 @@
 // should still work as long as accessibility is enabled, this framework provides no guarantees on
 // their correctness. For details, see
 // https://developer.apple.com/documentation/objectivec/nsobject/1615147-accessibilityelements
+
+// After recusively collecting all of the accessibility elements of a node, they get sorted. This sort determines
+// the order that a screen reader will traverse the elements. By default, we sort these elements based on their
+// origin: lower y origin comes first, then lower x origin. If 2 nodes have an equal origin, the node with the smaller
+// height is placed before the node with the smaller width. If two nodes have the exact same rect, we throw up our hands
+// and return NSOrderedSame.
+//
+// In general this seems to work fairly well. However, if you want to provide a custom sort you can do so via
+// setUserDefinedComparator(). The two elements you are comparing are NSObjects, which conforms to the informal
+// UIAccessibilityProtocol, so you can safely compare properties like accessibilityFrame.
+typedef NSComparisonResult (^ASSortAccessibilityElementsComparator)(NSObject *, NSObject *);
+
+// Use this method to supply your own custom sort comparator used to determine the order of the accessibility elements
+void setUserDefinedAccessibilitySortComparator(ASSortAccessibilityElementsComparator userDefinedComparator);

--- a/Source/Details/_ASDisplayViewAccessiblity.h
+++ b/Source/Details/_ASDisplayViewAccessiblity.h
@@ -22,8 +22,8 @@
 // and return NSOrderedSame.
 //
 // In general this seems to work fairly well. However, if you want to provide a custom sort you can do so via
-// setUserDefinedComparator(). The two elements you are comparing are NSObjects, which conforms to the informal
-// UIAccessibility protocol, so you can safely compare properties like accessibilityFrame.
+// setUserDefinedAccessibilitySortComparator(). The two elements you are comparing are NSObjects, which conforms to the
+// informal UIAccessibility protocol, so you can safely compare properties like accessibilityFrame.
 typedef NSComparisonResult (^ASSortAccessibilityElementsComparator)(NSObject *, NSObject *);
 
 // Use this method to supply your own custom sort comparator used to determine the order of the accessibility elements

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -244,7 +244,7 @@ static void CollectAccessibilityElements(ASDisplayNode *node, NSMutableArray *el
     }
     // If a subnode is outside of the view's window, exclude it
     CGRect nodeInWindowCoords = [node convertRect:subnode.frame toNode:nil];
-    if (!CGRectIntersectsRect(view.window.frame, nodeInWindowCoords)) {
+    if (view.window && !CGRectIntersectsRect(view.window.frame, nodeInWindowCoords)) {
       continue;
     }
     

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -22,9 +22,11 @@
 
 #pragma mark - UIAccessibilityElement
 
-static ASSortAccessibilityElementsComparator _userDefinedComparator = nil;
+static ASSortAccessibilityElementsComparator currentAccessibilityComparator = nil;
+static ASSortAccessibilityElementsComparator defaultComparator = nil;
+
 void setUserDefinedAccessibilitySortComparator(ASSortAccessibilityElementsComparator userDefinedComparator) {
-  _userDefinedComparator = userDefinedComparator;
+  currentAccessibilityComparator = userDefinedComparator ?: defaultComparator;
 }
 
 /// Sort accessiblity elements first by y and than by x origin.
@@ -32,7 +34,6 @@ void SortAccessibilityElements(NSMutableArray *elements)
 {
   ASDisplayNodeCAssertNotNil(elements, @"Should pass in a NSMutableArray");
   
-  static ASSortAccessibilityElementsComparator defaultComparator = nil;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     defaultComparator = ^NSComparisonResult(NSObject *a, NSObject *b) {
@@ -55,13 +56,13 @@ void SortAccessibilityElements(NSMutableArray *elements)
       }
       return (originA.y < originB.y) ? NSOrderedAscending : NSOrderedDescending;
     };
+    
+    if (!currentAccessibilityComparator) {
+      currentAccessibilityComparator = defaultComparator;
+    }
   });
   
-  if (_userDefinedComparator) {
-    [elements sortUsingComparator:_userDefinedComparator];
-  } else {
-    [elements sortUsingComparator:defaultComparator];
-  }
+  [elements sortUsingComparator:currentAccessibilityComparator];
 }
 
 static CGRect ASAccessibilityFrameForNode(ASDisplayNode *node) {

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -227,6 +227,11 @@ static void CollectAccessibilityElements(ASDisplayNode *node, NSMutableArray *el
 
   UIView *view = node.view;
 
+  // If we don't have a window, let's just bail out
+  if (!view.window) {
+    return;
+  }
+
   if (node.isAccessibilityContainer && !anySubNodeIsCollection) {
     CollectAccessibilityElementsForContainer(node, view, elements);
     return;
@@ -237,7 +242,7 @@ static void CollectAccessibilityElements(ASDisplayNode *node, NSMutableArray *el
     CollectUIAccessibilityElementsForNode(node, node, view, elements);
     return;
   }
-
+  
   for (ASDisplayNode *subnode in node.subnodes) {
     // If a node is hidden or has an alpha of 0.0 we should not include it
     if (subnode.hidden || subnode.alpha == 0.0) {
@@ -245,7 +250,7 @@ static void CollectAccessibilityElements(ASDisplayNode *node, NSMutableArray *el
     }
     // If a subnode is outside of the view's window, exclude it
     CGRect nodeInWindowCoords = [node convertRect:subnode.frame toNode:nil];
-    if (view.window && !CGRectIntersectsRect(view.window.frame, nodeInWindowCoords)) {
+    if (!CGRectIntersectsRect(view.window.frame, nodeInWindowCoords)) {
       continue;
     }
     

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -23,10 +23,10 @@
 #pragma mark - UIAccessibilityElement
 
 static ASSortAccessibilityElementsComparator currentAccessibilityComparator = nil;
-static ASSortAccessibilityElementsComparator defaultComparator = nil;
+static ASSortAccessibilityElementsComparator defaultAccessibilityComparator = nil;
 
 void setUserDefinedAccessibilitySortComparator(ASSortAccessibilityElementsComparator userDefinedComparator) {
-  currentAccessibilityComparator = userDefinedComparator ?: defaultComparator;
+  currentAccessibilityComparator = userDefinedComparator ?: defaultAccessibilityComparator;
 }
 
 /// Sort accessiblity elements first by y and than by x origin.
@@ -36,7 +36,7 @@ void SortAccessibilityElements(NSMutableArray *elements)
   
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    defaultComparator = ^NSComparisonResult(NSObject *a, NSObject *b) {
+    defaultAccessibilityComparator = ^NSComparisonResult(NSObject *a, NSObject *b) {
       CGPoint originA = a.accessibilityFrame.origin;
       CGPoint originB = b.accessibilityFrame.origin;
       if (originA.y == originB.y) {
@@ -58,7 +58,7 @@ void SortAccessibilityElements(NSMutableArray *elements)
     };
     
     if (!currentAccessibilityComparator) {
-      currentAccessibilityComparator = defaultComparator;
+      currentAccessibilityComparator = defaultAccessibilityComparator;
     }
   });
   

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -53,7 +53,8 @@ static ASExperimentalFeatures features[] = {
     @"exp_dispatch_apply",
     @"exp_oom_bg_dealloc_disable",
     @"exp_drawing_global",
-    @"exp_optimize_data_controller_pipeline"
+    @"exp_optimize_data_controller_pipeline",
+    @"exp_do_not_cache_accessibility_elements",
   ];
 }
 

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -29,7 +29,9 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalDispatchApply,
   ASExperimentalOOMBackgroundDeallocDisable,
   ASExperimentalDrawingGlobal,
-  ASExperimentalOptimizeDataControllerPipeline
+  ASExperimentalOptimizeDataControllerPipeline,
+  ASExperimentalTraitCollectionDidChangeWithPreviousCollection,
+  ASExperimentalDoNotCacheAccessibilityElements,
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -54,6 +56,7 @@ static ASExperimentalFeatures features[] = {
     @"exp_oom_bg_dealloc_disable",
     @"exp_drawing_global",
     @"exp_optimize_data_controller_pipeline",
+    @"exp_trait_collection_did_change_with_previous_collection",
     @"exp_do_not_cache_accessibility_elements",
   ];
 }

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -123,6 +123,7 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
   NSArray<UIAccessibilityElement *> *accessibilityElements = container.view.accessibilityElements;
   XCTAssertEqual(accessibilityElements.count, 2);
   XCTAssertEqualObjects(accessibilityElements[1].accessibilityLabel, @"hello, world");
+
 }
 
 - (void)testAccessibilityNonLayerbackedNodesOperationInNonContainer

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -305,7 +305,7 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
 
 - (void)testAccessibilityElementsNotInAppWindow {
   
-  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 568)];
   ASDisplayNode *node = [[ASDisplayNode alloc] init];
   node.automaticallyManagesSubnodes = YES;
   

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -348,9 +348,9 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
 
   NSArray *elements = [node accessibilityElements];
   XCTAssertTrue(elements.count == 3);
-  XCTAssertEqual(elements[0], label.view);
-  XCTAssertEqual(elements[1], partiallyOnScreenNodeX.view);
-  XCTAssertEqual(elements[2], partiallyOnScreenNodeY.view);
+  XCTAssertTrue([elements containsObject:label.view]);
+  XCTAssertTrue([elements containsObject:partiallyOnScreenNodeX.view]);
+  XCTAssertTrue([elements containsObject:partiallyOnScreenNodeY.view]);
 }
 
 - (void)testAccessibilitySort {

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -123,7 +123,6 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
   NSArray<UIAccessibilityElement *> *accessibilityElements = container.view.accessibilityElements;
   XCTAssertEqual(accessibilityElements.count, 2);
   XCTAssertEqualObjects(accessibilityElements[1].accessibilityLabel, @"hello, world");
-
 }
 
 - (void)testAccessibilityNonLayerbackedNodesOperationInNonContainer

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -38,6 +38,11 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
   ASDisplayNode *subnode = nil;
   node = [[ASDisplayNode alloc] init];
   subnode = [[ASDisplayNode alloc] init];
+  
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 560)];
+  [window addSubnode:node];
+  [window makeKeyAndVisible];
+
   NSString *label = @"foo";
   subnode.isAccessibilityElement = YES;
   subnode.accessibilityLabel = label;
@@ -59,6 +64,10 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
   node = [[ASDisplayNode alloc] init];
   innerNode1 = [[ASDisplayNode alloc] init];
   innerNode2 = [[ASDisplayNode alloc] init];
+
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 560)];
+  [window addSubnode:node];
+  [window makeKeyAndVisible];
 
   // Initialize nodes with relevant accessibility data
   node.isAccessibilityContainer = YES;
@@ -82,6 +91,10 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
   node = [[ASDisplayNode alloc] init];
   innerNode = [[ASDisplayNode alloc] init];
 
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 560)];
+  [window addSubnode:node];
+  [window makeKeyAndVisible];
+
   // Initialize nodes with relevant accessibility data
   node.isAccessibilityContainer = YES;
   node.accessibilityLabel = @"hello";
@@ -98,6 +111,10 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
 - (void)testAccessibilityLayerBackedContainerWithinAccessibilityContainer
 {
   ASDisplayNode *container = [[ASDisplayNode alloc] init];
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 560)];
+  [window addSubnode:container];
+  [window makeKeyAndVisible];
+
   container.frame = CGRectMake(50, 50, 200, 600);
   container.isAccessibilityContainer = YES;
 
@@ -206,7 +223,12 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
 - (void)fakeSelector:(id)sender { }
 
 - (void)testThatAccessibilityElementsWorks {
+  
   ASDisplayNode *containerNode = [[ASDisplayNode alloc] init];
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 560)];
+  [window addSubnode:containerNode];
+  [window makeKeyAndVisible];
+  
   containerNode.frame = CGRectMake(0, 0, 100, 200);
 
   ASTextNode *label = [[ASTextNode alloc] init];
@@ -257,6 +279,10 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
 
 - (void)testHiddenAccessibilityElements {
   ASDisplayNode *containerNode = [[ASDisplayNode alloc] init];
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 560)];
+  [window addSubnode:containerNode];
+  [window makeKeyAndVisible];
+
   containerNode.frame = CGRectMake(0, 0, 100, 200);
 
   ASTextNode *label = [[ASTextNode alloc] init];
@@ -281,6 +307,9 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
 
 - (void)testTransparentAccessibilityElements {
   ASDisplayNode *containerNode = [[ASDisplayNode alloc] init];
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 560)];
+  [window addSubnode:containerNode];
+  [window makeKeyAndVisible];
   containerNode.frame = CGRectMake(0, 0, 100, 200);
 
   ASTextNode *label = [[ASTextNode alloc] init];

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -13,14 +13,18 @@
 #import <XCTest/XCTest.h>
 
 #import <AsyncDisplayKit/_ASDisplayView.h>
+#import <AsyncDisplayKit/_ASDisplayViewAccessiblity.h>
 #import <AsyncDisplayKit/ASButtonNode.h>
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
 #import <AsyncDisplayKit/ASTextNode.h>
 #import <AsyncDisplayKit/ASConfiguration.h>
 #import <AsyncDisplayKit/ASConfigurationInternal.h>
+#import <AsyncDisplayKit/ASViewController.h>
 #import <OCMock/OCMock.h>
 #import "ASDisplayNodeTestsHelper.h"
+
+extern void SortAccessibilityElements(NSMutableArray *elements);
 
 @interface ASDisplayViewAccessibilityTests : XCTestCase
 @end
@@ -250,5 +254,155 @@
   XCTAssertTrue(elements.count == 1);
   XCTAssertEqual(elements.firstObject, label);
 }
+
+- (void)testHiddenAccessibilityElements {
+  ASDisplayNode *containerNode = [[ASDisplayNode alloc] init];
+  containerNode.frame = CGRectMake(0, 0, 100, 200);
+
+  ASTextNode *label = [[ASTextNode alloc] init];
+  label.attributedText = [[NSAttributedString alloc] initWithString:@"test label"];
+  label.frame = CGRectMake(0, 0, 100, 20);
+
+  ASTextNode *hiddenLabel = [[ASTextNode alloc] init];
+  hiddenLabel.attributedText = [[NSAttributedString alloc] initWithString:@"hidden label"];
+  hiddenLabel.frame = CGRectMake(0, 24, 100, 20);
+  hiddenLabel.hidden = YES;
+  
+  [containerNode addSubnode:label];
+  [containerNode addSubnode:hiddenLabel];
+  
+  // force load
+  __unused UIView *view = containerNode.view;
+  
+  NSArray *elements = [containerNode accessibilityElements];
+  XCTAssertTrue(elements.count == 1);
+  XCTAssertEqual(elements.firstObject, label.view);
+}
+
+- (void)testTransparentAccessibilityElements {
+  ASDisplayNode *containerNode = [[ASDisplayNode alloc] init];
+  containerNode.frame = CGRectMake(0, 0, 100, 200);
+
+  ASTextNode *label = [[ASTextNode alloc] init];
+  label.attributedText = [[NSAttributedString alloc] initWithString:@"test label"];
+  label.frame = CGRectMake(0, 0, 100, 20);
+
+  ASTextNode *hiddenLabel = [[ASTextNode alloc] init];
+  hiddenLabel.attributedText = [[NSAttributedString alloc] initWithString:@"hidden label"];
+  hiddenLabel.frame = CGRectMake(0, 24, 100, 20);
+  hiddenLabel.alpha = 0.0;
+  
+  [containerNode addSubnode:label];
+  [containerNode addSubnode:hiddenLabel];
+  
+  // force load
+  __unused UIView *view = containerNode.view;
+  
+  NSArray *elements = [containerNode accessibilityElements];
+  XCTAssertTrue(elements.count == 1);
+  XCTAssertEqual(elements.firstObject, label.view);
+}
+
+- (void)testAccessibilityElementsNotInAppWindow {
+  
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  node.automaticallyManagesSubnodes = YES;
+  
+  ASViewController *vc = [[ASViewController alloc] initWithNode:node];
+  window.rootViewController = vc;
+  [window makeKeyAndVisible];
+  [window layoutIfNeeded];
+
+  CGSize windowSize = window.frame.size;
+  ASTextNode *label = [[ASTextNode alloc] init];
+  label.attributedText = [[NSAttributedString alloc] initWithString:@"on screen"];
+  label.frame = CGRectMake(0, 0, 100, 20);
+
+  ASTextNode *partiallyOnScreenNodeY = [[ASTextNode alloc] init];
+  partiallyOnScreenNodeY.attributedText = [[NSAttributedString alloc] initWithString:@"partially on screen y"];
+  partiallyOnScreenNodeY.frame = CGRectMake(0, windowSize.height - 10, 100, 20);
+
+  ASTextNode *partiallyOnScreenNodeX = [[ASTextNode alloc] init];
+  partiallyOnScreenNodeX.attributedText = [[NSAttributedString alloc] initWithString:@"partially on screen x"];
+  partiallyOnScreenNodeX.frame = CGRectMake(0, 100, windowSize.width - 10, 20);
+
+  ASTextNode *offScreenNodeY = [[ASTextNode alloc] init];
+  offScreenNodeY.attributedText = [[NSAttributedString alloc] initWithString:@"off screen y"];
+  offScreenNodeY.frame = CGRectMake(0, windowSize.height + 10, 100, 20);
+
+  ASTextNode *offScreenNodeX = [[ASTextNode alloc] init];
+  offScreenNodeX.attributedText = [[NSAttributedString alloc] initWithString:@"off screen x"];
+  offScreenNodeX.frame = CGRectMake(windowSize.width + 1, 200, 100, 20);
+
+  ASTextNode *offScreenNode = [[ASTextNode alloc] init];
+  offScreenNode.attributedText = [[NSAttributedString alloc] initWithString:@"off screen"];
+  offScreenNode.frame = CGRectMake(windowSize.width + 1, windowSize.height + 1, 100, 20);
+
+  [node addSubnode:label];
+  [node addSubnode:partiallyOnScreenNodeY];
+  [node addSubnode:partiallyOnScreenNodeX];
+  [node addSubnode:offScreenNodeY];
+  [node addSubnode:offScreenNodeX];
+  [node addSubnode:offScreenNode];
+
+  NSArray *elements = [node accessibilityElements];
+  XCTAssertTrue(elements.count == 3);
+  XCTAssertEqual(elements[0], label.view);
+  XCTAssertEqual(elements[1], partiallyOnScreenNodeX.view);
+  XCTAssertEqual(elements[2], partiallyOnScreenNodeY.view);
+}
+
+- (void)testAccessibilitySort {
+  ASDisplayNode *node1 = [[ASDisplayNode alloc] init];
+  node1.accessibilityFrame = CGRectMake(0, 0, 50, 200);
+  
+  ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
+  node2.accessibilityFrame = CGRectMake(0, 0, 100, 200);
+
+  ASDisplayNode *node3 = [[ASDisplayNode alloc] init];
+  node3.accessibilityFrame = CGRectMake(0, 1, 100, 200);
+
+  ASDisplayNode *node4 = [[ASDisplayNode alloc] init];
+  node4.accessibilityFrame = CGRectMake(1, 1, 100, 200);
+  
+  NSMutableArray *elements = [@[node2, node4, node3, node1] mutableCopy];
+  SortAccessibilityElements(elements);
+  XCTAssertEqual(elements[0], node1);
+  XCTAssertEqual(elements[1], node2);
+  XCTAssertEqual(elements[2], node3);
+  XCTAssertEqual(elements[3], node4);
+}
+
+- (void)testCustomAccessibilitySort {
+  
+  // silly custom sorter that puts items with the largest height first.
+  setUserDefinedAccessibilitySortComparator(^NSComparisonResult(NSObject *a, NSObject *b) {
+    if (a.accessibilityFrame.size.height == b.accessibilityFrame.size.height) {
+      return NSOrderedSame;
+    }
+    return a.accessibilityFrame.size.height > b.accessibilityFrame.size.height ? NSOrderedAscending : NSOrderedDescending;
+  });
+  
+  ASDisplayNode *node1 = [[ASDisplayNode alloc] init];
+  node1.accessibilityFrame = CGRectMake(0, 0, 50, 300);
+  
+  ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
+  node2.accessibilityFrame = CGRectMake(0, 0, 100, 250);
+
+  ASDisplayNode *node3 = [[ASDisplayNode alloc] init];
+  node3.accessibilityFrame = CGRectMake(0, 0, 100, 200);
+
+  ASDisplayNode *node4 = [[ASDisplayNode alloc] init];
+  node4.accessibilityFrame = CGRectMake(0, 0, 100, 150);
+  
+  NSMutableArray *elements = [@[node2, node4, node3, node1] mutableCopy];
+  SortAccessibilityElements(elements);
+  XCTAssertEqual(elements[0], node1);
+  XCTAssertEqual(elements[1], node2);
+  XCTAssertEqual(elements[2], node3);
+  XCTAssertEqual(elements[3], node4);
+}
+
 
 @end

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -325,7 +325,7 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
 
   ASTextNode *partiallyOnScreenNodeX = [[ASTextNode alloc] init];
   partiallyOnScreenNodeX.attributedText = [[NSAttributedString alloc] initWithString:@"partially on screen x"];
-  partiallyOnScreenNodeX.frame = CGRectMake(0, 100, windowSize.width - 10, 20);
+  partiallyOnScreenNodeX.frame = CGRectMake(windowSize.width - 10, 100, 100, 20);
 
   ASTextNode *offScreenNodeY = [[ASTextNode alloc] init];
   offScreenNodeY.attributedText = [[NSAttributedString alloc] initWithString:@"off screen y"];

--- a/Tests/ASScrollNodeTests.mm
+++ b/Tests/ASScrollNodeTests.mm
@@ -170,6 +170,10 @@
 
 - (void)testASScrollNodeAccessibility {
   ASDisplayNode *scrollNode = [[ASDisplayNode alloc] init];
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 560)];
+  [window addSubnode:scrollNode];
+  [window makeKeyAndVisible];
+
   ASDisplayNode *node = [[ASDisplayNode alloc] init];
   node.isAccessibilityContainer = YES;
   node.accessibilityLabel = @"node";


### PR DESCRIPTION
This diff includes a few improvements for accessibility in Texture.

* When determining a node’s accessibility elements, ignore any elements that are hidden, transparent, or out of the window. This matches UIKit’s behavior.
* When sorting the accessible elements and their origins are equal, give precedence to elements with shorter accessibility frames, followed by elements with narrower widths.
* Allow the ability to customize the comparator block that sorts the accessibility elements
* Create an experiment to stop caching accessibilityElements in `_ASDisplayView`. If we cache elements, we will require users to clear the cache (by calling `setAccessibilityElements` to get the side effect of clearing the cache) when nodes change their hidden state or opacity. This seems like a lot to request of the user. We will put this in an experiment so we can see the perf implication is both when using voice over and when not using voice over.

A few other notes:
* I got rid of the `ASAccessibilityElementPositioning` protocol in favor of passing `NSObjects` to the sort comparator. `NSObject` implements the informal `UIAccessibility` protocol and therefore has an `accessibilityFrame` property.
* I removed `static` from the `SortAccessibilityElements()` method definition. This allows me to declare it as `extern` in test it via unit tests.
