### PR TITLE
[CI] Remove the example builds to see if that stops all the cancels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,6 @@ jobs:
             name: Build Texture as a static library
           - mode: carthage
             name: Verify that Carthage works
-          - mode: examples-pt1
-            name: Build examples (examples-pt1)
-          - mode: examples-pt2
-            name: Build examples (examples-pt2)
-          - mode: examples-pt3
-            name: Build examples (examples-pt3)
-          - mode: examples-pt4
-            name: Build examples (examples-pt4)
     name: ${{ matrix.name }}
     runs-on: macOS-latest
     steps:


### PR DESCRIPTION
Most PR CI builds are failing without any useful information. I've personally changed nothing but white space and had a build go from failing to passing. I wanted to see if we stop building the examples on each PR if the build will stop cancelling. 

This isn't a long term solution. We need to figure out why these examples build locally but not on github.