### PR TITLE
[ASTextKitRenderer] Adding locking when accessing the text renderer cache

### DIFF
--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -31,6 +31,8 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalDisableGlobalTextkitLock = 1 << 10,                         // exp_disable_global_textkit_lock
   ASExperimentalMainThreadOnlyDataController = 1 << 11,                     // exp_main_thread_only_data_controller
   ASExperimentalRangeUpdateOnChangesetUpdate = 1 << 12,                     // exp_range_update_on_changeset_update
+  ASExperimentalNoTextRendererCache = 1 << 13,                              // exp_no_text_renderer_cache
+  ASExperimentalLockTextRendererCache = 1 << 14,                            // exp_lock_text_renderer_cache
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -24,7 +24,10 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_optimize_data_controller_pipeline",
                                       @"exp_disable_global_textkit_lock",
                                       @"exp_main_thread_only_data_controller",
-                                      @"exp_range_update_on_changeset_update"]));
+                                      @"exp_range_update_on_changeset_update",
+                                      @"exp_no_text_renderer_cache",
+                                      @"exp_lock_text_renderer_cache"]));
+
   if (flags == ASExperimentalFeatureAll) {
     return allNames;
   }


### PR DESCRIPTION
While NSCache is thread safe, that alone does not make `rendererForAttributes` thread safe. This experiment will add a lock to `rendererForAttributes` to see how that affects performance/stability. As second experiment will forego the cache altogether to validate that we are getting some value out of having a renderer cache.