### PR TITLE
Clean out NSNulls in removedSubnodes list (fixes #2059)

### DIFF
--- a/Source/Private/ASLayoutTransition.mm
+++ b/Source/Private/ASLayoutTransition.mm
@@ -184,7 +184,11 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
                                             moves:&moves];
 
     _insertedSubnodePositions = findNodesInLayoutAtIndexes(pendingLayout, insertions, &_insertedSubnodes);
-    _removedSubnodes = [previousNodes objectsAtIndexes:deletions];
+    
+    NSMutableArray *mutableRemovedNodes = [[previousNodes objectsAtIndexes:deletions] mutableCopy];
+    [mutableRemovedNodes removeObjectIdenticalTo:[NSNull null]];
+    _removedSubnodes = [mutableRemovedNodes copy];
+      
     // These should arrive sorted in ascending order of move destinations.
     for (NSIndexPath *move in moves) {
       _subnodeMoves.emplace_back(previousLayout.sublayouts[([move indexAtPosition:0])].layoutElement,


### PR DESCRIPTION
This PR fixes https://github.com/TextureGroup/Texture/issues/2059.

Starting Swift 5.6 (Xcode 13.3), I'm seeing `NSNull`s populating the `_removedSubnodes` list and causing `unrecognized selector` crashes. I'm not sure where this is coming from because it only occurs in Release builds which makes debugging really hard, but I have confirmed this PR to fix the issue.

If anyone can provide a better fix, please suggest.
