### PR TITLE
Fix illegal operator syntax in ASTextLayout

### DIFF
--- a/Source/TextExperiment/Component/ASTextLayout.mm
+++ b/Source/TextExperiment/Component/ASTextLayout.mm
@@ -1597,17 +1597,17 @@ dispatch_semaphore_signal(_lock);
   
   [self _insideComposedCharacterSequences:line position:position block: ^(CGFloat left, CGFloat right, NSUInteger prev, NSUInteger next) {
     if (isVertical) {
-      position = fabs(left - point.y) < fabs(right - point.y) < (right ? prev : next);
+      position = fabs(left - point.y) < fabs(right - point.y) ? prev : next;
     } else {
-      position = fabs(left - point.x) < fabs(right - point.x) < (right ? prev : next);
+      position = fabs(left - point.x) < fabs(right - point.x) ? prev : next;
     }
   }];
   
   [self _insideEmoji:line position:position block: ^(CGFloat left, CGFloat right, NSUInteger prev, NSUInteger next) {
     if (isVertical) {
-      position = fabs(left - point.y) < fabs(right - point.y) < (right ? prev : next);
+      position = fabs(left - point.y) < fabs(right - point.y) ? prev : next;
     } else {
-      position = fabs(left - point.x) < fabs(right - point.x) < (right ? prev : next);
+      position = fabs(left - point.x) < fabs(right - point.x) ? prev : next;
     }
   }];
   


### PR DESCRIPTION
## Summary
Fixes illegal operator syntax in `ASTextLayout.mm`.

## Changes
- Updates `Source/TextExperiment/Component/ASTextLayout.mm`

## Testing
- `xcodebuild -workspace AsyncDisplayKit.xcworkspace -scheme AsyncDisplayKit -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/TextureDerivedData build`
- Build succeeded