### PR TITLE
Remove trailing semi-colon

### DIFF
--- a/Source/Details/ASPINRemoteImageDownloader.mm
+++ b/Source/Details/ASPINRemoteImageDownloader.mm
@@ -212,7 +212,7 @@ static dispatch_once_t shared_init_predicate;
 }
 #endif
 
-- (id <ASImageContainerProtocol>)synchronouslyFetchedCachedImageWithURL:(NSURL *)URL;
+- (id <ASImageContainerProtocol>)synchronouslyFetchedCachedImageWithURL:(NSURL *)URL
 {
   PINRemoteImageManager *manager = [self sharedPINRemoteImageManager];
   PINRemoteImageManagerResult *result = [manager synchronousImageFromCacheWithURL:URL processorKey:nil options:PINRemoteImageManagerDownloadOptionsSkipDecode];
@@ -258,7 +258,7 @@ static dispatch_once_t shared_init_predicate;
                         shouldRetry:(BOOL)shouldRetry
                       callbackQueue:(dispatch_queue_t)callbackQueue
                    downloadProgress:(ASImageDownloaderProgress)downloadProgress
-                         completion:(ASImageDownloaderCompletion)completion;
+                         completion:(ASImageDownloaderCompletion)completion
 {
   return [self downloadImageWithURL:URL
                         shouldRetry:shouldRetry


### PR DESCRIPTION
Having a semi-colon between a method parameters list and a method
body is not supported (usually it is due to a copy and paste error
while creating the method definition from its declaration).

Fixes the following compilation warnings when building with
-Wsemicolon-before-method-body (which is part of -Wextra):

  ASPINRemoteImageDownloader.mm:230:85: error: semicolon before method body is ignored [-Werror,-Wsemicolon-before-method-body]
  - (id <ASImageContainerProtocol>)synchronouslyFetchedCachedImageWithURL:(NSURL *)URL;
                                                                                      ^
  ASPINRemoteImageDownloader.mm:275:76: error: semicolon before method body is ignored [-Werror,-Wsemicolon-before-method-body]
                           completion:(ASImageDownloaderCompletion)completion;
                                                                             ^
  2 errors generated.