### PR TITLE
Fix mutation of variable that is never read

### DIFF
--- a/Source/ASDisplayNodeExtras.mm
+++ b/Source/ASDisplayNodeExtras.mm
@@ -65,7 +65,7 @@ ASInterfaceState ASInterfaceStateForDisplayNode(ASDisplayNode *displayNode, UIWi
         // if not already, about to be set to invisible as it is not possible for an element to be visible
         // while outside of a window.
         ASInterfaceState interfaceState = displayNode.pendingInterfaceState;
-        return (window == nil ? (interfaceState &= (~ASInterfaceStateVisible)) : interfaceState);
+        return (window == nil ? (interfaceState & (~ASInterfaceStateVisible)) : interfaceState);
     } else {
         // For not range managed nodes we might be on our own to try to guess if we're visible.
         return (window == nil ? ASInterfaceStateNone : (ASInterfaceStateVisible | ASInterfaceStateDisplay));


### PR DESCRIPTION
Please allow me to try to convince you that this mutation wasn't used, per the static analyzer:

The original code was:

```objc
ASInterfaceState interfaceState = displayNode.pendingInterfaceState;
return (window == nil ? (interfaceState &= (~ASInterfaceStateVisible)) : interfaceState);
```

And then the local `interfaceState` variable is never used again after that line.

First, we expand out the ternary to get this:

```objc
ASInterfaceState interfaceState = displayNode.pendingInterfaceState;
if (window == nil) {
    return (interfaceState &= (~ASInterfaceStateVisible));
} else {
    return interfaceState;
}
```

Now, zooming in on just the line in the "true" branch":

```objc
return (interfaceState &= (~ASInterfaceStateVisible));
```

Let's expand this by replacing `a &= b` with its longer form: `a = a & b`.

```objc
return (interfaceState = interfaceState & (~ASInterfaceStateVisible));
```

This is returning the result of an assignment: `return (a = b)`. This is somewhat common in C and its kin, because an assignment expression returns the result of the assignment. If we expand it out, what it's really saying is this:

```objc
ASInterfaceState newState = interfaceState & (~ASInterfaceStateVisible));
interfaceState = newState;
return interfaceState;
```

However, we already saw that `interfaceState` is not read again after that line, so I contend that it does not need to be mutated, and therefore, the original use of `&=` was a mistake. (Or at least, it became a mistake through subsequent refactoring.) It isn't doing anything useful, so it should be removed. Q.E.D.

/cc @bolsinga how does that sound?

Supplants half of #1958 