### PR TITLE
Add experiment to ensure ASCollectionView's range controller updates …

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -2311,6 +2311,9 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
       
       // Flush any range changes that happened as part of submitting the update.
       as_activity_scope(changeSet.rootActivity);
+      if (numberOfUpdates > 0 && ASActivateExperimentalFeature(ASExperimentalRangeUpdateOnChangesetUpdate)) {
+        [self->_rangeController setNeedsUpdate];
+      }
       [self->_rangeController updateIfNeeded];
     }
   });

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -30,6 +30,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalOptimizeDataControllerPipeline = 1 << 9,                    // exp_optimize_data_controller_pipeline
   ASExperimentalDisableGlobalTextkitLock = 1 << 10,                         // exp_disable_global_textkit_lock
   ASExperimentalMainThreadOnlyDataController = 1 << 11,                     // exp_main_thread_only_data_controller
+  ASExperimentalRangeUpdateOnChangesetUpdate = 1 << 12,                     // exp_range_update_on_changeset_update
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -23,7 +23,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_drawing_global",
                                       @"exp_optimize_data_controller_pipeline",
                                       @"exp_disable_global_textkit_lock",
-                                      @"exp_main_thread_only_data_controller"]));
+                                      @"exp_main_thread_only_data_controller",
+                                      @"exp_range_update_on_changeset_update"]));
   if (flags == ASExperimentalFeatureAll) {
     return allNames;
   }

--- a/Tests/ASConfigurationTests.mm
+++ b/Tests/ASConfigurationTests.mm
@@ -30,6 +30,7 @@ static ASExperimentalFeatures features[] = {
   ASExperimentalOptimizeDataControllerPipeline,
   ASExperimentalDisableGlobalTextkitLock,
   ASExperimentalMainThreadOnlyDataController,
+  ASExperimentalRangeUpdateOnChangesetUpdate,
 };
 
 @interface ASConfigurationTests : ASTestCase <ASConfigurationDelegate>
@@ -53,7 +54,8 @@ static ASExperimentalFeatures features[] = {
     @"exp_drawing_global",
     @"exp_optimize_data_controller_pipeline",
     @"exp_disable_global_textkit_lock",
-    @"exp_main_thread_only_data_controller"
+    @"exp_main_thread_only_data_controller",
+    @"exp_range_update_on_changeset_update"
   ];
 }
 


### PR DESCRIPTION
…on changeset updates

This experiment makes sure a ASCollectionView's `rangeController` updates when
a changeset WITH updates is applied. Currently it is possible for nodes
inserted into the preload range to not get preloaded when performing a batch
update.

  For example, suppose a collection node has:
  - Tuning parameters with a preload range of 1 screenful for the given range
    mode.
  - Nodes A and B where A is visible and B is off screen.
  
  Currently if node B is deleted and a new node C is inserted in its place, node
  C will not get preloaded until the collection node is scrolled. This is because
  the preloading mechanism relies on a `setNeedsUpdate` call on the range
  controller as part of the `-collectionView:willDisplayCell:forItemAtIndexPath:`
  delegate method when the batch update is submitted. However, in the example
  outlined above, this sometimes doesn't happen automtically, causing the range
  update to be delayed until the next the view scrolls.