### PR TITLE
use https for slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ As the framework has grown, many features have been added that can save develope
 
 ## Getting Help
 
-We use Slack for real-time debugging, community updates, and general talk about Texture. [Signup](http://asdk-slack-auto-invite.herokuapp.com) yourself or email textureframework@gmail.com to get an invite.
+We use Slack for real-time debugging, community updates, and general talk about Texture. [Signup](https://asdk-slack-auto-invite.herokuapp.com) yourself or email textureframework@gmail.com to get an invite.
 
 ## Release process
 

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -4,7 +4,7 @@ layout: slack
 permalink: /slack.html
 ---
 
-<iframe src="http://asdk-slack-auto-invite.herokuapp.com/" style="position:fixed; top:100px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;">></iframe>
+<iframe src="https://asdk-slack-auto-invite.herokuapp.com/" style="position:fixed; top:100px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;">></iframe>
 
 
 If the auto-invite link above does not work for you, please email textureframework@gmail.com for an invite.


### PR DESCRIPTION
I wanted to join the slack group, but the page seems to be broken. The iframe isn't loading because the invite url is using http, but the service seems to be available over https as well.