### PR TITLE
[ASTextNode2] Fix centered text shorter than container size

### DIFF
--- a/Source/TextExperiment/Component/ASTextLayout.mm
+++ b/Source/TextExperiment/Component/ASTextLayout.mm
@@ -970,6 +970,23 @@ dispatch_semaphore_signal(_lock);
       size.width += container.size.width - (rect.origin.x + rect.size.width);
     } else {
       size.width += rect.origin.x;
+      // When computing the x offset of centered text, the entire width of our container's size is used.
+      // Even if the text is short and will not use the entire size, it is centered as though it will.
+      // However, the textBoundingSize is only the width of the text + the text's offset. This leads to
+      // the text node being smaller than the container's width. For example, if we were trying to center
+      // "hello" we would expect the text node to look like this (where | are the left right edges of the
+      // text node's frame):
+      // |    hello    |
+      // But what we'd end up with is:
+      // |    hello|
+      // The text is technically centered in the container's size, but not within the text node's size.
+      // Ideally we'd lay this out as:
+      // |hello|
+      // but that seems like a much larger change. Instead let's change the textBoundingSize to be the same
+      // as the container's size.
+      if ([text as_alignment] == NSTextAlignmentCenter) {
+        size.width = container.size.width;
+      }
     }
     size.height += rect.origin.y;
     if (size.width < 0) size.width = 0;

--- a/Tests/ASTextNode2Tests.mm
+++ b/Tests/ASTextNode2Tests.mm
@@ -180,4 +180,23 @@
   }];
 }
 
+- (void)testNonTruncatedCenteredText
+{
+  CGSize constrainedSize = CGSizeMake(100, 50);
+  
+  NSMutableParagraphStyle *paragraph = [[NSMutableParagraphStyle alloc] init];
+  paragraph.alignment = NSTextAlignmentCenter;
+  
+  // test that the centered text uses the entire container width
+  ASTextNode2 *textNode = [[ASTextNode2 alloc] init];
+  textNode.attributedText = [[NSAttributedString alloc] initWithString:@"hi" attributes:@{ NSParagraphStyleAttributeName : paragraph }];
+  CGSize size = [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
+  XCTAssertTrue(size.width == 100);
+
+  // non centered text should not use the entire container width
+  textNode.attributedText = [[NSAttributedString alloc] initWithString:@"hi"];
+  size = [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
+  XCTAssertTrue(size.width < 20);
+}
+
 @end


### PR DESCRIPTION
ASTextNode2 renders centered text a little strangely. If we have a small bit of text in a container size larger than the text, ASTN2 will use the entire container width to center the text but the text node's frame itself will not be the entire container size. For example, here is what ASTN2 looks like when centering text across the width of the phone:

<img width="373" alt="Screen Shot 2021-03-23 at 12 37 46 PM" src="https://user-images.githubusercontent.com/285809/112518426-96b3c600-8d56-11eb-83d7-aedefb31939f.png">

While the text is centered across the phone's width, the text is not centered in the text node itself. 

This fix will align the text node's frame with the container size that computes the offset of the centered text, like this:
<img width="439" alt="Screen Shot 2021-03-25 at 10 47 59 AM" src="https://user-images.githubusercontent.com/285809/112519423-9962eb00-8d57-11eb-867a-b79073622236.png">
