### PR TITLE
Do not expose tgmath.h to all clients of Texture

### DIFF
--- a/Source/Details/CoreGraphics+ASConvenience.h
+++ b/Source/Details/CoreGraphics+ASConvenience.h
@@ -42,7 +42,7 @@ ASDISPLAYNODE_INLINE CGFloat ASCGFloatFromNumber(NSNumber *number)
 
 ASDISPLAYNODE_INLINE BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
 {
-  return ABS(size1.width - size2.width) < delta && fabs(size1.height - size2.height) < delta;
+  return ABS(size1.width - size2.width) < delta && ABS(size1.height - size2.height) < delta;
 };
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
- tgmath.h #undef the `log` macro for mathematical reasons. Code that may also use a log name (such as CocoaLumberjack) will get confused by this when they try to use `NS_SWIFT_NAME` with `log` as part of the name.
- `ABS` from NSObjCRuntime.h is what is typically used for abs on `CGFloat`.
- Note: removing tgmath.h from the Texture umbrella header may expose clients that implicitly depended upon it being imported. Sources may have to be updated after this to `#import <tgmath.h>` explicitly.
- Found this hint here: https://github.com/CocoaLumberjack/CocoaLumberjack/issues/1086