### PR TITLE
[ASTextNode2] Check that rangeOut is non-nil before dereferencing

### DIFF
--- a/Source/ASTextNode2.mm
+++ b/Source/ASTextNode2.mm
@@ -702,7 +702,9 @@ static NSArray *DefaultLinkAttributeNames() {
         continue;
       }
 
-      *rangeOut = NSIntersectionRange(visibleRange, effectiveRange);
+      if (rangeOut != NULL) {
+        *rangeOut = NSIntersectionRange(visibleRange, effectiveRange);
+      }
 
       if (attributeNameOut != NULL) {
         *attributeNameOut = attributeName;


### PR DESCRIPTION
`rangeOut` is a nullable parameter, but we are treating it as though it is always not null. Make sure it is not null before dereferencing it.