### PR TITLE
[Accessibility] Do not exclude elements outside the window’s rect that are subviews of UIScrollView

### DIFF
--- a/.github/workflows/ci-master-only.yml
+++ b/.github/workflows/ci-master-only.yml
@@ -8,11 +8,11 @@ on:
 jobs:
   cocoapods-lint:
     env: 
-        DEVELOPER_DIR: /Applications/Xcode_11.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_11.4.1.app/Contents/Developer
     name: Verify that podspec lints
     runs-on: macOS-latest
     steps:
     - name: Checkout the Git repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Run build.sh with cocoapods-lint mode
       run: ./build.sh cocoapods-lint

--- a/.github/workflows/ci-pull-requests-only.yml
+++ b/.github/workflows/ci-pull-requests-only.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   buildsh:
     env:
-        DEVELOPER_DIR: /Applications/Xcode_11.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_11.4.1.app/Contents/Developer
     strategy:
       matrix:
         mode: [cocoapods-lint-default-subspecs, cocoapods-lint-other-subspecs]
@@ -21,6 +21,6 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout the Git repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Run build script
       run: ./build.sh ${{ matrix.mode }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   buildsh:
     env:
-        DEVELOPER_DIR: /Applications/Xcode_11.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_11.4.1.app/Contents/Developer
     strategy:
       matrix:
         mode: [tests, framework, life-without-cocoapods, carthage, examples-pt1, examples-pt2, examples-pt3, examples-pt4]
@@ -30,6 +30,6 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout the Git repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Run build script
       run: ./build.sh ${{ matrix.mode }}

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -4,8 +4,8 @@ on: [pull_request]
 
 jobs:
   buildsh:
-    env: 
-        DEVELOPER_DIR: /Applications/Xcode_11.app/Contents/Developer
+    env:
+        DEVELOPER_DIR: /Applications/Xcode_11.4.1.app/Contents/Developer
     strategy:
       matrix:
         mode: [danger]

--- a/Source/Details/ASGraphicsContext.h
+++ b/Source/Details/ASGraphicsContext.h
@@ -31,6 +31,23 @@ NS_ASSUME_NONNULL_BEGIN
 AS_EXTERN UIImage *ASGraphicsCreateImageWithOptions(CGSize size, BOOL opaque, CGFloat scale, UIImage * _Nullable sourceImage, asdisplaynode_iscancelled_block_t NS_NOESCAPE _Nullable isCancelled, void (NS_NOESCAPE ^work)(void)) ASDISPLAYNODE_DEPRECATED_MSG("Use ASGraphicsCreateImageWithTraitCollectionAndOptions instead");
 
 /**
+* A wrapper for the UIKit drawing APIs. If you are in ASExperimentalDrawingGlobal, and you have iOS >= 10, we will create
+* a UIGraphicsRenderer with an appropriate format. Otherwise, we will use UIGraphicsBeginImageContext et al.
+*
+* @param traitCollection Trait collection. The `work` block will be executed with this trait collection, so it will affect dynamic colors, etc.
+* @param size The size of the context.
+* @param opaque Whether the context should be opaque or not.
+* @param scale The scale of the context. 0 uses main screen scale.
+* @param sourceImage If you are planning to render a UIImage into this context, provide it here and we will use its
+*   preferred renderer format if we are using UIGraphicsImageRenderer.
+* @param isCancelled An optional block for canceling the drawing before forming the image.
+* @param work A block, wherein the current UIGraphics context is set based on the arguments.
+*
+* @return The rendered image. You can also render intermediary images using UIGraphicsGetImageFromCurrentImageContext.
+*/
+AS_EXTERN UIImage *ASGraphicsCreateImage(ASPrimitiveTraitCollection traitCollection, CGSize size, BOOL opaque, CGFloat scale, UIImage * _Nullable sourceImage, asdisplaynode_iscancelled_block_t _Nullable NS_NOESCAPE isCancelled, void (NS_NOESCAPE ^work)(void));
+
+/**
 * A wrapper for the UIKit drawing APIs.
 *
 * @param traitCollection Trait collection. The `work` block will be executed with this trait collection, so it will affect dynamic colors, etc.

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -210,6 +210,17 @@ static void CollectAccessibilityElementsForContainer(ASDisplayNode *container, U
   [elements addObject:accessiblityElement];
 }
 
+/// Check if a view is a subviews of an UIScrollView. This is used to determine whether to enforce that
+/// accessibility elements must be on screen
+static BOOL recusivelyCheckSuperviewsForScrollView(UIView *view) {
+    if (!view) {
+        return NO;
+    } else if ([view isKindOfClass:[UIScrollView class]]) {
+        return YES;
+    }
+    return recusivelyCheckSuperviewsForScrollView(view.superview);
+}
+
 /// Collect all accessibliity elements for a given view and view node
 static void CollectAccessibilityElements(ASDisplayNode *node, NSMutableArray *elements)
 {
@@ -248,10 +259,12 @@ static void CollectAccessibilityElements(ASDisplayNode *node, NSMutableArray *el
     if (subnode.hidden || subnode.alpha == 0.0) {
         continue;
     }
-    // If a subnode is outside of the view's window, exclude it
+    
+    // If a subnode is outside of the view's window, exclude it UNLESS it is a subview of an UIScrollView.
+    // In this case UIKit will return the element even if it is outside of the window or the scrollView's visible rect (contentOffset + contentSize)
     CGRect nodeInWindowCoords = [node convertRect:subnode.frame toNode:nil];
-    if (!CGRectIntersectsRect(view.window.frame, nodeInWindowCoords)) {
-      continue;
+    if (!CGRectIntersectsRect(view.window.frame, nodeInWindowCoords) && !recusivelyCheckSuperviewsForScrollView(view)) {
+        continue;
     }
     
     if (subnode.isAccessibilityElement) {

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -237,7 +237,6 @@ static void CollectAccessibilityElements(ASDisplayNode *node, NSMutableArray *el
   }));
 
   UIView *view = node.view;
-
   // If we don't have a window, let's just bail out
   if (!view.window) {
     return;

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -257,14 +257,14 @@ static void CollectAccessibilityElements(ASDisplayNode *node, NSMutableArray *el
   for (ASDisplayNode *subnode in node.subnodes) {
     // If a node is hidden or has an alpha of 0.0 we should not include it
     if (subnode.hidden || subnode.alpha == 0.0) {
-        continue;
+      continue;
     }
     
     // If a subnode is outside of the view's window, exclude it UNLESS it is a subview of an UIScrollView.
     // In this case UIKit will return the element even if it is outside of the window or the scrollView's visible rect (contentOffset + contentSize)
     CGRect nodeInWindowCoords = [node convertRect:subnode.frame toNode:nil];
     if (!CGRectIntersectsRect(view.window.frame, nodeInWindowCoords) && !recusivelyCheckSuperviewsForScrollView(view)) {
-        continue;
+      continue;
     }
     
     if (subnode.isAccessibilityElement) {

--- a/Source/Details/_ASDisplayViewAccessiblity.mm
+++ b/Source/Details/_ASDisplayViewAccessiblity.mm
@@ -237,6 +237,7 @@ static void CollectAccessibilityElements(ASDisplayNode *node, NSMutableArray *el
   }));
 
   UIView *view = node.view;
+  
   // If we don't have a window, let's just bail out
   if (!view.window) {
     return;

--- a/Source/Private/ASIGListAdapterBasedDataSource.mm
+++ b/Source/Private/ASIGListAdapterBasedDataSource.mm
@@ -86,6 +86,21 @@ typedef struct {
   [self.delegate collectionView:collectionNode.view didSelectItemAtIndexPath:indexPath];
 }
 
+- (void)collectionNode:(ASCollectionNode *)collectionNode didDeselectItemAtIndexPath:(NSIndexPath *)indexPath
+{
+  [self.delegate collectionView:collectionNode.view didDeselectItemAtIndexPath:indexPath];
+}
+
+- (void)collectionNode:(ASCollectionNode *)collectionNode didHighlightItemAtIndexPath:(NSIndexPath *)indexPath
+{
+  [self.delegate collectionView:collectionNode.view didHighlightItemAtIndexPath:indexPath];
+}
+
+- (void)collectionNode:(ASCollectionNode *)collectionNode didUnhighlightItemAtIndexPath:(NSIndexPath *)indexPath
+{
+  [self.delegate collectionView:collectionNode.view didUnhighlightItemAtIndexPath:indexPath];
+}
+
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
   [self.delegate scrollViewDidScroll:scrollView];
@@ -145,6 +160,32 @@ typedef struct {
   ASIGSectionController *ctrl = self.sectionControllerForBatchFetching;
   self.sectionControllerForBatchFetching = nil;
   [ctrl beginBatchFetchWithContext:context];
+}
+
+- (void)collectionNode:(ASCollectionNode *)collectionNode willDisplayItemWithNode:(ASCellNode *)node
+{
+  NSIndexPath *indexPath = [collectionNode.view indexPathForNode:node];
+  UIView *contentView = node.view.superview;
+  UICollectionViewCell *cell = contentView.superview;
+
+  if (cell == nil || indexPath == nil) {
+    return;
+  }
+
+  [self.delegate collectionView:collectionNode.view willDisplayCell:cell forItemAtIndexPath:indexPath];
+}
+
+- (void)collectionNode:(ASCollectionNode *)collectionNode didEndDisplayingItemWithNode:(ASCellNode *)node
+{
+  NSIndexPath *indexPath = [collectionNode.view indexPathForNode:node];
+  UIView *contentView = node.view.superview;
+  UICollectionViewCell *cell = contentView.superview;
+
+  if (cell == nil || indexPath == nil) {
+    return;
+  }
+
+  [self.delegate collectionView:collectionNode.view didEndDisplayingCell:cell forItemAtIndexPath:indexPath];
 }
 
 /**

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -182,18 +182,6 @@
   [ASConfigurationManager test_resetWithConfiguration:config];
 }
 
-- (void)tearDown
-{
-  // We can't prevent the system from retaining windows, but we can at least clear them out to avoid
-  // pollution between test cases.
-  for (UIWindow *window in [UIApplication sharedApplication].windows) {
-    for (UIView *subview in window.subviews) {
-      [subview removeFromSuperview];
-    }
-  }
-  [super tearDown];
-}
-
 - (void)testDataSourceImplementsNecessaryMethods
 {
   UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];

--- a/Tests/ASDisplayViewAccessibilityTests.mm
+++ b/Tests/ASDisplayViewAccessibilityTests.mm
@@ -20,6 +20,7 @@
 #import <AsyncDisplayKit/ASTextNode.h>
 #import <AsyncDisplayKit/ASConfiguration.h>
 #import <AsyncDisplayKit/ASConfigurationInternal.h>
+#import <AsyncDisplayKit/ASScrollNode.h>
 #import <AsyncDisplayKit/ASViewController.h>
 #import <OCMock/OCMock.h>
 #import "ASDisplayNodeTestsHelper.h"
@@ -380,6 +381,60 @@ extern void SortAccessibilityElements(NSMutableArray *elements);
   XCTAssertTrue([elements containsObject:label.view]);
   XCTAssertTrue([elements containsObject:partiallyOnScreenNodeX.view]);
   XCTAssertTrue([elements containsObject:partiallyOnScreenNodeY.view]);
+}
+
+- (void)testAccessibilityElementsNotInAppWindowButInScrollView {
+  
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 568)];
+  ASScrollNode *node = [[ASScrollNode alloc] init];
+  node.automaticallyManagesSubnodes = YES;
+  
+  ASViewController *vc = [[ASViewController alloc] initWithNode:node];
+  window.rootViewController = vc;
+  [window makeKeyAndVisible];
+  [window layoutIfNeeded];
+
+  CGSize windowSize = window.frame.size;
+  node.view.contentSize = CGSizeMake(window.frame.size.width, window.frame.size.height * 2.0);
+  ASTextNode *label = [[ASTextNode alloc] init];
+  label.attributedText = [[NSAttributedString alloc] initWithString:@"on screen"];
+  label.frame = CGRectMake(0, 0, 100, 20);
+
+  ASTextNode *partiallyOnScreenNodeY = [[ASTextNode alloc] init];
+  partiallyOnScreenNodeY.attributedText = [[NSAttributedString alloc] initWithString:@"partially on screen y"];
+  partiallyOnScreenNodeY.frame = CGRectMake(0, windowSize.height - 10, 100, 20);
+
+  ASTextNode *partiallyOnScreenNodeX = [[ASTextNode alloc] init];
+  partiallyOnScreenNodeX.attributedText = [[NSAttributedString alloc] initWithString:@"partially on screen x"];
+  partiallyOnScreenNodeX.frame = CGRectMake(windowSize.width - 10, 100, 100, 20);
+
+  ASTextNode *offScreenNodeY = [[ASTextNode alloc] init];
+  offScreenNodeY.attributedText = [[NSAttributedString alloc] initWithString:@"off screen y"];
+  offScreenNodeY.frame = CGRectMake(0, windowSize.height + 10, 100, 20);
+
+  ASTextNode *offScreenNodeX = [[ASTextNode alloc] init];
+  offScreenNodeX.attributedText = [[NSAttributedString alloc] initWithString:@"off screen x"];
+  offScreenNodeX.frame = CGRectMake(windowSize.width + 1, 200, 100, 20);
+
+  ASTextNode *offScreenNode = [[ASTextNode alloc] init];
+  offScreenNode.attributedText = [[NSAttributedString alloc] initWithString:@"off screen"];
+  offScreenNode.frame = CGRectMake(windowSize.width + 1, windowSize.height + 1, 100, 20);
+
+  [node addSubnode:label];
+  [node addSubnode:partiallyOnScreenNodeY];
+  [node addSubnode:partiallyOnScreenNodeX];
+  [node addSubnode:offScreenNodeY];
+  [node addSubnode:offScreenNodeX];
+  [node addSubnode:offScreenNode];
+
+  NSArray *elements = [node accessibilityElements];
+  XCTAssertTrue(elements.count == 6);
+  XCTAssertTrue([elements containsObject:label.view]);
+  XCTAssertTrue([elements containsObject:partiallyOnScreenNodeX.view]);
+  XCTAssertTrue([elements containsObject:partiallyOnScreenNodeY.view]);
+  XCTAssertTrue([elements containsObject:offScreenNodeY.view]);
+  XCTAssertTrue([elements containsObject:offScreenNodeX.view]);
+  XCTAssertTrue([elements containsObject:offScreenNode.view]);
 }
 
 - (void)testAccessibilitySort {

--- a/Tests/ASGraphicsContextTests.mm
+++ b/Tests/ASGraphicsContextTests.mm
@@ -28,6 +28,44 @@
 
 
 #if AS_AT_LEAST_IOS13
+- (void)testCanceled
+{
+  if (AS_AVAILABLE_IOS_TVOS(13, 13)) {
+    CGSize size = CGSize{.width=100, .height=100};
+    
+    XCTestExpectation *expectationCancelled = [self expectationWithDescription:@"canceled"];
+    
+    asdisplaynode_iscancelled_block_t isCancelledBlock =^BOOL{
+      [expectationCancelled fulfill];
+      return true;
+    };
+    
+    ASPrimitiveTraitCollection traitCollection = ASPrimitiveTraitCollectionMakeDefault();
+    UIImage *canceledImage = ASGraphicsCreateImage(traitCollection, size, false, 0, nil, isCancelledBlock, ^{});
+    
+    XCTAssertNil(canceledImage);
+    
+    [self waitForExpectations:@[expectationCancelled] timeout:1];
+  }
+}
+
+- (void)testCanceledNil
+{
+  if (AS_AVAILABLE_IOS_TVOS(13, 13)) {
+    CGSize size = CGSize{.width=100, .height=100};
+    ASPrimitiveTraitCollection traitCollection = ASPrimitiveTraitCollectionMakeDefault();
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"normal"];
+    UIImage *image = ASGraphicsCreateImage(traitCollection, size, false, 0, nil, nil, ^{
+      [expectation fulfill];
+    });
+ 
+    XCTAssert(image);
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+  }
+}
+
 - (void)testTraitCollectionPassedToWork
 {
   if (AS_AVAILABLE_IOS_TVOS(13, 13)) {
@@ -36,7 +74,7 @@
     XCTestExpectation *expectationDark = [self expectationWithDescription:@"trait collection dark"];
     ASPrimitiveTraitCollection traitCollectionDark = ASPrimitiveTraitCollectionMakeDefault();
     traitCollectionDark.userInterfaceStyle = UIUserInterfaceStyleDark;
-    ASGraphicsCreateImageWithTraitCollectionAndOptions(traitCollectionDark, size, false, 0, nil, ^{
+    ASGraphicsCreateImage(traitCollectionDark, size, false, 0, nil, nil, ^{
       UITraitCollection *currentTraitCollection = [UITraitCollection currentTraitCollection];
       XCTAssertEqual(currentTraitCollection.userInterfaceStyle, UIUserInterfaceStyleDark);
       [expectationDark fulfill];
@@ -45,7 +83,7 @@
     XCTestExpectation *expectationLight = [self expectationWithDescription:@"trait collection light"];
     ASPrimitiveTraitCollection traitCollectionLight = ASPrimitiveTraitCollectionMakeDefault();
     traitCollectionLight.userInterfaceStyle = UIUserInterfaceStyleLight;
-    ASGraphicsCreateImageWithTraitCollectionAndOptions(traitCollectionLight, size, false, 0, nil, ^{
+    ASGraphicsCreateImage(traitCollectionLight, size, false, 0, nil, nil, ^{
       UITraitCollection *currentTraitCollection = [UITraitCollection currentTraitCollection];
       XCTAssertEqual(currentTraitCollection.userInterfaceStyle, UIUserInterfaceStyleLight);
       [expectationLight fulfill];

--- a/Texture.podspec
+++ b/Texture.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |spec|
   end
   
   spec.subspec 'PINRemoteImage' do |pin|
-    pin.dependency 'PINRemoteImage/iOS', '= 3.0.0-beta.14'
+    pin.dependency 'PINRemoteImage/iOS', '~> 3.0.0'
     pin.dependency 'PINRemoteImage/PINCache'
     pin.dependency 'Texture/Core'
   end

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
+# echo ************* diagnostics
+# echo available devices
+# instruments -s devices
+# echo available sdk
+# xcodebuild -showsdks
+# echo available Xcode
+# ls -ld /Applications/Xcode*
+# echo ************* diagnostics end
 
-PLATFORM="${TEXTURE_BUILD_PLATFORM:-platform=iOS Simulator,OS=13.0,name=iPhone 8}"
-SDK="${TEXTURE_BUILD_SDK:-iphonesimulator13.0}"
+PLATFORM="${TEXTURE_BUILD_PLATFORM:-platform=iOS Simulator,OS=13.4.1,name=iPhone 8}"
+SDK="${TEXTURE_BUILD_SDK:-iphonesimulator13.4}"
 DERIVED_DATA_PATH="~/ASDKDerivedData"
 
 # It is pitch black.


### PR DESCRIPTION
Previously I put up a diff to exclude accessibility elements that were outside of the current window rect. However, I didn’t take the case of scrollViews (including table and collection views) into consideration. By ignoring cells outside of the window, the scroll view would not advance to additional elements in the scrollView but off screen.

I did some side-by-side testing with UIKit and it appears that no elements are excluded that are in a scroll view, even if the element’s rect is outside of the scroll view’s visible rect. In order to match this behavior, I added a recursive superview check to see if an element that is off screen has a scrollView as a parent. If so, we do not exclude it:

```    
if (!CGRectIntersectsRect(view.window.frame, nodeInWindowCoords) &&
     !recusivelyCheckSuperviewsForScrollView(view)) {
        continue;
}
```