### PR TITLE
Add NS_SWIFT_UI_ACTOR to methods always called on main

### DIFF
--- a/Source/ASCellNode.h
+++ b/Source/ASCellNode.h
@@ -133,7 +133,7 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  * The backing view controller, or @c nil if the node wasn't initialized with backing view controller
  * @note This property must be accessed on the main thread.
  */
-@property (nullable, nonatomic, readonly) UIViewController *viewController;
+@property (nullable, nonatomic, readonly) UIViewController *viewController NS_SWIFT_UI_ACTOR;
 
 
 /**

--- a/Source/ASCollectionNode+Beta.h
+++ b/Source/ASCollectionNode+Beta.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The elements that are currently displayed. The "UIKit index space". Must be accessed on main thread.
  */
-@property (nonatomic, readonly) ASElementMap *visibleElements;
+@property (nonatomic, readonly) ASElementMap *visibleElements NS_SWIFT_UI_ACTOR;
 
 @property (nullable, readonly) id<ASCollectionLayoutDelegate> layoutDelegate;
 
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  When isSynchronized == YES, the block is run block immediately (before the method returns).
  */
-- (void)onDidFinishSynchronizing:(void (^)(void))didFinishSynchronizing;
+- (void)onDidFinishSynchronizing:(NS_SWIFT_UI_ACTOR void (^)(void))didFinishSynchronizing;
 
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(nullable id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator;
 

--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -266,7 +266,7 @@ NS_ASSUME_NONNULL_BEGIN
  *                    Boolean parameter that contains the value YES if all of the related animations completed successfully or
  *                    NO if they were interrupted. This parameter may be nil. If supplied, the block is run on the main thread.
  */
-- (void)performBatchAnimated:(BOOL)animated updates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable void (^)(BOOL finished))completion NS_SWIFT_UI_ACTOR;
+- (void)performBatchAnimated:(BOOL)animated updates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable NS_SWIFT_UI_ACTOR void (^)(BOOL finished))completion NS_SWIFT_UI_ACTOR;
 
 /**
  *  Perform a batch of updates asynchronously, optionally disabling all animations in the batch. This method must be called from the main thread.

--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -226,7 +226,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * This method must be called on the main thread.
  */
-- (void)scrollToItemAtIndexPath:(NSIndexPath *)indexPath atScrollPosition:(UICollectionViewScrollPosition)scrollPosition animated:(BOOL)animated;
+- (void)scrollToItemAtIndexPath:(NSIndexPath *)indexPath atScrollPosition:(UICollectionViewScrollPosition)scrollPosition animated:(BOOL)animated NS_SWIFT_UI_ACTOR;
 
 /**
  * Determines collection node's current scroll direction. Supports 2-axis collection nodes.
@@ -266,7 +266,7 @@ NS_ASSUME_NONNULL_BEGIN
  *                    Boolean parameter that contains the value YES if all of the related animations completed successfully or
  *                    NO if they were interrupted. This parameter may be nil. If supplied, the block is run on the main thread.
  */
-- (void)performBatchAnimated:(BOOL)animated updates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable void (^)(BOOL finished))completion;
+- (void)performBatchAnimated:(BOOL)animated updates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable void (^)(BOOL finished))completion NS_SWIFT_UI_ACTOR;
 
 /**
  *  Perform a batch of updates asynchronously, optionally disabling all animations in the batch. This method must be called from the main thread.
@@ -277,7 +277,7 @@ NS_ASSUME_NONNULL_BEGIN
  *                    Boolean parameter that contains the value YES if all of the related animations completed successfully or
  *                    NO if they were interrupted. This parameter may be nil. If supplied, the block is run on the main thread.
  */
-- (void)performBatchUpdates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable void (^)(BOOL finished))completion;
+- (void)performBatchUpdates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable void (^)(BOOL finished))completion NS_SWIFT_UI_ACTOR;
 
 /**
  *  Returns YES if the ASCollectionNode is still processing changes from performBatchUpdates:.
@@ -306,7 +306,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  Calling -waitUntilAllUpdatesAreProcessed is one way to flush any pending update completion blocks.
  */
-- (void)onDidFinishProcessingUpdates:(void (^)(void))didFinishProcessingUpdates;
+- (void)onDidFinishProcessingUpdates:(NS_SWIFT_UI_ACTOR void (^)(void))didFinishProcessingUpdates;
 
 /**
  *  Blocks execution of the main thread until all section and item updates are committed to the view. This method must be called from the main thread.
@@ -321,7 +321,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The data source must be updated to reflect the changes
  * before this method is called.
  */
-- (void)insertSections:(NSIndexSet *)sections;
+- (void)insertSections:(NSIndexSet *)sections NS_SWIFT_UI_ACTOR;
 
 /**
  * Deletes one or more sections.
@@ -331,7 +331,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The data source must be updated to reflect the changes
  * before this method is called.
  */
-- (void)deleteSections:(NSIndexSet *)sections;
+- (void)deleteSections:(NSIndexSet *)sections NS_SWIFT_UI_ACTOR;
 
 /**
  * Reloads the specified sections.
@@ -341,7 +341,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The data source must be updated to reflect the changes
  * before this method is called.
  */
-- (void)reloadSections:(NSIndexSet *)sections;
+- (void)reloadSections:(NSIndexSet *)sections NS_SWIFT_UI_ACTOR;
 
 /**
  * Moves a section to a new location.
@@ -353,7 +353,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The data source must be updated to reflect the changes
  * before this method is called.
  */
-- (void)moveSection:(NSInteger)section toSection:(NSInteger)newSection;
+- (void)moveSection:(NSInteger)section toSection:(NSInteger)newSection NS_SWIFT_UI_ACTOR;
 
 /**
  * Inserts items at the locations identified by an array of index paths.
@@ -363,7 +363,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The data source must be updated to reflect the changes
  * before this method is called.
  */
-- (void)insertItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
+- (void)insertItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths NS_SWIFT_UI_ACTOR;
 
 /**
  * Deletes the items specified by an array of index paths.
@@ -373,7 +373,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The data source must be updated to reflect the changes
  * before this method is called.
  */
-- (void)deleteItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
+- (void)deleteItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths NS_SWIFT_UI_ACTOR;
 
 /**
  * Reloads the specified items.
@@ -383,7 +383,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The data source must be updated to reflect the changes
  * before this method is called.
  */
-- (void)reloadItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
+- (void)reloadItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths NS_SWIFT_UI_ACTOR;
 
 /**
  * Moves the item at a specified location to a destination location.
@@ -395,7 +395,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The data source must be updated to reflect the changes
  * before this method is called.
  */
-- (void)moveItemAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath;
+- (void)moveItemAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath NS_SWIFT_UI_ACTOR;
 
 /**
  * Reload everything from scratch, destroying the working range and all cached nodes.
@@ -404,7 +404,7 @@ NS_ASSUME_NONNULL_BEGIN
  * the main thread.
  * @warning This method is substantially more expensive than UICollectionView's version.
  */
-- (void)reloadDataWithCompletion:(nullable void (^)(void))completion;
+- (void)reloadDataWithCompletion:(nullable NS_SWIFT_UI_ACTOR void (^)(void))completion;
 
 
 /**
@@ -441,7 +441,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This method must be called from the main thread.
  */
-- (void)selectItemAtIndexPath:(nullable NSIndexPath *)indexPath animated:(BOOL)animated scrollPosition:(UICollectionViewScrollPosition)scrollPosition;
+- (void)selectItemAtIndexPath:(nullable NSIndexPath *)indexPath animated:(BOOL)animated scrollPosition:(UICollectionViewScrollPosition)scrollPosition NS_SWIFT_UI_ACTOR;
 
 /**
  * Deselects the item at the specified index.
@@ -454,7 +454,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This method must be called from the main thread.
  */
-- (void)deselectItemAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated;
+- (void)deselectItemAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated NS_SWIFT_UI_ACTOR;
 
 #pragma mark - Querying Data
 
@@ -477,7 +477,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return an array containing the nodes being displayed on screen. This must be called on the main thread.
  */
-@property (nonatomic, readonly) NSArray<__kindof ASCellNode *> *visibleNodes;
+@property (nonatomic, readonly) NSArray<__kindof ASCellNode *> *visibleNodes NS_SWIFT_UI_ACTOR;
 
 /**
  * Retrieves the node for the item at the given index path.
@@ -513,7 +513,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return an array containing the index paths of all visible items. This must be called on the main thread.
  */
-@property (nonatomic, readonly) NSArray<NSIndexPath *> *indexPathsForVisibleItems;
+@property (nonatomic, readonly) NSArray<NSIndexPath *> *indexPathsForVisibleItems NS_SWIFT_UI_ACTOR;
 
 /**
  * Retrieve the index path of the item at the given point.
@@ -522,7 +522,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return The indexPath for the item at the given point. This must be called on the main thread.
  */
-- (nullable NSIndexPath *)indexPathForItemAtPoint:(CGPoint)point AS_WARN_UNUSED_RESULT;
+- (nullable NSIndexPath *)indexPathForItemAtPoint:(CGPoint)point AS_WARN_UNUSED_RESULT NS_SWIFT_UI_ACTOR;
 
 /**
  * Retrieve the cell at the given index path.
@@ -531,7 +531,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return The cell for the given index path. This must be called on the main thread.
  */
-- (nullable UICollectionViewCell *)cellForItemAtIndexPath:(NSIndexPath *)indexPath;
+- (nullable UICollectionViewCell *)cellForItemAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_UI_ACTOR;
 
 /**
  * Retrieves the context object for the given section, as provided by the data source in
@@ -610,7 +610,7 @@ NS_ASSUME_NONNULL_BEGIN
  *   not implement reuse (it will be called once per item).  Unlike UICollectionView's version,
  *   this method is not called when the item is about to display.
  */
-- (ASCellNode *)collectionNode:(ASCollectionNode *)collectionNode nodeForItemAtIndexPath:(NSIndexPath *)indexPath;
+- (ASCellNode *)collectionNode:(ASCollectionNode *)collectionNode nodeForItemAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_UI_ACTOR;
 
 /**
  * Asks the data source to provide a node-block to display for the given supplementary element in the collection view.

--- a/Source/ASCollectionView.h
+++ b/Source/ASCollectionView.h
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return The context object, or @c nil if no context was provided.
  */
-- (nullable id<ASSectionContext>)contextForSection:(NSInteger)section AS_WARN_UNUSED_RESULT;
+- (nullable id<ASSectionContext>)contextForSection:(NSInteger)section AS_WARN_UNUSED_RESULT NS_SWIFT_UI_ACTOR;
 
 @end
 

--- a/Source/ASDisplayNode+Convenience.h
+++ b/Source/ASDisplayNode+Convenience.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @warning This property may only be accessed on the main thread. This property may
  *   be @c nil until the node's view is actually hosted in the view hierarchy.
  */
-@property (nonatomic, nullable, readonly) __kindof UIViewController *closestViewController;
+@property (nonatomic, nullable, readonly) __kindof UIViewController *closestViewController NS_SWIFT_UI_ACTOR;
 
 @end
 

--- a/Source/ASDisplayNode+InterfaceState.h
+++ b/Source/ASDisplayNode+InterfaceState.h
@@ -46,63 +46,63 @@ typedef NS_OPTIONS(unsigned char, ASInterfaceState)
  * @discussion Subclasses may use this to monitor when they become visible, should free cached data, and much more.
  * @see ASInterfaceState
  */
-- (void)interfaceStateDidChange:(ASInterfaceState)newState fromState:(ASInterfaceState)oldState;
+- (void)interfaceStateDidChange:(ASInterfaceState)newState fromState:(ASInterfaceState)oldState NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Called whenever the node becomes visible.
  * @discussion Subclasses may use this to monitor when they become visible.
  * @note This method is guaranteed to be called on main.
  */
-- (void)didEnterVisibleState;
+- (void)didEnterVisibleState NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Called whenever the node is no longer visible.
  * @discussion Subclasses may use this to monitor when they are no longer visible.
  * @note This method is guaranteed to be called on main.
  */
-- (void)didExitVisibleState;
+- (void)didExitVisibleState NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Called whenever the the node has entered the display state.
  * @discussion Subclasses may use this to monitor when a node should be rendering its content.
  * @note This method is guaranteed to be called on main.
  */
-- (void)didEnterDisplayState;
+- (void)didEnterDisplayState NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Called whenever the the node has exited the display state.
  * @discussion Subclasses may use this to monitor when a node should no longer be rendering its content.
  * @note This method is guaranteed to be called on main.
  */
-- (void)didExitDisplayState;
+- (void)didExitDisplayState NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Called whenever the the node has entered the preload state.
  * @discussion Subclasses may use this to monitor data for a node should be preloaded, either from a local or remote source.
  * @note This method is guaranteed to be called on main.
  */
-- (void)didEnterPreloadState;
+- (void)didEnterPreloadState NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Called whenever the the node has exited the preload state.
  * @discussion Subclasses may use this to monitor whether preloading data for a node should be canceled.
  * @note This method is guaranteed to be called on main.
  */
-- (void)didExitPreloadState;
+- (void)didExitPreloadState NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Called when the node has completed applying the layout.
  * @discussion Can be used for operations that are performed after layout has completed.
  * @note This method is guaranteed to be called on main.
  */
-- (void)nodeDidLayout;
+- (void)nodeDidLayout NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Called when the node loads.
  * @discussion Can be used for operations that are performed after the node's view is available.
  * @note This method is guaranteed to be called on main.
  */
-- (void)nodeDidLoad;
+- (void)nodeDidLoad NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Indicates that the receiver and all subnodes have finished displaying.
@@ -114,7 +114,7 @@ typedef NS_OPTIONS(unsigned char, ASInterfaceState)
  * the progressImage block.
  * @note This method is guaranteed to be called on main.
  */
-- (void)hierarchyDisplayDidFinish;
+- (void)hierarchyDisplayDidFinish NS_SWIFT_UI_ACTOR;
 
 @optional
 /**
@@ -125,7 +125,7 @@ typedef NS_OPTIONS(unsigned char, ASInterfaceState)
  * to attempt to ascend the node tree when handling this, as the root node is locked when this is
  * called.
  */
-- (void)nodeWillCalculateLayout:(ASSizeRange)constrainedSize;
+- (void)nodeWillCalculateLayout:(ASSizeRange)constrainedSize NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Called when the node's layer is about to enter the hierarchy.
@@ -134,7 +134,7 @@ typedef NS_OPTIONS(unsigned char, ASInterfaceState)
  * re-parented multiple times, and each time will trigger this call.
  * @note This method is guaranteed to be called on main.
  */
-- (void)didEnterHierarchy;
+- (void)didEnterHierarchy NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Called when the node's layer has exited the hierarchy.
@@ -143,6 +143,6 @@ typedef NS_OPTIONS(unsigned char, ASInterfaceState)
  * re-parented multiple times, and each time will trigger this call.
  * @note This method is guaranteed to be called on main.
  */
-- (void)didExitHierarchy;
+- (void)didExitHierarchy NS_SWIFT_UI_ACTOR;
 
 @end

--- a/Source/ASDisplayNode+Subclasses.h
+++ b/Source/ASDisplayNode+Subclasses.h
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This is the best time to add gesture recognizers to the view.
  */
 AS_CATEGORY_IMPLEMENTABLE
-- (void)didLoad ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)didLoad ASDISPLAYNODE_REQUIRES_SUPER NS_SWIFT_UI_ACTOR;
 
 /**
  * An empty method that you can implement in a category to add global
@@ -95,7 +95,7 @@ AS_CATEGORY_IMPLEMENTABLE
  *
  * @discussion Subclasses override this method to layout all subnodes or subviews.
  */
-- (void)layout ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)layout ASDISPLAYNODE_REQUIRES_SUPER NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Called on the main thread by the view's -layoutSubviews, after -layout.
@@ -104,7 +104,7 @@ AS_CATEGORY_IMPLEMENTABLE
  * out.
  */
 AS_CATEGORY_IMPLEMENTABLE
-- (void)layoutDidFinish ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)layoutDidFinish ASDISPLAYNODE_REQUIRES_SUPER NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Called on a background thread if !isNodeLoaded - called on the main thread if isNodeLoaded.
@@ -255,7 +255,7 @@ AS_CATEGORY_IMPLEMENTABLE
  *
  * @note Called on the main thread only
  */
-- (nullable id<NSObject>)drawParametersForAsyncLayer:(_ASDisplayLayer *)layer;
+- (nullable id<NSObject>)drawParametersForAsyncLayer:(_ASDisplayLayer *)layer NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Indicates that the receiver is about to display.
@@ -317,7 +317,7 @@ AS_CATEGORY_IMPLEMENTABLE
  * @discussion Called by -recursivelyClearContents. Always called on main thread. Base class implements self.contents = nil, clearing any backing
  * store, for asynchronous regeneration when needed.
  */
-- (void)clearContents ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)clearContents ASDISPLAYNODE_REQUIRES_SUPER NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Indicates that the receiver is about to display its subnodes. This method is not called if there are no

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -124,7 +124,7 @@ ASDK_EXTERN NSInteger const ASDefaultDrawingPriority;
  * @return An ASDisplayNode instance that loads its view with the given block that is guaranteed to run on the main
  * queue. The view will render synchronously and -layout and touch handling methods on the node will not be called.
  */
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock;
+- (instancetype)initWithViewBlock:(NS_SWIFT_UI_ACTOR ASDisplayNodeViewBlock)viewBlock;
 
 /**
  * @abstract Alternative initializer with a block to create the backing view.
@@ -135,7 +135,8 @@ ASDK_EXTERN NSInteger const ASDefaultDrawingPriority;
  * @return An ASDisplayNode instance that loads its view with the given block that is guaranteed to run on the main
  * queue. The view will render synchronously and -layout and touch handling methods on the node will not be called.
  */
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock;
+- (instancetype)initWithViewBlock:(NS_SWIFT_UI_ACTOR ASDisplayNodeViewBlock)viewBlock
+                     didLoadBlock:(nullable NS_SWIFT_UI_ACTOR ASDisplayNodeDidLoadBlock)didLoadBlock;
 
 /**
  * @abstract Alternative initializer with a block to create the backing layer.
@@ -145,7 +146,7 @@ ASDK_EXTERN NSInteger const ASDefaultDrawingPriority;
  * @return An ASDisplayNode instance that loads its layer with the given block that is guaranteed to run on the main
  * queue. The layer will render synchronously and -layout and touch handling methods on the node will not be called.
  */
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)layerBlock;
+- (instancetype)initWithLayerBlock:(NS_SWIFT_UI_ACTOR ASDisplayNodeLayerBlock)layerBlock;
 
 /**
  * @abstract Alternative initializer with a block to create the backing layer.
@@ -156,7 +157,8 @@ ASDK_EXTERN NSInteger const ASDefaultDrawingPriority;
  * @return An ASDisplayNode instance that loads its layer with the given block that is guaranteed to run on the main
  * queue. The layer will render synchronously and -layout and touch handling methods on the node will not be called.
  */
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)layerBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock;
+- (instancetype)initWithLayerBlock:(NS_SWIFT_UI_ACTOR ASDisplayNodeLayerBlock)layerBlock
+                      didLoadBlock:(nullable NS_SWIFT_UI_ACTOR  ASDisplayNodeDidLoadBlock)didLoadBlock;
 
 /**
  * @abstract Add a block of work to be performed on the main thread when the node's view or layer is loaded. Thread safe.
@@ -167,7 +169,7 @@ ASDK_EXTERN NSInteger const ASDefaultDrawingPriority;
  *
  * @precondition The node is not already loaded.
  */
-- (void)onDidLoad:(ASDisplayNodeDidLoadBlock)body;
+- (void)onDidLoad:(NS_SWIFT_UI_ACTOR ASDisplayNodeDidLoadBlock)body;
 
 /**
  * Set the block that should be used to load this node's view.
@@ -178,7 +180,7 @@ ASDK_EXTERN NSInteger const ASDefaultDrawingPriority;
  *
  * @note You will usually NOT call this. See the limitations documented in @c initWithViewBlock:
  */
-- (void)setViewBlock:(ASDisplayNodeViewBlock)viewBlock;
+- (void)setViewBlock:(NS_SWIFT_UI_ACTOR ASDisplayNodeViewBlock)viewBlock;
 
 /**
  * Set the block that should be used to load this node's layer.
@@ -189,7 +191,7 @@ ASDK_EXTERN NSInteger const ASDefaultDrawingPriority;
  *
  * @note You will usually NOT call this. See the limitations documented in @c initWithLayerBlock:
  */
-- (void)setLayerBlock:(ASDisplayNodeLayerBlock)layerBlock;
+- (void)setLayerBlock:(NS_SWIFT_UI_ACTOR ASDisplayNodeLayerBlock)layerBlock;
 
 /** 
  * @abstract Returns whether the node is synchronous.
@@ -275,7 +277,7 @@ ASDK_EXTERN NSInteger const ASDefaultDrawingPriority;
  *
  * @see ASInterfaceState
  */
-- (void)addInterfaceStateDelegate:(id <ASInterfaceStateDelegate>)interfaceStateDelegate;
+- (void)addInterfaceStateDelegate:(id <ASInterfaceStateDelegate>)interfaceStateDelegate NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Removes a delegate from receiving notifications on interfaceState changes.
@@ -284,7 +286,7 @@ ASDK_EXTERN NSInteger const ASDefaultDrawingPriority;
  *
  * @see ASInterfaceState
  */
-- (void)removeInterfaceStateDelegate:(id <ASInterfaceStateDelegate>)interfaceStateDelegate;
+- (void)removeInterfaceStateDelegate:(id <ASInterfaceStateDelegate>)interfaceStateDelegate NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Class property that allows to set a block that can be called on non-fatal errors. This
@@ -920,7 +922,7 @@ typedef NS_ENUM(NSInteger, ASLayoutEngineType) {
 - (void)transitionLayoutWithSizeRange:(ASSizeRange)constrainedSize
                              animated:(BOOL)animated
                    shouldMeasureAsync:(BOOL)shouldMeasureAsync
-                measurementCompletion:(nullable void(^)(void))completion;
+                measurementCompletion:(nullable void(^)(void))completion NS_SWIFT_UI_ACTOR;
 
 
 /**
@@ -937,7 +939,7 @@ typedef NS_ENUM(NSInteger, ASLayoutEngineType) {
  */
 - (void)transitionLayoutWithAnimation:(BOOL)animated
                    shouldMeasureAsync:(BOOL)shouldMeasureAsync
-                measurementCompletion:(nullable void(^)(void))completion;
+                measurementCompletion:(nullable void(^)(void))completion NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Cancels all performing layout transitions. Can be called on any thread.

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -922,7 +922,7 @@ typedef NS_ENUM(NSInteger, ASLayoutEngineType) {
 - (void)transitionLayoutWithSizeRange:(ASSizeRange)constrainedSize
                              animated:(BOOL)animated
                    shouldMeasureAsync:(BOOL)shouldMeasureAsync
-                measurementCompletion:(nullable void(^)(void))completion NS_SWIFT_UI_ACTOR;
+                measurementCompletion:(nullable NS_SWIFT_UI_ACTOR void(^)(void))completion NS_SWIFT_UI_ACTOR;
 
 
 /**
@@ -939,7 +939,7 @@ typedef NS_ENUM(NSInteger, ASLayoutEngineType) {
  */
 - (void)transitionLayoutWithAnimation:(BOOL)animated
                    shouldMeasureAsync:(BOOL)shouldMeasureAsync
-                measurementCompletion:(nullable void(^)(void))completion NS_SWIFT_UI_ACTOR;
+                measurementCompletion:(nullable NS_SWIFT_UI_ACTOR void(^)(void))completion NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract Cancels all performing layout transitions. Can be called on any thread.

--- a/Source/ASEditableTextNode.h
+++ b/Source/ASEditableTextNode.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
   @abstract Access to underlying UITextView for more configuration options.
   @warning This property should only be used on the main thread and should not be accessed before the editable text node's view is created.
  */
-@property (nonatomic, readonly) UITextView *textView;
+@property (nonatomic, readonly) UITextView *textView NS_SWIFT_UI_ACTOR;
 
 //! @abstract The attributes to apply to new text being entered by the user.
 @property (nullable, nonatomic, copy) NSDictionary<NSString *, id> *typingAttributes;

--- a/Source/ASImageNode.h
+++ b/Source/ASImageNode.h
@@ -119,7 +119,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image, 
  * `displaySuspended` is YES, `displayCompletionBlock` is will be
  * performed immediately and `YES` will be passed for `canceled`.
  */
-- (void)setNeedsDisplayWithCompletion:(nullable void (^)(BOOL canceled))displayCompletionBlock;
+- (void)setNeedsDisplayWithCompletion:(nullable NS_SWIFT_UI_ACTOR void (^)(BOOL canceled))displayCompletionBlock;
 
 #if TARGET_OS_TV
 /** 

--- a/Source/ASMapNode.h
+++ b/Source/ASMapNode.h
@@ -66,7 +66,7 @@ typedef NS_OPTIONS(NSUInteger, ASMapNodeShowAnnotationsOptions)
  
  If the live map view has been created, this may only be set on the main thread.
  */
-@property (nonatomic, weak) id <MKMapViewDelegate> mapDelegate;
+@property (nonatomic, weak) id <MKMapViewDelegate> mapDelegate NS_SWIFT_UI_ACTOR;
 
 /**
  * @abstract The annotations to display on the map.

--- a/Source/ASNetworkImageNode.h
+++ b/Source/ASNetworkImageNode.h
@@ -165,7 +165,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Called on the main thread.
  */
-- (void)imageNodeDidStartFetchingData:(ASNetworkImageNode *)imageNode;
+- (void)imageNodeDidStartFetchingData:(ASNetworkImageNode *)imageNode NS_SWIFT_UI_ACTOR;
 
 /**
  * Notification that the image node will load image from cache
@@ -174,7 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Called on the main thread.
  */
-- (void)imageNodeWillLoadImageFromCache:(ASNetworkImageNode *)imageNode;
+- (void)imageNodeWillLoadImageFromCache:(ASNetworkImageNode *)imageNode NS_SWIFT_UI_ACTOR;
 
 /**
  * Notification that the image node finished loading image from cache
@@ -183,7 +183,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Called on the main thread.
  */
-- (void)imageNodeDidLoadImageFromCache:(ASNetworkImageNode *)imageNode;
+- (void)imageNodeDidLoadImageFromCache:(ASNetworkImageNode *)imageNode NS_SWIFT_UI_ACTOR;
 
 /**
  * Notification that the image node failed to load image from cache
@@ -192,7 +192,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Called on the main thread.
  */
-- (void)imageNodeDidFailToLoadImageFromCache:(ASNetworkImageNode *)imageNode;
+- (void)imageNodeDidFailToLoadImageFromCache:(ASNetworkImageNode *)imageNode NS_SWIFT_UI_ACTOR;
 
 /**
  * Notification that the image node will load image from network
@@ -201,7 +201,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Called on the main thread.
  */
-- (void)imageNodeWillLoadImageFromNetwork:(ASNetworkImageNode *)imageNode;
+- (void)imageNodeWillLoadImageFromNetwork:(ASNetworkImageNode *)imageNode NS_SWIFT_UI_ACTOR;
 
 /**
  * Notification that the image node will start display
@@ -210,7 +210,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Called on the main thread.
  */
-- (void)imageNodeWillStartDisplayAsynchronously:(ASNetworkImageNode *)imageNode;
+- (void)imageNodeWillStartDisplayAsynchronously:(ASNetworkImageNode *)imageNode NS_SWIFT_UI_ACTOR;
 
 /**
  * Notification that the image node finished downloading an image, with additional info.
@@ -251,7 +251,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Called on the main thread.
  */
-- (void)imageNodeDidFinishDecoding:(ASNetworkImageNode *)imageNode;
+- (void)imageNodeDidFinishDecoding:(ASNetworkImageNode *)imageNode NS_SWIFT_UI_ACTOR;
 
 
 @end

--- a/Source/ASPagerNode.h
+++ b/Source/ASPagerNode.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  *   not implement reuse (it will be called once per row).  Unlike UICollectionView's version,
  *   this method is not called when the row is about to display.
  */
-- (ASCellNode *)pagerNode:(ASPagerNode *)pagerNode nodeAtIndex:(NSInteger)index;
+- (ASCellNode *)pagerNode:(ASPagerNode *)pagerNode nodeAtIndex:(NSInteger)index NS_SWIFT_UI_ACTOR;
 
 /**
  * This method replaces -collectionView:nodeBlockForItemAtIndexPath:
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns the current page index. Main thread only.
  */
-@property (nonatomic, readonly) NSInteger currentPageIndex;
+@property (nonatomic, readonly) NSInteger currentPageIndex NS_SWIFT_UI_ACTOR;
 
 /**
  * Scroll the contents of the receiver to ensure that the page is visible

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -196,7 +196,7 @@ NS_ASSUME_NONNULL_BEGIN
  *                    Boolean parameter that contains the value YES if all of the related animations completed successfully or
  *                    NO if they were interrupted. This parameter may be nil. If supplied, the block is run on the main thread.
  */
-- (void)performBatchAnimated:(BOOL)animated updates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable void (^)(BOOL finished))completion NS_SWIFT_UI_ACTOR;
+- (void)performBatchAnimated:(BOOL)animated updates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable NS_SWIFT_UI_ACTOR void (^)(BOOL finished))completion NS_SWIFT_UI_ACTOR;
 
 /**
  *  Perform a batch of updates asynchronously with animations in the batch. This method must be called from the main thread.
@@ -207,7 +207,7 @@ NS_ASSUME_NONNULL_BEGIN
  *                    Boolean parameter that contains the value YES if all of the related animations completed successfully or
  *                    NO if they were interrupted. This parameter may be nil. If supplied, the block is run on the main thread.
  */
-- (void)performBatchUpdates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable void (^)(BOOL finished))completion NS_SWIFT_UI_ACTOR;
+- (void)performBatchUpdates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable NS_SWIFT_UI_ACTOR void (^)(BOOL finished))completion NS_SWIFT_UI_ACTOR;
 
 /**
  *  Returns YES if the ASCollectionNode is still processing changes from performBatchUpdates:.

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -161,7 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * This method must be called on the main thread.
  */
-- (void)scrollToRowAtIndexPath:(NSIndexPath *)indexPath atScrollPosition:(UITableViewScrollPosition)scrollPosition animated:(BOOL)animated;
+- (void)scrollToRowAtIndexPath:(NSIndexPath *)indexPath atScrollPosition:(UITableViewScrollPosition)scrollPosition animated:(BOOL)animated NS_SWIFT_UI_ACTOR;
 
 /**
  * Reload everything from scratch, destroying the working range and all cached nodes.
@@ -170,7 +170,7 @@ NS_ASSUME_NONNULL_BEGIN
  * the main thread.
  * @warning This method is substantially more expensive than UITableView's version.
  */
-- (void)reloadDataWithCompletion:(nullable void (^)(void))completion;
+- (void)reloadDataWithCompletion:(nullable NS_SWIFT_UI_ACTOR void (^)(void))completion;
 
 /**
  * Reload everything from scratch, destroying the working range and all cached nodes.
@@ -196,7 +196,7 @@ NS_ASSUME_NONNULL_BEGIN
  *                    Boolean parameter that contains the value YES if all of the related animations completed successfully or
  *                    NO if they were interrupted. This parameter may be nil. If supplied, the block is run on the main thread.
  */
-- (void)performBatchAnimated:(BOOL)animated updates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable void (^)(BOOL finished))completion;
+- (void)performBatchAnimated:(BOOL)animated updates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable void (^)(BOOL finished))completion NS_SWIFT_UI_ACTOR;
 
 /**
  *  Perform a batch of updates asynchronously with animations in the batch. This method must be called from the main thread.
@@ -207,7 +207,7 @@ NS_ASSUME_NONNULL_BEGIN
  *                    Boolean parameter that contains the value YES if all of the related animations completed successfully or
  *                    NO if they were interrupted. This parameter may be nil. If supplied, the block is run on the main thread.
  */
-- (void)performBatchUpdates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable void (^)(BOOL finished))completion;
+- (void)performBatchUpdates:(nullable AS_NOESCAPE void (^)(void))updates completion:(nullable void (^)(BOOL finished))completion NS_SWIFT_UI_ACTOR;
 
 /**
  *  Returns YES if the ASCollectionNode is still processing changes from performBatchUpdates:.
@@ -236,12 +236,12 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  Calling -waitUntilAllUpdatesAreProcessed is one way to flush any pending update completion blocks.
  */
-- (void)onDidFinishProcessingUpdates:(void (^)(void))didFinishProcessingUpdates;
+- (void)onDidFinishProcessingUpdates:(NS_SWIFT_UI_ACTOR void (^)(void))didFinishProcessingUpdates;
 
 /**
  *  Blocks execution of the main thread until all section and item updates are committed to the view. This method must be called from the main thread.
  */
-- (void)waitUntilAllUpdatesAreProcessed;
+- (void)waitUntilAllUpdatesAreProcessed NS_SWIFT_UI_ACTOR;
 
 /**
  * Inserts one or more sections, with an option to animate the insertion.
@@ -253,7 +253,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
-- (void)insertSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation;
+- (void)insertSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation NS_SWIFT_UI_ACTOR;
 
 /**
  * Deletes one or more sections, with an option to animate the deletion.
@@ -265,7 +265,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
-- (void)deleteSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation;
+- (void)deleteSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation NS_SWIFT_UI_ACTOR;
 
 /**
  * Reloads the specified sections using a given animation effect.
@@ -277,7 +277,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
-- (void)reloadSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation;
+- (void)reloadSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation NS_SWIFT_UI_ACTOR;
 
 /**
  * Moves a section to a new location.
@@ -289,7 +289,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
-- (void)moveSection:(NSInteger)section toSection:(NSInteger)newSection;
+- (void)moveSection:(NSInteger)section toSection:(NSInteger)newSection NS_SWIFT_UI_ACTOR;
 
 /**
  * Inserts rows at the locations identified by an array of index paths, with an option to animate the insertion.
@@ -301,7 +301,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
-- (void)insertRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation;
+- (void)insertRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation NS_SWIFT_UI_ACTOR;
 
 /**
  * Deletes the rows specified by an array of index paths, with an option to animate the deletion.
@@ -313,7 +313,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
-- (void)deleteRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation;
+- (void)deleteRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation NS_SWIFT_UI_ACTOR;
 
 /**
  * Reloads the specified rows using a given animation effect.
@@ -325,7 +325,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
-- (void)reloadRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation;
+- (void)reloadRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation NS_SWIFT_UI_ACTOR;
 
 /**
  * Moves the row at a specified location to a destination location.
@@ -337,7 +337,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
-- (void)moveRowAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath;
+- (void)moveRowAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath NS_SWIFT_UI_ACTOR;
 
 #pragma mark - Selection
 
@@ -353,7 +353,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This method must be called from the main thread.
  */
-- (void)selectRowAtIndexPath:(nullable NSIndexPath *)indexPath animated:(BOOL)animated scrollPosition:(UITableViewScrollPosition)scrollPosition;
+- (void)selectRowAtIndexPath:(nullable NSIndexPath *)indexPath animated:(BOOL)animated scrollPosition:(UITableViewScrollPosition)scrollPosition  NS_SWIFT_UI_ACTOR;
 
 /*
  * Deselects a given row identified by index path, with an option to animate the deselection.
@@ -366,7 +366,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This method must be called from the main thread.
  */
-- (void)deselectRowAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated;
+- (void)deselectRowAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated NS_SWIFT_UI_ACTOR;
 
 #pragma mark - Querying Data
 
@@ -389,7 +389,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return an array containing the nodes being displayed on screen. This must be called on the main thread.
  */
-@property (nonatomic, readonly) NSArray<__kindof ASCellNode *> *visibleNodes;
+@property (nonatomic, readonly) NSArray<__kindof ASCellNode *> *visibleNodes NS_SWIFT_UI_ACTOR;
 
 /**
  * Retrieves the node for the row at the given index path.
@@ -419,7 +419,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This method must be called from the main thread.
  */
-- (CGRect)rectForRowAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT;
+- (CGRect)rectForRowAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT NS_SWIFT_UI_ACTOR;
 
 /**
  * Similar to -[UITableView cellForRowAtIndexPath:]
@@ -430,7 +430,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This method must be called from the main thread.
  */
-- (nullable __kindof UITableViewCell *)cellForRowAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT;
+- (nullable __kindof UITableViewCell *)cellForRowAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT NS_SWIFT_UI_ACTOR;
 
 /**
  * Similar to UITableView.indexPathForSelectedRow
@@ -442,9 +442,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This method must be called from the main thread.
  */
-@property (nullable, nonatomic, copy, readonly) NSIndexPath *indexPathForSelectedRow;
+@property (nullable, nonatomic, copy, readonly) NSIndexPath *indexPathForSelectedRow NS_SWIFT_UI_ACTOR;
 
-@property (nonatomic, readonly, nullable) NSArray<NSIndexPath *> *indexPathsForSelectedRows;
+@property (nonatomic, readonly, nullable) NSArray<NSIndexPath *> *indexPathsForSelectedRows NS_SWIFT_UI_ACTOR;
 
 /**
  * Similar to -[UITableView indexPathForRowAtPoint:]
@@ -456,7 +456,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This method must be called from the main thread.
  */
-- (nullable NSIndexPath *)indexPathForRowAtPoint:(CGPoint)point AS_WARN_UNUSED_RESULT;
+- (nullable NSIndexPath *)indexPathForRowAtPoint:(CGPoint)point AS_WARN_UNUSED_RESULT NS_SWIFT_UI_ACTOR;
 
 /**
  * Similar to -[UITableView indexPathsForRowsInRect:]
@@ -468,7 +468,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This method must be called from the main thread.
  */
-- (nullable NSArray<NSIndexPath *> *)indexPathsForRowsInRect:(CGRect)rect AS_WARN_UNUSED_RESULT;
+- (nullable NSArray<NSIndexPath *> *)indexPathsForRowsInRect:(CGRect)rect AS_WARN_UNUSED_RESULT NS_SWIFT_UI_ACTOR;
 
 /**
  * Similar to -[UITableView indexPathsForVisibleRows]
@@ -478,7 +478,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This method must be called from the main thread.
  */
-- (NSArray<NSIndexPath *> *)indexPathsForVisibleRows AS_WARN_UNUSED_RESULT;
+- (NSArray<NSIndexPath *> *)indexPathsForVisibleRows AS_WARN_UNUSED_RESULT NS_SWIFT_UI_ACTOR;
 
 @end
 
@@ -528,7 +528,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @return a node to display for this row. This will be called on the main thread and should not implement reuse (it will be called once per row). Unlike UITableView's version, this method
  * is not called when the row is about to display.
  */
-- (ASCellNode *)tableNode:(ASTableNode *)tableNode nodeForRowAtIndexPath:(NSIndexPath *)indexPath;
+- (ASCellNode *)tableNode:(ASTableNode *)tableNode nodeForRowAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_UI_ACTOR;
 
 /**
  * Similar to -tableView:cellForRowAtIndexPath:.

--- a/Source/UIResponder+AsyncDisplayKit.h
+++ b/Source/UIResponder+AsyncDisplayKit.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * This property must be accessed on the main thread.
  */
-@property (nonatomic, nullable, readonly) __kindof UIViewController *asdk_associatedViewController;
+@property (nonatomic, nullable, readonly) __kindof UIViewController *asdk_associatedViewController NS_SWIFT_UI_ACTOR;
 
 @end
 


### PR DESCRIPTION
Initial attempt to mark all methods that are guaranteed to run on main as `NS_SWIFT_UI_ACTOR`. 