### PR TITLE
fix format specifier

### DIFF
--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -888,7 +888,7 @@ static std::atomic_bool _useMainThreadDelegateCallbacks(true);
             if (delegateDidLoadImageFromCache) {
               [delegate imageNodeDidLoadImageFromCache:self];
             }
-            as_log_verbose(ASImageLoadingLog(), "Decached image for %@ img: %@ url: %@ cacheType: %@", self, [imageContainer asdk_image], URL, cacheType);
+            as_log_verbose(ASImageLoadingLog(), "Decached image for %@ img: %@ url: %@ cacheType: %ld", self, [imageContainer asdk_image], URL, (long) cacheType);
             finished(imageContainer, nil, nil, cacheType == ASImageCacheTypeSynchronous ? ASNetworkImageSourceSynchronousCache : ASNetworkImageSourceAsynchronousCache, nil);
           }
         };


### PR DESCRIPTION
This applies the suggested fix that shows up when `ASEnableVerboseLogging` is enabled:

```
external/Texture/Source/ASNetworkImageNode.mm:891:144: error: enum values with underlying type 'NSInteger' should not be used as format arguments; add an explicit cast to 'long' instead [-Werror,-Wformat]
            as_log_verbose(ASImageLoadingLog(), "Decached image for %@ img: %@ url: %@ cacheType: %@", self, [imageContainer asdk_image], URL, cacheType);```
