### PR TITLE
Fix override user interface style

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -453,6 +453,11 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
           CGFloat cornerRadius = _cornerRadius;
           ASCornerRoundingType cornerRoundingType = _cornerRoundingType;
           UIColor *backgroundColor = _backgroundColor;
+          if (@available(iOS 13.0, *)) {
+             UITraitCollection *tempTraitCollection = [UITraitCollection traitCollectionWithUserInterfaceStyle:_primitiveTraitCollection.userInterfaceStyle];
+             backgroundColor = [backgroundColor resolvedColorWithTraitCollection:tempTraitCollection];
+          }
+         
           __instanceLock__.unlock();
           // TODO: we should resolve color using node's trait collection
           // but Texture changes it from many places, so we may receive the wrong one.
@@ -590,7 +595,10 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   } else {
     TIME_SCOPED(_debugTimeToCreateView);
     _view = [self _locked_viewToLoad];
-    _primitiveTraitCollection = ASPrimitiveTraitCollectionFromUITraitCollection(_view.traitCollection);
+    if ([self supernode] == nil) {
+      // Move to supernode wil propagateDown other way
+        _primitiveTraitCollection = ASPrimitiveTraitCollectionFromUITraitCollection(_view.traitCollection);
+    }
     _view.asyncdisplaykit_node = self;
     _layer = _view.layer;
   }

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -590,6 +590,7 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
   } else {
     TIME_SCOPED(_debugTimeToCreateView);
     _view = [self _locked_viewToLoad];
+    _primitiveTraitCollection = ASPrimitiveTraitCollectionFromUITraitCollection(_view.traitCollection);
     _view.asyncdisplaykit_node = self;
     _layer = _view.layer;
   }

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -525,9 +525,6 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
       UITraitCollection *tempTraitCollection = [UITraitCollection traitCollectionWithUserInterfaceStyle:key.userInterfaceStyle];
       backgroundColor = [backgroundColor resolvedColorWithTraitCollection:tempTraitCollection];
       tintColor = [tintColor resolvedColorWithTraitCollection:tempTraitCollection];
-
-    } else {
-      // Fallback on earlier versions
     }
 
     // if view is opaque, fill the context with background color

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -517,10 +517,22 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
       key.willDisplayNodeContentWithRenderingContext(context, drawParameters);
       contextIsClean = NO;
     }
+    
+    UIColor *backgroundColor = key.backgroundColor;
+    UIColor *tintColor = key.tintColor;
+    
+    if (@available(iOS 13.0, *)) {
+      UITraitCollection *tempTraitCollection = [UITraitCollection traitCollectionWithUserInterfaceStyle:key.userInterfaceStyle];
+      backgroundColor = [backgroundColor resolvedColorWithTraitCollection:tempTraitCollection];
+      tintColor = [tintColor resolvedColorWithTraitCollection:tempTraitCollection];
+
+    } else {
+      // Fallback on earlier versions
+    }
 
     // if view is opaque, fill the context with background color
-    if (key.isOpaque && key.backgroundColor) {
-      [key.backgroundColor setFill];
+    if (key.isOpaque && backgroundColor) {
+      [backgroundColor setFill];
       UIRectFill({ .size = key.backingSize });
       contextIsClean = NO;
     }
@@ -541,8 +553,8 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
     BOOL canUseCopy = (contextIsClean || ASImageAlphaInfoIsOpaque(CGImageGetAlphaInfo(image.CGImage)));
     CGBlendMode blendMode = canUseCopy ? kCGBlendModeCopy : kCGBlendModeNormal;
     UIImageRenderingMode renderingMode = [image renderingMode];
-    if (renderingMode == UIImageRenderingModeAlwaysTemplate && key.tintColor) {
-      [key.tintColor setFill];
+    if (renderingMode == UIImageRenderingModeAlwaysTemplate && tintColor) {
+      [tintColor setFill];
     }
 
     @synchronized(image) {


### PR DESCRIPTION
For further detail & discuss here https://github.com/TextureGroup/Texture/pull/1798

## Before
`UIView` & `UIViewController` both has a callback when traitCollection changed:
`- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection`

ASDK depends on it to switch between different user interface style

## Let's see why `ASViewController` works
When u r using **UIViewController**
**Case 0:**
1. init a UIViewController
2. set UIViewController `overrideUserInterfaceStyle`
3. You get callback from **UIViewController** that `traitCollectionDidChange`

When `overrideUserInterfaceStyle` is set, `UIViewController` will get this callback ,  thus `ASViewController` get a chance to update  **TraitCollection** to right the one

Also `ASViewController` update  TraitCollection in several different callback like `viewWillLayoutSubviews`. So clearly `ASViewController` has more opportunity to sync **TraitCollection** from UIKit

But we just miss that chance  when just using **Node** instead of **ViewController**

## Actually `ASViewController` also has same problem

If you check out [Demo22.zip](https://github.com/TextureGroup/Texture/files/4710776/Demo22.zip)

You will find out problem still there even though using `ASViewController`, when ViewController **has child viewController**, user interface style is NOT pass through

## And why UIKit causing this problem
When you r using **UIView**
**Case 1:**
1. init a UIView
2. set UIView `overrideUserInterfaceStyle`
3. You get callback from **UIView** that `traitCollectionDidChange`

**Case 2:**
1. init a UIViewController &  set UIViewController `overrideUserInterfaceStyle`
2. add a UIView to  UIViewController
3.  This UIView won‘t get the same callback, deep inside UIView (I don't know whether is apple's bug), UIView just take it as initial value,  no callback of `traitCollectionDidChange`

We now are facing **Case 2**, and got to find a way to sync **TraitCollection** from its **initial value**, because there is no callback tell you that TraitCollection is **changed**.

---
Now the problem as I described at the beginning:
>ASDisplayNode init with userInterfaceStyle = .unspecific, and only update userInterfaceStyle when UIView call traitCollectionDidChange, it will miss UIView's default value of traitCollection.userInterfaceStyle

## Now review what I did:
* Sync **TraitCollection** when node's view is loaded, **make sure the initial value is correct**
  * Ignored when superNode != nil, because we get other way to propagate from super to children
* Resolve color depends on **TraitCollection** to make sure we r using right color
  * Because **a color var** is independent, it just don't know who owned it & how to use it to render what, and not connected to owner's  traitCollection, so it's loyal to system's traitCollection.

I don't think init **Node**'s traitCollection with correct value is strange synchronization logic, otherwise, init with `unspecific` witch **is NOT the same with it's view**, that's strange.

I have tried to make minimum changes to fix it, and my project runs well for now.
If there are better solutions, it would be great.