### PR TITLE
Bring back ASInitializeFrameworkMainThread so we don't break the API

### DIFF
--- a/Source/Private/ASInternalHelpers.h
+++ b/Source/Private/ASInternalHelpers.h
@@ -20,6 +20,10 @@ NS_ASSUME_NONNULL_BEGIN
 ASDK_EXTERN void ASInitializeFrameworkMainThreadOnConstructor(void);
 ASDK_EXTERN void ASInitializeFrameworkMainThreadOnDestructor(void);
 
+// Calls both ASInitializeFrameworkMainThreadOnConstructor and ASInitializeFrameworkMainThreadOnDestructor
+// Used when manually initializing texture
+ASDK_EXTERN void ASInitializeFrameworkMainThread(void);
+
 ASDK_EXTERN BOOL ASDefaultAllowsGroupOpacity(void);
 ASDK_EXTERN BOOL ASDefaultAllowsEdgeAntialiasing(void);
 

--- a/Source/Private/ASInternalHelpers.mm
+++ b/Source/Private/ASInternalHelpers.mm
@@ -89,6 +89,12 @@ void ASInitializeFrameworkMainThreadOnDestructor(void)
   });
 }
 
+ASDK_EXTERN void ASInitializeFrameworkMainThread(void)
+{
+  ASInitializeFrameworkMainThreadOnConstructor();
+  ASInitializeFrameworkMainThreadOnDestructor();
+}
+
 BOOL ASSubclassOverridesSelector(Class superclass, Class subclass, SEL selector)
 {
   if (superclass == subclass) return NO; // Even if the class implements the selector, it doesn't override itself.


### PR DESCRIPTION
In PR 2032 we added alloc/dealloc texture initialization methods for the case where texture is automatically initializing. However, in doing so we have removed the `ASInitializeFrameworkMainThread` method that clients may already be using.

This PR brings back the `ASInitializeFrameworkMainThread` to live side by side with `ASInitializeFrameworkMainThreadOnConstructor` and `ASInitializeFrameworkMainThreadOnDestructor`. This should keep the old functionality in place for any client using `ASInitializeFrameworkMainThread` directly.