### PR TITLE
[3.1.0] Create new version of Texture

### DIFF
--- a/Texture.podspec
+++ b/Texture.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'Texture'
-  spec.version      = '3.0.0'
+  spec.version      = '3.1.0'
   spec.license      =  { :type => 'Apache 2',  }
   spec.homepage     = 'http://texturegroup.org'
   spec.authors      = { 'Huy Nguyen' => 'hi@huynguyen.dev', 'Garrett Moon' => 'garrett@excitedpixel.com', 'Scott Goodson' => 'scottgoodson@gmail.com', 'Michael Schneider' => 'mischneider1@gmail.com', 'Adlai Holler' => 'adlai@icloud.com' }

--- a/ThreeMigrationGuide.md
+++ b/ThreeMigrationGuide.md
@@ -1,6 +1,10 @@
-## Texture 3.0 Migration Guide
+## Texture 3.1 Migration Guide
 
 Got a tip for upgrading? Please open a PR to this document!
+
+- Rename all instances of ASNavigationController to ASDKNavigationController
+
+## Texture 3.0 Migration Guide
 
 - Rename all instances of ASViewController to ASDKViewController
 


### PR DESCRIPTION
With the breaking change of renaming ASNavigationController to ASDKNavigationController, we have released a new version of Texture. Please see `ThreeMigrationGuide.md` for how to handle the breaking changes in 3.1.0.