### PR TITLE
[RTL] Guard access of flipsHorizontallyInOppositeLayoutDirection for iOS >= 11

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -1859,8 +1859,11 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 {
   // Since we are accessing self.collectionViewLayout, we should make sure we are on main
   ASDisplayNodeAssertMainThread();
-  
-  if (ASDisplayShouldFetchBatchForScrollView(self, self.scrollDirection, self.scrollableDirections, contentOffset, velocity, self.collectionViewLayout.flipsHorizontallyInOppositeLayoutDirection)) {
+  BOOL flipsHorizontallyInOppositeLayoutDirection = NO;
+  if (AS_AVAILABLE_IOS(11.0)) {
+    flipsHorizontallyInOppositeLayoutDirection = self.collectionViewLayout.flipsHorizontallyInOppositeLayoutDirection;
+  }
+  if (ASDisplayShouldFetchBatchForScrollView(self, self.scrollDirection, self.scrollableDirections, contentOffset, velocity, flipsHorizontallyInOppositeLayoutDirection)) {
     [self _beginBatchFetching];
   }
 }


### PR DESCRIPTION
`flipsHorizontallyInOppositeLayoutDirection` is available in iOS11 and greater. Texture still supports iOS9 so we need to make sure not to call this it in those cases.

Thanks @foxware00 for the bug report! https://github.com/TextureGroup/Texture/issues/2001