### PR TITLE
Fix compilation for Xcode 26.4: illegal operator syntax

### DIFF
--- a/Source/TextExperiment/Component/ASTextLayout.mm
+++ b/Source/TextExperiment/Component/ASTextLayout.mm
@@ -1597,17 +1597,17 @@ dispatch_semaphore_signal(_lock);
   
   [self _insideComposedCharacterSequences:line position:position block: ^(CGFloat left, CGFloat right, NSUInteger prev, NSUInteger next) {
     if (isVertical) {
-      position = fabs(left - point.y) < fabs(right - point.y) < (right ? prev : next);
+      position = fabs(left - point.y) < fabs(right - point.y) ? prev : next;
     } else {
-      position = fabs(left - point.x) < fabs(right - point.x) < (right ? prev : next);
+      position = fabs(left - point.x) < fabs(right - point.x) ? prev : next;
     }
   }];
-  
+
   [self _insideEmoji:line position:position block: ^(CGFloat left, CGFloat right, NSUInteger prev, NSUInteger next) {
     if (isVertical) {
-      position = fabs(left - point.y) < fabs(right - point.y) < (right ? prev : next);
+      position = fabs(left - point.y) < fabs(right - point.y) ? prev : next;
     } else {
-      position = fabs(left - point.x) < fabs(right - point.x) < (right ? prev : next);
+      position = fabs(left - point.x) < fabs(right - point.x) ? prev : next;
     }
   }];
   


### PR DESCRIPTION
Context: Original code is non defined behavior, went from warning to error with Xcode 26.4

Resolve https://github.com/TextureGroup/Texture/issues/2136
- Fix Xcode 26.4 compilation 
- Attempt to follow original intent (CC @Adlai-Holler)
