### PR TITLE
Podfile improvements

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,3 @@
-source 'https://github.com/CocoaPods/Specs.git'
-
 platform :ios, '9.0'
 
 target :'AsyncDisplayKitTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - OCMock (~> 3.6)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - iOSSnapshotTestCase
     - OCMock
 
@@ -15,6 +15,6 @@ SPEC CHECKSUMS:
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
 
-PODFILE CHECKSUM: ff1a1777e31f49e6e4b7b148d0f10e504db7fa26
+PODFILE CHECKSUM: 1b4ea0e8ab7d94a46b1964a2354686c2e599c8c2
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.10.0


### PR DESCRIPTION
I updated the Podfile slightly to allow CocoaPods to pull from the [CDN](https://blog.cocoapods.org/CocoaPods-1.7.2/), which is way faster than the old trunk repo. This doesn't impact clients of Texture, but makes developing a lot easier.