### PR TITLE
Propagate leadingScreensForBatching down to the view

### DIFF
--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -323,6 +323,7 @@
     view.layoutInspector                = pendingState.layoutInspector;
     view.showsVerticalScrollIndicator   = pendingState.showsVerticalScrollIndicator;
     view.showsHorizontalScrollIndicator = pendingState.showsHorizontalScrollIndicator;
+    view.leadingScreensForBatching      = pendingState.leadingScreensForBatching;
 #if !TARGET_OS_TV
     view.pagingEnabled                  = pendingState.pagingEnabled;
 #endif

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -163,6 +163,7 @@
     view.allowsMultipleSelection              = pendingState.allowsMultipleSelection;
     view.allowsMultipleSelectionDuringEditing = pendingState.allowsMultipleSelectionDuringEditing;
     view.automaticallyAdjustsContentOffset    = pendingState.automaticallyAdjustsContentOffset;
+    view.leadingScreensForBatching            = pendingState.leadingScreensForBatching;
 #if !TARGET_OS_TV
     view.pagingEnabled                        = pendingState.pagingEnabled;
 #endif


### PR DESCRIPTION
Collection nodes/table nodes' leadingScreensForBatching property wasn't getting updated once the view was loaded. This fixes that.