### PR TITLE
[ASTextNode] call initialize after possibly dynamically changing the superclass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
         DEVELOPER_DIR: /Applications/Xcode_11.5.app/Contents/Developer
     strategy:
       matrix:
-        mode: [tests, framework, life-without-cocoapods, carthage, examples-pt1, examples-pt2, examples-pt3, examples-pt4]
+        mode: [tests, framework, life-without-cocoapods, examples-pt1, examples-pt2, examples-pt3, examples-pt4]
         include:
           - mode: tests
             name: Build and run tests
@@ -16,8 +16,6 @@ jobs:
             name: Build Texture as a dynamic framework
           - mode: life-without-cocoapods
             name: Build Texture as a static library
-          - mode: carthage
-            name: Verify that Carthage works
           - mode: examples-pt1
             name: Build examples (examples-pt1)
           - mode: examples-pt2

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -1495,9 +1495,6 @@ static NSAttributedString *DefaultTruncationAttributedString()
 // All direct descendants of ASTextNode get their superclass replaced by ASTextNode2.
 + (void)initialize
 {
-  // Texture requires that node subclasses call [super initialize]
-  [super initialize];
-
   if (class_getSuperclass(self) == [ASTextNode class]
       && ASActivateExperimentalFeature(ASExperimentalTextNode)) {
 #pragma clang diagnostic push
@@ -1505,6 +1502,12 @@ static NSAttributedString *DefaultTruncationAttributedString()
     class_setSuperclass(self, [ASTextNode2 class]);
 #pragma clang diagnostic pop
   }
+  
+  // Texture requires that node subclasses call [super initialize]
+  // Note: initialize must be called AFTER swapping superclass so that we use the proper class to set up the node's _flags.
+  // ASTextNode implements displayWithParameters:isCancelled: whereas ASTextNode2 implements drawRect:withParameters:isCancelled:isRasterizing:
+  // When we set up _flags, if we use the class before switching then ASTextNode2 will think it responds to displayWithParameters:isCancelled:!
+  [super initialize];
 }
 
 // For direct allocations of ASTextNode itself, we override allocWithZone:


### PR DESCRIPTION
In order to experiment with ASTN2 we do some crazy obj-c voodoo to change the superclass of an object from `ASTextNode` to `ASTextNode2`. However, before we do that we set up the object’s `_flags` which, among other things, caches whether or not a class responds to certain selectors.

ASTN and ASTN2 draw themselves differently, with ASTN using `displayWithParameters:isCancelled:` and ASTN2 using `drawRect:withParameters:isCancelled:isRasterizing:`. If we are experimenting with ASTN2, if we set up `_flags` before teh swap our eventual ASTN2 class will think it responds to `displayWithParameters:isCancelled:`. If we wait until after the possible swap to setup `_flags` everything works as expected!.