### PR TITLE
[_ASDisplayLayer] Add protection around setting a layer’s position and transform

### DIFF
--- a/Source/Details/_ASDisplayLayer.mm
+++ b/Source/Details/_ASDisplayLayer.mm
@@ -39,6 +39,26 @@
   }
 }
 
+- (void)setPosition:(CGPoint)position
+{
+  BOOL valid = ASDisplayNodeAssertNonFatal(ASIsCGPositionValidForLayout(position), @"Caught attempt to set invalid position %@ on %@.", NSStringFromCGPoint(position), self);
+  if (!valid) {
+    return;
+  }
+  
+  [super setPosition:position];
+}
+
+- (void)setTransform:(CATransform3D)transform
+{
+  BOOL valid = ASDisplayNodeAssertNonFatal(ASIsTransformValidForLayout(transform), @"Caught attempt to set invalid transform on %@.", self);
+  if (!valid) {
+    return;
+  }
+  
+  [super setTransform:transform];
+}
+
 - (void)setBounds:(CGRect)bounds
 {
   BOOL valid = ASDisplayNodeAssertNonFatal(ASIsCGRectValidForLayout(bounds), @"Caught attempt to set invalid bounds %@ on %@.", NSStringFromCGRect(bounds), self);

--- a/Source/Layout/ASDimension.h
+++ b/Source/Layout/ASDimension.h
@@ -12,6 +12,7 @@
 #import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 #import <AsyncDisplayKit/ASAssert.h>
+#import <QuartzCore/QuartzCore.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -52,6 +53,14 @@ ASDISPLAYNODE_INLINE BOOL ASIsCGPositionValidForLayout(CGPoint point)
 ASDISPLAYNODE_INLINE BOOL ASIsCGRectValidForLayout(CGRect rect)
 {
   return (ASIsCGPositionValidForLayout(rect.origin) && ASIsCGSizeValidForLayout(rect.size));
+}
+
+ASDISPLAYNODE_INLINE BOOL ASIsTransformValidForLayout(CATransform3D t)
+{
+  return !isnan(t.m11) && !isnan(t.m12) && !isnan(t.m13) && !isnan(t.m14) &&
+  !isnan(t.m21) && !isnan(t.m22) && !isnan(t.m23) && !isnan(t.m24) &&
+  !isnan(t.m31) && !isnan(t.m32) && !isnan(t.m33) && !isnan(t.m34) &&
+  !isnan(t.m41) && !isnan(t.m42) && !isnan(t.m43) && !isnan(t.m44);
 }
 
 #pragma mark - ASDimension

--- a/Tests/ASDisplayLayerTests.mm
+++ b/Tests/ASDisplayLayerTests.mm
@@ -595,4 +595,117 @@ static _ASDisplayLayerTestDelegateClassModes _class_modes;
   [self checkSuspendResume:NO];
 }
 
+- (void)testSetPosition
+{
+  _ASDisplayLayer *layer = [[_ASDisplayLayer alloc] init];
+  CGPoint origin = CGPointMake(20, 20);
+  layer.position = CGPointZero; // Make sure CGPointZero doesn't throw
+  
+  layer.position = origin;
+  XCTAssertTrue(CGPointEqualToPoint(layer.position, origin));
+  
+  XCTAssertThrows(layer.position = CGPointMake(NAN, 50));
+  XCTAssertTrue(CGPointEqualToPoint(layer.position, origin));
+  
+  XCTAssertThrows(layer.position = CGPointMake(NAN, NAN));
+  XCTAssertTrue(CGPointEqualToPoint(layer.position, origin));
+  
+  XCTAssertThrows(layer.position = CGPointMake(50, NAN));
+  XCTAssertTrue(CGPointEqualToPoint(layer.position, origin));
+  
+  origin = CGPointMake(10, 10);
+  layer.position = origin;
+  XCTAssertTrue(CGPointEqualToPoint(layer.position, origin));
+}
+
+- (void)testSetTransform
+{
+  _ASDisplayLayer *layer = [[_ASDisplayLayer alloc] init];
+  
+  CATransform3D transform = CATransform3DIdentity;
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  
+  transform.m11 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m12 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m13 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m14 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m21 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m22 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m23 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m24 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m31 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m32 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m33 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m34 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m41 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m42 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m43 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  transform.m44 = NAN;
+  XCTAssertThrows(layer.transform = transform);
+  XCTAssertTrue(CATransform3DEqualToTransform(layer.transform, CATransform3DIdentity));
+  transform = CATransform3DIdentity;
+  
+  layer.transform = transform;
+}
+
 @end


### PR DESCRIPTION
There is built in protection around setting invalid bounds for `_ASDisplayLayer`. Let’s extend this to also include protecting against setting an invalid position and an invalid transform.