### PR TITLE
Always use the correct representation when drawing image

### DIFF
--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -181,7 +181,6 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
 
   _imageNodeFlags.cropEnabled = YES;
   _imageNodeFlags.forceUpscaling = NO;
-  _imageNodeFlags.regenerateFromImageAsset = NO;
   _cropRect = CGRectMake(0.5, 0.5, 0, 0);
   _cropDisplayBounds = CGRectNull;
   _placeholderColor = ASDisplayNodeDefaultPlaceholderColor();
@@ -295,8 +294,7 @@ typedef void (^ASImageNodeDrawParametersBlock)(ASWeakMapEntry *entry);
     ASLockScopeSelf();
     UIImage *drawImage = _image;
     if (AS_AVAILABLE_IOS_TVOS(13, 10)) {
-      if (_imageNodeFlags.regenerateFromImageAsset && drawImage != nil) {
-        _imageNodeFlags.regenerateFromImageAsset = NO;
+      if (drawImage != nil && drawImage.imageAsset != nil) {
         UITraitCollection *tc = [UITraitCollection traitCollectionWithUserInterfaceStyle:_primitiveTraitCollection.userInterfaceStyle];
         UIImage *generatedImage = [drawImage.imageAsset imageWithTraitCollection:tc];
         if ( generatedImage != nil ) {
@@ -775,19 +773,6 @@ static ASWeakMap<ASImageNodeContentsKey *, UIImage *> *cache = nil;
     NSFontAttributeName: [UIFont systemFontOfSize:15.0],
     NSForegroundColorAttributeName: [UIColor redColor]
   };
-}
-
-- (void)asyncTraitCollectionDidChangeWithPreviousTraitCollection:(ASPrimitiveTraitCollection)previousTraitCollection {
-  [super asyncTraitCollectionDidChangeWithPreviousTraitCollection:previousTraitCollection];
-
-  if (AS_AVAILABLE_IOS_TVOS(13, 10)) {
-    AS::MutexLocker l(__instanceLock__);
-      // update image if userInterfaceStyle was changed (dark mode)
-      if (_image != nil
-          && _primitiveTraitCollection.userInterfaceStyle != previousTraitCollection.userInterfaceStyle) {
-        _imageNodeFlags.regenerateFromImageAsset = YES;
-      }
-  }
 }
 
 

--- a/Source/Private/ASImageNode+AnimatedImagePrivate.h
+++ b/Source/Private/ASImageNode+AnimatedImagePrivate.h
@@ -28,7 +28,6 @@
     unsigned int animatedImagePaused:1;
     unsigned int cropEnabled:1; // Defaults to YES.
     unsigned int forceUpscaling:1; //Defaults to NO.
-    unsigned int regenerateFromImageAsset:1; //Defaults to NO.
   } _imageNodeFlags;
 }
 


### PR DESCRIPTION
Before this change, the image asset (which may contain multiple reps
of an image for differing traits) was only consulted when the trait
collection changed. But in cases where display was scheduled
on the node and the trait collection had not changed, the image node
ends up with the default representation instead.

An example of this:

You have an image asset with two versions: light (default) and dark.
The device is currently in dark mode
The image is being presented in an item in a collection node.

1. Item node is first added to hierarchy. Trait collection doesn't match
so regenerateFromImageAsset=true.
2. Dark image is rendered, as expected
3. Item node is scrolled off screen
4. Item is scrolled back on screen
5. This triggers display on the item node
6. Trait collection has NOT changed so regenerateFromImageAsset=false
7. So, imageAsset is not consulted and default (Light) image is rendered

After looking at this a lot, I don’t see any reason why we need the
regenerateFromImageAsset flag at all (introduced in #1663).  Whenever
the image node is displayed we need to make sure we are generating the
correct representation.