### PR TITLE
Add missing PINRemoteImage to IGListKit subspecs to make working with images as smooth as in Texture. 

### DIFF
--- a/Texture.podspec
+++ b/Texture.podspec
@@ -50,6 +50,7 @@ Pod::Spec.new do |spec|
     igl.dependency 'IGListKit', '~> 4.0'
     igl.dependency 'IGListDiffKit', '~> 4.0'
     igl.dependency 'Texture/Core'
+    igl.dependency 'Texture/PINRemoteImage'
   end
 
   spec.subspec 'Yoga' do |yoga|


### PR DESCRIPTION
Currently when we opt to use IGListKit supported version of Texture we have to specify in Podfile like so: - 
`pod 'Texture/IGListKit'` doing so will just install `Texture/Core `and `IGListKit`  without `PINRemoteImage` unless we manually install it if we want to take advantage of image caching and other cool stuffs from `PINRemoteImage`. 

However the behavior is different when installing Texture without IGListKit,If I specify `pod 'Texture'` and run pod install it automatically download `PINRemoteImage` without listing it manually in `Podfile`. 


This PR makes `'Texture/IGListKit'` behave the same way by automatically install PINRemoteImage without listing in manually in Podfile. 

I have simply added  PINRemoteImage as one of the dependencies of IGListKit  in /Texture.podspec
ie: (`igl.dependency 'Texture/PINRemoteImage'`) 