### PR TITLE
Remove AssetsLibrary dependency for tvOS

### DIFF
--- a/Texture.podspec
+++ b/Texture.podspec
@@ -83,8 +83,8 @@ Pod::Spec.new do |spec|
   end
 
   spec.subspec 'AssetsLibrary' do |assetslib|
-    assetslib.frameworks = 'AssetsLibrary'
-    assetslib.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) AS_USE_ASSETS_LIBRARY=1' }
+    assetslib.ios.frameworks = 'AssetsLibrary'
+    assetslib.ios.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) AS_USE_ASSETS_LIBRARY=1' }
     assetslib.dependency 'Texture/Core'
   end
 


### PR DESCRIPTION
- The framework isn't available on tvOS. This causes CocoaPods linting to fail which prevented me from pushing the new release out.
- One way to fix this is to have a different `default_subspecs` for tvOS that doesn't have AssetsLibrary subspec, but per-platform `default_subspecs` doesn't seem to be supported by CocoaPods. So I updated the subspec itself to only depend on the framework for iOS. This means the subspec is empty/useless for tvOS (and other platforms FWIW).
- Tested with `pod spec lint Texture.podspec`.
- Fixes #1992 and part of #1549. Also unblocks 3.1.0 release.
- For the long term, we can remove the subspec entirely when iOS 9 is deprecated (#1828).