### PR TITLE
Update asdkGram swift sample to swift version 5.3

### DIFF
--- a/examples/ASCollectionView/Podfile.lock
+++ b/examples/ASCollectionView/Podfile.lock
@@ -1,0 +1,59 @@
+PODS:
+  - PINCache (3.0.1-beta.8):
+    - PINCache/Arc-exception-safe (= 3.0.1-beta.8)
+    - PINCache/Core (= 3.0.1-beta.8)
+  - PINCache/Arc-exception-safe (3.0.1-beta.8):
+    - PINCache/Core
+  - PINCache/Core (3.0.1-beta.8):
+    - PINOperation (~> 1.1.1)
+  - PINOperation (1.1.2)
+  - PINRemoteImage/Core (3.0.0):
+    - PINOperation
+  - PINRemoteImage/iOS (3.0.0):
+    - PINRemoteImage/Core
+  - PINRemoteImage/PINCache (3.0.0):
+    - PINCache (= 3.0.1-beta.8)
+    - PINRemoteImage/Core
+  - Texture (2.8.1):
+    - Texture/AssetsLibrary (= 2.8.1)
+    - Texture/Core (= 2.8.1)
+    - Texture/MapKit (= 2.8.1)
+    - Texture/Photos (= 2.8.1)
+    - Texture/PINRemoteImage (= 2.8.1)
+    - Texture/Video (= 2.8.1)
+  - Texture/AssetsLibrary (2.8.1):
+    - Texture/Core
+  - Texture/Core (2.8.1)
+  - Texture/MapKit (2.8.1):
+    - Texture/Core
+  - Texture/Photos (2.8.1):
+    - Texture/Core
+  - Texture/PINRemoteImage (2.8.1):
+    - PINRemoteImage/iOS (~> 3.0.0)
+    - PINRemoteImage/PINCache
+    - Texture/Core
+  - Texture/Video (2.8.1):
+    - Texture/Core
+
+DEPENDENCIES:
+  - Texture (from `../..`)
+
+SPEC REPOS:
+  https://github.com/CocoaPods/Specs.git:
+    - PINCache
+    - PINOperation
+    - PINRemoteImage
+
+EXTERNAL SOURCES:
+  Texture:
+    :path: "../.."
+
+SPEC CHECKSUMS:
+  PINCache: 534fd41d358d828dfdf227a0d327f3673a65e20b
+  PINOperation: 24b774353ca248fcf87d67b2d61eef42087c125a
+  PINRemoteImage: e2b89e19fb6e77ffc099f9d9f3b3fe1745e3f9f9
+  Texture: ad4b83ac33d473dc767a087305174d628c0b8c03
+
+PODFILE CHECKSUM: b17902b22e47a614d87184388d54379942b9e58c
+
+COCOAPODS: 1.9.1

--- a/examples/ASCollectionView/Sample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/ASCollectionView/Sample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/ASViewController/Sample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/ASViewController/Sample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/examples/ASViewController/Sample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/ASViewController/Sample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/CustomCollectionView-Swift/Podfile.lock
+++ b/examples/CustomCollectionView-Swift/Podfile.lock
@@ -1,0 +1,59 @@
+PODS:
+  - PINCache (3.0.1-beta.8):
+    - PINCache/Arc-exception-safe (= 3.0.1-beta.8)
+    - PINCache/Core (= 3.0.1-beta.8)
+  - PINCache/Arc-exception-safe (3.0.1-beta.8):
+    - PINCache/Core
+  - PINCache/Core (3.0.1-beta.8):
+    - PINOperation (~> 1.1.1)
+  - PINOperation (1.1.2)
+  - PINRemoteImage/Core (3.0.0):
+    - PINOperation
+  - PINRemoteImage/iOS (3.0.0):
+    - PINRemoteImage/Core
+  - PINRemoteImage/PINCache (3.0.0):
+    - PINCache (= 3.0.1-beta.8)
+    - PINRemoteImage/Core
+  - Texture (2.8.1):
+    - Texture/AssetsLibrary (= 2.8.1)
+    - Texture/Core (= 2.8.1)
+    - Texture/MapKit (= 2.8.1)
+    - Texture/Photos (= 2.8.1)
+    - Texture/PINRemoteImage (= 2.8.1)
+    - Texture/Video (= 2.8.1)
+  - Texture/AssetsLibrary (2.8.1):
+    - Texture/Core
+  - Texture/Core (2.8.1)
+  - Texture/MapKit (2.8.1):
+    - Texture/Core
+  - Texture/Photos (2.8.1):
+    - Texture/Core
+  - Texture/PINRemoteImage (2.8.1):
+    - PINRemoteImage/iOS (~> 3.0.0)
+    - PINRemoteImage/PINCache
+    - Texture/Core
+  - Texture/Video (2.8.1):
+    - Texture/Core
+
+DEPENDENCIES:
+  - Texture (from `../..`)
+
+SPEC REPOS:
+  https://github.com/CocoaPods/Specs.git:
+    - PINCache
+    - PINOperation
+    - PINRemoteImage
+
+EXTERNAL SOURCES:
+  Texture:
+    :path: "../.."
+
+SPEC CHECKSUMS:
+  PINCache: 534fd41d358d828dfdf227a0d327f3673a65e20b
+  PINOperation: 24b774353ca248fcf87d67b2d61eef42087c125a
+  PINRemoteImage: e2b89e19fb6e77ffc099f9d9f3b3fe1745e3f9f9
+  Texture: ad4b83ac33d473dc767a087305174d628c0b8c03
+
+PODFILE CHECKSUM: 316495acd32fa1807206d27d639fc360fc516643
+
+COCOAPODS: 1.9.1

--- a/examples/CustomCollectionView-Swift/Sample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/CustomCollectionView-Swift/Sample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/HorizontalWithinVerticalScrolling/Sample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/HorizontalWithinVerticalScrolling/Sample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/HorizontalWithinVerticalScrolling/Sample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/HorizontalWithinVerticalScrolling/Sample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/VerticalWithinHorizontalScrolling/Sample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/VerticalWithinHorizontalScrolling/Sample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples_extra/ASDKgram-Swift/ASDKgram-Swift.xcodeproj/project.pbxproj
+++ b/examples_extra/ASDKgram-Swift/ASDKgram-Swift.xcodeproj/project.pbxproj
@@ -262,6 +262,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -294,7 +295,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-ASDKgram-Swift/Pods-ASDKgram-Swift-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-ASDKgram-Swift/Pods-ASDKgram-Swift-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/PINCache/PINCache.framework",
 				"${BUILT_PRODUCTS_DIR}/PINOperation/PINOperation.framework",
 				"${BUILT_PRODUCTS_DIR}/PINRemoteImage/PINRemoteImage.framework",
@@ -309,7 +310,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ASDKgram-Swift/Pods-ASDKgram-Swift-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ASDKgram-Swift/Pods-ASDKgram-Swift-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		3A7BEDD71E254278005769D4 /* ShellScript */ = {
@@ -438,6 +439,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -486,6 +488,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -504,7 +507,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.3;
 			};
 			name = Debug;
 		};
@@ -520,7 +523,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.RenaldoMoon.ASDKgram-Swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.3;
 			};
 			name = Release;
 		};

--- a/examples_extra/ASDKgram-Swift/ASDKgram-Swift/AppDelegate.swift
+++ b/examples_extra/ASDKgram-Swift/ASDKgram-Swift/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 	var window: UIWindow?
 
-	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
 		// UIKit Home Feed viewController & navController
 

--- a/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoFeedTableNodeController.swift
+++ b/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoFeedTableNodeController.swift
@@ -14,12 +14,12 @@ class PhotoFeedTableNodeController: ASDKViewController<ASTableNode> {
     // MARK: Lifecycle
 	
     private lazy var activityIndicatorView: UIActivityIndicatorView = {
-        return UIActivityIndicatorView(activityIndicatorStyle: .gray)
+        return UIActivityIndicatorView(style: .gray)
     }()
 	
 	var photoFeedModel = PhotoFeedModel(photoFeedModelType: .photoFeedModelTypePopular)
 	
-	init() {
+    override init() {
         super.init(node: ASTableNode())
 		
         navigationItem.title = "ASDK"
@@ -90,7 +90,7 @@ extension PhotoFeedTableNodeController: ASTableDataSource, ASTableDelegate {
 	
 	func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
         let photo = photoFeedModel.itemAtIndexPath(indexPath)
-		let nodeBlock: ASCellNodeBlock = { _ in
+        let nodeBlock: ASCellNodeBlock = {
 			return PhotoTableNodeCell(photoModel: photo)
 		}
 		return nodeBlock

--- a/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoFeedTableViewController.swift
+++ b/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoFeedTableViewController.swift
@@ -49,7 +49,7 @@ class PhotoFeedTableViewController: UITableViewController {
 	
 	// Helper functions
 	func setupActivityIndicator() {
-		let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+        let activityIndicator = UIActivityIndicatorView(style: .gray)
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
 		self.activityIndicator = activityIndicator
         self.tableView.addSubview(activityIndicator)
@@ -63,7 +63,7 @@ class PhotoFeedTableViewController: UITableViewController {
 	func configureTableView() {
 		tableView.register(PhotoTableViewCell.self, forCellReuseIdentifier: "photoCell")
 		tableView.allowsSelection = false
-		tableView.rowHeight = UITableViewAutomaticDimension
+        tableView.rowHeight = UITableView.automaticDimension
 		tableView.separatorStyle = .none
 	}
 }

--- a/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoModel.swift
+++ b/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoModel.swift
@@ -81,16 +81,16 @@ extension PhotoModel {
 	
 	func attributedStringForUserName(withSize size: CGFloat) -> NSAttributedString {
 		let attributes = [
-			NSForegroundColorAttributeName : UIColor.darkGray,
-			NSFontAttributeName: UIFont.boldSystemFont(ofSize: size)
+            NSAttributedString.Key.foregroundColor : UIColor.darkGray,
+            NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: size)
 		]
 		return NSAttributedString(string: user.userName, attributes: attributes)
 	}
 	
 	func attributedStringForDescription(withSize size: CGFloat) -> NSAttributedString {
 		let attributes = [
-			NSForegroundColorAttributeName : UIColor.darkGray,
-			NSFontAttributeName: UIFont.systemFont(ofSize: size)
+            NSAttributedString.Key.foregroundColor : UIColor.darkGray,
+            NSAttributedString.Key.font: UIFont.systemFont(ofSize: size)
 		]
 		return NSAttributedString(string: descriptionText ?? "", attributes: attributes)
 	}
@@ -101,14 +101,14 @@ extension PhotoModel {
         }
 		
         let likesAttributes = [
-            NSForegroundColorAttributeName : UIColor.mainBarTintColor,
-            NSFontAttributeName: UIFont.systemFont(ofSize: size)
+            NSAttributedString.Key.foregroundColor : UIColor.mainBarTintColor,
+            NSAttributedString.Key.font: UIFont.systemFont(ofSize: size)
         ]
 		let likesAttrString = NSAttributedString(string: "\(formattedLikesNumber) Likes", attributes: likesAttributes)
 		
 		let heartAttributes = [
-            NSForegroundColorAttributeName : UIColor.red,
-            NSFontAttributeName: UIFont.systemFont(ofSize: size)
+            NSAttributedString.Key.foregroundColor : UIColor.red,
+            NSAttributedString.Key.font: UIFont.systemFont(ofSize: size)
         ]
 		let heartAttrString = NSAttributedString(string: "♥︎ ", attributes: heartAttributes)
 		
@@ -124,8 +124,8 @@ extension PhotoModel {
         }
 
         let attributes = [
-			NSForegroundColorAttributeName : UIColor.mainBarTintColor,
-			NSFontAttributeName: UIFont.systemFont(ofSize: size)
+            NSAttributedString.Key.foregroundColor : UIColor.mainBarTintColor,
+            NSAttributedString.Key.font: UIFont.systemFont(ofSize: size)
 		]
 		
 		return NSAttributedString(string: Date.timeStringSince(fromConverted: date), attributes: attributes)

--- a/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoTableViewCell.swift
+++ b/examples_extra/ASDKgram-Swift/ASDKgram-Swift/PhotoTableViewCell.swift
@@ -70,7 +70,7 @@ class PhotoTableViewCell: UITableViewCell {
 		return label
 	}()
 	
-	override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
 		super.init(style: style, reuseIdentifier: reuseIdentifier)
 		setupViews()
 	}

--- a/examples_extra/ASDKgram-Swift/Podfile.lock
+++ b/examples_extra/ASDKgram-Swift/Podfile.lock
@@ -1,0 +1,44 @@
+PODS:
+  - PINCache (3.0.3):
+    - PINCache/Arc-exception-safe (= 3.0.3)
+    - PINCache/Core (= 3.0.3)
+  - PINCache/Arc-exception-safe (3.0.3):
+    - PINCache/Core
+  - PINCache/Core (3.0.3):
+    - PINOperation (~> 1.2.1)
+  - PINOperation (1.2.1)
+  - PINRemoteImage/Core (3.0.3):
+    - PINOperation
+  - PINRemoteImage/iOS (3.0.3):
+    - PINRemoteImage/Core
+  - PINRemoteImage/PINCache (3.0.3):
+    - PINCache (~> 3.0.3)
+    - PINRemoteImage/Core
+  - Texture/Core (3.0.0)
+  - Texture/PINRemoteImage (3.0.0):
+    - PINRemoteImage/iOS (~> 3.0.0)
+    - PINRemoteImage/PINCache
+    - Texture/Core
+
+DEPENDENCIES:
+  - Texture/PINRemoteImage (from `../..`)
+
+SPEC REPOS:
+  https://github.com/CocoaPods/Specs.git:
+    - PINCache
+    - PINOperation
+    - PINRemoteImage
+
+EXTERNAL SOURCES:
+  Texture:
+    :path: "../.."
+
+SPEC CHECKSUMS:
+  PINCache: 7a8fc1a691173d21dbddbf86cd515de6efa55086
+  PINOperation: 00c935935f1e8cf0d1e2d6b542e75b88fc3e5e20
+  PINRemoteImage: f1295b29f8c5e640e25335a1b2bd9d805171bd01
+  Texture: 41ce7d2fdff193a45cc8cfa3c254115cf776068a
+
+PODFILE CHECKSUM: b5184b4d7838af27c267b131a26a505b747bbf7a
+
+COCOAPODS: 1.10.1

--- a/examples_extra/EditableText/Sample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples_extra/EditableText/Sample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
This fixes: Fix: `SWIFT_VERSION '3.0' is unsupported, supported versions are: 4.0, 4.2, 5.0`. when running on Xcode 12+. 

Minor changes have been added as follows: - 
1. Changed the version number on ASDKGram sample Build Settings from Swift 3 to Swift 5.3.
2. Renamed a couple of method calls on ASDKGram sample to satisfy new Swift 5.3 API.