### PR TITLE
support cancelation in ASGraphicsCreateImage

### DIFF
--- a/Source/Details/ASGraphicsContext.h
+++ b/Source/Details/ASGraphicsContext.h
@@ -39,6 +39,22 @@ AS_EXTERN UIImage *ASGraphicsCreateImageWithOptions(CGSize size, BOOL opaque, CG
 * @param scale The scale of the context. 0 uses main screen scale.
 * @param sourceImage If you are planning to render a UIImage into this context, provide it here and we will use its
 *   preferred renderer format if we are using UIGraphicsImageRenderer.
+* @param isCancelled An optional block for canceling the drawing before forming the image.
+* @param work A block, wherein the current UIGraphics context is set based on the arguments.
+*
+* @return The rendered image. You can also render intermediary images using UIGraphicsGetImageFromCurrentImageContext.
+*/
+AS_EXTERN UIImage *ASGraphicsCreateImage(ASPrimitiveTraitCollection traitCollection, CGSize size, BOOL opaque, CGFloat scale, UIImage * _Nullable sourceImage, asdisplaynode_iscancelled_block_t _Nullable NS_NOESCAPE isCancelled, void (NS_NOESCAPE ^work)(void));
+
+/**
+* A wrapper for the UIKit drawing APIs.
+*
+* @param traitCollection Trait collection. The `work` block will be executed with this trait collection, so it will affect dynamic colors, etc.
+* @param size The size of the context.
+* @param opaque Whether the context should be opaque or not.
+* @param scale The scale of the context. 0 uses main screen scale.
+* @param sourceImage If you are planning to render a UIImage into this context, provide it here and we will use its
+*   preferred renderer format if we are using UIGraphicsImageRenderer.
 * @param work A block, wherein the current UIGraphics context is set based on the arguments.
 *
 * @return The rendered image. You can also render intermediary images using UIGraphicsGetImageFromCurrentImageContext.

--- a/Source/Details/ASGraphicsContext.h
+++ b/Source/Details/ASGraphicsContext.h
@@ -31,7 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 AS_EXTERN UIImage *ASGraphicsCreateImageWithOptions(CGSize size, BOOL opaque, CGFloat scale, UIImage * _Nullable sourceImage, asdisplaynode_iscancelled_block_t NS_NOESCAPE _Nullable isCancelled, void (NS_NOESCAPE ^work)(void)) ASDISPLAYNODE_DEPRECATED_MSG("Use ASGraphicsCreateImageWithTraitCollectionAndOptions instead");
 
 /**
-* A wrapper for the UIKit drawing APIs.
+* A wrapper for the UIKit drawing APIs. If you are in ASExperimentalDrawingGlobal, and you have iOS >= 10, we will create
+* a UIGraphicsRenderer with an appropriate format. Otherwise, we will use UIGraphicsBeginImageContext et al.
 *
 * @param traitCollection Trait collection. The `work` block will be executed with this trait collection, so it will affect dynamic colors, etc.
 * @param size The size of the context.

--- a/Tests/ASGraphicsContextTests.mm
+++ b/Tests/ASGraphicsContextTests.mm
@@ -28,6 +28,44 @@
 
 
 #if AS_AT_LEAST_IOS13
+- (void)testCanceled
+{
+  if (AS_AVAILABLE_IOS_TVOS(13, 13)) {
+    CGSize size = CGSize{.width=100, .height=100};
+    
+    XCTestExpectation *expectationCancelled = [self expectationWithDescription:@"canceled"];
+    
+    asdisplaynode_iscancelled_block_t isCancelledBlock =^BOOL{
+      [expectationCancelled fulfill];
+      return true;
+    };
+    
+    ASPrimitiveTraitCollection traitCollection = ASPrimitiveTraitCollectionMakeDefault();
+    UIImage *canceledImage = ASGraphicsCreateImage(traitCollection, size, false, 0, nil, isCancelledBlock, ^{});
+    
+    XCTAssertNil(canceledImage);
+    
+    [self waitForExpectations:@[expectationCancelled] timeout:1];
+  }
+}
+
+- (void)testCanceledNil
+{
+  if (AS_AVAILABLE_IOS_TVOS(13, 13)) {
+    CGSize size = CGSize{.width=100, .height=100};
+    ASPrimitiveTraitCollection traitCollection = ASPrimitiveTraitCollectionMakeDefault();
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"normal"];
+    UIImage *image = ASGraphicsCreateImage(traitCollection, size, false, 0, nil, nil, ^{
+      [expectation fulfill];
+    });
+ 
+    XCTAssert(image);
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+  }
+}
+
 - (void)testTraitCollectionPassedToWork
 {
   if (AS_AVAILABLE_IOS_TVOS(13, 13)) {
@@ -36,7 +74,7 @@
     XCTestExpectation *expectationDark = [self expectationWithDescription:@"trait collection dark"];
     ASPrimitiveTraitCollection traitCollectionDark = ASPrimitiveTraitCollectionMakeDefault();
     traitCollectionDark.userInterfaceStyle = UIUserInterfaceStyleDark;
-    ASGraphicsCreateImageWithTraitCollectionAndOptions(traitCollectionDark, size, false, 0, nil, ^{
+    ASGraphicsCreateImage(traitCollectionDark, size, false, 0, nil, nil, ^{
       UITraitCollection *currentTraitCollection = [UITraitCollection currentTraitCollection];
       XCTAssertEqual(currentTraitCollection.userInterfaceStyle, UIUserInterfaceStyleDark);
       [expectationDark fulfill];
@@ -45,7 +83,7 @@
     XCTestExpectation *expectationLight = [self expectationWithDescription:@"trait collection light"];
     ASPrimitiveTraitCollection traitCollectionLight = ASPrimitiveTraitCollectionMakeDefault();
     traitCollectionLight.userInterfaceStyle = UIUserInterfaceStyleLight;
-    ASGraphicsCreateImageWithTraitCollectionAndOptions(traitCollectionLight, size, false, 0, nil, ^{
+    ASGraphicsCreateImage(traitCollectionLight, size, false, 0, nil, nil, ^{
       UITraitCollection *currentTraitCollection = [UITraitCollection currentTraitCollection];
       XCTAssertEqual(currentTraitCollection.userInterfaceStyle, UIUserInterfaceStyleLight);
       [expectationLight fulfill];


### PR DESCRIPTION
this PR is an adoption of https://github.com/TextureGroup/Texture/pull/1696

followups: replace `ASGraphicsCreateImageWithTraitCollectionAndOptions` with `ASGraphicsCreateImage`. Deprecate `ASGraphicsCreateImageWithTraitCollectionAndOptions `.