### PR TITLE
Update podspec to latest stable PINRemoteImage and PINCache dependencies

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - iOSSnapshotTestCase/Core (6.2.0)
-  - OCMock (3.6)
+  - OCMock (3.7.1)
 
 DEPENDENCIES:
   - iOSSnapshotTestCase/Core (~> 6.2)
@@ -13,8 +13,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
-  OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
+  OCMock: 75fbeaa46a9b11f8c182bbb1d1f7e9a35ccc9955
 
 PODFILE CHECKSUM: ff1a1777e31f49e6e4b7b148d0f10e504db7fa26
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.9.3

--- a/Texture.podspec
+++ b/Texture.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'Texture'
-  spec.version      = '3.0.0'
+  spec.version      = '3.0.1'
   spec.license      =  { :type => 'Apache 2',  }
   spec.homepage     = 'http://texturegroup.org'
   spec.authors      = { 'Huy Nguyen' => 'hi@huynguyen.dev', 'Garrett Moon' => 'garrett@excitedpixel.com', 'Scott Goodson' => 'scottgoodson@gmail.com', 'Michael Schneider' => 'mischneider1@gmail.com', 'Adlai Holler' => 'adlai@icloud.com' }
@@ -39,7 +39,7 @@ Pod::Spec.new do |spec|
   end
   
   spec.subspec 'PINRemoteImage' do |pin|
-    pin.dependency 'PINRemoteImage/iOS', '~> 3.0.0'
+    pin.dependency 'PINRemoteImage/iOS', '~> 3.0.1'
     pin.dependency 'PINRemoteImage/PINCache'
     pin.dependency 'Texture/Core'
   end


### PR DESCRIPTION
To address issues with using Texture pod in Xcode 12

Important note: Tests have been passed without issues using Xcode 11 locally for those changes, but fails in Xcode 12 (c++ language related issue in mock logic)