### PR TITLE
[ASTextNode2] Integrating Google’s changes

### DIFF
--- a/Source/ASTextNode2.h
+++ b/Source/ASTextNode2.h
@@ -7,7 +7,6 @@
 //
 
 #import <AsyncDisplayKit/ASControlNode.h>
-#import <AsyncDisplayKit/ASDisplayNode+Beta.h>
 #import <AsyncDisplayKit/ASTextNodeCommon.h>
 
 @protocol ASTextLinePositionModifier;
@@ -209,22 +208,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  @abstract if YES will not intercept touches for non-link areas of the text. Default is NO.
- @discussion If you still want to handle tap truncation action when passthroughNonlinkTouches is YES,
- you should set the alwaysHandleTruncationTokenTap to YES.
  */
 @property (nonatomic) BOOL passthroughNonlinkTouches;
-
-/**
- @abstract Always handle tap truncationAction, even the passthroughNonlinkTouches is YES. Default is NO.
- @discussion if this is set to YES, the [ASTextNodeDelegate textNodeTappedTruncationToken:] callback will be called.
- */
-@property (nonatomic) BOOL alwaysHandleTruncationTokenTap;
-
-/**
- @abstract if YES will use the value of `self.tintColor` if the foreground color of text is not defined.
- @discussion This is mainly used from ASButtonNode since by default text nodes do not respect tintColor settings unless contained within a interactive control
- */
-@property (nonatomic) BOOL textColorFollowsTintColor;
 
 + (void)enableDebugging;
 

--- a/Source/TextExperiment/Component/ASTextLayout.mm
+++ b/Source/TextExperiment/Component/ASTextLayout.mm
@@ -16,6 +16,8 @@
 #import <AsyncDisplayKit/NSAttributedString+ASText.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 
+#import <pthread.h>
+
 const CGSize ASTextContainerMaxSize = (CGSize){0x100000, 0x100000};
 
 typedef struct {
@@ -381,7 +383,7 @@ dispatch_semaphore_signal(_lock);
 - (NSString *)description
 {
   return [NSString stringWithFormat:@"lines: %ld, visibleRange:%@, textBoundingRect:%@",
-                                    (long)[self.lines count],
+                                    [self.lines count],
                                     NSStringFromRange(self.visibleRange),
                                     NSStringFromCGRect(self.textBoundingRect)];
 }
@@ -832,8 +834,7 @@ dispatch_semaphore_signal(_lock);
             }
           }
           int i = 0;
-          if (type != kCTLineTruncationStart) { // Middle or End/Tail wants to collect some text (at least one line's
-              // worth) preceding the truncated content, with which to construct a "truncated line".
+          if (type != kCTLineTruncationStart) { // Middle or End/Tail wants text preceding truncated content.
             i = (int)removedLines.count - 1;
             while (atLeastOneLine < truncatedWidth && i >= 0) {
               if (lastLineText.length > 0 && [lastLineText.string characterAtIndex:lastLineText.string.length - 1] == '\n') { // Explicit newlines are always "long enough".
@@ -845,8 +846,7 @@ dispatch_semaphore_signal(_lock);
             }
             [lastLineText appendAttributedString:truncationToken];
           }
-          if (type != kCTLineTruncationEnd && removedLines.count > 0) { // Middle or Start/Head wants to collect some
-              // text following the truncated content.
+          if (type != kCTLineTruncationEnd && removedLines.count > 0) { // Middle or Start/Head wants text following truncated content.
             i = 0;
             atLeastOneLine = removedLines[i].width;
             while (atLeastOneLine < truncatedWidth && i < removedLines.count) {
@@ -860,9 +860,7 @@ dispatch_semaphore_signal(_lock);
                 [lastLineText appendAttributedString:nextLine];
               }
             }
-            if (type == kCTLineTruncationStart) {
-              [lastLineText insertAttributedString:truncationToken atIndex:0];
-            }
+            [lastLineText insertAttributedString:truncationToken atIndex:0];
           }
 
           CTLineRef ctLastLineExtend = CTLineCreateWithAttributedString((CFAttributedStringRef) lastLineText);
@@ -969,16 +967,15 @@ dispatch_semaphore_signal(_lock);
       [truncationToken enumerateAttributesInRange:NSMakeRange(0, truncationToken.length) options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired usingBlock:block];
     }
   }
+  
+  attachments = [NSMutableArray new];
+  attachmentRanges = [NSMutableArray new];
+  attachmentRects = [NSMutableArray new];
+  attachmentContentsSet = [NSMutableSet new];
   for (NSUInteger i = 0, max = lines.count; i < max; i++) {
     ASTextLine *line = lines[i];
     if (truncatedLine && line.index == truncatedLine.index) line = truncatedLine;
     if (line.attachments.count > 0) {
-      if (!attachments) {
-        attachments = [[NSMutableArray alloc] init];
-        attachmentRanges = [[NSMutableArray alloc] init];
-        attachmentRects = [[NSMutableArray alloc] init];
-        attachmentContentsSet = [[NSMutableSet alloc] init];
-      }
       [attachments addObjectsFromArray:line.attachments];
       [attachmentRanges addObjectsFromArray:line.attachmentRanges];
       [attachmentRects addObjectsFromArray:line.attachmentRects];
@@ -988,6 +985,9 @@ dispatch_semaphore_signal(_lock);
         }
       }
     }
+  }
+  if (attachments.count == 0) {
+    attachments = attachmentRanges = attachmentRects = nil;
   }
 
   layout.frame = ctFrame;
@@ -2142,9 +2142,7 @@ dispatch_semaphore_signal(_lock);
       if (isVertical) {
         topRect.rect = CGRectMake(startLine.left, topOffset, startLine.width, (_container.path ? startLine.bottom : _container.size.height - _container.insets.bottom) - topOffset);
       } else {
-        // TODO: Fixes highlighting first row only to the end of the text and not highlight
-        //       the while line to the end. Needs to brought over to multiline support
-        topRect.rect = CGRectMake(topOffset, startLine.top, (_container.path ? startLine.right : _container.size.width - _container.insets.right) - topOffset - (_container.size.width - _container.insets.right - startLine.right), startLine.height);
+        topRect.rect = CGRectMake(topOffset, startLine.top, (_container.path ? startLine.right : _container.size.width - _container.insets.right) - topOffset, startLine.height);
       }
     }
     [rects addObject:topRect];

--- a/Source/TextExperiment/Component/ASTextLine.mm
+++ b/Source/TextExperiment/Component/ASTextLine.mm
@@ -76,9 +76,9 @@
   NSUInteger runCount = CFArrayGetCount(runs);
   if (runCount == 0) return;
   
-  NSMutableArray<ASTextAttachment *> *attachments = nil;
-  NSMutableArray<NSValue *> *attachmentRanges = nil;
-  NSMutableArray<NSValue *> *attachmentRects = nil;
+  NSMutableArray *attachments = [NSMutableArray new];
+  NSMutableArray *attachmentRanges = [NSMutableArray new];
+  NSMutableArray *attachmentRects = [NSMutableArray new];
   for (NSUInteger r = 0; r < runCount; r++) {
     CTRunRef run = (CTRunRef)CFArrayGetValueAtIndex(runs, r);
     CFIndex glyphCount = CTRunGetGlyphCount(run);
@@ -104,19 +104,14 @@
       }
       
       NSRange runRange = ASTextNSRangeFromCFRange(CTRunGetStringRange(run));
-      if (!attachments) {
-        attachments = [[NSMutableArray alloc] init];
-        attachmentRanges = [[NSMutableArray alloc] init];
-        attachmentRects = [[NSMutableArray alloc] init];
-      }
       [attachments addObject:attachment];
       [attachmentRanges addObject:[NSValue valueWithRange:runRange]];
       [attachmentRects addObject:[NSValue valueWithCGRect:runTypoBounds]];
     }
   }
-  _attachments = attachments;
-  _attachmentRanges = attachmentRanges;
-  _attachmentRects = attachmentRects;
+  _attachments = attachments.count ? attachments : nil;
+  _attachmentRanges = attachmentRanges.count ? attachmentRanges : nil;
+  _attachmentRects = attachmentRects.count ? attachmentRects : nil;
 }
 
 - (CGSize)size {

--- a/Source/TextExperiment/String/ASTextAttribute.mm
+++ b/Source/TextExperiment/String/ASTextAttribute.mm
@@ -8,6 +8,7 @@
 //
 
 #import "ASTextAttribute.h"
+#import <UIKit/UIKit.h>
 #import <CoreText/CoreText.h>
 #import <AsyncDisplayKit/NSAttributedString+ASText.h>
 

--- a/Source/TextExperiment/String/ASTextRunDelegate.h
+++ b/Source/TextExperiment/String/ASTextRunDelegate.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Additional information about the the run delegate.
  */
-@property (nullable, nonatomic, copy) NSDictionary *userInfo;
+@property (nullable, nonatomic) NSDictionary *userInfo;
 
 /**
  The typographic ascent of glyphs in the run.

--- a/Source/TextExperiment/Utility/ASTextUtilities.h
+++ b/Source/TextExperiment/Utility/ASTextUtilities.h
@@ -132,6 +132,7 @@ static inline CGFloat ASTextEmojiGetDescentWithFontSize(CGFloat fontSize) {
   } else {
     return 0.3125 * fontSize;
   }
+  return 0;
 }
 
 /**

--- a/Source/TextExperiment/Utility/ASTextUtilities.mm
+++ b/Source/TextExperiment/Utility/ASTextUtilities.mm
@@ -7,6 +7,7 @@
 //
 
 #import "ASTextUtilities.h"
+#import <Accelerate/Accelerate.h>
 
 NSCharacterSet *ASTextVerticalFormRotateCharacterSet() {
   static NSMutableCharacterSet *set;

--- a/Tests/ASTextNode2Tests.mm
+++ b/Tests/ASTextNode2Tests.mm
@@ -8,13 +8,12 @@
 
 #import <CoreText/CoreText.h>
 
-#import <XCTest/XCTest.h>
+#import "ASTestCase.h"
 
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
 #import <AsyncDisplayKit/ASTextNode2.h>
-#import <AsyncDisplayKit/ASTextNode+Beta.h>
 
-#import "ASTestCase.h"
+#import <XCTest/XCTest.h>
 
 @interface ASTextNode2Tests : XCTestCase
 
@@ -64,14 +63,6 @@
   _textNode.attributedText = _attributedText;
 }
 
-- (void)testTruncation
-{
-  XCTAssertTrue([(ASTextNode *)_textNode shouldTruncateForConstrainedSize:ASSizeRangeMake(CGSizeMake(100, 100))], @"Text Node should truncate");
-
-  _textNode.frame = CGRectMake(0, 0, 100, 100);
-  XCTAssertTrue(_textNode.isTruncated, @"Text Node should be truncated");
-}
-
 - (void)testAccessibility
 {
   XCTAssertTrue(_textNode.isAccessibilityElement, @"Should be an accessibility element");
@@ -89,45 +80,6 @@
   XCTAssertTrue([_textNode.defaultAccessibilityLabel isEqualToString:_attributedText.string],
                 @"Default accessibility label incorrectly returns \n%@\n when it should be \n%@\n",
                 _textNode.defaultAccessibilityLabel, _attributedText.string);
-}
-
-- (void)testRespectingAccessibilitySetting
-{
-  ASTextNode2 *textNode = [[ASTextNode2 alloc] init];
-  textNode.attributedText = _attributedText;
-  textNode.isAccessibilityElement = NO;
-  
-  textNode.attributedText = [[NSAttributedString alloc] initWithString:@"new string"];
-  XCTAssertFalse(textNode.isAccessibilityElement);
-  
-  // Ensure removing string on an accessible text node updates the setting.
-  ASTextNode2 *accessibleTextNode = [ASTextNode2 new];
-  accessibleTextNode.attributedText = _attributedText;
-  accessibleTextNode.attributedText = nil;
-  XCTAssertFalse(accessibleTextNode.isAccessibilityElement);
-}
-
-- (void)testSupportsLayerBacking
-{
-  ASTextNode2 *textNode = [[ASTextNode2 alloc] init];
-  textNode.attributedText = [[NSAttributedString alloc] initWithString:@"new string"];
-  XCTAssertTrue(textNode.supportsLayerBacking);
-
-  NSString *link = @"https://texturegroup.com";
-  NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"Texture Website: %@", link]];
-  NSRange linkRange = [attributedText.string rangeOfString:link];
-  [attributedText addAttribute:NSLinkAttributeName value:link range:linkRange];
-  textNode.attributedText = attributedText;
-  XCTAssertFalse(textNode.supportsLayerBacking);
-}
-
-- (void)testEmptyStringSize
-{
-  CGSize constrainedSize = CGSizeMake(100, CGFLOAT_MAX);
-  _textNode.attributedText = [[NSAttributedString alloc] initWithString:@""];
-  CGSize sizeWithEmptyString = [_textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
-  XCTAssertTrue(ASIsCGSizeValidForSize(sizeWithEmptyString));
-  XCTAssertTrue(sizeWithEmptyString.width == 0);
 }
 
 @end


### PR DESCRIPTION
I isolated the changes from `ASTextNode2` from the large google diff. I got things building, but some snapshot tests are failing for `ASTextNode2`. The tests that are failing are:

```
-[ASTextNode2SnapshotTests testTextContainerInsetHighlight_ASTextNode2]
-[ASTextNode2SnapshotTests testTextTintColor_ASTextNode2]
-[ASTextNode2SnapshotTests testTextTruncationModes_ASTextNode2]
-[ASTextNode2SnapshotTests testTextTruncationModes_ASTextNode2]
-[ASTextNode2SnapshotTests testThatDefaultTruncationTokenAttributesAreInheritedFromTextWhenTruncated_ASTextNode2]
-[ASTextNode2SnapshotTests testTintColorHierarchyChange]
```

I also noticed that several tests were removed from ASTextNode2Tests.mm.

Some notes on my merge:
* I reverted the `ASDN` namespace back to `AS` until we can change everything at once
* I called `DISABLED_ASAssertLocked` instead of `ASAssertLocked`. Again thinking if this changed, we could do them all in one diff
* Brought back `AS_TN2_CLASSNAME` since the text experiment still exists and `ASTextNode` is the default text node on master

I’d like to discuss the snapshot failures and if they are expected/how to fix them. I’m also curious why some other tests were removed.