### PR TITLE
[Accessibility] Ship ASExperimentalDoNotCacheAccessibilityElements

### DIFF
--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -28,7 +28,6 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalDispatchApply = 1 << 7,                                     // exp_dispatch_apply
   ASExperimentalDrawingGlobal = 1 << 8,                                     // exp_drawing_global
   ASExperimentalOptimizeDataControllerPipeline = 1 << 9,                    // exp_optimize_data_controller_pipeline
-  ASExperimentalDoNotCacheAccessibilityElements = 1 << 10,                  // exp_do_not_cache_accessibility_elements
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -21,8 +21,7 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_did_enter_preload_skip_asm_layout",
                                       @"exp_dispatch_apply",
                                       @"exp_drawing_global",
-                                      @"exp_optimize_data_controller_pipeline",
-                                      @"exp_do_not_cache_accessibility_elements"]));
+                                      @"exp_optimize_data_controller_pipeline"]));
   if (flags == ASExperimentalFeatureAll) {
     return allNames;
   }

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -1137,22 +1137,6 @@ nodeProperty = nodeValueExpr; _setToViewOnly(viewAndPendingViewStateProperty, vi
 
 @implementation ASDisplayNode (UIViewBridgeAccessibility)
 
-// Walks up the view tree to nil out all the cached accsesibilityElements. This is required when changing
-// accessibility properties like accessibilityViewIsModal.
-- (void)invalidateAccessibilityElements
-{
-  // If we are not caching accessibilityElements we don't need to do anything here.
-  if (ASActivateExperimentalFeature(ASExperimentalDoNotCacheAccessibilityElements)) {
-    return;
-  }
-  
-  // we want to check if we are on the main thread first, since _loaded checks the layer and can only be done on main
-  if (ASDisplayNodeThreadIsMain() && _loaded(self)) {
-    self.view.accessibilityElements = nil;
-    [self.supernode invalidateAccessibilityElements];
-  }
-}
-
 - (BOOL)isAccessibilityElement
 {
   _bridge_prologue_read;
@@ -1310,13 +1294,7 @@ nodeProperty = nodeValueExpr; _setToViewOnly(viewAndPendingViewStateProperty, vi
 - (void)setAccessibilityElementsHidden:(BOOL)accessibilityElementsHidden
 {
   _bridge_prologue_write;
-  BOOL oldHiddenValue = _getFromViewOnly(accessibilityElementsHidden);
   _setAccessibilityToViewAndProperty(_flags.accessibilityElementsHidden, accessibilityElementsHidden, accessibilityElementsHidden, accessibilityElementsHidden);
-
-  // if we made a change, we need to clear the view's accessibilityElements cache.
-  if (!ASActivateExperimentalFeature(ASExperimentalDoNotCacheAccessibilityElements) && self.isNodeLoaded && oldHiddenValue != accessibilityElementsHidden) {
-    [self invalidateAccessibilityElements];
-  }
 }
 
 - (BOOL)accessibilityViewIsModal
@@ -1328,15 +1306,8 @@ nodeProperty = nodeValueExpr; _setToViewOnly(viewAndPendingViewStateProperty, vi
 - (void)setAccessibilityViewIsModal:(BOOL)accessibilityViewIsModal
 {
   _bridge_prologue_write;
-  BOOL oldAccessibilityViewIsModal = _getFromViewOnly(accessibilityViewIsModal);
   _setAccessibilityToViewAndProperty(_flags.accessibilityViewIsModal, accessibilityViewIsModal, accessibilityViewIsModal, accessibilityViewIsModal);
-  
-  // if we made a change, we need to clear the view's accessibilityElements cache.
-  if (!ASActivateExperimentalFeature(ASExperimentalDoNotCacheAccessibilityElements) && self.isNodeLoaded && oldAccessibilityViewIsModal != accessibilityViewIsModal) {
-    [self invalidateAccessibilityElements];
-  }
 }
-
 
 - (BOOL)shouldGroupAccessibilityChildren
 {

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -28,7 +28,6 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalDispatchApply,
   ASExperimentalDrawingGlobal,
   ASExperimentalOptimizeDataControllerPipeline,
-  ASExperimentalDoNotCacheAccessibilityElements,
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -51,7 +50,6 @@ static ASExperimentalFeatures features[] = {
     @"exp_dispatch_apply",
     @"exp_drawing_global",
     @"exp_optimize_data_controller_pipeline",
-    @"exp_do_not_cache_accessibility_elements",
   ];
 }
 


### PR DESCRIPTION
We did not notice any effect on performance of the Pinterest app by not caching `accessibilityElements` in `_ASDisplayView`. By not caching the elements, we can be sure that the elements will be correct even when nodes change visibility state. There will be a performance impact when voice over is enabled, but providing the correct elements for the current state of a view is more important than performance in this case.

https://github.com/TextureGroup/Texture/issues/1853