### PR TITLE
Resolve dynamic background colors against the node's trait collection (behind experiment flag)

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -458,10 +458,10 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
         CGFloat cornerRadius = self->_cornerRadius;
         ASCornerRoundingType cornerRoundingType = self->_cornerRoundingType;
         UIColor *backgroundColor = self->_backgroundColor;
+        ASPrimitiveTraitCollection currentPrimitiveTraitCollection = self->_primitiveTraitCollection;
         self->__instanceLock__.unlock();
-        // TODO: we should resolve color using node's trait collection
-        // but Texture changes it from many places, so we may receive the wrong one.
-        CGColorRef cgBackgroundColor = backgroundColor.CGColor;
+        UITraitCollection *traitCollection = ASPrimitiveTraitCollectionToUITraitCollection(currentPrimitiveTraitCollection);
+        CGColorRef cgBackgroundColor = [backgroundColor resolvedColorWithTraitCollection:traitCollection].CGColor;
         if (!CGColorEqualToColor(self->_layer.backgroundColor, cgBackgroundColor)) {
           // Background colors do not dynamically update for layer backed nodes since they utilize CGColorRef
           // instead of UIColor. Non layer backed node also receive color to the layer (see [_ASPendingState -applyToView:withSpecialPropertiesHandling:]).

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -460,8 +460,15 @@ ASSynthesizeLockingMethodsWithMutex(__instanceLock__);
         UIColor *backgroundColor = self->_backgroundColor;
         ASPrimitiveTraitCollection currentPrimitiveTraitCollection = self->_primitiveTraitCollection;
         self->__instanceLock__.unlock();
-        UITraitCollection *traitCollection = ASPrimitiveTraitCollectionToUITraitCollection(currentPrimitiveTraitCollection);
-        CGColorRef cgBackgroundColor = [backgroundColor resolvedColorWithTraitCollection:traitCollection].CGColor;
+        CGColorRef cgBackgroundColor;
+        if (ASActivateExperimentalFeature(ASExperimentalResolveBackgroundColorWithNodeTraits)) {
+          UITraitCollection *traitCollection = ASPrimitiveTraitCollectionToUITraitCollection(currentPrimitiveTraitCollection);
+          cgBackgroundColor = [backgroundColor resolvedColorWithTraitCollection:traitCollection].CGColor;
+        } else {
+          // TODO: we should resolve color using node's trait collection
+          // but Texture changes it from many places, so we may receive the wrong one.
+          cgBackgroundColor = backgroundColor.CGColor;
+        }
         if (!CGColorEqualToColor(self->_layer.backgroundColor, cgBackgroundColor)) {
           // Background colors do not dynamically update for layer backed nodes since they utilize CGColorRef
           // instead of UIColor. Non layer backed node also receive color to the layer (see [_ASPendingState -applyToView:withSpecialPropertiesHandling:]).

--- a/Source/ASExperimentalFeatures.h
+++ b/Source/ASExperimentalFeatures.h
@@ -35,6 +35,7 @@ typedef NS_OPTIONS(NSUInteger, ASExperimentalFeatures) {
   ASExperimentalLockTextRendererCache = 1 << 14,                            // exp_lock_text_renderer_cache
   ASExperimentalHierarchyDisplayDidFinishIsRecursive = 1 << 15,             // exp_hierarchy_display_did_finish_is_recursive
   ASExperimentalCheckBatchFetchingOnScroll = 1 << 16,                       // exp_check_batch_fetching_on_scroll
+  ASExperimentalResolveBackgroundColorWithNodeTraits = 1 << 17,             // exp_resolve_background_color_with_node_traits
   ASExperimentalFeatureAll = 0xFFFFFFFF
 };
 

--- a/Source/ASExperimentalFeatures.mm
+++ b/Source/ASExperimentalFeatures.mm
@@ -28,7 +28,8 @@ NSArray<NSString *> *ASExperimentalFeaturesGetNames(ASExperimentalFeatures flags
                                       @"exp_no_text_renderer_cache",
                                       @"exp_lock_text_renderer_cache",
                                       @"exp_hierarchy_display_did_finish_is_recursive",
-                                      @"exp_check_batch_fetching_on_scroll"]));
+                                      @"exp_check_batch_fetching_on_scroll",
+                                      @"exp_resolve_background_color_with_node_traits"]));
 
   if (flags == ASExperimentalFeatureAll) {
     return allNames;

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -762,8 +762,9 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
   if (shouldApply) {
     UIColor *oldBackgroundColor = _backgroundColor;
     _backgroundColor = newBackgroundColor;
+    UITraitCollection *traitCollection = ASPrimitiveTraitCollectionToUITraitCollection(_primitiveTraitCollection);
     if (_flags.layerBacked) {
-      _layer.backgroundColor = _backgroundColor.CGColor;
+      _layer.backgroundColor = [_backgroundColor resolvedColorWithTraitCollection:traitCollection].CGColor;
     } else {
       /*
        NOTE: Setting to the view and layer individually is necessary.
@@ -775,7 +776,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
        */
       _view.backgroundColor = _backgroundColor;
       // Gather the CGColorRef from the view incase there are any changes it might apply to which CGColorRef is returned for dynamic colors
-      _layer.backgroundColor = _view.backgroundColor.CGColor;
+      _layer.backgroundColor = [_backgroundColor resolvedColorWithTraitCollection:traitCollection].CGColor;
     }
 
     if (![oldBackgroundColor isEqual:newBackgroundColor]) {

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -762,9 +762,10 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
   if (shouldApply) {
     UIColor *oldBackgroundColor = _backgroundColor;
     _backgroundColor = newBackgroundColor;
-    UITraitCollection *traitCollection = ASPrimitiveTraitCollectionToUITraitCollection(_primitiveTraitCollection);
+    BOOL resolveWithNodeTraits = ASActivateExperimentalFeature(ASExperimentalResolveBackgroundColorWithNodeTraits);
+    UITraitCollection *traitCollection = resolveWithNodeTraits ? ASPrimitiveTraitCollectionToUITraitCollection(_primitiveTraitCollection) : nil;
     if (_flags.layerBacked) {
-      _layer.backgroundColor = [_backgroundColor resolvedColorWithTraitCollection:traitCollection].CGColor;
+      _layer.backgroundColor = resolveWithNodeTraits ? [_backgroundColor resolvedColorWithTraitCollection:traitCollection].CGColor : _backgroundColor.CGColor;
     } else {
       /*
        NOTE: Setting to the view and layer individually is necessary.
@@ -776,7 +777,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
        */
       _view.backgroundColor = _backgroundColor;
       // Gather the CGColorRef from the view incase there are any changes it might apply to which CGColorRef is returned for dynamic colors
-      _layer.backgroundColor = [_backgroundColor resolvedColorWithTraitCollection:traitCollection].CGColor;
+      _layer.backgroundColor = resolveWithNodeTraits ? [_backgroundColor resolvedColorWithTraitCollection:traitCollection].CGColor : _view.backgroundColor.CGColor;
     }
 
     if (![oldBackgroundColor isEqual:newBackgroundColor]) {


### PR DESCRIPTION
## Summary
Layer-backed nodes store their background color as a `CGColorRef`, which has no trait collection, so dynamic (light/dark) colors could resolve against the wrong appearance. This resolves the `UIColor` via `-resolvedColorWithTraitCollection:` using the node's own trait collection before extracting the `CGColorRef`.

## Changes
- **`ASDisplayNode+UIViewBridge.mm`** (`-setBackgroundColor:`): resolve the color against the node's trait collection before assigning `_layer.backgroundColor`, for both layer-backed and view-backed paths.
- **`ASDisplayNode.mm`** (trait-collection-change handler): resolve the color the same way when reapplying the background color after a user-interface-style change.

## Experiment flag
Gated behind `ASExperimentalResolveBackgroundColorWithNodeTraits` (`exp_resolve_background_color_with_node_traits`). When off, the original behavior is fully preserved.

## Testing
✅ **Build succeeded**
```
xcodebuild -workspace AsyncDisplayKit.xcworkspace -scheme AsyncDisplayKit -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/TextureDerivedData build
```