### PR TITLE
Fix: Transfer leadingScreensForBatching from pending state on node load

### DIFF
--- a/.github/workflows/ci-master-only.yml
+++ b/.github/workflows/ci-master-only.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   cocoapods-lint:
     env: 
-        DEVELOPER_DIR: /Applications/Xcode_16.4.0.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_26.0.1.app/Contents/Developer
     name: Verify that podspec lints
     runs-on: macos-latest
     steps:

--- a/.github/workflows/ci-pull-requests-only.yml
+++ b/.github/workflows/ci-pull-requests-only.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   buildsh:
     env:
-        DEVELOPER_DIR: /Applications/Xcode_16.4.0.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_26.0.1.app/Contents/Developer
     strategy:
       matrix:
         mode: [cocoapods-lint-default-subspecs, cocoapods-lint-other-subspecs]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   buildsh:
     env:
-        DEVELOPER_DIR: /Applications/Xcode_16.4.0.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_26.0.1.app/Contents/Developer
     strategy:
       matrix:
         mode: [tests, framework, life-without-cocoapods, carthage, examples-pt1, examples-pt2, examples-pt3, examples-pt4]

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -345,6 +345,10 @@
       [view setContentOffset:contentOffset animated:pendingState.animatesContentOffset];
     }
     
+    if (pendingState.leadingScreensForBatching != 0) {
+      view.leadingScreensForBatching = pendingState.leadingScreensForBatching;
+    }
+    
     const auto tuningParametersVector = pendingState->_tuningParameters;
     const auto tuningParametersVectorSize = tuningParametersVector.size();
     for (NSInteger rangeMode = 0; rangeMode < tuningParametersVectorSize; rangeMode++) {

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -82,6 +82,7 @@
     _flags.inverted = NO;
     _contentInset = UIEdgeInsetsZero;
     _contentOffset = CGPointZero;
+    _leadingScreensForBatching = 2.0;
     _flags.animatesContentOffset = NO;
     _flags.showsVerticalScrollIndicator = YES;
     _flags.showsHorizontalScrollIndicator = YES;
@@ -323,6 +324,7 @@
     view.layoutInspector                = pendingState.layoutInspector;
     view.showsVerticalScrollIndicator   = pendingState.showsVerticalScrollIndicator;
     view.showsHorizontalScrollIndicator = pendingState.showsHorizontalScrollIndicator;
+    view.leadingScreensForBatching      = pendingState.leadingScreensForBatching;
 #if !TARGET_OS_TV
     view.pagingEnabled                  = pendingState.pagingEnabled;
 #endif
@@ -343,10 +345,6 @@
     CGPoint contentOffset = pendingState.contentOffset;
     if (!CGPointEqualToPoint(contentOffset, CGPointZero)) {
       [view setContentOffset:contentOffset animated:pendingState.animatesContentOffset];
-    }
-    
-    if (pendingState.leadingScreensForBatching != 0) {
-      view.leadingScreensForBatching = pendingState.leadingScreensForBatching;
     }
     
     const auto tuningParametersVector = pendingState->_tuningParameters;

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -178,6 +178,7 @@
       [view setContentOffset:contentOffset animated:pendingState.animatesContentOffset];
     }
       
+
     const auto tuningParametersVector = pendingState->_tuningParameters;
     const auto tuningParametersVectorSize = tuningParametersVector.size();
     for (NSInteger rangeMode = 0; rangeMode < tuningParametersVectorSize; rangeMode++) {

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -176,6 +176,10 @@
     if (!CGPointEqualToPoint(contentOffset, CGPointZero)) {
       [view setContentOffset:contentOffset animated:pendingState.animatesContentOffset];
     }
+
+     if (pendingState.leadingScreensForBatching != 0) {
+       view.leadingScreensForBatching = pendingState.leadingScreensForBatching;
+     }
       
     const auto tuningParametersVector = pendingState->_tuningParameters;
     const auto tuningParametersVectorSize = tuningParametersVector.size();

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -178,7 +178,6 @@
       [view setContentOffset:contentOffset animated:pendingState.animatesContentOffset];
     }
       
-
     const auto tuningParametersVector = pendingState->_tuningParameters;
     const auto tuningParametersVectorSize = tuningParametersVector.size();
     for (NSInteger rangeMode = 0; rangeMode < tuningParametersVectorSize; rangeMode++) {

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -163,6 +163,7 @@
     view.allowsMultipleSelection              = pendingState.allowsMultipleSelection;
     view.allowsMultipleSelectionDuringEditing = pendingState.allowsMultipleSelectionDuringEditing;
     view.automaticallyAdjustsContentOffset    = pendingState.automaticallyAdjustsContentOffset;
+    view.leadingScreensForBatching            = pendingState.leadingScreensForBatching;
 #if !TARGET_OS_TV
     view.pagingEnabled                        = pendingState.pagingEnabled;
 #endif
@@ -176,10 +177,6 @@
     if (!CGPointEqualToPoint(contentOffset, CGPointZero)) {
       [view setContentOffset:contentOffset animated:pendingState.animatesContentOffset];
     }
-
-     if (pendingState.leadingScreensForBatching != 0) {
-       view.leadingScreensForBatching = pendingState.leadingScreensForBatching;
-     }
       
     const auto tuningParametersVector = pendingState->_tuningParameters;
     const auto tuningParametersVectorSize = tuningParametersVector.size();

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -1299,4 +1299,63 @@
 
 }
 
+- (void)testAllPendingStatePropertiesTransferredToView {
+  // Create node without loading view
+  UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+  ASCollectionNode *node = [[ASCollectionNode alloc] initWithFrame:CGRectZero 
+                                             collectionViewLayout:layout];
+  
+  XCTAssertFalse(node.isNodeLoaded, @"View should not be loaded before setting properties");
+  
+  // Set pending state properties before view loads
+  node.leadingScreensForBatching = 3.6;
+  node.inverted = YES;
+  node.allowsMultipleSelection = YES;
+  node.alwaysBounceVertical = YES;
+  node.alwaysBounceHorizontal = YES;
+  node.pagingEnabled = YES;
+  node.showsVerticalScrollIndicator = NO;
+  node.showsHorizontalScrollIndicator = NO;
+  UIEdgeInsets testInsets = UIEdgeInsetsMake(10, 20, 30, 40);
+  node.contentInset = testInsets;
+  CGPoint testOffset = CGPointMake(50, 60);
+  node.contentOffset = testOffset;
+  ASCollectionViewTestDelegate *delegate = [[ASCollectionViewTestDelegate alloc] initWithNumberOfSections:10 numberOfItemsInSection:10];
+  node.delegate = delegate;
+  ASCollectionViewTestDelegate *dataSource = [[ASCollectionViewTestDelegate alloc] initWithNumberOfSections:20 numberOfItemsInSection:20];
+  node.dataSource = dataSource;
+
+  
+  // Load the view (triggers pending state transfer)
+  ASCollectionView *view = node.view;
+  
+  XCTAssertTrue(node.isNodeLoaded, @"View should be loaded after accessing node.view");
+  
+  // Verify properties were transferred correctly
+  XCTAssertEqual(view.leadingScreensForBatching, 3.6, 
+                 @"leadingScreensForBatching should transfer from pending state");
+  XCTAssertEqual(view.inverted, YES, 
+                 @"inverted should transfer from pending state");
+  XCTAssertEqual(view.allowsMultipleSelection, YES,
+                 @"allowsMultipleSelection should transfer from pending state");
+  XCTAssertEqual(view.alwaysBounceVertical, YES, 
+                 @"alwaysBounceVertical should transfer from pending state");
+  XCTAssertEqual(view.alwaysBounceHorizontal, YES, 
+                 @"alwaysBounceHorizontal should transfer from pending state");
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(view.contentInset, testInsets), 
+                @"contentInset should transfer from pending state");
+  XCTAssertTrue(CGPointEqualToPoint(view.contentOffset, testOffset), 
+                @"contentOffset should transfer from pending state");
+  XCTAssertEqual(view.showsVerticalScrollIndicator, NO, 
+                 @"showsVerticalScrollIndicator should transfer from pending state");
+  XCTAssertEqual(view.showsHorizontalScrollIndicator, NO, 
+                 @"showsHorizontalScrollIndicator should transfer from pending state");
+  XCTAssertEqual(view.pagingEnabled, YES, 
+                 @"pagingEnabled should transfer from pending state");
+  XCTAssertEqual(view.asyncDelegate, delegate,
+                 @"delegate should transfer from pending state");
+  XCTAssertEqual(view.asyncDataSource, dataSource,
+                 @"dataSource should transfer from pending state");
+}
+
 @end

--- a/Tests/ASTableViewTests.mm
+++ b/Tests/ASTableViewTests.mm
@@ -1049,4 +1049,57 @@
   XCTAssertTrue(areColorsEqual);
 }
 
+- (void)testAllPendingStatePropertiesTransferredToView {
+  // Create node without loading view
+  ASTableNode *node = [[ASTableNode alloc] initWithStyle:UITableViewStylePlain];
+  
+  XCTAssertFalse(node.isNodeLoaded, @"View should not be loaded before setting properties");
+  
+  // Set pending state properties before view loads
+  node.leadingScreensForBatching = 3.6;
+  node.inverted = YES;
+  node.allowsSelectionDuringEditing = YES;
+  node.allowsMultipleSelection = YES;
+  node.allowsMultipleSelectionDuringEditing = YES;
+  node.pagingEnabled = YES;
+  node.automaticallyAdjustsContentOffset = NO;
+  UIEdgeInsets testInsets = UIEdgeInsetsMake(10, 20, 30, 40);
+  node.contentInset = testInsets;
+  CGPoint testOffset = CGPointMake(50, 60);
+  node.contentOffset = testOffset;
+  ASTableViewFilledDelegate *delegate = [ASTableViewFilledDelegate new];
+  node.delegate = delegate;
+  ASTableViewFilledDataSource *dataSource = [ASTableViewFilledDataSource new];
+  node.dataSource = dataSource;
+  
+  // Load the view (triggers pending state transfer)
+  ASTableView *view = node.view;
+  
+  XCTAssertTrue(node.isNodeLoaded, @"View should be loaded after accessing node.view");
+  
+  // Verify properties were transferred correctly
+  XCTAssertEqual(view.leadingScreensForBatching, 3.6,
+                 @"leadingScreensForBatching should transfer from pending state");
+  XCTAssertEqual(view.inverted, YES, 
+                 @"inverted should transfer from pending state");
+  XCTAssertEqual(view.allowsSelectionDuringEditing, YES,
+                 @"allowsSelectionDuringEditing should transfer from pending state");
+  XCTAssertEqual(view.allowsMultipleSelection, YES, 
+                 @"allowsMultipleSelection should transfer from pending state");
+  XCTAssertEqual(view.allowsMultipleSelectionDuringEditing, YES, 
+                 @"allowsMultipleSelectionDuringEditing should transfer from pending state");
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(view.contentInset, testInsets), 
+                @"contentInset should transfer from pending state");
+  XCTAssertTrue(CGPointEqualToPoint(view.contentOffset, testOffset), 
+                @"contentOffset should transfer from pending state");
+  XCTAssertEqual(view.automaticallyAdjustsContentOffset, NO, 
+                 @"automaticallyAdjustsContentOffset should transfer from pending state");
+  XCTAssertEqual(view.pagingEnabled, YES, 
+                 @"pagingEnabled should transfer from pending state");
+  XCTAssertEqual(view.asyncDelegate, delegate,
+                 @"delegate should transfer from pending state");
+  XCTAssertEqual(view.asyncDataSource, dataSource,
+                 @"dataSource should transfer from pending state");
+}
+
 @end


### PR DESCRIPTION
## Problem

When `leadingScreensForBatching` is set on `ASCollectionNode` or `ASTableNode` before the node loads, the value is not properly transferred to the underlying view. This causes the property to retain the default value of `2.0` instead of the configured value.

### Root Cause
It looks like `leadingScreensForBatching` was accidentally omitted when transferring the pendingState to the view in the `didLoad` function. 

#### Examples 
Broken Example
```
- (instancetype)init {
    self = [super init];
    if (self) {
        _collectionNode = [[ASCollectionNode alloc] init...];
        _collectionNode.leadingScreensForBatching = 3.6;  // Stored in pending state but never transferred to view
        [self addSubnode:_collectionNode];
    }
    return self;
}
```
Result: leadingScreensForBatching stays at 2.0

Working Example
```
override func didLoadInternal() {
    let collectionView = collectionNode.view  // This triggers node load
    collectionNode.leadingScreensForBatching = 2.4  // Set after load, goes directly to view
}
```
Result: leadingScreensForBatching is correctly set to 2.4 since the view had already been loaded. 

`leadingScreensForBatching` setter: leadingScreensForBatching goes to pendingState if it exists else it goes to the underlying view. The pendingState value wasn't being transferred to the underlying view on view creation. 
```
- (void)setLeadingScreensForBatching:(CGFloat)leadingScreensForBatching
{
  if ([self pendingState]) {
    _pendingState.leadingScreensForBatching = leadingScreensForBatching;
  } else {
    ASDisplayNodeAssert([self isNodeLoaded], @"ASCollectionNode should be loaded if pendingState doesn't exist");
    self.view.leadingScreensForBatching = leadingScreensForBatching;
  }
}
```