### PR TITLE
Fix xcode 14.3 deprecation warning

### DIFF
--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -20,7 +20,7 @@
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 #import <AsyncDisplayKit/ASRecursiveUnfairLock.h>
 
-ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT BOOL ASDisplayNodeThreadIsMain()
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT BOOL ASDisplayNodeThreadIsMain(void)
 {
   return 0 != pthread_main_np();
 }

--- a/Source/Layout/ASDimensionInternal.h
+++ b/Source/Layout/ASDimensionInternal.h
@@ -38,7 +38,7 @@ typedef struct {
 /**
  * Returns an ASLayoutElementSize with default values.
  */
-ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASLayoutElementSize ASLayoutElementSizeMake()
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASLayoutElementSize ASLayoutElementSizeMake(void)
 {
   return (ASLayoutElementSize){
     .width = ASDimensionAuto,


### PR DESCRIPTION
This PR fixes the following deprecation warning: "Function declaration without a prototype"