### PR TITLE
-[ASNetworkImageNode setURL:resetToDefault:] forget to reset animatedImage

### DIFF
--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -216,6 +216,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
     if (reset || hadURL) {
       [self _setCurrentImageQuality:(hadURL ? 0.0 : 1.0)];
       [self _locked__setImage:_defaultImage];
+      [self _locked_setAnimatedImage:nil];
     }
   }
 

--- a/Tests/ASNetworkImageNodeTests.mm
+++ b/Tests/ASNetworkImageNodeTests.mm
@@ -20,6 +20,9 @@
 @interface ASTestImageCache : NSObject <ASImageCacheProtocol>
 @end
 
+@interface ASTestAnimatedImage : NSObject <ASAnimatedImageProtocol>
+@end
+
 @implementation ASNetworkImageNodeTests {
   ASNetworkImageNode *node;
   id downloader;
@@ -71,6 +74,18 @@
   [[downloader expect] setProgressImageBlock:[OCMArg isNotNil] callbackQueue:OCMOCK_ANY withDownloadIdentifier:@1];
   node.URL = [NSURL URLWithString:@"http://imageB"];
   [downloader verifyWithDelay:5];
+}
+
+- (void)testThatAnimatedImageClearedCorrectlyOnChangeURL
+{
+  [node layer];
+  [node enterInterfaceState:ASInterfaceStateInHierarchy];
+
+  // Set URL while visible, should set progress block
+  node.animatedImage = [ASTestAnimatedImage new];
+  [node setURL:[NSURL URLWithString:@"http://imageA"] resetToDefault:YES];
+
+  XCTAssertEqualObjects(nil, node.animatedImage);
 }
 
 - (void)testThatSettingAnImageWillStayForEnteringAndExitingPreloadState
@@ -132,4 +147,62 @@
 {
   // nop
 }
+@end
+
+@implementation ASTestAnimatedImage
+@synthesize playbackReadyCallback;
+
+- (UIImage *)coverImage
+{
+  return [UIImage new];
+}
+
+- (BOOL)coverImageReady
+{
+  return YES;
+}
+
+- (CFTimeInterval)totalDuration
+{
+  return 1;
+}
+
+- (NSUInteger)frameInterval
+{
+  return 0.2;
+}
+
+- (size_t)loopCount
+{
+  return 0;
+}
+
+- (size_t)frameCount
+{
+  return 5;
+}
+
+- (BOOL)playbackReady
+{
+  return YES;
+}
+
+- (NSError *)error
+{
+  return nil;
+}
+
+- (CGImageRef)imageAtIndex:(NSUInteger)index
+{
+  return [[UIImage new] CGImage];
+}
+
+- (CFTimeInterval)durationAtIndex:(NSUInteger)index
+{
+  return 0.2;
+}
+
+- (void)clearAnimatedImageCache
+{}
+
 @end


### PR DESCRIPTION
If you have a ASNetworkImageNode with animatedImage

Then you call [ImageNode setURL:someLink resetToDefault:true]
Node will still always display Old animatedImage, the new static image will never be display

Related issue https://github.com/TextureGroup/Texture/issues/1815