### PR TITLE
Fix documentation for ASCornerRoundingTypeClipping

### DIFF
--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -649,8 +649,8 @@ AS_EXTERN NSInteger const ASDefaultDrawingPriority;
  * thus works best for ASImageNodes or containers showing a background around their children.
  *
  * - ASCornerRoundingTypeClipping: overlays 4 separate opaque corners on top of the content that needs
- * corner rounding. Requires .backgroundColor and .cornerRadius to be set. Use clip corners in situations 
- * in which is movement through the corner, with an opaque background (no movement underneath the corner).
+ * corner rounding. Requires .backgroundColor and .cornerRadius to be set. Use clip corners in situations
+ * where there is movement through the corner, with an opaque background (no movement underneath the corner).
  * Clipped corners are ideal for animating / resizing views, and still outperform CALayer.
  *
  * For more information and examples, see http://texturegroup.org/docs/corner-rounding.html


### PR DESCRIPTION
This is a small fix to the documentation for ASCornerRoundingTypeClipping