### PR TITLE
Increase default diskCache byte limit from 20 to 50MB(PINCache default)

### DIFF
--- a/Source/Details/ASPINRemoteImageDownloader.mm
+++ b/Source/Details/ASPINRemoteImageDownloader.mm
@@ -99,8 +99,8 @@ static inline PINRemoteImageManagerPriority PINRemoteImageManagerPriorityWithASI
       if ([diskCache respondsToSelector:@selector(setByteLimit:)]) {
         // Set a default byteLimit. PINCache recently implemented a 50MB default (PR #201).
         // Ensure that older versions of PINCache also have a byteLimit applied.
-        // NOTE: Using 20MB limit while large cache initialization is being optimized (Issue #144).
-        ((id <ASPINDiskCache>)diskCache).byteLimit = 20 * 1024 * 1024;
+        // NOTE: Matching PINCache defualt 50MB limit.
+        ((id <ASPINDiskCache>)diskCache).byteLimit = 50 * 1024 * 1024;
       }
     }
   });


### PR DESCRIPTION
As discussed on our slack [thread](https://asyncdisplaykit.slack.com/archives/C0V63R86T/p1622253713035200)  since PINCache have already been optimized we no longer need to trade default size limit, thus I have simply increased the default disk cache limit from the original 20 MB to 50MB to support larger objects in the cache. 

NB: History to why the limit was set to 20MB can be found [here](https://github.com/TextureGroup/Texture/pull/595)

Thanks :) 