### PR TITLE
Remove trailing semicolons between method parameters and body

### DIFF
--- a/Source/ASCellNode.mm
+++ b/Source/ASCellNode.mm
@@ -159,7 +159,7 @@
   }
 }
 
-- (void)__setSelectedFromUIKit:(BOOL)selected;
+- (void)__setSelectedFromUIKit:(BOOL)selected
 {
   // Note: Race condition could mean redundant sets. Risk is low.
   if (ASLockedSelf(_selected != selected)) {
@@ -169,7 +169,7 @@
   }
 }
 
-- (void)__setHighlightedFromUIKit:(BOOL)highlighted;
+- (void)__setHighlightedFromUIKit:(BOOL)highlighted
 {
   // Note: Race condition could mean redundant sets. Risk is low.
   if (ASLockedSelf(_highlighted != highlighted)) {

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -1168,7 +1168,7 @@
 
 #pragma mark - ASRangeControllerUpdateRangeProtocol
 
-- (void)updateCurrentRangeWithMode:(ASLayoutRangeMode)rangeMode;
+- (void)updateCurrentRangeWithMode:(ASLayoutRangeMode)rangeMode
 {
   if ([self pendingState]) {
     _pendingState.rangeMode = rangeMode;

--- a/Source/ASPagerNode.mm
+++ b/Source/ASPagerNode.mm
@@ -51,7 +51,7 @@
   return [self initWithCollectionViewLayout:flowLayout];
 }
 
-- (instancetype)initWithCollectionViewLayout:(ASPagerFlowLayout *)flowLayout;
+- (instancetype)initWithCollectionViewLayout:(ASPagerFlowLayout *)flowLayout
 {
   ASDisplayNodeAssert([flowLayout isKindOfClass:[ASPagerFlowLayout class]], @"ASPagerNode requires a flow layout.");
   ASDisplayNodeAssertTrue(flowLayout.scrollDirection == UICollectionViewScrollDirectionHorizontal);

--- a/Source/Debug/AsyncDisplayKit+Debug.mm
+++ b/Source/Debug/AsyncDisplayKit+Debug.mm
@@ -25,7 +25,7 @@ static BOOL __shouldShowImageScalingOverlay = NO;
 
 @implementation ASImageNode (Debugging)
 
-+ (void)setShouldShowImageScalingOverlay:(BOOL)show;
++ (void)setShouldShowImageScalingOverlay:(BOOL)show
 {
   __shouldShowImageScalingOverlay = show;
 }
@@ -437,7 +437,7 @@ static BOOL __shouldShowRangeDebugOverlay = NO;
                     rangeMode:(ASLayoutRangeMode)rangeMode
       displayTuningParameters:(ASRangeTuningParameters)displayTuningParameters
       preloadTuningParameters:(ASRangeTuningParameters)preloadTuningParameters
-               interfaceState:(ASInterfaceState)interfaceState;
+               interfaceState:(ASInterfaceState)interfaceState
 {
   _ASRangeDebugBarView *viewToUpdate = [self barViewForRangeController:controller];
   

--- a/Source/Details/ASPINRemoteImageDownloader.mm
+++ b/Source/Details/ASPINRemoteImageDownloader.mm
@@ -212,7 +212,7 @@ static dispatch_once_t shared_init_predicate;
 }
 #endif
 
-- (id <ASImageContainerProtocol>)synchronouslyFetchedCachedImageWithURL:(NSURL *)URL;
+- (id <ASImageContainerProtocol>)synchronouslyFetchedCachedImageWithURL:(NSURL *)URL
 {
   PINRemoteImageManager *manager = [self sharedPINRemoteImageManager];
   PINRemoteImageManagerResult *result = [manager synchronousImageFromCacheWithURL:URL processorKey:nil options:PINRemoteImageManagerDownloadOptionsSkipDecode];
@@ -258,7 +258,7 @@ static dispatch_once_t shared_init_predicate;
                         shouldRetry:(BOOL)shouldRetry
                       callbackQueue:(dispatch_queue_t)callbackQueue
                    downloadProgress:(ASImageDownloaderProgress)downloadProgress
-                         completion:(ASImageDownloaderCompletion)completion;
+                         completion:(ASImageDownloaderCompletion)completion
 {
   return [self downloadImageWithURL:URL
                         shouldRetry:shouldRetry

--- a/Source/Details/Transactions/_ASAsyncTransaction.mm
+++ b/Source/Details/Transactions/_ASAsyncTransaction.mm
@@ -44,7 +44,7 @@ NSInteger const ASDefaultTransactionPriority = 0;
   NSAssert(_operationCompletionBlock == nil, @"Should have been called and released before -dealloc");
 }
 
-- (void)callAndReleaseCompletionBlock:(BOOL)canceled;
+- (void)callAndReleaseCompletionBlock:(BOOL)canceled
 {
   ASDisplayNodeAssertMainThread();
   if (_operationCompletionBlock) {

--- a/Source/Layout/ASCenterLayoutSpec.mm
+++ b/Source/Layout/ASCenterLayoutSpec.mm
@@ -17,7 +17,7 @@
 
 - (instancetype)initWithCenteringOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions
                            sizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions
-                                   child:(id<ASLayoutElement>)child;
+                                   child:(id<ASLayoutElement>)child
 {
   ASRelativeLayoutSpecPosition verticalPosition = [self verticalPositionFromCenteringOptions:centeringOptions];
   ASRelativeLayoutSpecPosition horizontalPosition = [self horizontalPositionFromCenteringOptions:centeringOptions];

--- a/Source/Layout/ASInsetLayoutSpec.mm
+++ b/Source/Layout/ASInsetLayoutSpec.mm
@@ -39,7 +39,7 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
 
 @implementation ASInsetLayoutSpec
 
-- (instancetype)initWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutElement>)child;
+- (instancetype)initWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutElement>)child
 {
   if (!(self = [super init])) {
     return nil;

--- a/Source/Layout/ASRatioLayoutSpec.mm
+++ b/Source/Layout/ASRatioLayoutSpec.mm
@@ -31,7 +31,7 @@
   return [[self alloc] initWithRatio:ratio child:child];
 }
 
-- (instancetype)initWithRatio:(CGFloat)ratio child:(id<ASLayoutElement>)child;
+- (instancetype)initWithRatio:(CGFloat)ratio child:(id<ASLayoutElement>)child
 {
   if (!(self = [super init])) {
     return nil;

--- a/Source/Private/ASCollectionViewFlowLayoutInspector.mm
+++ b/Source/Private/ASCollectionViewFlowLayoutInspector.mm
@@ -34,7 +34,7 @@
 
 #pragma mark Lifecycle
 
-- (instancetype)initWithFlowLayout:(UICollectionViewFlowLayout *)flowLayout;
+- (instancetype)initWithFlowLayout:(UICollectionViewFlowLayout *)flowLayout
 {
   NSParameterAssert(flowLayout);
   
@@ -47,7 +47,7 @@
 
 #pragma mark ASCollectionViewLayoutInspecting
 
-- (void)didChangeCollectionViewDelegate:(id<ASCollectionDelegate>)delegate;
+- (void)didChangeCollectionViewDelegate:(id<ASCollectionDelegate>)delegate
 {
   if (delegate == nil) {
     memset(&_delegateFlags, 0, sizeof(_delegateFlags));

--- a/Source/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/Source/Private/ASDisplayNode+AsyncDisplay.mm
@@ -485,7 +485,7 @@ using AS::MutexLocker;
   _willDisplayNodeContentWithRenderingContext = contextModifier;
 }
 
-- (void)setDidDisplayNodeContentWithRenderingContext:(ASDisplayNodeContextModifier)contextModifier;
+- (void)setDidDisplayNodeContentWithRenderingContext:(ASDisplayNodeContextModifier)contextModifier
 {
   MutexLocker l(__instanceLock__);
   _didDisplayNodeContentWithRenderingContext = contextModifier;

--- a/Source/TextKit/ASTextKitFontSizeAdjuster.mm
+++ b/Source/TextKit/ASTextKitFontSizeAdjuster.mm
@@ -40,7 +40,7 @@
 
 - (instancetype)initWithContext:(ASTextKitContext *)context
                 constrainedSize:(CGSize)constrainedSize
-              textKitAttributes:(const ASTextKitAttributes &)textComponentAttributes;
+              textKitAttributes:(const ASTextKitAttributes &)textComponentAttributes
 {
   if (self = [super init]) {
     _context = context;

--- a/Source/TextKit/ASTextKitRenderer.mm
+++ b/Source/TextKit/ASTextKitRenderer.mm
@@ -190,7 +190,7 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
 
 #pragma mark - Drawing
 
-- (void)drawInContext:(CGContextRef)context bounds:(CGRect)bounds;
+- (void)drawInContext:(CGContextRef)context bounds:(CGRect)bounds
 {
   // We add an assertion so we can track the rare conditions where a graphics context is not present
   ASDisplayNodeAssertNotNil(context, @"This is no good without a context.");

--- a/docs/_docs/automatic-subnode-mgmt.md
+++ b/docs/_docs/automatic-subnode-mgmt.md
@@ -27,7 +27,7 @@ By setting `.automaticallyManagesSubnodes` to `YES` on the `ASCellNode`, we _no 
 </span>
 <div class = "code">
 <pre lang="objc" class="objcCode">
-- (instancetype)initWithPhotoObject:(PhotoModel *)photo;
+- (instancetype)initWithPhotoObject:(PhotoModel *)photo
 {
   self = [super init];
   
@@ -103,7 +103,7 @@ class PhotoCellNode {
 </span>
 <div class = "code">
 <pre lang="objc" class="objcCode">
-- (instancetype)initWithPhotoObject:(PhotoModel *)photo;
+- (instancetype)initWithPhotoObject:(PhotoModel *)photo
 {
   self = [super init];
   

--- a/docs/_docs/multiplex-image-node.md
+++ b/docs/_docs/multiplex-image-node.md
@@ -90,7 +90,7 @@ For example, in the case that you want to react to the fact that a new image arr
             didUpdateImage:(UIImage *)image 
             withIdentifier:(id)imageIdentifier 
                  fromImage:(UIImage *)previousImage 
-            withIdentifier:(id)previousImageIdentifier;
+            withIdentifier:(id)previousImageIdentifier
 {    
         // this is optional, in case you want to react to the fact that a new image came in
 }

--- a/examples/ASCollectionView/Sample/ViewController.m
+++ b/examples/ASCollectionView/Sample/ViewController.m
@@ -142,7 +142,7 @@ static CGSize const kItemSize = (CGSize){180, 90};
 
 #pragma mark - ASCollectionDataSource
 
-- (ASCellNodeBlock)collectionNode:(ASCollectionNode *)collectionNode nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath;
+- (ASCellNodeBlock)collectionNode:(ASCollectionNode *)collectionNode nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   NSString *text = self.data[indexPath.section][indexPath.item];
   return ^{

--- a/examples/ASDKTube/Sample/ViewController.m
+++ b/examples/ASDKTube/Sample/ViewController.m
@@ -73,7 +73,7 @@
   return cellNode;
 }
 
-- (ASVideoPlayerNode *)videoPlayerNode;
+- (ASVideoPlayerNode *)videoPlayerNode
 {
   if (_videoPlayerNode) {
     return _videoPlayerNode;

--- a/examples/ASDKgram/Sample/PhotoCellNode.m
+++ b/examples/ASDKgram/Sample/PhotoCellNode.m
@@ -46,7 +46,7 @@
 
 #pragma mark - Lifecycle
 
-- (instancetype)initWithPhotoObject:(PhotoModel *)photo;
+- (instancetype)initWithPhotoObject:(PhotoModel *)photo
 {
   self = [super init];
   

--- a/examples/ASDKgram/Sample/PhotoTableViewCell.m
+++ b/examples/ASDKgram/Sample/PhotoTableViewCell.m
@@ -41,7 +41,7 @@
 
 #pragma mark - Class Methods
 
-+ (CGFloat)heightForPhotoModel:(PhotoModel *)photo withWidth:(CGFloat)width;
++ (CGFloat)heightForPhotoModel:(PhotoModel *)photo withWidth:(CGFloat)width
 {
   CGFloat photoHeight = width;
   

--- a/examples/ASDKgram/Sample/UserModel.m
+++ b/examples/ASDKgram/Sample/UserModel.m
@@ -65,7 +65,7 @@
   });
 }
 
-- (void)downloadCompleteUserDataWithCompletionBlock:(void(^)(UserModel *))block;
+- (void)downloadCompleteUserDataWithCompletionBlock:(void(^)(UserModel *))block
 {
   if (_fullUserInfoFetchDone) {
     NSAssert(!_fullUserInfoCompletionBlock, @"Should not have a waiting block at this point");

--- a/examples/VerticalWithinHorizontalScrolling/Sample/ViewController.m
+++ b/examples/VerticalWithinHorizontalScrolling/Sample/ViewController.m
@@ -74,7 +74,7 @@
   };
 }
 
-- (ASSizeRange)pagerNode:(ASPagerNode *)pagerNode constrainedSizeForNodeAtIndex:(NSInteger)index;
+- (ASSizeRange)pagerNode:(ASPagerNode *)pagerNode constrainedSizeForNodeAtIndex:(NSInteger)index
 {
   return ASSizeRangeMake(pagerNode.bounds.size);
 }

--- a/examples/Videos/Sample/ASVideoNode.m
+++ b/examples/Videos/Sample/ASVideoNode.m
@@ -16,12 +16,12 @@
 
 @implementation ASVideoNode
 
-- (instancetype)initWithURL:(NSURL *)URL;
+- (instancetype)initWithURL:(NSURL *)URL
 {
   return [self initWithURL:URL videoGravity:ASVideoGravityResizeAspect];
 }
 
-- (instancetype)initWithURL:(NSURL *)URL videoGravity:(ASVideoGravity)gravity;
+- (instancetype)initWithURL:(NSURL *)URL videoGravity:(ASVideoGravity)gravity
 {
   if (!(self = [super initWithLayerBlock:^CALayer *{
     AVPlayerLayer *layer = [[AVPlayerLayer alloc] init];
@@ -37,7 +37,7 @@
   return self;
 }
 
-- (void)setGravity:(ASVideoGravity)gravity;
+- (void)setGravity:(ASVideoGravity)gravity
 {
   switch (gravity) {
     case ASVideoGravityResize:
@@ -55,7 +55,7 @@
   }
 }
 
-- (ASVideoGravity)gravity;
+- (ASVideoGravity)gravity
 {
   if ([((AVPlayerLayer *)self.layer).contentsGravity isEqualToString:AVLayerVideoGravityResize]) {
     return ASVideoGravityResize;
@@ -67,12 +67,12 @@
   return ASVideoGravityResizeAspect;
 }
 
-- (void)play;
+- (void)play
 {
   [[((AVPlayerLayer *)self.layer) player] play];
 }
 
-- (void)pause;
+- (void)pause
 {
   [[((AVPlayerLayer *)self.layer) player] pause];
 }

--- a/examples/Videos/Sample/ViewController.m
+++ b/examples/Videos/Sample/ViewController.m
@@ -72,7 +72,7 @@
 
 #pragma mark - Getter / Setter
 
-- (ASVideoNode *)guitarVideoNode;
+- (ASVideoNode *)guitarVideoNode
 {
   if (_guitarVideoNode) {
     return _guitarVideoNode;
@@ -88,7 +88,7 @@
   return _guitarVideoNode;
 }
 
-- (ASVideoNode *)nicCageVideoNode;
+- (ASVideoNode *)nicCageVideoNode
 {
   ASVideoNode *nicCageVideoNode = [[ASVideoNode alloc] init];
   nicCageVideoNode.delegate = self;
@@ -117,7 +117,7 @@
   return simonVideoNode;
 }
 
-- (ASVideoNode *)hlsVideoNode;
+- (ASVideoNode *)hlsVideoNode
 {
   ASVideoNode *hlsVideoNode = [[ASVideoNode alloc] init];
   
@@ -134,7 +134,7 @@
   return hlsVideoNode;
 }
 
-- (ASButtonNode *)playButton;
+- (ASButtonNode *)playButton
 {
   ASButtonNode *playButtonNode = [[ASButtonNode alloc] init];
   

--- a/examples_extra/CollectionViewWithViewControllerCells/Sample/ImageViewController.m
+++ b/examples_extra/CollectionViewWithViewControllerCells/Sample/ImageViewController.m
@@ -35,7 +35,7 @@
   self.imageView.contentMode = UIViewContentModeScaleAspectFill;
 }
 
-- (void)tapped;
+- (void)tapped
 {
   NSLog(@"tapped!");
 }


### PR DESCRIPTION
Having a semi-colon between a method parameters list and a method
body is not not correct and is usually caused by a copy and paste
error while creating the method definition from its declaration.

Fixes the following compilation warnings when building with
-Wsemicolon-before-method-body (which is part of -Wextra):

  ASPINRemoteImageDownloader.mm:230:85: error: semicolon before method body is ignored [-Werror,-Wsemicolon-before-method-body]
  - (id <ASImageContainerProtocol>)synchronouslyFetchedCachedImageWithURL:(NSURL *)URL;
                                                                                      ^
  ASPINRemoteImageDownloader.mm:275:76: error: semicolon before method body is ignored [-Werror,-Wsemicolon-before-method-body]
                           completion:(ASImageDownloaderCompletion)completion;
                                                                             ^
  2 errors generated.

Fixes applied to both code, examples and samples in documentation.