### PR TITLE
Improve ThreeMigrationGuide.md

### DIFF
--- a/ThreeMigrationGuide.md
+++ b/ThreeMigrationGuide.md
@@ -1,4 +1,4 @@
-## Texture 3.0 Migration Guide ###
+## Texture 3.0 Migration Guide
 
 Got a tip for upgrading? Please open a PR to this document!
 
@@ -21,4 +21,3 @@ ASPINRemoteImageDownloader.shared().cachedImage(with: url, callbackQueue: .main)
     …
 }
 ```
-

--- a/ThreeMigrationGuide.md
+++ b/ThreeMigrationGuide.md
@@ -1,3 +1,24 @@
-### Texture 3.0 Migration Guide ###
+## Texture 3.0 Migration Guide ###
 
 Got a tip for upgrading? Please open a PR to this document!
+
+
+### Breaking API Changes
+
+`ASImageCacherCompletion` typedef has a new parameter: `ASImageCacheType cacheType`. Example:
+
+
+```swift
+ASPINRemoteImageDownloader.shared().cachedImage(with: url, callbackQueue: .main) { result in
+    …
+}
+```
+
+Becomes
+
+```swift
+ASPINRemoteImageDownloader.shared().cachedImage(with: url, callbackQueue: .main) { result, cacheType in
+    …
+}
+```
+


### PR DESCRIPTION
## Description

This PR adds `ASImageCacherCompletion` breaking API change to the Texture 3.0 Migration Guide.

This is the only point of contact that I had modify in order to make my project compile. It's not clear whether there're more changes or not, I can't easily tell without looking at the tens of PRs that got merged since 2.8.0 🙈 

Texture 3.0 is now under QA process at Tellus and I'll keep this Migration Guide updated with any other internal details we find.

Thanks once again for pushing this release to the finish line :) it's been a long time! 😄 

Cheers!