### PR TITLE
[ASTextNode2] Expose all of ASTextNode2 as public files in via the podspec

### DIFF
--- a/Texture.podspec
+++ b/Texture.podspec
@@ -25,8 +25,7 @@ Pod::Spec.new do |spec|
       'Source/Debug/**/*.h',
       'Source/TextKit/ASTextNodeTypes.h',
       'Source/TextKit/ASTextKitComponents.h',
-      'Source/TextExperiment/Component/*.h',
-      'Source/TextExperiment/String/ASTextAttribute.h',
+      'Source/TextExperiment/**/*.h'
     ]
     
     core.source_files = [


### PR DESCRIPTION
There were methods like `as_setTextStrikethrough:range:` that ASTN2 uses to implement strikethrough (`NSStrikethroughStyleAttributeName` doesn’t work) that were not public because the `Utility` folder of `TextExperiment` was not exported in the pod.

Make all *.h files in `TextExperiment` part of `public_header_files`