### PR TITLE
Decode alternative image types in ASImageNode at render time

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "pinterest/PINRemoteImage" "3.0.0-beta.14"
+github "pinterest/PINRemoteImage" "3.0.3"
 github "pinterest/PINCache" "3.0.1-beta.7"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-git "https://chromium.googlesource.com/webm/libwebp" "v0.6.0"
+git "https://chromium.googlesource.com/webm/libwebp" "v1.1.0"
 github "pinterest/PINCache" "3.0.1-beta.7"
-github "pinterest/PINOperation" "1.1.2"
-github "pinterest/PINRemoteImage" "3.0.0-beta.14"
+github "pinterest/PINOperation" "1.2.1"
+github "pinterest/PINRemoteImage" "3.0.3"

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -12,6 +12,7 @@
 #import <tgmath.h>
 
 #import <AsyncDisplayKit/_ASDisplayLayer.h>
+#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
@@ -29,6 +30,11 @@
 
 // TODO: It would be nice to remove this dependency; it's the only subclass using more than +FrameworkSubclasses.h
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h>
+
+#if AS_PIN_REMOTE_IMAGE
+#import <PINRemoteImage/PINRemoteImageMacros.h>
+#import <PINRemoteImage/PINImage+AlternativeTypes.h>
+#endif
 
 typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 
@@ -362,6 +368,11 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
   BOOL hasValidCropBounds = cropEnabled && !CGRectIsEmpty(cropDisplayBounds);
   CGRect bounds = (hasValidCropBounds ? cropDisplayBounds : drawParameterBounds);
 
+#if PIN_TARGET_IOS && AS_PIN_REMOTE_IMAGE 
+  if (image.pin_encodedImageData) {
+    image = [image pin_decodedImageUsingCustomDecodersWithSize:bounds.size];
+  }
+#endif
 
   ASDisplayNodeAssert(contentsScale > 0, @"invalid contentsScale at display time");
 


### PR DESCRIPTION
Adds support at the Texture level for decoding additional image formats at render time once the final image size is known

The Cartfile changes are because ASPINRemoteImageDownloader currently references API's that don't exist in the older version of PINRemoteImage

See (TODO, copy link to PR) for corresponding PINRemoteImage change

Upstreamed contribution from Google's fork of Texture