### PR TITLE
Update 2.7.5 - Adding Callback in Texture Assertion on Collection PerformUpdates

### DIFF
--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -547,6 +547,18 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable id<ASSectionContext>)contextForSection:(NSInteger)section AS_WARN_UNUSED_RESULT;
 
+#pragma mark - Collection Crash Logging
+
+/**
+ * A callback property that is going to be called during texture assertion of invalid section issue.
+ *
+ * This callback is used to determine the things that will be done during collection perform update crash issue,
+ * in which to log the current View Controller that is currently crashing.
+ *
+ * The default value is nil.
+*/
+@property (nonatomic, copy, nullable) void (^callbackOnAssert)(void);
+
 @end
 
 @interface ASCollectionNode (Deprecated)

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -65,6 +65,8 @@
 @property (nonatomic) BOOL showsVerticalScrollIndicator;
 @property (nonatomic) BOOL showsHorizontalScrollIndicator;
 @property (nonatomic) BOOL pagingEnabled;
+@property (nonatomic, copy, nullable) void (^callbackOnAssert)(void);
+
 @end
 
 @implementation _ASCollectionPendingState
@@ -86,6 +88,7 @@
     _flags.showsVerticalScrollIndicator = YES;
     _flags.showsHorizontalScrollIndicator = YES;
     _flags.pagingEnabled = NO;
+    _callbackOnAssert = nil;
   }
   return self;
 }
@@ -1163,6 +1166,15 @@
   ASDisplayNodeAssertMainThread();
   if (self.nodeLoaded) {
     [self.view moveItemAtIndexPath:indexPath toIndexPath:newIndexPath];
+  }
+}
+
+#pragma mark - Collection Crash Logging
+
+-(void)setCallbackOnAssert:(nullable void (^)(void))callbackOnAssert
+{
+  if (callbackOnAssert != nil) {
+      self.view.temporaryCallbackOnAssert = callbackOnAssert;
   }
 }
 

--- a/Source/ASCollectionView.h
+++ b/Source/ASCollectionView.h
@@ -81,6 +81,18 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable id<ASSectionContext>)contextForSection:(NSInteger)section AS_WARN_UNUSED_RESULT;
 
+#pragma mark - Collection Crash Logging
+
+/**
+ * A callback property that is going to be called during texture assertion of invalid section issue.
+ *
+ * This callback is used to determine the things that will be done during collection perform update crash issue,
+ * in which to log the current View Controller that is currently crashing.
+ *
+ * The default value is nil.
+*/
+@property (nonatomic, copy, nullable) void (^temporaryCallbackOnAssert)(void);
+
 @end
 
 @interface ASCollectionView (Deprecated)

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -920,6 +920,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   
   if (_batchUpdateCount == 0) {
     _changeSet = [[_ASHierarchyChangeSet alloc] initWithOldData:[_dataController itemCountsFromDataSource]];
+    _changeSet.callbackOnAssert = _temporaryCallbackOnAssert;
     _changeSet.rootActivity = as_activity_create("Perform async collection update", AS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT);
     _changeSet.submitActivity = as_activity_create("Submit changes for collection update", _changeSet.rootActivity, OS_ACTIVITY_FLAG_DEFAULT);
   }

--- a/Source/Private/_ASHierarchyChangeSet.h
+++ b/Source/Private/_ASHierarchyChangeSet.h
@@ -199,6 +199,16 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType);
 /// Returns all item indexes affected by changes of the given type in the given section.
 - (NSIndexSet *)indexesForItemChangesOfType:(_ASHierarchyChangeType)changeType inSection:(NSUInteger)section;
 
+/**
+ * A callback property that is going to be called during texture assertion of invalid section issue.
+ *
+ * This callback is used to determine the things that will be done during collection perform update crash issue,
+ * in which to log the current View Controller that is currently crashing.
+ *
+ * The default value is nil.
+*/
+@property (nonatomic, copy, nullable) void (^callbackOnAssert)(void);
+
 - (void)reloadData;
 - (void)deleteSections:(NSIndexSet *)sections animationOptions:(ASDataControllerAnimationOptions)options;
 - (void)insertSections:(NSIndexSet *)sections animationOptions:(ASDataControllerAnimationOptions)options;

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -150,6 +150,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
     _originalDeleteSectionChanges = [[NSMutableArray alloc] init];
     _deleteSectionChanges = [[NSMutableArray alloc] init];
     _reloadSectionChanges = [[NSMutableArray alloc] init];
+    _callbackOnAssert = nil;
   }
   return self;
 }
@@ -535,6 +536,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   NSInteger deletedSectionCount = _deletedSections.count;
   // Assert that the new section count is correct.
   if (newSectionCount != oldSectionCount + insertedSectionCount - deletedSectionCount) {
+    if (_callbackOnAssert != nil) {
+        _callbackOnAssert();
+    }
+
     ASFailUpdateValidation(@"Invalid number of sections. The number of sections after the update (%ld) must be equal to the number of sections before the update (%ld) plus or minus the number of sections inserted or deleted (%ld inserted, %ld deleted)", (long)newSectionCount, (long)oldSectionCount, (long)insertedSectionCount, (long)deletedSectionCount);
     return;
   }

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -552,6 +552,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
     invalidSectionDelete = [_deletedSections indexGreaterThanIndex:oldSectionCount - 1];
   }
   if (invalidSectionDelete != NSNotFound) {
+    if (_callbackOnAssert != nil) {
+        _callbackOnAssert();
+    }
+    
     ASFailUpdateValidation(@"Attempt to delete section %ld but there are only %ld sections before the update.", (long)invalidSectionDelete, (long)oldSectionCount);
     return;
   }
@@ -562,6 +566,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
       NSInteger section = indexPath.section;
       NSInteger item = indexPath.item;
       if (section >= oldSectionCount) {
+        if (_callbackOnAssert != nil) {
+            _callbackOnAssert();
+        }
+        
         ASFailUpdateValidation(@"Attempt to delete item %ld from section %ld, but there are only %ld sections before the update.", (long)item, (long)section, (long)oldSectionCount);
         return;
       }
@@ -569,6 +577,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
       // Assert that item delete happened to a valid item.
       NSInteger oldItemCount = _oldItemCounts[section];
       if (item >= oldItemCount) {
+        if (_callbackOnAssert != nil) {
+            _callbackOnAssert();
+        }
+        
         ASFailUpdateValidation(@"Attempt to delete item %ld from section %ld, which only contains %ld items before the update.", (long)item, (long)section, (long)oldItemCount);
         return;
       }
@@ -581,6 +593,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
       NSInteger item = indexPath.item;
       // Assert that item insert happened in a valid section.
       if (section >= newSectionCount) {
+        if (_callbackOnAssert != nil) {
+            _callbackOnAssert();
+        }
+        
         ASFailUpdateValidation(@"Attempt to insert item %ld into section %ld, but there are only %ld sections after the update.", (long)item, (long)section, (long)newSectionCount);
         return;
       }
@@ -588,6 +604,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
       // Assert that item delete happened to a valid item.
       NSInteger newItemCount = _newItemCounts[section];
       if (item >= newItemCount) {
+        if (_callbackOnAssert != nil) {
+            _callbackOnAssert();
+        }
+        
         ASFailUpdateValidation(@"Attempt to insert item %ld into section %ld, which only contains %ld items after the update.", (long)item, (long)section, (long)newItemCount);
         return;
       }
@@ -602,6 +622,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
     invalidSectionInsert = [_insertedSections indexGreaterThanIndex:newSectionCount - 1];
   }
   if (invalidSectionInsert != NSNotFound) {
+    if (_callbackOnAssert != nil) {
+        _callbackOnAssert();
+    }
+    
     ASFailUpdateValidation(@"Attempt to insert section %ld but there are only %ld sections after the update.", (long)invalidSectionInsert, (long)newSectionCount);
     return;
   }
@@ -626,6 +650,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
     // Assert that no reloaded items were deleted.
     NSInteger deletedReloadedItem = [originalDeletedItems as_intersectionWithIndexes:reloadedItems].firstIndex;
     if (deletedReloadedItem != NSNotFound) {
+      if (_callbackOnAssert != nil) {
+          _callbackOnAssert();
+      }
+      
       ASFailUpdateValidation(@"Attempt to delete and reload the same item at index path %@", [NSIndexPath indexPathForItem:deletedReloadedItem inSection:oldSection]);
       return;
     }
@@ -635,6 +663,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
     NSInteger insertedItemCount = originalInsertedItems.count;
     NSInteger deletedItemCount = originalDeletedItems.count;
     if (newItemCount != oldItemCount + insertedItemCount - deletedItemCount) {
+      if (_callbackOnAssert != nil) {
+          _callbackOnAssert();
+      }
+      
       ASFailUpdateValidation(@"Invalid number of items in section %ld. The number of items after the update (%ld) must be equal to the number of items before the update (%ld) plus or minus the number of items inserted or deleted (%ld inserted, %ld deleted).", (long)oldSection, (long)newItemCount, (long)oldItemCount, (long)insertedItemCount, (long)deletedItemCount);
       return;
     }


### PR DESCRIPTION
### Preview
This is how the callback will look like:
<img width="1091" alt="Screen Shot 2020-09-15 at 10 39 42" src="https://user-images.githubusercontent.com/17472033/93162848-d2cef400-f73f-11ea-9a59-e6fb971a2dd6.png">

### What
Adding callback on Texture assertion that is only applicable during CollectionNode's `PerfromUpdates`. The implementation of the callback will depend on the user.

### Why
If there is any crash occurred, we can determine which `ViewController` is causing that crash through this callback, making our debugging process easier.