### PR TITLE
Removes unnecessary `-tearDown` code.

### DIFF
--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -182,18 +182,6 @@
   [ASConfigurationManager test_resetWithConfiguration:config];
 }
 
-- (void)tearDown
-{
-  // We can't prevent the system from retaining windows, but we can at least clear them out to avoid
-  // pollution between test cases.
-  for (UIWindow *window in [UIApplication sharedApplication].windows) {
-    for (UIView *subview in window.subviews) {
-      [subview removeFromSuperview];
-    }
-  }
-  [super tearDown];
-}
-
 - (void)testDataSourceImplementsNecessaryMethods
 {
   UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];


### PR DESCRIPTION
All of the work being done in this tearDown is also being done in -[ASTest tearDown].
So we might as well get rid of the redundant code.