### PR TITLE
[ASTN2] Fix the podspec

### DIFF
--- a/Texture.podspec
+++ b/Texture.podspec
@@ -25,7 +25,10 @@ Pod::Spec.new do |spec|
       'Source/Debug/**/*.h',
       'Source/TextKit/ASTextNodeTypes.h',
       'Source/TextKit/ASTextKitComponents.h',
-      'Source/TextExperiment/**/*.h'
+      'Source/TextExperiment/Component/*.h',
+      'Source/TextExperiment/String/ASTextAttribute.h',
+      'Source/TextExperiment/Utility/NSAttributedString+ASText.h',
+      'Source/TextExperiment/Utility/NSParagraphStyle+ASText.h',
     ]
     
     core.source_files = [


### PR DESCRIPTION
I was too aggressive in including everything from `TextExperiment` as a public header file. `ASTextUtilities.h` includes a file (`ASInternalHelpers.h`) that isn’t exported as a public header and causes build issues. Hopefully this is the proper includes!