### PR TITLE
Don't mirror isAccessibilityElement on _ASTableViewCell

### DIFF
--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -116,7 +116,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     self.selectionStyle = node.selectionStyle; 
     self.focusStyle = node.focusStyle;
     self.accessoryType = node.accessoryType;
-    self.isAccessibilityElement = node.isAccessibilityElement;
     self.accessibilityElementsHidden = node.accessibilityElementsHidden;
     // the following ensures that we clip the entire cell to it's bounds if node.clipsToBounds is set (the default)
     // This is actually a workaround for a bug we are seeing in some rare cases (selected background view


### PR DESCRIPTION
This is a partial revert of #1941

The change in #1941 has caused some issues for us and others (see #1997). If I set `myNode.isAccessibilityElement = true,` then what ends up happening is that the table cell wrapper view (_ASTableViewCell) also has `isAccessibilityElement = true`. But then when iOS goes through the hierarchy it identifies the table cell wrapper view as the target and attempts to use that accessibilityLabel, which doesn't exist (because it's actually on the nested node view). So our node's label is never used.

I'm not sure why setting `isAccessibilityElement` in `_ASTableViewCell` was necessary in #1941 in order to make a node non-accessible, since the default value is already false.