### PR TITLE
Fix hit point test for inverted ASCollectionNode

### DIFF
--- a/Source/Details/_ASCollectionViewCell.mm
+++ b/Source/Details/_ASCollectionViewCell.mm
@@ -97,6 +97,9 @@
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
+  ASCellNode *node = self.node;
+  UIView *nodeView = node.view;
+  
   /**
    * The documentation for hitTest:withEvent: on an UIView explicitly states the fact that:
    * it ignores view objects that are hidden, that have disabled user interactions, or have an
@@ -106,12 +109,13 @@
    * superclass hitTest:withEvent: implementation. If this returns a valid value we can go on with
    * checking the node as it's expected to not be in one of these states.
    */
-  if (![super hitTest:self.bounds.origin withEvent:event]) {
+  CGPoint originPointOnView = [self convertPoint:nodeView.bounds.origin fromView:nodeView];
+  if (![super hitTest:originPointOnView withEvent:event]) {
     return nil;
   }
 
-  CGPoint pointOnNode = [self.node.view convertPoint:point fromView:self];
-  return [self.node hitTest:pointOnNode withEvent:event];
+  CGPoint pointOnNode = [node.view convertPoint:point fromView:self];
+  return [node hitTest:pointOnNode withEvent:event];
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(nullable UIEvent *)event


### PR DESCRIPTION
There are many chat applications that rely on inverted CollectionView. Cell taps were broken in the 3.0.0 release, this change fixes taps for such cases. It contains the same code as #1781 but that branch is stale and not fixes the issues. I intend on fixing those to get the changes merged