### PR TITLE
Fix the bug of incorrect as_resizableRoundedImageWithCornerRadius background color.

### DIFF
--- a/Source/UIImage+ASConvenience.mm
+++ b/Source/UIImage+ASConvenience.mm
@@ -214,6 +214,15 @@ UIImage *cachedImageNamed(NSString *imageName, UITraitCollection *traitCollectio
       BOOL canUseCopy = (CGColorGetAlpha(borderColor.CGColor) == 1);
       [strokePath strokeWithBlendMode:(canUseCopy ? kCGBlendModeCopy : kCGBlendModeNormal) alpha:1];
     }
+    // Refill the center area with fillColor since it may be contaminated by the sub pixel
+    // rendering.
+    if (borderWidth > 0) {
+      CGRect rect = CGRectMake(capInset, capInset, 1, 1);
+      CGContextRef context = UIGraphicsGetCurrentContext();
+      CGContextClearRect(context, rect);
+      CGContextSetFillColorWithColor(context, [fillColor CGColor]);
+      CGContextFillRect(context, rect);
+    }
   });
   
   UIEdgeInsets capInsets = UIEdgeInsetsMake(cornerRadius, cornerRadius, cornerRadius, cornerRadius);


### PR DESCRIPTION
The background in as_resizableRoundedImageWithCornerRadius is created using a stretchable image, whose center 1x1 area will be later stretched to fit the entire content area. However, the color of the center area may be affected by its nearby pixels. This can cause the image background area to have an incorrect background color.

This fix repaints the center 1x1 area with the fillColor specified by the user.