### PR TITLE
Update Swift collection view interop example

### DIFF
--- a/docs/_docs/uicollectionviewinterop.md
+++ b/docs/_docs/uicollectionviewinterop.md
@@ -77,6 +77,9 @@ For this example, the data source method `collectionNode:nodeBlockForItemAtIndex
                         nodeBlockForItemAt indexPath: IndexPath) -> ASCellNodeBlock! {
         return optionalNode
     }
+
+  // Click the "Edit on GitHub" button at the bottom of this  
+  // page to contribute the swift code for this section. Thanks!
   </pre>
 </div>
 </div>

--- a/docs/_docs/uicollectionviewinterop.md
+++ b/docs/_docs/uicollectionviewinterop.md
@@ -71,8 +71,12 @@ For this example, the data source method `collectionNode:nodeBlockForItemAtIndex
   </pre>
 
   <pre lang="swift" class = "swiftCode hidden">
-  // Click the "Edit on GitHub" button at the bottom of this 
-  // page to contribute the swift code for this section. Thanks!
+  // Setting the return type to implicitly unwrapped optional
+  // helps overcome compiler error when trying to return nil
+  func collectionNode(_ collectionNode: ASCollectionNode,
+                        nodeBlockForItemAt indexPath: IndexPath) -> ASCellNodeBlock! {
+        return optionalNode
+    }
   </pre>
 </div>
 </div>


### PR DESCRIPTION
There is an issue with interop in Swift - you can't return nil instead of node or node block. This would help people reading the documentation overcome the issue.

Confusion example:
https://stackoverflow.com/questions/47676341/texture-ascollectiondatasourceinterop-swift/61993513#61993513