### PR TITLE
Use ASReplaceMethodWithBlock instead of swizzling with a library

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,5 +5,4 @@ platform :ios, '9.0'
 target :'AsyncDisplayKitTests' do
   pod 'OCMock', '~>3.6'
   pod 'FBSnapshotTestCase/Core', '~> 2.1'
-  pod 'JGMethodSwizzler', :git => 'https://github.com/JonasGessner/JGMethodSwizzler', :branch => 'master'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,9 @@
 PODS:
   - FBSnapshotTestCase/Core (2.1.4)
-  - JGMethodSwizzler (2.0.1)
   - OCMock (3.6)
 
 DEPENDENCIES:
   - FBSnapshotTestCase/Core (~> 2.1)
-  - JGMethodSwizzler (from `https://github.com/JonasGessner/JGMethodSwizzler`, branch `master`)
   - OCMock (~> 3.6)
 
 SPEC REPOS:
@@ -13,21 +11,10 @@ SPEC REPOS:
     - FBSnapshotTestCase
     - OCMock
 
-EXTERNAL SOURCES:
-  JGMethodSwizzler:
-    :branch: master
-    :git: https://github.com/JonasGessner/JGMethodSwizzler
-
-CHECKOUT OPTIONS:
-  JGMethodSwizzler:
-    :commit: 8791eccc5342224bd293b5867348657e3a240c7f
-    :git: https://github.com/JonasGessner/JGMethodSwizzler
-
 SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  JGMethodSwizzler: 7328146117fffa8a4038c42eb7cd3d4c75006f97
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
 
-PODFILE CHECKSUM: 7e86f0142d0db2230d763087056ba6d9eb2afd54
+PODFILE CHECKSUM: 6c5ab754458e18efcf3a8b39a3b97bf96c3d2237
 
 COCOAPODS: 1.9.1

--- a/Tests/ASTableViewTests.mm
+++ b/Tests/ASTableViewTests.mm
@@ -8,10 +8,6 @@
 //
 
 #import <XCTest/XCTest.h>
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-#import <JGMethodSwizzler/JGMethodSwizzler.h>
-#pragma clang diagnostic pop
 
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 #import <AsyncDisplayKit/ASTableView.h>
@@ -40,13 +36,6 @@
   [super relayoutAllNodesWithInvalidationBlock:invalidationBlock];
 }
 
-@end
-
-@interface UITableView (Testing)
-// This will start recording all editing calls to UITableView
-// into the provided array.
-// Make sure to call [UITableView deswizzleInstanceMethods] to reset this.
-+ (void)as_recordEditingCallsIntoArray:(NSMutableArray<NSString *> *)selectors;
 @end
 
 @interface ASTestTableView : ASTableView
@@ -608,7 +597,6 @@
 
 - (void)testThatInitialDataLoadHappensInOneShot
 {
-  NSMutableArray *selectors = [NSMutableArray array];
   ASTableNode *node = [[ASTableNode alloc] initWithStyle:UITableViewStylePlain];
 
   ASTableViewFilledDataSource *dataSource = [ASTableViewFilledDataSource new];
@@ -617,23 +605,25 @@
   node.dataSource = dataSource;
   node.delegate = dataSource;
 
-  [UITableView as_recordEditingCallsIntoArray:selectors];
+  __block NSUInteger reloadCallCount = 0;
+  __block IMP originalIMP = ASReplaceMethodWithBlock(UITableView.class, @selector(reloadData), ^(UITableView *_tableView) {
+    reloadCallCount += 1;
+    ((void (*)(id,SEL))originalIMP)(_tableView, @selector(reloadData));
+  });
+
   XCTAssertGreaterThan(node.numberOfSections, 0);
   [node waitUntilAllUpdatesAreProcessed];
   XCTAssertGreaterThan(node.view.numberOfSections, 0);
 
   // The first reloadData call helps prevent UITableView from calling it multiple times while ASDataController is working.
   // The second reloadData call is the real one.
-  NSArray *expectedSelectors = @[ NSStringFromSelector(@selector(reloadData)),
-                                  NSStringFromSelector(@selector(reloadData)) ];
-  XCTAssertEqualObjects(selectors, expectedSelectors);
+  XCTAssertEqual(reloadCallCount, 2);
 
-  [UITableView deswizzleAllInstanceMethods];
+  method_setImplementation(class_getInstanceMethod(UITableView.class, @selector(reloadData)), (IMP)originalIMP);
 }
 
 - (void)testThatReloadDataHappensInOneShot
 {
-  NSMutableArray *selectors = [NSMutableArray array];
   ASTableNode *node = [[ASTableNode alloc] initWithStyle:UITableViewStylePlain];
 
   ASTableViewFilledDataSource *dataSource = [ASTableViewFilledDataSource new];
@@ -648,16 +638,19 @@
   XCTAssertGreaterThan(node.view.numberOfSections, 0);
 
   // Reload data.
-  [UITableView as_recordEditingCallsIntoArray:selectors];
+  __block NSUInteger reloadCallCount = 0;
+  __block IMP originalIMP = ASReplaceMethodWithBlock(UITableView.class, @selector(reloadData), ^(UITableView *_tableView) {
+    reloadCallCount += 1;
+    ((void (*)(id,SEL))originalIMP)(_tableView, @selector(reloadData));
+  });
   [node reloadData];
   [node waitUntilAllUpdatesAreProcessed];
 
   // Assert that the beginning of the call pattern is correct.
   // There is currently noise that comes after that we will allow for this test.
-  NSArray *expectedSelectors = @[ NSStringFromSelector(@selector(reloadData)) ];
-  XCTAssertEqualObjects(selectors, expectedSelectors);
+  XCTAssertEqual(reloadCallCount, 1);
 
-  [UITableView deswizzleAllInstanceMethods];
+  method_setImplementation(class_getInstanceMethod(UITableView.class, @selector(reloadData)), (IMP)originalIMP);
 }
 
 /**
@@ -905,56 +898,6 @@
   UITableViewCell *uikitCell = [tableView cellForRowAtIndexPath:indexPath];
   BOOL areColorsEqual = CGColorEqualToColor(uikitCell.tintColor.CGColor, UIColor.yellowColor.CGColor);
   XCTAssertTrue(areColorsEqual);
-}
-
-@end
-
-@implementation UITableView (Testing)
-
-+ (void)as_recordEditingCallsIntoArray:(NSMutableArray<NSString *> *)selectors
-{
-  [UITableView swizzleInstanceMethod:@selector(reloadData) withReplacement:JGMethodReplacementProviderBlock {
-    return JGMethodReplacement(void, UITableView *) {
-      JGOriginalImplementation(void);
-      [selectors addObject:NSStringFromSelector(_cmd)];
-    };
-  }];
-  [UITableView swizzleInstanceMethod:@selector(beginUpdates) withReplacement:JGMethodReplacementProviderBlock {
-    return JGMethodReplacement(void, UITableView *) {
-      JGOriginalImplementation(void);
-      [selectors addObject:NSStringFromSelector(_cmd)];
-    };
-  }];
-  [UITableView swizzleInstanceMethod:@selector(endUpdates) withReplacement:JGMethodReplacementProviderBlock {
-    return JGMethodReplacement(void, UITableView *) {
-      JGOriginalImplementation(void);
-      [selectors addObject:NSStringFromSelector(_cmd)];
-    };
-  }];
-  [UITableView swizzleInstanceMethod:@selector(insertRowsAtIndexPaths:withRowAnimation:) withReplacement:JGMethodReplacementProviderBlock {
-    return JGMethodReplacement(void, UITableView *, NSArray *indexPaths, UITableViewRowAnimation anim) {
-      JGOriginalImplementation(void, indexPaths, anim);
-      [selectors addObject:NSStringFromSelector(_cmd)];
-    };
-  }];
-  [UITableView swizzleInstanceMethod:@selector(deleteRowsAtIndexPaths:withRowAnimation:) withReplacement:JGMethodReplacementProviderBlock {
-    return JGMethodReplacement(void, UITableView *, NSArray *indexPaths, UITableViewRowAnimation anim) {
-      JGOriginalImplementation(void, indexPaths, anim);
-      [selectors addObject:NSStringFromSelector(_cmd)];
-    };
-  }];
-  [UITableView swizzleInstanceMethod:@selector(insertSections:withRowAnimation:) withReplacement:JGMethodReplacementProviderBlock {
-    return JGMethodReplacement(void, UITableView *, NSIndexSet *indexes, UITableViewRowAnimation anim) {
-      JGOriginalImplementation(void, indexes, anim);
-      [selectors addObject:NSStringFromSelector(_cmd)];
-    };
-  }];
-  [UITableView swizzleInstanceMethod:@selector(deleteSections:withRowAnimation:) withReplacement:JGMethodReplacementProviderBlock {
-    return JGMethodReplacement(void, UITableView *, NSIndexSet *indexes, UITableViewRowAnimation anim) {
-      JGOriginalImplementation(void, indexes, anim);
-      [selectors addObject:NSStringFromSelector(_cmd)];
-    };
-  }];
 }
 
 @end


### PR DESCRIPTION
- I tried to make these tests work with OCMock, but that only ever saw 1 call.
- All these do is count `-reloadData` calls. I'm not sure why so many other methods were recorded.
- Why we are doing this is the external library targets iOS 5 and is flagged as a warning in builds.