### PR TITLE
Switch UITextWritingDirection to NSWritingDirection

### DIFF
--- a/Source/TextExperiment/Component/ASTextInput.h
+++ b/Source/TextExperiment/Component/ASTextInput.h
@@ -75,7 +75,7 @@ typedef NS_ENUM(NSInteger, ASTextAffinity) {
 @interface ASTextSelectionRect : UITextSelectionRect <NSCopying>
 
 @property (nonatomic) CGRect rect;
-@property (nonatomic) UITextWritingDirection writingDirection;
+@property (nonatomic) NSWritingDirection writingDirection;
 @property (nonatomic) BOOL containsStart;
 @property (nonatomic) BOOL containsEnd;
 @property (nonatomic) BOOL isVertical;


### PR DESCRIPTION
UITextWritingDirection was deprecated in iOS 13 and NSWritingDirection was introduced in iOS 6