### PR TITLE
avoid padding a struct to be hashed

### DIFF
--- a/Source/Details/ASCollectionLayoutContext.mm
+++ b/Source/Details/ASCollectionLayoutContext.mm
@@ -85,7 +85,9 @@
 {
   struct {
     CGSize viewportSize;
-    ASScrollDirection scrollableDirections;
+    // Fields must be aligned without padding, otherwise hash result will be different for the same
+    // struct. That's why we use NSUInteger instead of ASScrollDirection.
+    NSUInteger scrollableDirections;
     NSUInteger elementsHash;
     NSUInteger layoutDelegateClassHash;
     NSUInteger additionalInfoHash;


### PR DESCRIPTION
alternatively

- (NSUInteger)hash
{
#pragma pack(push,1)
  struct {
    CGSize viewportSize;
    ASScrollDirection scrollableDirections;
    NSUInteger elementsHash;
    NSUInteger layoutDelegateClassHash;
    NSUInteger additionalInfoHash;
  } data = {
    _viewportSize,
    _scrollableDirections,
    _elements.hash,
    _layoutDelegateClass.hash,
    [_additionalInfo hash]
  };
#pragma pack(pop)
  return ASHashBytes(&data, sizeof(data));
}

I am less confident about what #pragma pack(push,1) is doing 