### PR TITLE
Fix order-dependent ASTextNodeTests

### DIFF
--- a/Tests/ASTextNodeTests.mm
+++ b/Tests/ASTextNodeTests.mm
@@ -61,6 +61,12 @@
 - (void)setUp
 {
   [super setUp];
+
+  // Reset experimental features to test the first version of ASTextNode.
+  ASConfiguration *config = [ASConfiguration new];
+  config.experimentalFeatures = kNilOptions;
+  [ASConfigurationManager test_resetWithConfiguration:config];
+  
   _textNode = [[ASTextNode alloc] init];
   _textNodeBucket = [[NSMutableArray alloc] init];
   


### PR DESCRIPTION
The ASTextNodeTests currently depend on executing in a specific order as some tests enable the `ASExperimentalTextNode` experimental feature. This is set in a global config, so running any tests which require this experimental feature to not be enabled after a test which enables it will cause that test to fail. This PR resets the experimental features to `kNilOptions` in the per-test setup, removing this ordering dependency.