### PR TITLE
Fix SwiftUI Previews

### DIFF
--- a/Source/ASInternalHelpers.mm
+++ b/Source/ASInternalHelpers.mm
@@ -65,7 +65,7 @@ void ASInitializeFrameworkMainThreadOnConstructor(void)
 {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    ASDisplayNodeCAssertMainThread();
+    ASDisplayNodeCAssert([NSThread isMainThread], @"This method must be called on the main/preview-host thread");
     ASNotifyInitialized();
 #if AS_SIGNPOST_ENABLE
     _ASInitializeSignpostObservers();
@@ -77,7 +77,7 @@ void ASInitializeFrameworkMainThreadOnDestructor(void)
 {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    ASDisplayNodeCAssertMainThread();
+    ASDisplayNodeCAssert([NSThread isMainThread], @"This method must be called on the main/preview-host thread");
     // Ensure these values are cached on the main thread before needed in the background.
     if (ASActivateExperimentalFeature(ASExperimentalLayerDefaults)) {
       // Nop. We will gather default values on-demand in ASDefaultAllowsGroupOpacity and ASDefaultAllowsEdgeAntialiasing


### PR DESCRIPTION
## Summary
Replaced internal main-thread assertions using `ASDisplayNodeCAssertMainThread()` with explicit `[NSThread isMainThread]` checks in `ASInternalHelpers.mm`.  

## Why this change
SwiftUI Previews run in a separate lightweight process (PreviewHost / XCPreviewAgent). While `Thread.isMainThread` / `[NSThread isMainThread]` returns `true` (because PreviewHost fakes the Foundation main thread for compatibility with SwiftUI, UIKit, and `@MainActor`), lower-level or custom main-thread checks (like the previous macro) could fail or behave inconsistently.  

This caused assertion failures or skipped initialization/cleanup logic during preview rendering, leading to crashes or broken previews.

| pthread_main_np()  | [NSThread isMainThread] |
|-------------------------------------------------------------------|--------------------------------------------------------------------------------------|
| Returns **false** (0)                                             | Returns **true**                                                                     |
| Checks if current pthread is the original process bootstrap thread | Checks if current thread is the Foundation-designated main thread                    |
| Not affected by PreviewHost fake-main-thread logic                | Fully affected — PreviewHost overrides/fakes it as main thread                       |
| Does **not** match SwiftUI / MainActor expectations              | Matches SwiftUI / UIKit / MainActor expectations                                    |
