### PR TITLE
Add an experiment that makes ASDataController to do everything on main thread

### DIFF
--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -29,6 +29,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalDrawingGlobal = 1 << 8,                                     // exp_drawing_global
   ASExperimentalOptimizeDataControllerPipeline = 1 << 9,                    // exp_optimize_data_controller_pipeline
   ASExperimentalDisableGlobalTextkitLock = 1 << 10,                         // exp_disable_global_textkit_lock
+  ASExperimentalMainThreadOnlyDataController = 1 << 11,                     // exp_main_thread_only_data_controller
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -22,7 +22,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_dispatch_apply",
                                       @"exp_drawing_global",
                                       @"exp_optimize_data_controller_pipeline",
-                                    @"exp_disable_global_textkit_lock"]));
+                                      @"exp_disable_global_textkit_lock",
+                                      @"exp_main_thread_only_data_controller"]));
   if (flags == ASExperimentalFeatureAll) {
     return allNames;
   }

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -33,8 +33,6 @@
 //#define LOG(...) NSLog(__VA_ARGS__)
 #define LOG(...)
 
-#define ASSERT_ON_EDITING_QUEUE ASDisplayNodeAssertNotNil(dispatch_get_specific(&kASDataControllerEditingQueueKey), @"%@ must be called on the editing transaction queue.", NSStringFromSelector(_cmd))
-
 const static char * kASDataControllerEditingQueueKey = "kASDataControllerEditingQueueKey";
 const static char * kASDataControllerEditingQueueContext = "kASDataControllerEditingQueueContext";
 
@@ -133,8 +131,6 @@ typedef void (^ASDataControllerSynchronizationBlock)();
 
 - (void)_allocateNodesFromElements:(NSArray<ASCollectionElement *> *)elements
 {
-  ASSERT_ON_EDITING_QUEUE;
-  
   NSUInteger nodeCount = elements.count;
   __weak id<ASDataControllerSource> weakDataSource = _dataSource;
   if (nodeCount == 0 || weakDataSource == nil) {

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -622,12 +622,9 @@ typedef void (^ASDataControllerSynchronizationBlock)();
   os_log_debug(ASCollectionLog(), "New content: %@", newMap.smallDescription);
 
   Class<ASDataControllerLayoutDelegate> layoutDelegateClass = [self.layoutDelegate class];
-  ++_editingTransactionGroupCount;
-  dispatch_group_async(_editingTransactionGroup, _editingTransactionQueue, ^{
-    __block __unused os_activity_scope_state_s preparationScope = {}; // unused if deployment target < iOS10
-    as_activity_scope_enter(as_activity_create("Prepare nodes for collection update", AS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT), &preparationScope);
 
-    // Step 3: Call the layout delegate if possible. Otherwise, allocate and layout all elements
+  // Step 3: Call the layout delegate if possible. Otherwise, allocate and layout all elements
+  dispatch_block_t step3 = ^{
     if (canDelegate) {
       [layoutDelegateClass calculateLayoutWithContext:layoutContext];
     } else {
@@ -643,6 +640,29 @@ typedef void (^ASDataControllerSynchronizationBlock)();
         }
       }
       [self _allocateNodesFromElements:elementsToProcess];
+    }
+  };
+
+  // Step 3 can be done on the main thread or on _editingTransactionQueue
+  // depending on an experiment.
+  BOOL mainThreadOnly = ASActivateExperimentalFeature(ASExperimentalMainThreadOnlyDataController);
+  if (mainThreadOnly) {
+    // We'll still dispatch to _editingTransactionQueue only to schedule a block
+    // to _mainSerialQueue to execute next steps. This is not optimized because
+    // in theory we can skip _editingTransactionQueue entirely, but it's much safer
+    // because change sets will still flow through the pipeline in pretty the same way
+    // (main thread -> _editingTransactionQueue -> _mainSerialQueue) and so
+    // any methods that block on _editingTransactionQueue will still work.
+    step3();
+  }
+
+  ++_editingTransactionGroupCount;
+  dispatch_group_async(_editingTransactionGroup, _editingTransactionQueue, ^{
+    __block __unused os_activity_scope_state_s preparationScope = {}; // unused if deployment target < iOS10
+    as_activity_scope_enter(as_activity_create("Prepare nodes for collection update", AS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT), &preparationScope);
+
+    if (!mainThreadOnly) {
+      step3();
     }
 
     // Step 4: Inform the delegate on main thread

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -50,6 +50,8 @@ static ASExperimentalFeatures features[] = {
     @"exp_dispatch_apply",
     @"exp_drawing_global",
     @"exp_optimize_data_controller_pipeline",
+    @"exp_disable_global_textkit_lock",
+    @"exp_main_thread_only_data_controller"
   ];
 }
 


### PR DESCRIPTION
- Under this experiment, ASDataController will allocate and layout all nodes on the main thread. This helps to avoid deadlocks that would otherwise occur if some of the node allocations or layouts caused ASDataController's background queue to block on main thread. As a bonus, this experiment also helps to measure how much performance wins we get from doing the work off main.